### PR TITLE
Fix API test timeouts on Raspberry Pi

### DIFF
--- a/tests/Radio.API.Tests/ApiTests.cs
+++ b/tests/Radio.API.Tests/ApiTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 
 namespace Radio.API.Tests;
 
@@ -6,11 +6,11 @@ namespace Radio.API.Tests;
 /// Integration tests for Radio.API project.
 /// Tests the API startup and basic endpoint functionality.
 /// </summary>
-public class ApiTests : IClassFixture<WebApplicationFactory<Program>>
+public class ApiTests : IClassFixture<CustomWebApplicationFactory<Program>>
 {
-  private readonly WebApplicationFactory<Program> _factory;
+  private readonly CustomWebApplicationFactory<Program> _factory;
 
-  public ApiTests(WebApplicationFactory<Program> factory)
+  public ApiTests(CustomWebApplicationFactory<Program> factory)
   {
     _factory = factory;
   }
@@ -21,15 +21,12 @@ public class ApiTests : IClassFixture<WebApplicationFactory<Program>>
     // Arrange
     var client = _factory.CreateClient();
 
-    // Act - try to access the swagger endpoint (should redirect or be available in development)
-    // This verifies the application starts without exceptions
-    var response = await client.GetAsync("/swagger/index.html");
+    // Act - hit a known API endpoint to verify the application starts without exceptions
+    var response = await client.GetAsync("/api/audio");
 
-    // Assert - We expect either success (200) or redirect (3xx) depending on environment
-    // The main thing is that the app didn't crash on startup
-    Assert.True(
-      response.IsSuccessStatusCode || (int)response.StatusCode >= 300 && (int)response.StatusCode < 400,
-      $"Expected success or redirect, but got {response.StatusCode}");
+    // Assert - the main thing is that the app didn't crash on startup
+    Assert.True(response.IsSuccessStatusCode,
+      $"Expected success, but got {response.StatusCode}");
   }
 
   [Fact]

--- a/tests/Radio.API.Tests/Controllers/AudioControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/AudioControllerTests.cs
@@ -1,5 +1,5 @@
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 using Radio.API.Models;
 
 namespace Radio.API.Tests.Controllers;
@@ -7,12 +7,12 @@ namespace Radio.API.Tests.Controllers;
 /// <summary>
 /// Integration tests for the AudioController.
 /// </summary>
-public class AudioControllerTests : IClassFixture<WebApplicationFactory<Program>>
+public class AudioControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
 {
-  private readonly WebApplicationFactory<Program> _factory;
+  private readonly CustomWebApplicationFactory<Program> _factory;
   private readonly HttpClient _client;
 
-  public AudioControllerTests(WebApplicationFactory<Program> factory)
+  public AudioControllerTests(CustomWebApplicationFactory<Program> factory)
   {
     _factory = factory;
     _client = _factory.CreateClient();

--- a/tests/Radio.API.Tests/Controllers/BluetoothControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/BluetoothControllerTests.cs
@@ -1,18 +1,18 @@
 using System.Net;
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 using Moq;
 using Radio.API.Models;
 using Radio.Core.Interfaces.Audio;
 
 namespace Radio.API.Tests.Controllers;
 
-public class BluetoothControllerTests : IClassFixture<WebApplicationFactory<Program>>
+public class BluetoothControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
 {
-  private readonly WebApplicationFactory<Program> _factory;
+  private readonly CustomWebApplicationFactory<Program> _factory;
   private readonly HttpClient _client;
 
-  public BluetoothControllerTests(WebApplicationFactory<Program> factory)
+  public BluetoothControllerTests(CustomWebApplicationFactory<Program> factory)
   {
     _factory = factory;
     _client = _factory.CreateClient();

--- a/tests/Radio.API.Tests/Controllers/ConfigurationControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/ConfigurationControllerTests.cs
@@ -1,5 +1,5 @@
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 using Radio.API.Models;
 
 namespace Radio.API.Tests.Controllers;
@@ -7,12 +7,12 @@ namespace Radio.API.Tests.Controllers;
 /// <summary>
 /// Integration tests for the ConfigurationController.
 /// </summary>
-public class ConfigurationControllerTests : IClassFixture<WebApplicationFactory<Program>>
+public class ConfigurationControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
 {
-  private readonly WebApplicationFactory<Program> _factory;
+  private readonly CustomWebApplicationFactory<Program> _factory;
   private readonly HttpClient _client;
 
-  public ConfigurationControllerTests(WebApplicationFactory<Program> factory)
+  public ConfigurationControllerTests(CustomWebApplicationFactory<Program> factory)
   {
     _factory = factory;
     _client = _factory.CreateClient();

--- a/tests/Radio.API.Tests/Controllers/DevicesControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/DevicesControllerTests.cs
@@ -1,5 +1,5 @@
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 using Radio.API.Models;
 
 namespace Radio.API.Tests.Controllers;
@@ -7,12 +7,12 @@ namespace Radio.API.Tests.Controllers;
 /// <summary>
 /// Integration tests for the DevicesController.
 /// </summary>
-public class DevicesControllerTests : IClassFixture<WebApplicationFactory<Program>>
+public class DevicesControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
 {
-  private readonly WebApplicationFactory<Program> _factory;
+  private readonly CustomWebApplicationFactory<Program> _factory;
   private readonly HttpClient _client;
 
-  public DevicesControllerTests(WebApplicationFactory<Program> factory)
+  public DevicesControllerTests(CustomWebApplicationFactory<Program> factory)
   {
     _factory = factory;
     _client = _factory.CreateClient();

--- a/tests/Radio.API.Tests/Controllers/FilesControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/FilesControllerTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Radio.API.Models;
@@ -13,14 +13,13 @@ namespace Radio.API.Tests.Controllers;
 /// <summary>
 /// Integration tests for FilesController.
 /// </summary>
-public class FilesControllerTests : IClassFixture<WebApplicationFactory<Program>>
+public class FilesControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
 {
-  private readonly WebApplicationFactory<Program> _factory;
   private readonly HttpClient _client;
 
-  public FilesControllerTests(WebApplicationFactory<Program> factory)
+  public FilesControllerTests(CustomWebApplicationFactory<Program> factory)
   {
-    _factory = factory.WithWebHostBuilder(builder =>
+    var customFactory = factory.WithWebHostBuilder(builder =>
     {
       builder.ConfigureServices(services =>
       {
@@ -45,7 +44,7 @@ public class FilesControllerTests : IClassFixture<WebApplicationFactory<Program>
       });
     });
 
-    _client = _factory.CreateClient();
+    _client = customFactory.CreateClient();
   }
 
   [Fact]

--- a/tests/Radio.API.Tests/Controllers/PlayHistoryControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/PlayHistoryControllerTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 using Radio.API.Models;
 
 namespace Radio.API.Tests.Controllers;
@@ -8,12 +8,12 @@ namespace Radio.API.Tests.Controllers;
 /// <summary>
 /// Integration tests for the PlayHistoryController.
 /// </summary>
-public class PlayHistoryControllerTests : IClassFixture<WebApplicationFactory<Program>>
+public class PlayHistoryControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
 {
-  private readonly WebApplicationFactory<Program> _factory;
+  private readonly CustomWebApplicationFactory<Program> _factory;
   private readonly HttpClient _client;
 
-  public PlayHistoryControllerTests(WebApplicationFactory<Program> factory)
+  public PlayHistoryControllerTests(CustomWebApplicationFactory<Program> factory)
   {
     _factory = factory;
     _client = _factory.CreateClient();

--- a/tests/Radio.API.Tests/Controllers/QueueControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/QueueControllerTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 using Radio.API.Models;
 
 namespace Radio.API.Tests.Controllers;
@@ -8,12 +8,12 @@ namespace Radio.API.Tests.Controllers;
 /// <summary>
 /// Integration tests for the QueueController.
 /// </summary>
-public class QueueControllerTests : IClassFixture<WebApplicationFactory<Program>>
+public class QueueControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
 {
-  private readonly WebApplicationFactory<Program> _factory;
+  private readonly CustomWebApplicationFactory<Program> _factory;
   private readonly HttpClient _client;
 
-  public QueueControllerTests(WebApplicationFactory<Program> factory)
+  public QueueControllerTests(CustomWebApplicationFactory<Program> factory)
   {
     _factory = factory;
     _client = _factory.CreateClient();

--- a/tests/Radio.API.Tests/Controllers/RadioControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/RadioControllerTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 using Radio.API.Models;
 
 namespace Radio.API.Tests.Controllers;
@@ -8,12 +8,12 @@ namespace Radio.API.Tests.Controllers;
 /// <summary>
 /// Integration tests for the RadioController.
 /// </summary>
-public class RadioControllerTests : IClassFixture<WebApplicationFactory<Program>>, IAsyncLifetime
+public class RadioControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>, IAsyncLifetime
 {
-  private readonly WebApplicationFactory<Program> _factory;
+  private readonly CustomWebApplicationFactory<Program> _factory;
   private readonly HttpClient _client;
 
-  public RadioControllerTests(WebApplicationFactory<Program> factory)
+  public RadioControllerTests(CustomWebApplicationFactory<Program> factory)
   {
     _factory = factory;
     _client = _factory.CreateClient();

--- a/tests/Radio.API.Tests/Controllers/SecretsControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/SecretsControllerTests.cs
@@ -1,17 +1,17 @@
 using System.Net;
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 
 namespace Radio.API.Tests.Controllers;
 
 /// <summary>
 /// Integration tests for the SecretsController.
 /// </summary>
-public class SecretsControllerTests : IClassFixture<WebApplicationFactory<Program>>
+public class SecretsControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
 {
   private readonly HttpClient _client;
 
-  public SecretsControllerTests(WebApplicationFactory<Program> factory)
+  public SecretsControllerTests(CustomWebApplicationFactory<Program> factory)
   {
     _client = factory.CreateClient();
   }

--- a/tests/Radio.API.Tests/Controllers/SourcesControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/SourcesControllerTests.cs
@@ -1,5 +1,5 @@
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 using Radio.API.Models;
 
 namespace Radio.API.Tests.Controllers;
@@ -7,12 +7,12 @@ namespace Radio.API.Tests.Controllers;
 /// <summary>
 /// Integration tests for the SourcesController.
 /// </summary>
-public class SourcesControllerTests : IClassFixture<WebApplicationFactory<Program>>
+public class SourcesControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
 {
-  private readonly WebApplicationFactory<Program> _factory;
+  private readonly CustomWebApplicationFactory<Program> _factory;
   private readonly HttpClient _client;
 
-  public SourcesControllerTests(WebApplicationFactory<Program> factory)
+  public SourcesControllerTests(CustomWebApplicationFactory<Program> factory)
   {
     _factory = factory;
     _client = _factory.CreateClient();

--- a/tests/Radio.API.Tests/Controllers/SystemControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/SystemControllerTests.cs
@@ -1,5 +1,5 @@
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Radio.API.Tests.TestSupport;
 using Radio.API.Models;
 
 namespace Radio.API.Tests.Controllers;
@@ -7,12 +7,12 @@ namespace Radio.API.Tests.Controllers;
 /// <summary>
 /// Integration tests for the SystemController.
 /// </summary>
-public class SystemControllerTests : IClassFixture<WebApplicationFactory<Program>>
+public class SystemControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
 {
-  private readonly WebApplicationFactory<Program> _factory;
+  private readonly CustomWebApplicationFactory<Program> _factory;
   private readonly HttpClient _client;
 
-  public SystemControllerTests(WebApplicationFactory<Program> factory)
+  public SystemControllerTests(CustomWebApplicationFactory<Program> factory)
   {
     _factory = factory;
     _client = _factory.CreateClient();

--- a/tests/Radio.API.Tests/TestSupport/CustomWebApplicationFactory.cs
+++ b/tests/Radio.API.Tests/TestSupport/CustomWebApplicationFactory.cs
@@ -29,22 +29,6 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProg
       {
         services.Remove(desc);
       }
-
-      // Additionally remove specific long-running services by type name if present.
-      // This is defensive: remove things like MetricsCollector, BufferedMetricsCollector,
-      // BackgroundIdentificationService, etc., which may have IHostedService registrations
-      // or other disposable resources that interact with SQLite during disposal.
-      var suspicious = services
-        .Where(d => d.ServiceType != null && d.ServiceType.FullName != null &&
-          (d.ServiceType.FullName.Contains("Metrics", System.StringComparison.OrdinalIgnoreCase)
-           || d.ServiceType.FullName.Contains("Identification", System.StringComparison.OrdinalIgnoreCase)
-           || d.ServiceType.FullName.Contains("Fingerprint", System.StringComparison.OrdinalIgnoreCase)))
-        .ToList();
-
-      foreach (var desc in suspicious)
-      {
-        services.Remove(desc);
-      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- All 12 API test classes now use `CustomWebApplicationFactory` instead of bare `WebApplicationFactory<Program>`, preventing background services (audio engine, Bluetooth, fingerprinting) from starting during tests
- Simplified `CustomWebApplicationFactory` by removing overly-broad service removal that was breaking ASP.NET Core SignalR internals (`HttpConnectionsMetrics`)
- Fixed `ApiApplication_StartsSuccessfully` test to use a real API endpoint instead of swagger (not available in Testing environment)

## Test plan
- [x] All 202 API tests pass locally on Windows
- [x] Full solution build: 0 warnings
- [x] Full test suite: Core 35, RTLSDRCore 125, Web.E2E 6, API 202, Infrastructure 689, Web 120, Integration 86 — all pass
- [ ] Verify on Raspberry Pi that the 4 previously-hanging tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)