### PR TITLE
fix: Pi deployment — missing file, network binding, deploy scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,10 @@
 [Ll]og/
 [Ll]ogs/
 
-# Data files
-data/
+# Data files (runtime databases, not source code)
+/data/
 *.db
+!src/**/Data/
 
 # NuGet
 *.nupkg

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -40,11 +40,11 @@ Output goes to `publish/linux-arm64/` or `publish/linux-x64/`.
 
 ```bash
 # Copy setup script and published files to the target
-scp -r deploy/raspberry-pi/setup.sh pi@<ip>:~/
-scp -r publish/linux-arm64/* pi@<ip>:/tmp/radio-console/
+scp -r deploy/raspberry-pi/setup.sh pi@piradio:~/
+scp -r publish/linux-arm64/* pi@piradio:/tmp/radio-console/
 
 # SSH into the target
-ssh pi@<ip>
+ssh pi@piradio
 
 # Run setup
 sudo ~/setup.sh
@@ -64,7 +64,7 @@ sudo systemctl status radio-console
 
 ### 4. Access the UI
 
-Open a browser to `http://<target-ip>:5000`
+Open a browser to `http://piradio:5000`
 
 ## Configuration
 
@@ -138,6 +138,86 @@ sudo systemctl enable radio-console
 sudo systemctl disable radio-console
 ```
 
+## Migrating Data to the Pi
+
+When moving from a development machine to the Pi (or between Pi installs), you need to
+migrate the SQLite databases and secrets. The deploy script intentionally **never overwrites**
+the `data/` directory, so migration is a one-time manual step.
+
+### What to Migrate
+
+| File | Contains | Required? |
+|---|---|---|
+| `data/config/configuration.db` | Audio preferences, radio presets, file player state, queue, all config sections | Yes — without it the app starts with defaults |
+| `data/secrets/secrets.db` | Encrypted API keys (AcoustID, Google TTS, Azure TTS) | Yes — fingerprinting and cloud TTS won't work without keys |
+| `data/fingerprints/fingerprints.db` | Fingerprint cache, track metadata, play history, TTS voice cache, playlists | Optional — rebuilds over time, but play history is lost |
+| `data/albumart/` | Cached album art JPEGs (content-addressed) | Optional — re-downloaded on demand |
+| `data/metrics/metrics.db` | Performance metrics history | Optional — only needed if you want historical graphs |
+
+### Migration Steps
+
+```powershell
+# 1. Stop the service on the Pi (if running)
+ssh pi@piradio "sudo systemctl stop radio-console 2>/dev/null; true"
+
+# 2. Ensure data directories exist on the Pi
+ssh pi@piradio "sudo mkdir -p /opt/radio-console/data/{config,secrets,fingerprints,albumart,metrics,backups} && sudo chown -R radio:radio /opt/radio-console/data"
+
+# 3. Copy databases from your dev machine to the Pi
+scp data/config/configuration.db pi@piradio:/tmp/config.db
+scp data/secrets/secrets.db pi@piradio:/tmp/secrets.db
+scp data/fingerprints/fingerprints.db pi@piradio:/tmp/fingerprints.db
+
+# 4. Move into place with correct ownership
+ssh pi@piradio @"
+  sudo cp /tmp/config.db /opt/radio-console/data/config/configuration.db
+  sudo cp /tmp/secrets.db /opt/radio-console/data/secrets/secrets.db
+  sudo cp /tmp/fingerprints.db /opt/radio-console/data/fingerprints/fingerprints.db
+  sudo chown -R radio:radio /opt/radio-console/data
+  rm -f /tmp/config.db /tmp/secrets.db /tmp/fingerprints.db
+"@
+
+# 5. Start the service
+ssh pi@piradio "sudo systemctl start radio-console"
+```
+
+### Secrets and Encryption
+
+The secrets database (`secrets.db`) stores API keys encrypted with a machine-specific key.
+If the encryption key is machine-bound (derived from machine ID), secrets encrypted on your
+Windows dev machine **won't decrypt on the Pi**. In that case, re-enter secrets via the
+System Config page (`http://piradio:5000/system-config`) after migration, or use the API:
+
+```bash
+# Set AcoustID API key on the Pi
+curl -X PUT http://piradio:5000/api/configuration/secrets/Fingerprinting:AcoustId:ApiKey \
+  -H "Content-Type: application/json" \
+  -d '"your-api-key-here"'
+```
+
+### Backing Up Pi Data
+
+```bash
+# Create a timestamped backup of all Pi databases
+ssh pi@piradio "sudo tar czf /tmp/radio-backup-\$(date +%Y%m%d).tar.gz -C /opt/radio-console data/"
+scp pi@piradio:/tmp/radio-backup-*.tar.gz ./backups/
+```
+
+### Configuration Differences Between Dev and Pi
+
+Some settings may need adjustment for the Pi environment:
+
+| Setting | Windows Dev | Pi |
+|---|---|---|
+| Audio device | Windows default output | ALSA/PulseAudio device |
+| File player root | `C:\Music` or similar | `/home/pi/music` or mounted USB |
+| RTL-SDR device | May not be connected | `/dev/swradio0` or USB dongle |
+| Bluetooth | Windows BT stack | BlueZ/PulseAudio |
+| fpcalc path | `tools\fpcalc\fpcalc.exe` | `/usr/bin/fpcalc` or `tools/fpcalc/fpcalc` |
+
+After migrating `configuration.db`, review these settings in the System Config page
+and update paths/devices as needed for the Pi hardware.
+
 ## Development Workflow: Building and Testing on the Pi
 
 ### Overview
@@ -155,41 +235,50 @@ the .NET SDK installed on the Pi at all.
 | Git pull + `dotnet build` on Pi | ~60-90s on Pi 5 | Yes (.NET 8 SDK) | Slow, needs SDK |
 | Git pull + pre-built artifacts | ~10s on dev PC | No | Medium — two steps |
 
-### Option A: Direct SCP Deploy (Recommended)
+### Option A: Direct Deploy from Windows (Recommended)
 
-Use the `deploy-to-pi.sh` script for single-command build-and-deploy:
+Use `Deploy-ToPi.ps1` for single-command build-and-deploy from PowerShell:
 
-```bash
-# First time: set your Pi's IP (or add to ~/.bashrc)
-export PI_HOST=192.168.1.100
-export PI_USER=pi
-
-# Build, push, and restart in one command
-./deploy/deploy-to-pi.sh
+```powershell
+# Build, push, and restart in one command (defaults to piradio host)
+.\deploy\Deploy-ToPi.ps1
 
 # Deploy without restarting (for inspecting the build first)
-./deploy/deploy-to-pi.sh --no-restart
+.\deploy\Deploy-ToPi.ps1 -NoRestart
 
 # Deploy and tail logs immediately
-./deploy/deploy-to-pi.sh --logs
+.\deploy\Deploy-ToPi.ps1 -Logs
+
+# Quick mode: framework-dependent (smaller, needs .NET runtime on Pi)
+.\deploy\Deploy-ToPi.ps1 -Quick
+
+# Override Pi host/user
+.\deploy\Deploy-ToPi.ps1 -PiHost 192.168.86.44 -PiUser mmack
 ```
+
+Default settings (override via parameters or environment variables):
+- `PI_HOST` = `piradio` (resolves to `piradio.lan` / `192.168.86.44`)
+- `PI_USER` = `pi`
+- `PI_PATH` = `/opt/radio-console`
 
 What the script does:
 1. Cross-compiles for `linux-arm64` with `dotnet publish`
 2. Stops the service on the Pi via SSH
-3. Uses `rsync` over SSH to sync only changed files (preserves `data/` and `logs/`)
-4. Fixes ownership/permissions
-5. Restarts the service
+3. Uses `rsync` (if available) or `scp` to sync files (preserves `data/` and `logs/`)
+4. Fixes ownership/permissions on the Pi
+5. Restarts the service and checks health
 6. Optionally tails `journalctl` so you see startup output
+
+A `deploy-to-pi.sh` bash script is also available for Linux/macOS/WSL development.
 
 **SSH key setup** (do this once so you're not prompted for passwords):
 
-```bash
+```powershell
 # Generate key if you don't have one
 ssh-keygen -t ed25519
 
-# Copy to Pi
-ssh-copy-id pi@192.168.1.100
+# Copy to Pi (from PowerShell)
+type $env:USERPROFILE\.ssh\id_ed25519.pub | ssh pi@piradio "mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys"
 ```
 
 ### Option B: Git Pull on Pi
@@ -251,13 +340,13 @@ dotnet test --configuration Release --no-build
 **Tail logs on Pi while developing on Windows** (keep a terminal open):
 
 ```bash
-ssh pi@192.168.1.100 "journalctl -u radio-console -f"
+ssh pi@piradio "journalctl -u radio-console -f"
 ```
 
 **Run the app manually** (instead of via systemd) for faster iteration and console output:
 
 ```bash
-ssh pi@192.168.1.100
+ssh pi@piradio
 sudo systemctl stop radio-console
 cd /opt/radio-console
 sudo -u radio ./Radio.API
@@ -269,7 +358,7 @@ sudo -u radio ./Radio.API
 ```bash
 # Faster than full self-contained publish for quick checks
 dotnet publish src/Radio.API -c Release -r linux-arm64 --no-self-contained -o publish/quick
-rsync -avz publish/quick/ pi@192.168.1.100:/opt/radio-console/
+rsync -avz publish/quick/ pi@piradio:/opt/radio-console/
 ```
 
 Note: `--no-self-contained` requires the .NET 8 runtime on the Pi (`sudo apt install dotnet-runtime-8.0`),
@@ -285,10 +374,10 @@ For production updates (when the Pi is deployed as the radio appliance):
 
 # Or manual steps:
 cd deploy/common && ./publish.sh arm64
-ssh pi@<ip> "sudo systemctl stop radio-console"
-rsync -avz --exclude='data' --exclude='logs' publish/linux-arm64/ pi@<ip>:/opt/radio-console/
-ssh pi@<ip> "sudo chown -R radio:radio /opt/radio-console && sudo chmod +x /opt/radio-console/Radio.API"
-ssh pi@<ip> "sudo systemctl start radio-console"
+ssh pi@piradio "sudo systemctl stop radio-console"
+rsync -avz --exclude='data' --exclude='logs' publish/linux-arm64/ pi@piradio:/opt/radio-console/
+ssh pi@piradio "sudo chown -R radio:radio /opt/radio-console && sudo chmod +x /opt/radio-console/Radio.API"
+ssh pi@piradio "sudo systemctl start radio-console"
 ```
 
 ## Troubleshooting

--- a/deploy/Deploy-ToPi.ps1
+++ b/deploy/Deploy-ToPi.ps1
@@ -1,0 +1,168 @@
+<#
+.SYNOPSIS
+  One-command build and deploy to Raspberry Pi from Windows.
+
+.DESCRIPTION
+  Cross-compiles for linux-arm64, syncs to the Pi via SCP/SSH, and restarts
+  the radio-console service. Uses rsync over SSH for incremental transfers.
+
+.PARAMETER NoRestart
+  Deploy without restarting the service.
+
+.PARAMETER Logs
+  Tail journalctl after restart.
+
+.PARAMETER Quick
+  Framework-dependent publish (smaller/faster, needs .NET runtime on Pi).
+
+.PARAMETER PiHost
+  Pi hostname or IP. Default: piradio (override with env var PI_HOST).
+
+.PARAMETER PiUser
+  SSH user. Default: pi (override with env var PI_USER).
+
+.PARAMETER PiPath
+  Install path on Pi. Default: /opt/radio-console (override with env var PI_PATH).
+
+.EXAMPLE
+  .\deploy\Deploy-ToPi.ps1
+  .\deploy\Deploy-ToPi.ps1 -Logs
+  .\deploy\Deploy-ToPi.ps1 -Quick -NoRestart
+  .\deploy\Deploy-ToPi.ps1 -PiHost 192.168.86.44
+#>
+[CmdletBinding()]
+param(
+  [switch]$NoRestart,
+  [switch]$Logs,
+  [switch]$Quick,
+  [string]$PiHost = ($env:PI_HOST ?? "piradio"),
+  [string]$PiUser = ($env:PI_USER ?? "pi"),
+  [string]$PiPath = ($env:PI_PATH ?? "/opt/radio-console")
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = (Resolve-Path "$PSScriptRoot\..").Path
+$PublishDir = Join-Path $RepoRoot "publish\linux-arm64"
+$SshTarget = "${PiUser}@${PiHost}"
+
+Write-Host "=== Radio Console Deploy ===" -ForegroundColor Cyan
+Write-Host "Target: ${SshTarget}:${PiPath}"
+Write-Host ""
+
+# --- Step 1: Build ---
+Write-Host "[1/4] Building for linux-arm64..." -ForegroundColor Yellow
+
+$publishArgs = @(
+  "publish", "$RepoRoot\src\Radio.API\Radio.API.csproj",
+  "--configuration", "Release",
+  "--runtime", "linux-arm64",
+  "--output", $PublishDir,
+  "-v", "quiet"
+)
+
+if ($Quick) {
+  $publishArgs += "--no-self-contained"
+  Write-Host "  (framework-dependent - .NET runtime required on Pi)" -ForegroundColor DarkGray
+} else {
+  $publishArgs += @(
+    "--self-contained", "true",
+    "-p:PublishSingleFile=true",
+    "-p:PublishTrimmed=false",
+    "-p:IncludeNativeLibrariesForSelfExtract=true"
+  )
+}
+
+dotnet @publishArgs
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Build failed!" -ForegroundColor Red
+  exit 1
+}
+
+$size = "{0:N1} MB" -f ((Get-ChildItem $PublishDir -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB)
+Write-Host "  Build complete ($size)" -ForegroundColor Green
+
+# --- Step 2: Stop service ---
+if (-not $NoRestart) {
+  Write-Host "[2/4] Stopping service on Pi..." -ForegroundColor Yellow
+  ssh $SshTarget "sudo systemctl stop radio-console 2>/dev/null; true"
+} else {
+  Write-Host "[2/4] Skipping service stop (--NoRestart)" -ForegroundColor DarkGray
+}
+
+# --- Step 3: Sync files ---
+Write-Host "[3/4] Syncing files to Pi..." -ForegroundColor Yellow
+
+# Use scp to copy to a temp dir, then rsync locally on the Pi to preserve data/logs.
+# This avoids needing rsync on Windows (not always available).
+# First, check if rsync is available locally (Git Bash, WSL, etc.)
+$useRsync = $false
+try {
+  $null = Get-Command rsync -ErrorAction Stop
+  $useRsync = $true
+} catch {
+  # rsync not available, fall back to scp
+}
+
+if ($useRsync) {
+  # rsync available (e.g., via Git for Windows, MSYS2, or WSL)
+  rsync -avz --delete `
+    --exclude='data' `
+    --exclude='logs' `
+    --exclude='appsettings.Production.json' `
+    "${PublishDir}/" "${SshTarget}:/tmp/radio-deploy/"
+} else {
+  # Fallback: scp entire directory
+  Write-Host "  (rsync not found, using scp - slower for incremental updates)" -ForegroundColor DarkGray
+  scp -r "${PublishDir}\*" "${SshTarget}:/tmp/radio-deploy/"
+}
+
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "File sync failed!" -ForegroundColor Red
+  exit 1
+}
+
+# Move files into place on the Pi, preserving data and logs
+ssh $SshTarget @"
+  sudo rsync -a --exclude='data' --exclude='logs' --exclude='appsettings.Production.json' /tmp/radio-deploy/ $PiPath/ &&
+  sudo chown -R radio:radio $PiPath &&
+  sudo chmod +x $PiPath/Radio.API &&
+  rm -rf /tmp/radio-deploy
+"@
+
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Remote file move failed!" -ForegroundColor Red
+  exit 1
+}
+
+Write-Host "  Files synced" -ForegroundColor Green
+
+# --- Step 4: Restart ---
+if (-not $NoRestart) {
+  Write-Host "[4/4] Starting service..." -ForegroundColor Yellow
+  ssh $SshTarget "sudo systemctl start radio-console"
+  Start-Sleep -Seconds 1
+
+  $status = ssh $SshTarget "systemctl is-active radio-console 2>/dev/null"
+  if ($status -eq "active") {
+    Write-Host ""
+    Write-Host "=== Deploy successful ===" -ForegroundColor Green
+    Write-Host "UI: http://${PiHost}:5000"
+  } else {
+    Write-Host ""
+    Write-Host "=== WARNING: Service may have failed to start ===" -ForegroundColor Red
+    Write-Host "Check: ssh $SshTarget 'journalctl -u radio-console -n 20'"
+  }
+} else {
+  Write-Host "[4/4] Skipping restart (--NoRestart)" -ForegroundColor DarkGray
+  Write-Host ""
+  Write-Host "=== Deploy complete (service not restarted) ===" -ForegroundColor Green
+  Write-Host "Start manually: ssh $SshTarget 'sudo systemctl start radio-console'"
+}
+
+# --- Optional: tail logs ---
+if ($Logs) {
+  Write-Host ""
+  Write-Host "--- Tailing logs (Ctrl+C to stop) ---" -ForegroundColor Cyan
+  ssh $SshTarget "journalctl -u radio-console -f"
+}

--- a/deploy/deploy-to-pi.sh
+++ b/deploy/deploy-to-pi.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-PI_HOST="${PI_HOST:-raspberry-pi.local}"
+PI_HOST="${PI_HOST:-piradio}"
 PI_USER="${PI_USER:-pi}"
 PI_PATH="${PI_PATH:-/opt/radio-console}"
 

--- a/src/Radio.API/appsettings.json
+++ b/src/Radio.API/appsettings.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/appsettings.json",
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://0.0.0.0:5000"
+      }
+    }
+  },
   "Serilog": {
     "Using": [
       "Serilog.Sinks.File",

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/Data/SqliteTTSVoiceRepository.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/Data/SqliteTTSVoiceRepository.cs
@@ -1,0 +1,173 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Radio.Core.Interfaces.Audio;
+
+namespace Radio.Infrastructure.Audio.Fingerprinting.Data;
+
+/// <summary>
+/// SQLite implementation of the TTS voice cache and favorites repository.
+/// </summary>
+public sealed class SqliteTTSVoiceRepository : ITTSVoiceRepository
+{
+  private readonly ILogger<SqliteTTSVoiceRepository> _logger;
+  private readonly FingerprintDbContext _dbContext;
+
+  public SqliteTTSVoiceRepository(
+    ILogger<SqliteTTSVoiceRepository> logger,
+    FingerprintDbContext dbContext)
+  {
+    _logger = logger;
+    _dbContext = dbContext;
+  }
+
+  /// <inheritdoc/>
+  public async Task<IReadOnlyList<TTSVoiceInfo>> GetCachedVoicesAsync(
+    TTSEngine engine, CancellationToken ct = default)
+  {
+    var conn = await _dbContext.GetConnectionAsync(ct);
+    var engineStr = engine.ToString();
+
+    // LEFT JOIN with favorites to get IsFavorite flag in one query
+    var sql = """
+      SELECT c.VoiceId, c.Name, c.Language, c.Gender, c.PriceTier,
+             CASE WHEN f.Id IS NOT NULL THEN 1 ELSE 0 END AS IsFavorite
+      FROM TTSVoiceCache c
+      LEFT JOIN TTSVoiceFavorites f ON c.Engine = f.Engine AND c.VoiceId = f.VoiceId
+      WHERE c.Engine = @Engine
+      ORDER BY c.Name
+      """;
+
+    await using var cmd = conn.CreateCommand();
+    cmd.CommandText = sql;
+    cmd.Parameters.AddWithValue("@Engine", engineStr);
+
+    var voices = new List<TTSVoiceInfo>();
+    await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+    while (await reader.ReadAsync(ct))
+    {
+      voices.Add(new TTSVoiceInfo
+      {
+        Id = reader.GetString(0),
+        Name = reader.GetString(1),
+        Language = reader.GetString(2),
+        Gender = Enum.TryParse<TTSVoiceGender>(reader.GetString(3), out var g) ? g : TTSVoiceGender.Neutral,
+        PriceTier = reader.GetString(4),
+        IsFavorite = reader.GetInt32(5) == 1
+      });
+    }
+
+    _logger.LogDebug("Retrieved {Count} cached voices for {Engine}", voices.Count, engine);
+    return voices;
+  }
+
+  /// <inheritdoc/>
+  public async Task ReplaceCachedVoicesAsync(
+    TTSEngine engine,
+    IReadOnlyList<TTSVoiceInfo> voices,
+    CancellationToken ct = default)
+  {
+    var conn = await _dbContext.GetConnectionAsync(ct);
+    var engineStr = engine.ToString();
+    var now = DateTime.UtcNow.ToString("O");
+
+    await using var transaction = await conn.BeginTransactionAsync(ct);
+    try
+    {
+      // Delete existing cache for this engine
+      await using var deleteCmd = conn.CreateCommand();
+      deleteCmd.CommandText = "DELETE FROM TTSVoiceCache WHERE Engine = @Engine";
+      deleteCmd.Parameters.AddWithValue("@Engine", engineStr);
+      deleteCmd.Transaction = (SqliteTransaction)transaction;
+      await deleteCmd.ExecuteNonQueryAsync(ct);
+
+      // Insert new voices
+      foreach (var voice in voices)
+      {
+        await using var insertCmd = conn.CreateCommand();
+        insertCmd.CommandText = """
+          INSERT INTO TTSVoiceCache (Engine, VoiceId, Name, Language, Gender, PriceTier, LastUpdated)
+          VALUES (@Engine, @VoiceId, @Name, @Language, @Gender, @PriceTier, @LastUpdated)
+          """;
+        insertCmd.Parameters.AddWithValue("@Engine", engineStr);
+        insertCmd.Parameters.AddWithValue("@VoiceId", voice.Id);
+        insertCmd.Parameters.AddWithValue("@Name", voice.Name);
+        insertCmd.Parameters.AddWithValue("@Language", voice.Language);
+        insertCmd.Parameters.AddWithValue("@Gender", voice.Gender.ToString());
+        insertCmd.Parameters.AddWithValue("@PriceTier", voice.PriceTier);
+        insertCmd.Parameters.AddWithValue("@LastUpdated", now);
+        insertCmd.Transaction = (SqliteTransaction)transaction;
+        await insertCmd.ExecuteNonQueryAsync(ct);
+      }
+
+      await transaction.CommitAsync(ct);
+      _logger.LogInformation("Cached {Count} voices for {Engine}", voices.Count, engine);
+    }
+    catch
+    {
+      await transaction.RollbackAsync(ct);
+      throw;
+    }
+  }
+
+  /// <inheritdoc/>
+  public async Task AddFavoriteAsync(
+    TTSEngine engine, string voiceId, CancellationToken ct = default)
+  {
+    var conn = await _dbContext.GetConnectionAsync(ct);
+
+    var sql = """
+      INSERT OR IGNORE INTO TTSVoiceFavorites (Engine, VoiceId, AddedAt)
+      VALUES (@Engine, @VoiceId, @AddedAt)
+      """;
+
+    await using var cmd = conn.CreateCommand();
+    cmd.CommandText = sql;
+    cmd.Parameters.AddWithValue("@Engine", engine.ToString());
+    cmd.Parameters.AddWithValue("@VoiceId", voiceId);
+    cmd.Parameters.AddWithValue("@AddedAt", DateTime.UtcNow.ToString("O"));
+    await cmd.ExecuteNonQueryAsync(ct);
+
+    _logger.LogDebug("Added favorite voice {VoiceId} for {Engine}", voiceId, engine);
+  }
+
+  /// <inheritdoc/>
+  public async Task RemoveFavoriteAsync(
+    TTSEngine engine, string voiceId, CancellationToken ct = default)
+  {
+    var conn = await _dbContext.GetConnectionAsync(ct);
+
+    var sql = "DELETE FROM TTSVoiceFavorites WHERE Engine = @Engine AND VoiceId = @VoiceId";
+
+    await using var cmd = conn.CreateCommand();
+    cmd.CommandText = sql;
+    cmd.Parameters.AddWithValue("@Engine", engine.ToString());
+    cmd.Parameters.AddWithValue("@VoiceId", voiceId);
+    await cmd.ExecuteNonQueryAsync(ct);
+
+    _logger.LogDebug("Removed favorite voice {VoiceId} for {Engine}", voiceId, engine);
+  }
+
+  /// <inheritdoc/>
+  public async Task<IReadOnlySet<string>> GetFavoriteIdsAsync(
+    TTSEngine engine, CancellationToken ct = default)
+  {
+    var conn = await _dbContext.GetConnectionAsync(ct);
+
+    var sql = "SELECT VoiceId FROM TTSVoiceFavorites WHERE Engine = @Engine";
+
+    await using var cmd = conn.CreateCommand();
+    cmd.CommandText = sql;
+    cmd.Parameters.AddWithValue("@Engine", engine.ToString());
+
+    var favorites = new HashSet<string>();
+    await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+    while (await reader.ReadAsync(ct))
+    {
+      favorites.Add(reader.GetString(0));
+    }
+
+    return favorites;
+  }
+}

--- a/src/Radio.Web/appsettings.json
+++ b/src/Radio.Web/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://0.0.0.0:5002"
+      }
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Warning",


### PR DESCRIPTION
## Summary

- **Fix Pi build error**: `SqliteTTSVoiceRepository.cs` was never committed because `.gitignore` had `data/` which matched `src/**/Data/` source directories on case-insensitive Windows. Fixed by changing to `/data/` (root-only) with `!src/**/Data/` negation.
- **Enable external network access**: Added Kestrel binding to `http://0.0.0.0:5000` (API) and `http://0.0.0.0:5002` (Web) so both are accessible from other machines on the network — critical for accessing the Pi's UI from a Windows dev machine.
- **Add PowerShell deploy script**: `deploy/Deploy-ToPi.ps1` for one-command build+deploy from Windows (cross-compiles for linux-arm64, syncs via rsync/scp, restarts service).
- **Expand deployment docs**: Data migration guide, secrets handling, PowerShell workflow, Pi-specific configuration notes.

## Test plan

- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [ ] Deploy to Pi with `.\deploy\Deploy-ToPi.ps1` and verify service starts
- [ ] Verify Web UI accessible at `http://piradio:5002` from Windows
- [ ] Verify API accessible at `http://piradio:5000/swagger` from Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)