### PR TITLE
feat: Audio pipeline metrics + Cast MP3 ARM64 fix

### DIFF
--- a/src/Radio.Infrastructure/Audio/Fingerprinting/MetadataLookupService.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/MetadataLookupService.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
+using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 
@@ -20,6 +21,7 @@ public sealed class MetadataLookupService : IMetadataLookupService
   private readonly FingerprintingOptions _options;
   private readonly AcoustIdClient? _acoustIdClient;
   private readonly HttpClient _httpClient;
+  private readonly IMetricsCollector? _metricsCollector;
 
   // Rate limiter: MusicBrainz enforces 1 request/second for anonymous clients
   private static readonly SemaphoreSlim _musicBrainzThrottle = new(1, 1);
@@ -36,13 +38,15 @@ public sealed class MetadataLookupService : IMetadataLookupService
   /// <param name="options">The fingerprinting options.</param>
   /// <param name="httpClient">HTTP client for MusicBrainz and Cover Art Archive API calls.</param>
   /// <param name="acoustIdClient">Optional AcoustID client for API lookups.</param>
+  /// <param name="metricsCollector">Optional metrics collector for fingerprint lookup metrics.</param>
   public MetadataLookupService(
     ILogger<MetadataLookupService> logger,
     IFingerprintCacheRepository cache,
     ITrackMetadataRepository metadataRepo,
     IOptions<FingerprintingOptions> options,
     HttpClient httpClient,
-    AcoustIdClient? acoustIdClient = null)
+    AcoustIdClient? acoustIdClient = null,
+    IMetricsCollector? metricsCollector = null)
   {
     _logger = logger;
     _cache = cache;
@@ -50,6 +54,7 @@ public sealed class MetadataLookupService : IMetadataLookupService
     _options = options.Value;
     _httpClient = httpClient;
     _acoustIdClient = acoustIdClient;
+    _metricsCollector = metricsCollector;
   }
 
   /// <inheritdoc/>
@@ -91,6 +96,9 @@ public sealed class MetadataLookupService : IMetadataLookupService
         }
       }
 
+      _metricsCollector?.Increment("audio.fingerprint.lookups", 1,
+        new Dictionary<string, string> { ["result"] = "cache_hit" });
+
       return new MetadataLookupResult
       {
         IsMatch = true,
@@ -105,6 +113,8 @@ public sealed class MetadataLookupService : IMetadataLookupService
     if (string.IsNullOrEmpty(_options.AcoustId.ApiKey))
     {
       _logger.LogDebug("No AcoustID API key configured, storing fingerprint for manual tagging");
+      _metricsCollector?.Increment("audio.fingerprint.lookups", 1,
+        new Dictionary<string, string> { ["result"] = "no_api_key" });
       var stored = await _cache.StoreAsync(fingerprint, null, ct);
       return new MetadataLookupResult
       {
@@ -119,6 +129,8 @@ public sealed class MetadataLookupService : IMetadataLookupService
     if (_acoustIdClient == null)
     {
       _logger.LogWarning("AcoustID client not available, storing fingerprint for manual tagging");
+      _metricsCollector?.Increment("audio.fingerprint.lookups", 1,
+        new Dictionary<string, string> { ["result"] = "no_client" });
       var stored = await _cache.StoreAsync(fingerprint, null, ct);
       return new MetadataLookupResult
       {
@@ -135,6 +147,8 @@ public sealed class MetadataLookupService : IMetadataLookupService
       _logger.LogWarning(
         "Fingerprint {FingerprintId} has no chromaprint hash, storing for manual tagging",
         fingerprint.Id);
+      _metricsCollector?.Increment("audio.fingerprint.lookups", 1,
+        new Dictionary<string, string> { ["result"] = "no_hash" });
 
       var stored = await _cache.StoreAsync(fingerprint, null, ct);
       return new MetadataLookupResult
@@ -164,6 +178,8 @@ public sealed class MetadataLookupService : IMetadataLookupService
     if (acoustIdResult == null || acoustIdResult.Recordings.Count == 0)
     {
       _logger.LogInformation("No AcoustID match found for fingerprint {FingerprintId}, storing for manual tagging", fingerprint.Id);
+      _metricsCollector?.Increment("audio.fingerprint.lookups", 1,
+        new Dictionary<string, string> { ["result"] = "no_match" });
       var stored = await _cache.StoreAsync(fingerprint, null, ct);
       return new MetadataLookupResult
       {
@@ -179,6 +195,8 @@ public sealed class MetadataLookupService : IMetadataLookupService
     if (bestRecording == null)
     {
       _logger.LogInformation("No recordings in AcoustID result for fingerprint {FingerprintId}", fingerprint.Id);
+      _metricsCollector?.Increment("audio.fingerprint.lookups", 1,
+        new Dictionary<string, string> { ["result"] = "no_match" });
       var stored = await _cache.StoreAsync(fingerprint, null, ct);
       return new MetadataLookupResult
       {
@@ -242,13 +260,23 @@ public sealed class MetadataLookupService : IMetadataLookupService
             UpdatedAt = DateTime.UtcNow
           };
 
+          _metricsCollector?.Increment("audio.fingerprint.musicbrainz_enrichments", 1,
+            new Dictionary<string, string> { ["result"] = "success" });
+
           _logger.LogInformation(
             "Enriched metadata from MusicBrainz: Album=\"{Album}\", Year={Year}, CoverArt={HasCoverArt}",
             trackMetadata.Album, trackMetadata.ReleaseYear, trackMetadata.CoverArtUrl != null);
         }
+        else
+        {
+          _metricsCollector?.Increment("audio.fingerprint.musicbrainz_enrichments", 1,
+            new Dictionary<string, string> { ["result"] = "no_data" });
+        }
       }
       catch (Exception ex)
       {
+        _metricsCollector?.Increment("audio.fingerprint.musicbrainz_enrichments", 1,
+          new Dictionary<string, string> { ["result"] = "error" });
         _logger.LogWarning(ex, "MusicBrainz enrichment failed for recording {RecordingId}, using AcoustID data only",
           bestRecording.Id);
       }
@@ -259,6 +287,10 @@ public sealed class MetadataLookupService : IMetadataLookupService
 
     // Also store the track metadata in the repository
     await _metadataRepo.StoreAsync(trackMetadata, ct);
+
+    _metricsCollector?.Increment("audio.fingerprint.lookups", 1,
+      new Dictionary<string, string> { ["result"] = "match" });
+    _metricsCollector?.Gauge("audio.fingerprint.confidence", acoustIdResult.Score);
 
     return new MetadataLookupResult
     {

--- a/src/Radio.Infrastructure/Audio/Outputs/HttpStreamOutput.cs
+++ b/src/Radio.Infrastructure/Audio/Outputs/HttpStreamOutput.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using NAudio.Lame;
 using NAudio.Wave;
 using Radio.Core.Configuration;
+using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
 
 namespace Radio.Infrastructure.Audio.Outputs;
@@ -21,6 +22,7 @@ public class HttpStreamOutput : AudioOutputBase
   private readonly ILogger<HttpStreamOutput> _logger;
   private readonly HttpStreamOutputOptions _options;
   private readonly IAudioEngine _audioEngine;
+  private readonly IMetricsCollector? _metricsCollector;
 
   private HttpListener? _httpListener;
   private CancellationTokenSource? _serverCts;
@@ -77,10 +79,12 @@ public class HttpStreamOutput : AudioOutputBase
   /// <param name="logger">The logger instance.</param>
   /// <param name="options">The HTTP stream output options.</param>
   /// <param name="audioEngine">The audio engine for getting the mixed output stream.</param>
+  /// <param name="metricsCollector">Optional metrics collector for pipeline metrics.</param>
   public HttpStreamOutput(
     ILogger<HttpStreamOutput> logger,
     IOptions<AudioOutputOptions> options,
-    IAudioEngine audioEngine)
+    IAudioEngine audioEngine,
+    IMetricsCollector? metricsCollector = null)
     : base("http-stream", $"HTTP Stream :{options?.Value?.HttpStream?.Port ?? 8080}",
         1.0f, // HTTP streams typically pass through at full volume
         options?.Value?.HttpStream?.Enabled ?? true)
@@ -88,6 +92,7 @@ public class HttpStreamOutput : AudioOutputBase
     _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     _options = options?.Value?.HttpStream ?? throw new ArgumentNullException(nameof(options));
     _audioEngine = audioEngine ?? throw new ArgumentNullException(nameof(audioEngine));
+    _metricsCollector = metricsCollector;
   }
 
   /// <inheritdoc />
@@ -320,6 +325,7 @@ public class HttpStreamOutput : AudioOutputBase
     var client = new HttpStreamClient(clientId, remoteEndpoint, context.Response);
 
     _connectedClients.TryAdd(clientId, client);
+    _metricsCollector?.Gauge("audio.stream.client_count", _connectedClients.Count);
     ClientConnected?.Invoke(this, new HttpStreamClientEventArgs { Client = client.ToInfo() });
 
     try
@@ -375,7 +381,7 @@ public class HttpStreamOutput : AudioOutputBase
             "MP3 encoder started (192 kbps CBR, {SampleRate}Hz, {Channels}ch) for client {ClientId}",
             _options.SampleRate, _options.Channels, clientId);
         }
-        catch (Exception ex) when (ex is DllNotFoundException or TypeInitializationException)
+        catch (Exception ex) when (ex is DllNotFoundException or TypeInitializationException or FileLoadException)
         {
           _logger.LogError(ex,
             "LAME MP3 encoder not available. Install libmp3lame: apt install libmp3lame-dev (Linux) or ensure LAME DLLs are present (Windows).");
@@ -471,6 +477,15 @@ public class HttpStreamOutput : AudioOutputBase
     {
       client.Disconnect();
       _connectedClients.TryRemove(clientId, out _);
+
+      // Report disconnect metrics
+      _metricsCollector?.Gauge("audio.stream.client_count", _connectedClients.Count);
+      if (client.BytesSent > 0)
+      {
+        var formatTag = requestPath.EndsWith("/mp3", StringComparison.OrdinalIgnoreCase) ? "mp3" : "wav";
+        _metricsCollector?.Increment("audio.stream.bytes_sent", client.BytesSent,
+          new Dictionary<string, string> { ["format"] = formatTag });
+      }
 
       try
       {

--- a/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Radio.Core.Interfaces;
 using SoundFlow.Abstracts;
 using SoundFlow.Structs;
 using System.Runtime.InteropServices;
@@ -32,6 +33,7 @@ public enum BufferOverflowStrategy
 public class BufferedSoundGenerator<T> : SoundComponent where T : struct
 {
     private readonly ILogger _logger;
+    private readonly IMetricsCollector? _metricsCollector;
     private readonly object _bufferLock = new();
     private readonly Queue<T> _sampleBuffer = new();
     private readonly int _maxBufferSamples;
@@ -40,6 +42,9 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
     private long _totalSamplesReceived;
     private long _totalSamplesDropped;
     private long _totalSamplesOutput;
+    private long _underrunCount;
+    private long _lastReportedDropped;
+    private long _lastReportedUnderruns;
     private DateTime _lastLogTime = DateTime.MinValue;
 
     /// <summary>
@@ -50,15 +55,18 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
     /// <param name="logger">Logger for diagnostic output.</param>
     /// <param name="maxBufferSeconds">Maximum seconds of audio to buffer (default: 2).</param>
     /// <param name="overflowStrategy">Strategy for buffer overflow (default: DropOldest).</param>
+    /// <param name="metricsCollector">Optional metrics collector for pipeline metrics.</param>
     public BufferedSoundGenerator(
         AudioEngine engine,
         AudioFormat format,
         ILogger logger,
         float maxBufferSeconds = 2.0f,
-        BufferOverflowStrategy overflowStrategy = BufferOverflowStrategy.DropOldest)
+        BufferOverflowStrategy overflowStrategy = BufferOverflowStrategy.DropOldest,
+        IMetricsCollector? metricsCollector = null)
         : base(engine, format)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _metricsCollector = metricsCollector;
         _overflowStrategy = overflowStrategy;
 
         // Calculate max buffer based on output format
@@ -171,6 +179,12 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
         if (samplesWritten < buffer.Length)
         {
             buffer.Slice(samplesWritten).Fill(0);
+
+            // Count underruns (requested data but buffer was empty, after first data received)
+            if (_totalSamplesReceived > 0)
+            {
+                _underrunCount++;
+            }
         }
 
         LogStats();
@@ -186,7 +200,7 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
             {
                 currentBuffer = _sampleBuffer.Count;
             }
-            
+
             // Don't log if completely idle (no received samples ever)
             if (_totalSamplesReceived > 0)
             {
@@ -194,6 +208,28 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
                     "Buffered audio ({Type}): received={Received}, output={Output}, dropped={Dropped}, buffered={Buffered}",
                     typeof(T).Name, _totalSamplesReceived, _totalSamplesOutput, _totalSamplesDropped, currentBuffer);
                 _lastLogTime = now;
+
+                // Report metrics (outside lock — reads of long fields are safe for approximate values)
+                if (_metricsCollector != null)
+                {
+                    var tags = new Dictionary<string, string> { ["type"] = typeof(T).Name };
+                    var fillPercent = (double)currentBuffer / _maxBufferSamples * 100.0;
+                    _metricsCollector.Gauge("audio.buffer.fill_percent", fillPercent, tags);
+
+                    var droppedDelta = _totalSamplesDropped - _lastReportedDropped;
+                    if (droppedDelta > 0)
+                    {
+                        _metricsCollector.Increment("audio.buffer.samples_dropped", droppedDelta, tags);
+                        _lastReportedDropped = _totalSamplesDropped;
+                    }
+
+                    var underrunDelta = _underrunCount - _lastReportedUnderruns;
+                    if (underrunDelta > 0)
+                    {
+                        _metricsCollector.Increment("audio.buffer.underruns", underrunDelta, tags);
+                        _lastReportedUnderruns = _underrunCount;
+                    }
+                }
             }
         }
     }

--- a/src/Radio.Infrastructure/Audio/SoundFlow/FingerprintTapModifier.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/FingerprintTapModifier.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Radio.Core.Interfaces;
 using SoundFlow.Abstracts;
 
 namespace Radio.Infrastructure.Audio.SoundFlow;
@@ -16,11 +17,16 @@ public class FingerprintTapModifier : SoundModifier
 {
   private readonly SoundFlowAudioEngine _audioEngine;
   private readonly ILogger? _logger;
+  private readonly IMetricsCollector? _metricsCollector;
   private readonly float[] _sampleBuffer;
   private readonly int _bufferSize;
   private int _bufferIndex;
   private readonly object _lock = new();
   private long _totalSamplesProcessed;
+  private long _batchCount;
+  private long _writeErrorCount;
+  private long _lastReportedBatches;
+  private long _lastReportedErrors;
   private bool _loggedFirstBatch;
   private DateTime _lastLogTime = DateTime.MinValue;
   private DateTime _lastProcessedTime = DateTime.MinValue;
@@ -31,13 +37,16 @@ public class FingerprintTapModifier : SoundModifier
   /// <param name="audioEngine">The audio engine to write samples to.</param>
   /// <param name="logger">Optional logger for diagnostic output.</param>
   /// <param name="bufferSize">Size of the sample buffer before writing to tap (default: 4096). Smaller values reduce latency but increase lock contention and GC pressure in the audio callback.</param>
+  /// <param name="metricsCollector">Optional metrics collector for pipeline metrics.</param>
   public FingerprintTapModifier(
     SoundFlowAudioEngine audioEngine,
     ILogger? logger = null,
-    int bufferSize = 4096)
+    int bufferSize = 4096,
+    IMetricsCollector? metricsCollector = null)
   {
     _audioEngine = audioEngine ?? throw new ArgumentNullException(nameof(audioEngine));
     _logger = logger;
+    _metricsCollector = metricsCollector;
     _bufferSize = bufferSize;
     _sampleBuffer = new float[bufferSize];
     _bufferIndex = 0;
@@ -71,6 +80,7 @@ public class FingerprintTapModifier : SoundModifier
 
           // Write to the output tap for fingerprinting/streaming
           _audioEngine.WriteToOutputTap(samplesForTap);
+          _batchCount++;
 
           // Log first batch at Information level for diagnostics
           if (!_loggedFirstBatch)
@@ -88,10 +98,29 @@ public class FingerprintTapModifier : SoundModifier
               "FingerprintTap: {TotalSamples} samples processed, writing {BufferSize} to tap",
               _totalSamplesProcessed, _bufferSize);
             _lastLogTime = _lastProcessedTime;
+
+            // Report metrics
+            if (_metricsCollector != null)
+            {
+              var batchDelta = _batchCount - _lastReportedBatches;
+              if (batchDelta > 0)
+              {
+                _metricsCollector.Increment("audio.tap.batches_written", batchDelta);
+                _lastReportedBatches = _batchCount;
+              }
+
+              var errorDelta = _writeErrorCount - _lastReportedErrors;
+              if (errorDelta > 0)
+              {
+                _metricsCollector.Increment("audio.tap.write_errors", errorDelta);
+                _lastReportedErrors = _writeErrorCount;
+              }
+            }
           }
         }
         catch (Exception ex)
         {
+          _writeErrorCount++;
           _logger?.LogWarning(ex, "Error writing samples to output tap");
         }
 

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
+using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
 using SoundFlow.Abstracts;
 using SoundFlow.Abstracts.Devices;
@@ -23,6 +24,7 @@ public class SoundFlowAudioEngine : IAudioEngine
   private readonly AudioEngineOptions _options;
   private readonly SoundFlowMasterMixer _masterMixer;
   private readonly SoundFlowDeviceManager _deviceManager;
+  private readonly IMetricsCollector? _metricsCollector;
 
   private MiniAudioEngine? _engine;
   private AudioPlaybackDevice? _playbackDevice;
@@ -49,16 +51,19 @@ public class SoundFlowAudioEngine : IAudioEngine
   /// <param name="options">The audio engine options.</param>
   /// <param name="masterMixer">The master mixer instance.</param>
   /// <param name="deviceManager">The device manager instance.</param>
+  /// <param name="metricsCollector">Optional metrics collector for pipeline metrics.</param>
   public SoundFlowAudioEngine(
     ILogger<SoundFlowAudioEngine> logger,
     IOptions<AudioEngineOptions> options,
     SoundFlowMasterMixer masterMixer,
-    SoundFlowDeviceManager deviceManager)
+    SoundFlowDeviceManager deviceManager,
+    IMetricsCollector? metricsCollector = null)
   {
     _logger = logger;
     _options = options.Value;
     _masterMixer = masterMixer;
     _deviceManager = deviceManager;
+    _metricsCollector = metricsCollector;
 
     // Subscribe to device manager events
     _deviceManager.DevicesChanged += OnDeviceManagerDevicesChanged;
@@ -177,7 +182,8 @@ public class SoundFlowAudioEngine : IAudioEngine
       _outputTap = new TappedOutputStream(
         _options.SampleRate,
         _options.Channels,
-        _options.OutputBufferSizeSeconds);
+        _options.OutputBufferSizeSeconds,
+        _metricsCollector);
 
       // Add modifiers to capture mixed audio for fingerprinting/streaming
       if (_playbackDevice != null)
@@ -188,7 +194,7 @@ public class SoundFlowAudioEngine : IAudioEngine
         _logger.LogInformation("Balance modifier added to MasterMixer");
 
         // Add fingerprint tap modifier after balance
-        _fingerprintTap = new FingerprintTapModifier(this, _logger);
+        _fingerprintTap = new FingerprintTapModifier(this, _logger, metricsCollector: _metricsCollector);
         _playbackDevice.MasterMixer.AddModifier(_fingerprintTap);
         _logger.LogInformation("Fingerprint tap modifier added to MasterMixer");
       }
@@ -212,6 +218,7 @@ public class SoundFlowAudioEngine : IAudioEngine
       }
 
       State = AudioEngineState.Ready;
+      _metricsCollector?.Gauge("audio.engine.buffer_size_samples", _options.BufferSize);
       _logger.LogInformation("SoundFlow audio engine initialized successfully");
     }
     catch (Exception ex)
@@ -400,7 +407,7 @@ public class SoundFlowAudioEngine : IAudioEngine
       }
       else
       {
-        _fingerprintTap = new FingerprintTapModifier(this, _logger);
+        _fingerprintTap = new FingerprintTapModifier(this, _logger, metricsCollector: _metricsCollector);
         _playbackDevice.MasterMixer.AddModifier(_fingerprintTap);
       }
 
@@ -491,7 +498,7 @@ public class SoundFlowAudioEngine : IAudioEngine
       // If it didn't exist (e.g. started with no device), create it now
       else
       {
-        _fingerprintTap = new FingerprintTapModifier(this, _logger);
+        _fingerprintTap = new FingerprintTapModifier(this, _logger, metricsCollector: _metricsCollector);
         _playbackDevice.MasterMixer.AddModifier(_fingerprintTap);
         _logger.LogInformation("Fingerprint tap created and attached to new playback device");
       }

--- a/src/Radio.Infrastructure/Audio/SoundFlow/TappedOutputStream.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/TappedOutputStream.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Radio.Core.Interfaces;
 
 namespace Radio.Infrastructure.Audio.SoundFlow;
 
@@ -14,6 +15,7 @@ internal sealed class TappedOutputStream : Stream
   private readonly int _sampleRate;
   private readonly int _channels;
   private readonly int _bytesPerSample;
+  private readonly IMetricsCollector? _metricsCollector;
   private int _writePosition;
   private readonly object _lock = new();
   private bool _disposed;
@@ -22,6 +24,10 @@ internal sealed class TappedOutputStream : Stream
   private long _totalBytesWritten;
   private long _totalWriteCalls;
   private DateTime _lastWriteTime;
+
+  // Metrics tracking
+  private DateTime _lastMetricsTime = DateTime.MinValue;
+  private long _lastMetricsBytesWritten;
 
   // Per-reader tracking: each reader has its own read position
   private readonly ConcurrentDictionary<string, int> _readerPositions = new();
@@ -32,11 +38,14 @@ internal sealed class TappedOutputStream : Stream
   /// <param name="sampleRate">The sample rate in Hz.</param>
   /// <param name="channels">The number of audio channels.</param>
   /// <param name="bufferSizeSeconds">The buffer size in seconds.</param>
-  public TappedOutputStream(int sampleRate = 48000, int channels = 2, int bufferSizeSeconds = 5)
+  /// <param name="metricsCollector">Optional metrics collector for pipeline metrics.</param>
+  public TappedOutputStream(int sampleRate = 48000, int channels = 2, int bufferSizeSeconds = 5,
+    IMetricsCollector? metricsCollector = null)
   {
     _sampleRate = sampleRate;
     _channels = channels;
     _bytesPerSample = 2; // 16-bit PCM
+    _metricsCollector = metricsCollector;
 
     // Calculate buffer size: sampleRate * channels * bytesPerSample * seconds
     _bufferSize = sampleRate * channels * _bytesPerSample * bufferSizeSeconds;
@@ -164,6 +173,8 @@ internal sealed class TappedOutputStream : Stream
         _writePosition = (_writePosition + 1) % _bufferSize;
       }
     }
+
+    ReportMetrics();
   }
 
   /// <summary>
@@ -196,6 +207,26 @@ internal sealed class TappedOutputStream : Stream
         _writePosition = (_writePosition + 1) % _bufferSize;
       }
     }
+
+    ReportMetrics();
+  }
+
+  private void ReportMetrics()
+  {
+    if (_metricsCollector == null) return;
+
+    var now = DateTime.UtcNow;
+    if ((now - _lastMetricsTime).TotalSeconds < 10) return;
+
+    var elapsed = _lastMetricsTime == DateTime.MinValue ? 10.0 : (now - _lastMetricsTime).TotalSeconds;
+    var bytesWrittenSinceLast = _totalBytesWritten - _lastMetricsBytesWritten;
+    var writeRate = bytesWrittenSinceLast / elapsed;
+
+    _metricsCollector.Gauge("audio.stream.ring_buffer_write_rate", writeRate);
+    _metricsCollector.Gauge("audio.stream.active_readers", _readerPositions.Count);
+
+    _lastMetricsTime = now;
+    _lastMetricsBytesWritten = _totalBytesWritten;
   }
 
   /// <summary>

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/SDRRadioAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/SDRRadioAudioSource.cs
@@ -726,7 +726,7 @@ public class SDRRadioAudioSource : PrimaryAudioSourceBase, Radio.Core.Interfaces
       // Create the sound generator with proper engine and format context
       if (_soundGenerator == null)
       {
-        _soundGenerator = new BufferedSoundGenerator<float>(engine, format, Logger);
+        _soundGenerator = new BufferedSoundGenerator<float>(engine, format, Logger, metricsCollector: MetricsCollector);
         _radioReceiver.AudioDataAvailable += OnAudioDataAvailable;
         Logger.LogDebug("📻 SDR RADIO: Created BufferedSoundGenerator and subscribed to AudioDataAvailable");
       }

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Windows/WasapiLoopbackCaptureSource.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Windows/WasapiLoopbackCaptureSource.cs
@@ -2,6 +2,7 @@ using System.Runtime.Versioning;
 using Microsoft.Extensions.Logging;
 using NAudio.CoreAudioApi;
 using NAudio.Wave;
+using Radio.Core.Interfaces;
 using Radio.Infrastructure.Audio.SoundFlow;
 using SoundFlow.Abstracts;
 using SoundFlow.Structs;
@@ -36,9 +37,10 @@ internal sealed class WasapiLoopbackCaptureSource : IDisposable
   /// Creates a BufferedSoundGenerator configured for the SoundFlow pipeline.
   /// Call this before StartCapture to get the component to register with the mixer.
   /// </summary>
-  public BufferedSoundGenerator<float> CreateGenerator(AudioEngine engine, AudioFormat format, ILogger generatorLogger)
+  public BufferedSoundGenerator<float> CreateGenerator(AudioEngine engine, AudioFormat format, ILogger generatorLogger,
+    IMetricsCollector? metricsCollector = null)
   {
-    return new BufferedSoundGenerator<float>(engine, format, generatorLogger);
+    return new BufferedSoundGenerator<float>(engine, format, generatorLogger, metricsCollector: metricsCollector);
   }
 
   /// <summary>

--- a/src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs
@@ -762,7 +762,7 @@ internal sealed class WindowsBluetoothService : IBluetoothService
 
                 var format = _playbackService.GetAudioFormat();
                 _loopbackCapture = new Windows.WasapiLoopbackCaptureSource(_logger);
-                _loopbackGenerator = _loopbackCapture.CreateGenerator(engine, format, _logger);
+                _loopbackGenerator = _loopbackCapture.CreateGenerator(engine, format, _logger, _metricsCollector);
 
                 _logger.LogInformation(
                   "WASAPI loopback capture device created — BT audio will route through SoundFlow pipeline");

--- a/src/Radio.Infrastructure/Radio.Infrastructure.csproj
+++ b/src/Radio.Infrastructure/Radio.Infrastructure.csproj
@@ -25,7 +25,7 @@
   <!-- Common packages -->
   <ItemGroup>
     <PackageReference Include="InTheHand.Net.Bluetooth" Version="4.2.2" />
-    <PackageReference Include="NAudio.Lame" Version="2.1.0" />
+    <PackageReference Include="NAudio.Lame.CrossPlatform" Version="2.2.1" />
     <PackageReference Include="SoundFlow" Version="1.*" />
     <PackageReference Include="SharpCaster" Version="3.0.0" />
     <PackageReference Include="Serilog" Version="4.*" />

--- a/tests/Radio.Infrastructure.Tests/Audio/TappedOutputStreamTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/TappedOutputStreamTests.cs
@@ -13,7 +13,7 @@ public class TappedOutputStreamTests
     // Use reflection to access the internal TappedOutputStream class
     var assembly = typeof(Radio.Infrastructure.DependencyInjection.AudioServiceExtensions).Assembly;
     var type = assembly.GetType("Radio.Infrastructure.Audio.SoundFlow.TappedOutputStream")!;
-    return (Stream)Activator.CreateInstance(type, sampleRate, channels, bufferSizeSeconds)!;
+    return (Stream)Activator.CreateInstance(type, sampleRate, channels, bufferSizeSeconds, null)!;
   }
 
   private static void InvokeWriteFromEngine(Stream stream, float[] samples)


### PR DESCRIPTION
## Summary

- **Fix Cast MP3 on Raspberry Pi ARM64**: Replace `NAudio.Lame` 2.1.0 (Windows-only `LameDLLWrap`) with `NAudio.Lame.CrossPlatform` 2.2.1 (P/Invokes `libmp3lame.so` directly). Same namespace, drop-in swap. Also add `FileLoadException` to the catch filter in `HttpStreamOutput` since that's what ARM64 throws.

- **Add 13 audio pipeline metrics** across 6 pipeline stages, all using time-gated reporting (every 10s) to avoid hot-path overhead:

  | Stage | Metrics |
  |-------|---------|
  | Source Buffer (`BufferedSoundGenerator`) | `audio.buffer.fill_percent`, `audio.buffer.samples_dropped`, `audio.buffer.underruns` |
  | Engine Config (`SoundFlowAudioEngine`) | `audio.engine.buffer_size_samples` (once at init) |
  | Fingerprint Tap (`FingerprintTapModifier`) | `audio.tap.batches_written`, `audio.tap.write_errors` |
  | Output Tap (`TappedOutputStream`) | `audio.stream.ring_buffer_write_rate`, `audio.stream.active_readers` |
  | HTTP Stream (`HttpStreamOutput`) | `audio.stream.client_count`, `audio.stream.bytes_sent` |
  | Fingerprint Lookup (`MetadataLookupService`) | `audio.fingerprint.lookups` (tagged: match/no_match/cache_hit/no_api_key/no_client/no_hash), `audio.fingerprint.confidence`, `audio.fingerprint.musicbrainz_enrichments` (tagged: success/no_data/error) |

- All new `IMetricsCollector?` constructor parameters are **optional** with null defaults — existing DI and test code works unchanged.

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] All existing tests pass (TappedOutputStream reflection test updated for new constructor param)
- [ ] Deploy to Pi: Cast/MP3 streaming works (no `LameDLLWrap` error)
- [ ] Pi setup: `sudo apt install libmp3lame-dev`
- [ ] Metrics dashboard shows new `audio.*` metrics when audio is playing

🤖 Generated with [Claude Code](https://claude.com/claude-code)