### PR TITLE
fix: BT connection drops, playlist race condition, enum serialization

### DIFF
--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -115,9 +115,11 @@ public class BluetoothAudioSource : USBAudioSourceBase
     }
     else
     {
-      Logger.LogWarning("BluetoothAudioSource: capture device not available (no connected device or no audio endpoint)");
-      MetricsCollector?.Increment("bluetooth.audio_capture_errors");
-      State = AudioSourceState.Error;
+      // No device connected yet — go to Ready state and wait for OnDeviceConnected
+      // to acquire the capture device. This is the normal flow when the user activates
+      // the Bluetooth source before pairing their phone.
+      Logger.LogInformation("BluetoothAudioSource: waiting for Bluetooth device connection");
+      State = AudioSourceState.Ready;
     }
   }
 
@@ -291,12 +293,12 @@ public class BluetoothAudioSource : USBAudioSourceBase
       }
       else
       {
-        Logger.LogDebug("BluetoothAudioSource: no audio capture device available for connected device");
+        Logger.LogWarning("BluetoothAudioSource: no audio capture device available after retries");
       }
     }
     catch (Exception ex)
     {
-      Logger.LogDebug(ex, "BluetoothAudioSource: failed to acquire audio capture device on connect");
+      Logger.LogWarning(ex, "BluetoothAudioSource: failed to acquire audio capture device on connect");
     }
   }
 

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
@@ -33,6 +33,7 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
   private readonly string _rootDir;
   private readonly Dictionary<string, object> _metadata = new();
   private readonly HashSet<string> _errorFiles = new();
+  private readonly object _playlistLock = new();
   private Queue<string> _playlist = new();
   private List<string> _originalOrder = new(); // Store original order for shuffle toggle
   private List<string> _playedHistory = new(); // Track played songs for Previous
@@ -314,9 +315,12 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
     }
 
     // Add current file to history before moving to next
-    if (_currentFile != null && !_playedHistory.Contains(_currentFile))
+    lock (_playlistLock)
     {
-      _playedHistory.Add(_currentFile);
+      if (_currentFile != null && !_playedHistory.Contains(_currentFile))
+      {
+        _playedHistory.Add(_currentFile);
+      }
     }
 
     // Track skip metric if this was user-initiated
@@ -326,7 +330,13 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
     }
 
     // Check if playlist has more tracks
-    if (_playlist.Count > 0)
+    bool hasMoreTracks;
+    lock (_playlistLock)
+    {
+      hasMoreTracks = _playlist.Count > 0;
+    }
+
+    if (hasMoreTracks)
     {
       await LoadCurrentFileAsync(cancellationToken);
 
@@ -349,8 +359,11 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
         files = ShuffleList(files);
       }
 
-      _playlist = new Queue<string>(files);
-      _playedHistory.Clear();
+      lock (_playlistLock)
+      {
+        _playlist = new Queue<string>(files);
+        _playedHistory.Clear();
+      }
       await LoadCurrentFileAsync(cancellationToken);
 
       if (State == AudioSourceState.Playing)
@@ -383,21 +396,33 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
     }
 
     // Go to previous track in history
-    if (_playedHistory.Count > 0)
+    string? previousFile;
+    lock (_playlistLock)
     {
-      var previousFile = _playedHistory[^1];
-      _playedHistory.RemoveAt(_playedHistory.Count - 1);
-
-      // Put current file back at front of playlist if it exists
-      if (_currentFile != null)
+      if (_playedHistory.Count > 0)
       {
-        var tempList = _playlist.ToList();
-        tempList.Insert(0, _currentFile);
-        _playlist = new Queue<string>(tempList);
-      }
+        previousFile = _playedHistory[^1];
+        _playedHistory.RemoveAt(_playedHistory.Count - 1);
 
-      // Load previous file
-      _currentFile = previousFile;
+        // Put current file back at front of playlist if it exists
+        if (_currentFile != null)
+        {
+          var tempList = _playlist.ToList();
+          tempList.Insert(0, _currentFile);
+          _playlist = new Queue<string>(tempList);
+        }
+
+        // Load previous file
+        _currentFile = previousFile;
+      }
+      else
+      {
+        previousFile = null;
+      }
+    }
+
+    if (previousFile != null)
+    {
       _position = TimeSpan.Zero;
       CleanupDataProvider();
 
@@ -405,19 +430,19 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
       try
       {
         _audioEngine ??= new MiniAudioEngine();
-        _fileStream = File.OpenRead(_currentFile);
+        _fileStream = File.OpenRead(previousFile);
         _dataProvider = new ChunkedDataProvider(_audioEngine, _fileStream);
-        Logger.LogDebug("Loaded previous file with SoundFlow: {File}", _currentFile);
+        Logger.LogDebug("Loaded previous file with SoundFlow: {File}", previousFile);
       }
       catch (Exception ex)
       {
-        Logger.LogWarning(ex, "SoundFlow could not decode previous file: {File}", _currentFile);
+        Logger.LogWarning(ex, "SoundFlow could not decode previous file: {File}", previousFile);
         _fileStream?.Dispose();
         _fileStream = null;
         _dataProvider = null;
       }
 
-      UpdateMetadataFromFile(_currentFile);
+      UpdateMetadataFromFile(previousFile);
 
       if (State == AudioSourceState.Playing)
       {
@@ -435,7 +460,10 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
 
       // Go to last track in original order
       var lastFile = _originalOrder[^1];
-      _currentFile = lastFile;
+      lock (_playlistLock)
+      {
+        _currentFile = lastFile;
+      }
       _position = TimeSpan.Zero;
       CleanupDataProvider();
 
@@ -1324,13 +1352,16 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
   /// </summary>
   private List<string> GetAllTracksInOrder()
   {
-    var allTracks = new List<string>();
-    if (_currentFile != null)
+    lock (_playlistLock)
     {
-      allTracks.Add(_currentFile);
+      var allTracks = new List<string>();
+      if (_currentFile != null)
+      {
+        allTracks.Add(_currentFile);
+      }
+      allTracks.AddRange(_playlist);
+      return allTracks;
     }
-    allTracks.AddRange(_playlist);
-    return allTracks;
   }
 
   /// <summary>
@@ -1338,13 +1369,16 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
   /// </summary>
   private List<string> GetFullPlaylistInOrder()
   {
-    var fullList = new List<string>(_playedHistory);
-    if (_currentFile != null)
+    lock (_playlistLock)
     {
-      fullList.Add(_currentFile);
+      var fullList = new List<string>(_playedHistory);
+      if (_currentFile != null)
+      {
+        fullList.Add(_currentFile);
+      }
+      fullList.AddRange(_playlist);
+      return fullList;
     }
-    fullList.AddRange(_playlist);
-    return fullList;
   }
 
   /// <summary>
@@ -1352,29 +1386,43 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
   /// </summary>
   private List<QueueItem> GetFullPlaylistInternal()
   {
+    // Snapshot collections under lock to avoid concurrent modification from skip/next
+    string[] playedSnapshot;
+    string? currentSnapshot;
+    string[] playlistSnapshot;
+    HashSet<string> errorSnapshot;
+
+    lock (_playlistLock)
+    {
+      playedSnapshot = _playedHistory.ToArray();
+      currentSnapshot = _currentFile;
+      playlistSnapshot = _playlist.ToArray();
+      errorSnapshot = new HashSet<string>(_errorFiles);
+    }
+
     var items = new List<QueueItem>();
     var fullPlaylistIndex = 0;
 
     // Played items
-    foreach (var file in _playedHistory)
+    foreach (var file in playedSnapshot)
     {
-      var state = _errorFiles.Contains(file) ? QueueItemState.Error : QueueItemState.Played;
+      var state = errorSnapshot.Contains(file) ? QueueItemState.Error : QueueItemState.Played;
       items.Add(CreateQueueItemWithState(file, fullPlaylistIndex, state));
       fullPlaylistIndex++;
     }
 
     // Current item
-    if (_currentFile != null)
+    if (currentSnapshot != null)
     {
-      var state = _errorFiles.Contains(_currentFile) ? QueueItemState.Error : QueueItemState.Current;
-      items.Add(CreateQueueItemWithState(_currentFile, fullPlaylistIndex, state));
+      var state = errorSnapshot.Contains(currentSnapshot) ? QueueItemState.Error : QueueItemState.Current;
+      items.Add(CreateQueueItemWithState(currentSnapshot, fullPlaylistIndex, state));
       fullPlaylistIndex++;
     }
 
     // Upcoming items
-    foreach (var file in _playlist)
+    foreach (var file in playlistSnapshot)
     {
-      var state = _errorFiles.Contains(file) ? QueueItemState.Error : QueueItemState.Upcoming;
+      var state = errorSnapshot.Contains(file) ? QueueItemState.Error : QueueItemState.Upcoming;
       items.Add(CreateQueueItemWithState(file, fullPlaylistIndex, state));
       fullPlaylistIndex++;
     }
@@ -1671,22 +1719,30 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
 
   private async Task LoadCurrentFileAsync(CancellationToken cancellationToken)
   {
-    if (_playlist.Count == 0)
+    string? fileToLoad;
+    lock (_playlistLock)
     {
-      _currentFile = null;
-      _currentIndex = -1;
+      if (_playlist.Count == 0)
+      {
+        _currentFile = null;
+        _currentIndex = -1;
+        fileToLoad = null;
+      }
+      else
+      {
+        _currentFile = _playlist.Dequeue();
+        _currentIndex = 0;
+        fileToLoad = _currentFile;
+      }
+    }
+
+    if (fileToLoad == null)
+    {
       OnPlaybackCompleted(PlaybackCompletionReason.EndOfContent);
       return;
     }
 
-    _currentFile = _playlist.Dequeue();
     _position = TimeSpan.Zero;
-
-    // Update current index - it should be 0 since we're loading the front of the queue
-    // But we need to account for the overall position in the original order
-    var allTracks = new List<string> { _currentFile };
-    allTracks.AddRange(_playlist);
-    _currentIndex = 0;
 
     // Clean up previous data provider
     CleanupDataProvider();
@@ -1698,26 +1754,26 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
 
       // Create a data provider from the file using SoundFlow
       // Note: We keep the FileStream open (stored as field) because ChunkedDataProvider needs it
-      _fileStream = File.OpenRead(_currentFile);
+      _fileStream = File.OpenRead(fileToLoad);
       _dataProvider = new ChunkedDataProvider(_audioEngine, _fileStream);
 
-      Logger.LogDebug("Loaded file with SoundFlow: {File}", _currentFile);
+      Logger.LogDebug("Loaded file with SoundFlow: {File}", fileToLoad);
     }
     catch (Exception ex)
     {
       // SoundFlow couldn't decode the file - this could happen with unsupported formats
       // or during testing with dummy files. Log and continue without a data provider.
-      Logger.LogWarning(ex, "SoundFlow could not decode file: {File}. Using basic file info only.", _currentFile);
-      _errorFiles.Add(_currentFile);
+      Logger.LogWarning(ex, "SoundFlow could not decode file: {File}. Using basic file info only.", fileToLoad);
+      lock (_playlistLock) { _errorFiles.Add(fileToLoad); }
       _fileStream?.Dispose();
       _fileStream = null;
       _dataProvider = null;
     }
 
     // Read metadata from the file (this uses SoundMetadataReader which is separate from decoding)
-    UpdateMetadataFromFile(_currentFile);
+    UpdateMetadataFromFile(fileToLoad);
 
-    Logger.LogDebug("Loaded file: {File}", _currentFile);
+    Logger.LogDebug("Loaded file: {File}", fileToLoad);
 
     if (State == AudioSourceState.Created)
     {
@@ -1729,7 +1785,7 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
     {
       ChangeType = QueueChangeType.CurrentChanged,
       AffectedIndex = _currentIndex,
-      AffectedItem = CreateQueueItem(_currentFile, _currentIndex, true)
+      AffectedItem = CreateQueueItem(fileToLoad, _currentIndex, true)
     });
 
     await Task.CompletedTask;

--- a/src/Radio.Infrastructure/Configuration/Services/PreferencesPersistenceService.cs
+++ b/src/Radio.Infrastructure/Configuration/Services/PreferencesPersistenceService.cs
@@ -5,6 +5,7 @@ using Radio.Core.Configuration;
 using Radio.Infrastructure.Configuration.Abstractions;
 using Radio.Infrastructure.Configuration.Models;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Radio.Infrastructure.Configuration.Services;
 
@@ -23,6 +24,10 @@ public class PreferencesPersistenceService : BackgroundService
   private readonly IConfigurationManager _configurationManager;
   private readonly IHostApplicationLifetime _lifetime;
   private readonly TimeSpan _savePeriod = TimeSpan.FromSeconds(30); // Save every 30 seconds
+  private static readonly JsonSerializerOptions _serializerOptions = new()
+  {
+    Converters = { new JsonStringEnumConverter() }
+  };
 
   public PreferencesPersistenceService(
     ILogger<PreferencesPersistenceService> logger,
@@ -118,7 +123,8 @@ public class PreferencesPersistenceService : BackgroundService
       }
 
       // Serialize preferences to key-value pairs, preserving JSON structure
-      var json = JsonSerializer.Serialize(preferences);
+      // Use JsonStringEnumConverter so enums are stored as names (e.g. "Off") not integers (e.g. 0)
+      var json = JsonSerializer.Serialize(preferences, _serializerOptions);
       var dict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
 
       if (dict != null)

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -150,6 +150,13 @@ namespace Radio.Infrastructure.Platform.Bluetooth
                 // BlueZ has no one to delegate the pairing decision to.
                 await RegisterAgentAsync();
 
+                // Watch for new interfaces (device connects/disconnects)
+                _discoveryWatcher = await _objectManager.WatchInterfacesAddedAsync(OnInterfaceAdded);
+
+                // Set up property watchers on all existing devices so we detect
+                // reconnections from already-paired phones.
+                await WatchExistingDevicesAsync();
+
                 State = BluetoothAdapterState.On;
                 StateChanged?.Invoke(this, new BluetoothAdapterStateChangedEventArgs { NewState = State });
                 return true;
@@ -214,6 +221,51 @@ namespace Radio.Infrastructure.Platform.Bluetooth
             }
         }
         
+        /// <summary>
+        /// Scans BlueZ for existing Device1 objects and sets up property watchers
+        /// so that reconnections from already-paired phones are detected even
+        /// without an explicit StartDiscoveryAsync call.
+        /// </summary>
+        private async Task WatchExistingDevicesAsync()
+        {
+            if (_objectManager == null) return;
+
+            try
+            {
+                var objects = await _objectManager.GetManagedObjectsAsync();
+                foreach (var obj in objects)
+                {
+                    if (!obj.Value.ContainsKey(Linux.BluezConstants.DeviceInterface))
+                        continue;
+
+                    var props = obj.Value[Linux.BluezConstants.DeviceInterface];
+                    var device = ParseDevice(obj.Key, props);
+
+                    lock (_deviceCache)
+                    {
+                        _deviceCache[obj.Key] = device;
+                    }
+
+                    // Watch property changes (Connected, etc.) on this device
+                    _ = WatchDevicePropertiesAsync(obj.Key);
+
+                    if (device.IsConnected)
+                    {
+                        _connectionStartTime = DateTime.UtcNow;
+                        _metricsCollector?.Increment("bluetooth.devices_connected_total");
+                        _metricsCollector?.Gauge("bluetooth.active_connections", 1);
+                        _logger.LogInformation("Bluetooth device already connected: {DeviceName} ({Address})",
+                            device.Name, device.Address);
+                        DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = device });
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to watch existing Bluetooth devices");
+            }
+        }
+
         private void OnInterfaceAdded((ObjectPath objectPath, IDictionary<string, IDictionary<string, object>> interfaces) change)
         {
             if (change.interfaces.ContainsKey(Linux.BluezConstants.DeviceInterface))
@@ -449,7 +501,7 @@ namespace Radio.Infrastructure.Platform.Bluetooth
             return null;
         }
 
-        public Task<object?> GetAudioCaptureDeviceAsync(CancellationToken cancellationToken = default)
+        public async Task<object?> GetAudioCaptureDeviceAsync(CancellationToken cancellationToken = default)
         {
             // Cleanup previous capture engine if any
             _captureEngine?.Dispose();
@@ -459,84 +511,124 @@ namespace Radio.Infrastructure.Platform.Bluetooth
             if (connected == null)
             {
                 _logger.LogWarning("No connected Bluetooth device — cannot create audio capture");
-                return Task.FromResult<object?>(null);
+                return null;
             }
 
-            try
+            // PulseAudio/PipeWire takes time to create the Bluetooth capture device
+            // after A2DP connection is established. Poll with retries.
+            const int maxRetries = 15;
+            const int retryDelayMs = 500;
+
+            for (var attempt = 1; attempt <= maxRetries; attempt++)
             {
-                _captureEngine = new MiniAudioEngine();
-                var captureDevices = _captureEngine.CaptureDevices;
+                cancellationToken.ThrowIfCancellationRequested();
 
-                _logger.LogInformation(
-                    "Searching for Bluetooth audio capture device among {Count} capture devices (connected: {DeviceName})",
-                    captureDevices.Length, connected.Name);
-
-                // On Linux with PulseAudio/PipeWire, Bluetooth audio devices appear as:
-                //   "bluez_output.<mac_address>.monitor" or "bluez_sink.<mac_address>.monitor"
-                //   or by the connected device name
-                DeviceInfo? targetDevice = null;
-
-                // Strategy 1: Match by "bluez" prefix (PulseAudio/PipeWire Bluetooth source)
-                foreach (var device in captureDevices)
+                // Re-check connection — phone may have disconnected during polling
+                if (ConnectedDevice == null)
                 {
-                    if (device.Name != null && device.Name.Contains("bluez", StringComparison.OrdinalIgnoreCase))
-                    {
-                        targetDevice = device;
-                        break;
-                    }
+                    _logger.LogWarning("Bluetooth device disconnected during capture device polling");
+                    return null;
                 }
 
-                // Strategy 2: Match by connected device name
-                if (targetDevice == null)
+                try
                 {
+                    _captureEngine?.Dispose();
+                    _captureEngine = new MiniAudioEngine();
+                    var captureDevices = _captureEngine.CaptureDevices;
+
+                    if (attempt == 1)
+                    {
+                        _logger.LogInformation(
+                            "Searching for Bluetooth audio capture device among {Count} capture devices (connected: {DeviceName})",
+                            captureDevices.Length, connected.Name);
+                    }
+
+                    // On Linux with PulseAudio/PipeWire, Bluetooth audio devices appear as:
+                    //   "bluez_output.<mac_address>.monitor" or "bluez_sink.<mac_address>.monitor"
+                    //   or by the connected device name
+                    DeviceInfo? targetDevice = null;
+
+                    // Strategy 1: Match by "bluez" prefix (PulseAudio/PipeWire Bluetooth source)
                     foreach (var device in captureDevices)
                     {
-                        if (device.Name != null && device.Name.Contains(connected.Name, StringComparison.OrdinalIgnoreCase))
+                        if (device.Name != null && device.Name.Contains("bluez", StringComparison.OrdinalIgnoreCase))
                         {
                             targetDevice = device;
                             break;
                         }
                     }
-                }
 
-                // Strategy 3: Match by "bluetooth" keyword
-                if (targetDevice == null)
-                {
-                    foreach (var device in captureDevices)
+                    // Strategy 2: Match by connected device name
+                    if (targetDevice == null)
                     {
-                        if (device.Name != null && device.Name.Contains("bluetooth", StringComparison.OrdinalIgnoreCase))
+                        foreach (var device in captureDevices)
                         {
-                            targetDevice = device;
-                            break;
+                            if (device.Name != null && device.Name.Contains(connected.Name, StringComparison.OrdinalIgnoreCase))
+                            {
+                                targetDevice = device;
+                                break;
+                            }
                         }
                     }
-                }
 
-                if (targetDevice != null)
+                    // Strategy 3: Match by "bluetooth" keyword
+                    if (targetDevice == null)
+                    {
+                        foreach (var device in captureDevices)
+                        {
+                            if (device.Name != null && device.Name.Contains("bluetooth", StringComparison.OrdinalIgnoreCase))
+                            {
+                                targetDevice = device;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (targetDevice != null)
+                    {
+                        var format = _options.AudioQuality == BluetoothAudioQuality.High
+                            ? new AudioFormat { SampleRate = 48000, Channels = 2, Format = SampleFormat.F32 }
+                            : AudioFormat.Cd;
+
+                        var captureDevice = _captureEngine.InitializeCaptureDevice(targetDevice, format);
+                        _logger.LogInformation(
+                            "Created Bluetooth audio capture device: {DeviceName} (attempt {Attempt})",
+                            targetDevice.Value.Name, attempt);
+                        return captureDevice;
+                    }
+
+                    if (attempt < maxRetries)
+                    {
+                        _logger.LogDebug(
+                            "Bluetooth capture device not yet available, retrying ({Attempt}/{Max})...",
+                            attempt, maxRetries);
+                        _captureEngine.Dispose();
+                        _captureEngine = null;
+                        await Task.Delay(retryDelayMs, cancellationToken);
+                    }
+                }
+                catch (OperationCanceledException)
                 {
-                    var format = _options.AudioQuality == BluetoothAudioQuality.High
-                        ? new AudioFormat { SampleRate = 48000, Channels = 2, Format = SampleFormat.F32 }
-                        : AudioFormat.Cd;
-
-                    var captureDevice = _captureEngine.InitializeCaptureDevice(targetDevice, format);
-                    _logger.LogInformation(
-                        "Created Bluetooth audio capture device: {DeviceName}", targetDevice.Value.Name);
-                    return Task.FromResult<object?>(captureDevice);
+                    throw;
                 }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Capture device search attempt {Attempt} failed", attempt);
+                    _captureEngine?.Dispose();
+                    _captureEngine = null;
 
-                _logger.LogWarning("No Bluetooth audio capture device found on this system");
-                _captureEngine.Dispose();
-                _captureEngine = null;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to create Bluetooth audio capture device");
-                _metricsCollector?.Increment("bluetooth.audio_capture_errors");
-                _captureEngine?.Dispose();
-                _captureEngine = null;
+                    if (attempt < maxRetries)
+                    {
+                        await Task.Delay(retryDelayMs, cancellationToken);
+                    }
+                }
             }
 
-            return Task.FromResult<object?>(null);
+            _logger.LogWarning("No Bluetooth audio capture device found after {MaxRetries} attempts", maxRetries);
+            _metricsCollector?.Increment("bluetooth.audio_capture_errors");
+            _captureEngine?.Dispose();
+            _captureEngine = null;
+            return null;
         }
 
         public async ValueTask DisposeAsync()

--- a/tests/Radio.Infrastructure.Tests/Audio/BluetoothAudioSourceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/BluetoothAudioSourceTests.cs
@@ -125,22 +125,22 @@ public class BluetoothAudioSourceTests : IAsyncDisposable
   }
 
   [Fact]
-  public async Task InitializeAsync_WhenNoCaptureDevice_SetsErrorState()
+  public async Task InitializeAsync_WhenNoCaptureDevice_SetsReadyState()
   {
     // MockBluetoothService returns "mock-capture-endpoint" (string, not AudioCaptureDevice)
-    // so InitializeAsync should fail the `is AudioCaptureDevice` check
+    // InitializeAsync should set Ready state (waiting for device to connect)
 
     await _source.InitializeAsync(CancellationToken.None);
 
-    Assert.Equal(AudioSourceState.Error, _source.State);
+    Assert.Equal(AudioSourceState.Ready, _source.State);
   }
 
   [Fact]
-  public async Task InitializeAsync_WhenNoCaptureDevice_RecordsMetric()
+  public async Task InitializeAsync_WhenNoCaptureDevice_DoesNotRecordErrorMetric()
   {
     await _source.InitializeAsync(CancellationToken.None);
 
-    _metricsMock.Verify(m => m.Increment("bluetooth.audio_capture_errors", 1.0, null), Times.Once);
+    _metricsMock.Verify(m => m.Increment("bluetooth.audio_capture_errors", 1.0, null), Times.Never);
   }
 
   [Fact]

--- a/tests/Radio.Infrastructure.Tests/Audio/WasapiLoopbackTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/WasapiLoopbackTests.cs
@@ -130,7 +130,7 @@ public class WasapiLoopbackTests : IAsyncDisposable
   }
 
   [Fact]
-  public async Task InitializeAsync_WhenNullCaptureDevice_SetsErrorState()
+  public async Task InitializeAsync_WhenNullCaptureDevice_SetsReadyState()
   {
     var btMock = new Mock<IBluetoothService>();
     btMock.Setup(b => b.IsAudioManagedByPlatform).Returns(false);
@@ -149,8 +149,8 @@ public class WasapiLoopbackTests : IAsyncDisposable
 
     await source.InitializeAsync(CancellationToken.None);
 
-    Assert.Equal(AudioSourceState.Error, source.State);
-    _metricsMock.Verify(m => m.Increment("bluetooth.audio_capture_errors", 1.0, null), Times.Once);
+    // Now goes to Ready (waiting for device) instead of Error
+    Assert.Equal(AudioSourceState.Ready, source.State);
 
     await source.DisposeAsync();
   }


### PR DESCRIPTION
## Summary
- **Bluetooth on Pi**: Phone connections were dropping after 1-2 seconds because `LinuxBluetoothService.StartAsync` never watched for device connections, `InitializeAsync` immediately errored with no device, and capture device polling had no retries
- **Playlist crash**: `AudioStateUpdateService` reading the playlist while skip/next modified it caused `InvalidOperationException: Collection was modified` — added `_playlistLock` with snapshot-based reads
- **RepeatMode serialization**: `PreferencesPersistenceService` serialized `RepeatMode.Off` as `0` (integer), causing Web DTO `JsonException` — now uses `JsonStringEnumConverter`

## Changes
| File | Change |
|------|--------|
| `LinuxBluetoothService.cs` | Watch `InterfacesAdded` + existing device properties in `StartAsync`; poll up to 15x for capture device |
| `BluetoothAudioSource.cs` | `InitializeAsync` → Ready (not Error) when no device connected; upgraded log levels |
| `FilePlayerAudioSource.cs` | Added `_playlistLock`; snapshot reads in `GetFullPlaylistInternal`/`GetAllTracksInOrder`/`GetFullPlaylistInOrder`; lock mutations in `Next`/`Previous`/`LoadCurrentFile` |
| `PreferencesPersistenceService.cs` | Added `JsonStringEnumConverter` to serialization options |
| `BluetoothAudioSourceTests.cs` | Updated to expect Ready state instead of Error |
| `WasapiLoopbackTests.cs` | Updated to expect Ready state instead of Error |

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings
- [x] All 689 Infrastructure tests pass (including updated BT tests)
- [x] All 202 API tests pass
- [x] All 35 Core tests pass
- [ ] Deploy to Pi: verify BT phone stays connected and audio capture acquires
- [ ] Rapid skip through playlist — no `Collection was modified` errors
- [ ] Verify RepeatMode persists and loads correctly as string ("Off"/"One"/"All")

🤖 Generated with [Claude Code](https://claude.com/claude-code)