### PR TITLE
fix: BluezAgent methods not exposed on D-Bus — A2DP auth fails

### DIFF
--- a/src/Radio.Infrastructure/Platform/Bluetooth/Linux/BluezAgent.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Linux/BluezAgent.cs
@@ -11,9 +11,10 @@ namespace Radio.Infrastructure.Platform.Bluetooth.Linux;
 /// Registered on D-Bus so BlueZ delegates pairing decisions to this agent instead of
 /// prompting via the default agent (which doesn't exist in a headless environment).
 /// Uses "NoInputNoOutput" capability to enable "Just Works" pairing (no PIN required).
+/// Must implement IAgent1 (not just IDBusObject) so Tmds.DBus exposes all methods
+/// on D-Bus — BlueZ calls AuthorizeService to approve A2DP/HFP profiles.
 /// </summary>
-[DBusInterface("org.bluez.Agent1")]
-internal sealed class BluezAgent : IDBusObject
+internal sealed class BluezAgent : IAgent1
 {
   private readonly ILogger _logger;
   private readonly bool _autoAccept;

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Linux/BluezInterfaces.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Linux/BluezInterfaces.cs
@@ -69,6 +69,20 @@ namespace Radio.Infrastructure.Platform.Bluetooth.Linux
         Task RequestDefaultAgentAsync(ObjectPath agent);
     }
 
+    [DBusInterface("org.bluez.Agent1")]
+    public interface IAgent1 : IDBusObject
+    {
+        Task ReleaseAsync();
+        Task<string> RequestPinCodeAsync(ObjectPath device);
+        Task DisplayPinCodeAsync(ObjectPath device, string pincode);
+        Task<uint> RequestPasskeyAsync(ObjectPath device);
+        Task DisplayPasskeyAsync(ObjectPath device, uint passkey, ushort entered);
+        Task RequestConfirmationAsync(ObjectPath device, uint passkey);
+        Task RequestAuthorizationAsync(ObjectPath device);
+        Task AuthorizeServiceAsync(ObjectPath device, string uuid);
+        Task CancelAsync();
+    }
+
     // Helper for property changes
     public static class BluezConstants
     {

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -541,6 +541,12 @@ namespace Radio.Infrastructure.Platform.Bluetooth
                         _logger.LogInformation(
                             "Searching for Bluetooth audio capture device among {Count} capture devices (connected: {DeviceName})",
                             captureDevices.Length, connected.Name);
+
+                        // Log all available capture devices for diagnostics
+                        for (var i = 0; i < captureDevices.Length; i++)
+                        {
+                            _logger.LogInformation("  Capture device [{Index}]: {Name}", i, captureDevices[i].Name ?? "(null)");
+                        }
                     }
 
                     // On Linux with PulseAudio/PipeWire, Bluetooth audio devices appear as:


### PR DESCRIPTION
## Summary
- Phone connects via Bluetooth but disconnects after ~5 seconds because BlueZ can't authorize the A2DP audio profile
- Root cause: `[DBusInterface("org.bluez.Agent1")]` was on the `BluezAgent` **class**, but Tmds.DBus only discovers D-Bus methods from **interfaces** with that attribute
- BlueZ log: `Method "AuthorizeService" with signature "os" on interface "org.bluez.Agent1" doesn't exist`

## Fix
- Created `IAgent1` interface with `[DBusInterface("org.bluez.Agent1")]` defining all 9 Agent1 methods
- Changed `BluezAgent` to implement `IAgent1` instead of just `IDBusObject`
- Added capture device name logging for diagnostics

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings
- [x] All 15 Bluetooth tests pass
- [ ] Deploy to Pi: phone should stay connected and A2DP audio should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)