### PR TITLE
Audio pipeline, Bluetooth, Cast, Web UI, and queue panel improvements

### DIFF
--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -138,21 +138,156 @@ sudo systemctl enable radio-console
 sudo systemctl disable radio-console
 ```
 
-## Updating
+## Development Workflow: Building and Testing on the Pi
+
+### Overview
+
+The recommended workflow is: **develop on Windows, cross-compile, push directly to Pi via SCP**.
+This is faster than git-pull-and-build-on-Pi because the Pi 5's ARM64 CPU is significantly
+slower at .NET compilation than a desktop machine, and self-contained publishes avoid needing
+the .NET SDK installed on the Pi at all.
+
+### Workflow Comparison
+
+| Approach | Build time | Requires SDK on Pi | Iteration speed |
+|---|---|---|---|
+| **SCP deploy script (recommended)** | ~10s on dev PC | No | Fastest — one command |
+| Git pull + `dotnet build` on Pi | ~60-90s on Pi 5 | Yes (.NET 8 SDK) | Slow, needs SDK |
+| Git pull + pre-built artifacts | ~10s on dev PC | No | Medium — two steps |
+
+### Option A: Direct SCP Deploy (Recommended)
+
+Use the `deploy-to-pi.sh` script for single-command build-and-deploy:
 
 ```bash
-# 1. Build new version on dev machine
+# First time: set your Pi's IP (or add to ~/.bashrc)
+export PI_HOST=192.168.1.100
+export PI_USER=pi
+
+# Build, push, and restart in one command
+./deploy/deploy-to-pi.sh
+
+# Deploy without restarting (for inspecting the build first)
+./deploy/deploy-to-pi.sh --no-restart
+
+# Deploy and tail logs immediately
+./deploy/deploy-to-pi.sh --logs
+```
+
+What the script does:
+1. Cross-compiles for `linux-arm64` with `dotnet publish`
+2. Stops the service on the Pi via SSH
+3. Uses `rsync` over SSH to sync only changed files (preserves `data/` and `logs/`)
+4. Fixes ownership/permissions
+5. Restarts the service
+6. Optionally tails `journalctl` so you see startup output
+
+**SSH key setup** (do this once so you're not prompted for passwords):
+
+```bash
+# Generate key if you don't have one
+ssh-keygen -t ed25519
+
+# Copy to Pi
+ssh-copy-id pi@192.168.1.100
+```
+
+### Option B: Git Pull on Pi
+
+If you prefer using Git as the transfer mechanism (useful if you want the Pi to have
+the full repo for debugging):
+
+```bash
+# One-time setup on the Pi
+sudo apt install -y dotnet-sdk-8.0
+cd ~ && git clone https://github.com/youruser/RTest.git
+cd RTest
+
+# Each iteration
+git pull
+dotnet build --configuration Release
+dotnet run --project src/Radio.API
+```
+
+This is slower but gives you the ability to edit and test small fixes directly on the Pi.
+Build times are ~60-90 seconds on Pi 5 vs ~10 seconds on a modern desktop.
+
+### Option C: Hybrid — Git Pull Pre-Built Artifacts
+
+Build on Windows and commit the publish output to a separate branch or use GitHub Actions
+to produce artifacts. This works but adds complexity and bloats the repo.
+
+### Running Tests on the Pi
+
+Some tests require real hardware (audio devices, Bluetooth, RTL-SDR) that only exist on
+the Pi. To run tests:
+
+```bash
+# Run all tests (requires .NET SDK on Pi)
+dotnet test --configuration Release --verbosity normal
+
+# Run only integration tests (most likely to differ on Pi)
+dotnet test tests/Radio.IntegrationTests --configuration Release --verbosity normal
+
+# Run a specific test
+dotnet test --filter "FullyQualifiedName~BluetoothServiceTests" --configuration Release
+
+# Run tests without building (if you built recently)
+dotnet test --configuration Release --no-build
+```
+
+**Tests that behave differently on Pi:**
+- Audio device enumeration — real ALSA/PulseAudio devices instead of mock
+- Bluetooth A2DP sink — requires BlueZ and a BT adapter
+- RTL-SDR radio tests — require a plugged-in USB dongle
+- Google Cast discovery — requires mDNS on the local network
+- Audio fingerprinting — `fpcalc` binary must match the ARM64 platform
+
+**Hardware-dependent tests are skipped** by default when the required device isn't present
+(check for `[Fact(Skip = ...)]` or `Assert.Skip` patterns).
+
+### Quick Iteration Tips
+
+**Tail logs on Pi while developing on Windows** (keep a terminal open):
+
+```bash
+ssh pi@192.168.1.100 "journalctl -u radio-console -f"
+```
+
+**Run the app manually** (instead of via systemd) for faster iteration and console output:
+
+```bash
+ssh pi@192.168.1.100
+sudo systemctl stop radio-console
+cd /opt/radio-console
+sudo -u radio ./Radio.API
+# Ctrl+C to stop, re-deploy, repeat
+```
+
+**Test a single component** without full deploy — publish just the DLL:
+
+```bash
+# Faster than full self-contained publish for quick checks
+dotnet publish src/Radio.API -c Release -r linux-arm64 --no-self-contained -o publish/quick
+rsync -avz publish/quick/ pi@192.168.1.100:/opt/radio-console/
+```
+
+Note: `--no-self-contained` requires the .NET 8 runtime on the Pi (`sudo apt install dotnet-runtime-8.0`),
+but the transfer is much smaller (~20MB vs ~100MB).
+
+## Updating (Production)
+
+For production updates (when the Pi is deployed as the radio appliance):
+
+```bash
+# Single-command deploy
+./deploy/deploy-to-pi.sh
+
+# Or manual steps:
 cd deploy/common && ./publish.sh arm64
-
-# 2. Stop the service on target
 ssh pi@<ip> "sudo systemctl stop radio-console"
-
-# 3. Copy new files (preserves data directories)
-scp -r publish/linux-arm64/* pi@<ip>:/tmp/radio-update/
-ssh pi@<ip> "sudo rsync -av --exclude='data' --exclude='logs' /tmp/radio-update/ /opt/radio-console/"
+rsync -avz --exclude='data' --exclude='logs' publish/linux-arm64/ pi@<ip>:/opt/radio-console/
 ssh pi@<ip> "sudo chown -R radio:radio /opt/radio-console && sudo chmod +x /opt/radio-console/Radio.API"
-
-# 4. Start the service
 ssh pi@<ip> "sudo systemctl start radio-console"
 ```
 

--- a/deploy/deploy-to-pi.sh
+++ b/deploy/deploy-to-pi.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# deploy-to-pi.sh — One-command build + deploy to Raspberry Pi
+#
+# Usage:
+#   ./deploy/deploy-to-pi.sh              # Build, deploy, restart
+#   ./deploy/deploy-to-pi.sh --no-restart # Build and deploy only
+#   ./deploy/deploy-to-pi.sh --logs       # Build, deploy, restart, tail logs
+#   ./deploy/deploy-to-pi.sh --quick      # Framework-dependent (smaller, faster, needs runtime on Pi)
+#
+# Environment variables:
+#   PI_HOST  — Pi IP address or hostname (default: raspberry-pi.local)
+#   PI_USER  — SSH user (default: pi)
+#   PI_PATH  — Install path on Pi (default: /opt/radio-console)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PI_HOST="${PI_HOST:-raspberry-pi.local}"
+PI_USER="${PI_USER:-pi}"
+PI_PATH="${PI_PATH:-/opt/radio-console}"
+
+RESTART=true
+TAIL_LOGS=false
+QUICK=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-restart) RESTART=false ;;
+    --logs) TAIL_LOGS=true ;;
+    --quick) QUICK=true ;;
+    --help|-h)
+      echo "Usage: $0 [--no-restart] [--logs] [--quick]"
+      echo ""
+      echo "  --no-restart  Deploy without restarting the service"
+      echo "  --logs        Tail journalctl after restart"
+      echo "  --quick       Framework-dependent publish (smaller, needs .NET runtime on Pi)"
+      echo ""
+      echo "Environment:"
+      echo "  PI_HOST=$PI_HOST"
+      echo "  PI_USER=$PI_USER"
+      echo "  PI_PATH=$PI_PATH"
+      exit 0
+      ;;
+  esac
+done
+
+SSH_TARGET="$PI_USER@$PI_HOST"
+PUBLISH_DIR="$REPO_ROOT/publish/linux-arm64"
+
+echo "=== Radio Console Deploy ==="
+echo "Target: $SSH_TARGET:$PI_PATH"
+echo ""
+
+# Step 1: Build
+echo "[1/4] Building for linux-arm64..."
+if [ "$QUICK" = true ]; then
+  dotnet publish "$REPO_ROOT/src/Radio.API/Radio.API.csproj" \
+    --configuration Release \
+    --runtime linux-arm64 \
+    --no-self-contained \
+    --output "$PUBLISH_DIR" \
+    -p:PublishSingleFile=false \
+    -v quiet
+  echo "  (framework-dependent — .NET runtime required on Pi)"
+else
+  dotnet publish "$REPO_ROOT/src/Radio.API/Radio.API.csproj" \
+    --configuration Release \
+    --runtime linux-arm64 \
+    --self-contained true \
+    --output "$PUBLISH_DIR" \
+    -p:PublishSingleFile=true \
+    -p:PublishTrimmed=false \
+    -p:IncludeNativeLibrariesForSelfExtract=true \
+    -v quiet
+fi
+echo "  Build complete ($(du -sh "$PUBLISH_DIR" | cut -f1))"
+
+# Step 2: Stop service
+if [ "$RESTART" = true ]; then
+  echo "[2/4] Stopping service on Pi..."
+  ssh "$SSH_TARGET" "sudo systemctl stop radio-console 2>/dev/null || true"
+else
+  echo "[2/4] Skipping service stop (--no-restart)"
+fi
+
+# Step 3: Sync files
+echo "[3/4] Syncing files to Pi..."
+rsync -avz --delete \
+  --exclude='data' \
+  --exclude='logs' \
+  --exclude='appsettings.Production.json' \
+  "$PUBLISH_DIR/" "$SSH_TARGET:/tmp/radio-deploy/"
+
+ssh "$SSH_TARGET" "
+  sudo rsync -a /tmp/radio-deploy/ $PI_PATH/ &&
+  sudo chown -R radio:radio $PI_PATH &&
+  sudo chmod +x $PI_PATH/Radio.API &&
+  rm -rf /tmp/radio-deploy
+"
+
+CHANGED=$(rsync -avz --dry-run --delete \
+  --exclude='data' --exclude='logs' --exclude='appsettings.Production.json' \
+  "$PUBLISH_DIR/" "$SSH_TARGET:$PI_PATH/" 2>/dev/null | grep -c '^[^.]' || true)
+echo "  Files synced"
+
+# Step 4: Restart
+if [ "$RESTART" = true ]; then
+  echo "[4/4] Starting service..."
+  ssh "$SSH_TARGET" "sudo systemctl start radio-console"
+  sleep 1
+  # Quick health check
+  if ssh "$SSH_TARGET" "systemctl is-active --quiet radio-console"; then
+    echo ""
+    echo "=== Deploy successful ==="
+    echo "UI: http://$PI_HOST:5000"
+  else
+    echo ""
+    echo "=== WARNING: Service may have failed to start ==="
+    echo "Check: ssh $SSH_TARGET 'journalctl -u radio-console -n 20'"
+  fi
+else
+  echo "[4/4] Skipping restart (--no-restart)"
+  echo ""
+  echo "=== Deploy complete (service not restarted) ==="
+  echo "Start manually: ssh $SSH_TARGET 'sudo systemctl start radio-console'"
+fi
+
+# Optional: tail logs
+if [ "$TAIL_LOGS" = true ]; then
+  echo ""
+  echo "--- Tailing logs (Ctrl+C to stop) ---"
+  ssh "$SSH_TARGET" "journalctl -u radio-console -f"
+fi


### PR DESCRIPTION
## Summary

- **Bluetooth audio pipeline**: A2DP sink with WASAPI loopback capture on Windows, BlueZ/PulseAudio on Linux, media session metadata, auto-switch on connect, metrics integration
- **Google Cast streaming fixes**: `StreamType.Live` for infinite MP3 streams, LAME encoder flush, proper HTTP headers, bidirectional volume sync, metadata push to Cast display
- **WASAPI loopback capture**: Captures system audio pre-mute via `AudioPlaybackConnection` + NAudio loopback for visualization/fingerprinting while BT audio plays through Windows endpoint
- **Album art file cache**: Content-addressed file cache (`/api/albumart/{hash}.jpg`) so Cast devices and UI can reference art by stable URL
- **Queue panel full playlist**: Shows played + current + upcoming with state-dependent styling (highlight current, dim played, strikethrough errors), click-to-replay played tracks, auto-skip unplayable files with infinite-loop protection
- **Web UI refinements**: Consolidated navigation, deployment scripts, accurate VBR MP3 duration reader (TagLib), improved metadata lookup
- **Deployment**: `deploy-to-pi.sh` single-command cross-compile + rsync deploy script, systemd service, setup scripts for Pi and Debian x64

## Key changes by area

**Core** (interfaces/models):
- `QueueItemState` enum, `GetFullPlaylistAsync`, `JumpToFullPlaylistIndexAsync` on `IPlayQueue`
- `IAudioSampleProvider` interface for BT audio data flow
- Bluetooth service interface extensions for A2DP sink

**Infrastructure** (audio engine):
- `BluetoothAudioSource` — full A2DP pipeline with play history, visualization, fingerprinting
- `WasapiLoopbackCaptureSource` — Windows loopback capture for BT audio
- `WindowsA2dpSinkManager` — MSIX sparse identity + `AudioPlaybackConnection`
- `FilePlayerAudioSource` — error file tracking, auto-skip, full playlist assembly
- `GoogleCastOutput` — Live stream type, metadata push, volume sync
- `AlbumArtCacheService` — content-addressed cache with HTTP proxy endpoint
- `AccurateDurationReader` — TagLib-based VBR MP3 duration

**API**:
- `GET /api/queue/full`, `POST /api/queue/jump-playlist/{index}`
- `GET /api/albumart/{filename}` proxy endpoint
- SignalR broadcasts full playlist with state annotations
- Cast volume bidirectional sync via `AudioStateUpdateService`

**Web**:
- Queue panel: full playlist view with state icons, played count header, scroll fix
- Bluetooth management page
- Consolidated layout navigation
- System config improvements

**Deploy**:
- `deploy-to-pi.sh` — one-command build + rsync + restart with `--logs` and `--quick` options
- Pi and Debian x64 setup scripts, systemd service file
- Comprehensive deployment and Pi testing documentation

## Test plan

- [x] `dotnet build --configuration Release` — 0 warnings
- [x] `dotnet test --configuration Release` — 1,263 tests pass (3 skipped as expected)
- [ ] Manual: Load directory of MP3s, verify full playlist shows, click played tracks to replay
- [ ] Manual: Verify auto-skip for corrupt/unplayable files
- [ ] Manual: Cast streaming with metadata display on Google Home
- [ ] Manual: Bluetooth A2DP sink on Raspberry Pi (Linux BlueZ)
- [ ] Manual: Deploy to Pi via `deploy-to-pi.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)