### PR TITLE
Fix Bluetooth D-Bus connection type for agent registration

### DIFF
--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -112,7 +112,7 @@ namespace Radio.Infrastructure.Platform.Bluetooth
         {
             try
             {
-                _connection = Connection.System;
+                _connection = new Connection(Address.System);
                 await _connection.ConnectAsync();
                 
                 _objectManager = _connection.CreateProxy<Linux.IObjectManager>(Linux.BluezConstants.ServiceName, "/");


### PR DESCRIPTION
## Summary
- `Connection.System` (Tmds.DBus) returns an `AutoConnect` connection that doesn't support `RegisterObjectAsync`, causing agent registration to fail with `InvalidOperationException: Operation not supported for AutoConnect Connection`
- Changed to `new Connection(Address.System)` which creates a standard system bus connection that supports exporting local D-Bus objects
- Without a registered agent, BlueZ falls back to default pairing — phones show a confirmation code dialog that the headless Pi can't handle. With the fix, the `BluezAgent.RequestConfirmationAsync` method auto-accepts pairing requests

## Test plan
- [x] Builds with 0 warnings
- [ ] Deploy to Pi and verify agent registration succeeds (no warning in logs)
- [ ] Pair phone to "Grandpas Radio" — should complete without a code prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)