### PR TITLE
fix: Prevent concurrent MiniAudioEngine crash during BT capture search

### DIFF
--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -34,6 +34,7 @@ namespace Radio.Infrastructure.Platform.Bluetooth
 
         // Maps object path to device info
         private readonly Dictionary<ObjectPath, BluetoothDeviceInfo> _deviceCache = new();
+        private readonly SemaphoreSlim _captureDeviceLock = new(1, 1);
         private Linux.BluezAgent? _agent;
 
         public LinuxBluetoothService(
@@ -503,10 +504,6 @@ namespace Radio.Infrastructure.Platform.Bluetooth
 
         public async Task<object?> GetAudioCaptureDeviceAsync(CancellationToken cancellationToken = default)
         {
-            // Cleanup previous capture engine if any
-            _captureEngine?.Dispose();
-            _captureEngine = null;
-
             var connected = ConnectedDevice;
             if (connected == null)
             {
@@ -514,10 +511,35 @@ namespace Radio.Infrastructure.Platform.Bluetooth
                 return null;
             }
 
+            // Prevent concurrent calls — multiple DeviceConnected events fire simultaneously
+            // and MiniAudioEngine is not safe to instantiate concurrently.
+            if (!await _captureDeviceLock.WaitAsync(0, cancellationToken))
+            {
+                _logger.LogDebug("Capture device search already in progress, skipping duplicate call");
+                return null;
+            }
+
+            try
+            {
+                return await SearchForCaptureDeviceAsync(connected, cancellationToken);
+            }
+            finally
+            {
+                _captureDeviceLock.Release();
+            }
+        }
+
+        private async Task<object?> SearchForCaptureDeviceAsync(
+            BluetoothDeviceInfo connected, CancellationToken cancellationToken)
+        {
+            // Cleanup previous capture engine
+            _captureEngine?.Dispose();
+            _captureEngine = null;
+
             // PulseAudio/PipeWire takes time to create the Bluetooth capture device
-            // after A2DP connection is established. Poll with retries.
-            const int maxRetries = 15;
-            const int retryDelayMs = 500;
+            // after A2DP is authorized. Poll with retries.
+            const int maxRetries = 20;
+            const int retryDelayMs = 1000;
 
             for (var attempt = 1; attempt <= maxRetries; attempt++)
             {
@@ -532,63 +554,29 @@ namespace Radio.Infrastructure.Platform.Bluetooth
 
                 try
                 {
+                    // Create a fresh engine each attempt to re-enumerate devices.
+                    // PipeWire may add the bluez source between enumerations.
                     _captureEngine?.Dispose();
                     _captureEngine = new MiniAudioEngine();
                     var captureDevices = _captureEngine.CaptureDevices;
 
+                    _logger.LogDebug(
+                        "Capture device search attempt {Attempt}/{Max}: {Count} devices",
+                        attempt, maxRetries, captureDevices.Length);
+
                     if (attempt == 1)
                     {
-                        _logger.LogInformation(
-                            "Searching for Bluetooth audio capture device among {Count} capture devices (connected: {DeviceName})",
-                            captureDevices.Length, connected.Name);
-
-                        // Log all available capture devices for diagnostics
                         for (var i = 0; i < captureDevices.Length; i++)
                         {
-                            _logger.LogInformation("  Capture device [{Index}]: {Name}", i, captureDevices[i].Name ?? "(null)");
+                            _logger.LogInformation("  Capture device [{Index}]: {Name}",
+                                i, captureDevices[i].Name ?? "(null)");
                         }
                     }
 
                     // On Linux with PulseAudio/PipeWire, Bluetooth audio devices appear as:
                     //   "bluez_output.<mac_address>.monitor" or "bluez_sink.<mac_address>.monitor"
                     //   or by the connected device name
-                    DeviceInfo? targetDevice = null;
-
-                    // Strategy 1: Match by "bluez" prefix (PulseAudio/PipeWire Bluetooth source)
-                    foreach (var device in captureDevices)
-                    {
-                        if (device.Name != null && device.Name.Contains("bluez", StringComparison.OrdinalIgnoreCase))
-                        {
-                            targetDevice = device;
-                            break;
-                        }
-                    }
-
-                    // Strategy 2: Match by connected device name
-                    if (targetDevice == null)
-                    {
-                        foreach (var device in captureDevices)
-                        {
-                            if (device.Name != null && device.Name.Contains(connected.Name, StringComparison.OrdinalIgnoreCase))
-                            {
-                                targetDevice = device;
-                                break;
-                            }
-                        }
-                    }
-
-                    // Strategy 3: Match by "bluetooth" keyword
-                    if (targetDevice == null)
-                    {
-                        foreach (var device in captureDevices)
-                        {
-                            if (device.Name != null && device.Name.Contains("bluetooth", StringComparison.OrdinalIgnoreCase))
-                            {
-                                targetDevice = device;
-                                break;
-                            }
-                        }
-                    }
+                    var targetDevice = FindBluetoothCaptureDevice(captureDevices, connected.Name);
 
                     if (targetDevice != null)
                     {
@@ -598,18 +586,26 @@ namespace Radio.Infrastructure.Platform.Bluetooth
 
                         var captureDevice = _captureEngine.InitializeCaptureDevice(targetDevice, format);
                         _logger.LogInformation(
-                            "Created Bluetooth audio capture device: {DeviceName} (attempt {Attempt})",
-                            targetDevice.Value.Name, attempt);
+                            "Created Bluetooth audio capture device: {DeviceName} (attempt {Attempt}/{Max})",
+                            targetDevice.Value.Name, attempt, maxRetries);
                         return captureDevice;
                     }
 
+                    // Log new devices that appear on subsequent attempts
+                    if (attempt > 1 && captureDevices.Length > 1)
+                    {
+                        for (var i = 0; i < captureDevices.Length; i++)
+                        {
+                            _logger.LogDebug("  Capture device [{Index}]: {Name}",
+                                i, captureDevices[i].Name ?? "(null)");
+                        }
+                    }
+
+                    _captureEngine.Dispose();
+                    _captureEngine = null;
+
                     if (attempt < maxRetries)
                     {
-                        _logger.LogDebug(
-                            "Bluetooth capture device not yet available, retrying ({Attempt}/{Max})...",
-                            attempt, maxRetries);
-                        _captureEngine.Dispose();
-                        _captureEngine = null;
                         await Task.Delay(retryDelayMs, cancellationToken);
                     }
                 }
@@ -630,10 +626,34 @@ namespace Radio.Infrastructure.Platform.Bluetooth
                 }
             }
 
-            _logger.LogWarning("No Bluetooth audio capture device found after {MaxRetries} attempts", maxRetries);
+            _logger.LogWarning("No Bluetooth audio capture device found after {MaxRetries}s", maxRetries);
             _metricsCollector?.Increment("bluetooth.audio_capture_errors");
-            _captureEngine?.Dispose();
-            _captureEngine = null;
+            return null;
+        }
+
+        private static DeviceInfo? FindBluetoothCaptureDevice(DeviceInfo[] devices, string connectedName)
+        {
+            // Strategy 1: Match by "bluez" prefix (PipeWire Bluetooth source)
+            foreach (var device in devices)
+            {
+                if (device.Name != null && device.Name.Contains("bluez", StringComparison.OrdinalIgnoreCase))
+                    return device;
+            }
+
+            // Strategy 2: Match by connected device name
+            foreach (var device in devices)
+            {
+                if (device.Name != null && device.Name.Contains(connectedName, StringComparison.OrdinalIgnoreCase))
+                    return device;
+            }
+
+            // Strategy 3: Match by "bluetooth" keyword
+            foreach (var device in devices)
+            {
+                if (device.Name != null && device.Name.Contains("bluetooth", StringComparison.OrdinalIgnoreCase))
+                    return device;
+            }
+
             return null;
         }
 


### PR DESCRIPTION
## Summary
- API process crashes silently on Pi when phone connects via Bluetooth
- Root cause: 3 concurrent `DeviceConnected` events each call `GetAudioCaptureDeviceAsync`, which creates `new MiniAudioEngine()` — concurrent native audio context init crashes the process

## Fix
- Added `SemaphoreSlim(1,1)` to `GetAudioCaptureDeviceAsync` — only one capture search runs at a time, duplicates return immediately
- Increased polling to 20 attempts at 1s intervals (20s total) since PipeWire needs time after A2DP authorization to create the `bluez_sink` capture device
- Extracted `FindBluetoothCaptureDevice` helper and `SearchForCaptureDeviceAsync` for clarity

## Test plan
- [x] Build: 0 warnings
- [x] 15 Bluetooth tests pass
- [ ] Deploy to Pi: process should not crash when phone connects
- [ ] Verify capture device polling continues for 20s after connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)