### PR TITLE
fix: Metrics flush crash from transaction/connection mismatch

### DIFF
--- a/src/Radio.Infrastructure/Metrics/Data/MetricsDbContext.cs
+++ b/src/Radio.Infrastructure/Metrics/Data/MetricsDbContext.cs
@@ -120,6 +120,7 @@ public sealed class MetricsDbContext : IAsyncDisposable
     string key,
     int type,
     string? unit,
+    SqliteTransaction? transaction = null,
     CancellationToken ct = default)
   {
     // Check cache first
@@ -130,6 +131,7 @@ public sealed class MetricsDbContext : IAsyncDisposable
 
     // Query database
     await using var cmd = Connection.CreateCommand();
+    cmd.Transaction = transaction;
     cmd.CommandText = "SELECT Id FROM MetricDefinitions WHERE Key = @Key";
     cmd.Parameters.AddWithValue("@Key", key);
 

--- a/src/Radio.Infrastructure/Metrics/Repositories/SqliteMetricsRepository.cs
+++ b/src/Radio.Infrastructure/Metrics/Repositories/SqliteMetricsRepository.cs
@@ -42,12 +42,6 @@ public sealed class SqliteMetricsRepository : IMetricsReader
       return;
     }
 
-    var metricId = await _dbContext.GetOrCreateMetricDefinitionIdAsync(
-      key,
-      (int)metricType,
-      unit,
-      ct);
-
     var tableName = resolution switch
     {
       MetricResolution.Minute => "MetricData_Minute",
@@ -95,6 +89,18 @@ public sealed class SqliteMetricsRepository : IMetricsReader
 
       try
       {
+        // Resolve metric definition inside the transaction lock and pass the
+        // transaction so the command is associated with the same connection/
+        // transaction pair.  Previously this was called outside the lock, which
+        // caused "transaction not associated with this command" errors when a
+        // concurrent flush had already begun a transaction on the shared
+        // connection.
+        var metricId = await _dbContext.GetOrCreateMetricDefinitionIdAsync(
+          key,
+          (int)metricType,
+          unit,
+          transaction,
+          ct);
         foreach (var bucket in buckets)
         {
           await using var cmd = _dbContext.Connection.CreateCommand();

--- a/tests/Radio.Infrastructure.Tests/Metrics/MetricsDbContextTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Metrics/MetricsDbContextTests.cs
@@ -67,7 +67,7 @@ public class MetricsDbContextTests : IAsyncLifetime
       "test.counter",
       0,
       "count",
-      CancellationToken.None);
+      ct: CancellationToken.None);
 
     // Assert
     Assert.True(id > 0);
@@ -82,14 +82,14 @@ public class MetricsDbContextTests : IAsyncLifetime
       key,
       1,
       "MB",
-      CancellationToken.None);
+      ct: CancellationToken.None);
 
     // Act
     var id2 = await _dbContext.GetOrCreateMetricDefinitionIdAsync(
       key,
       1,
       "MB",
-      CancellationToken.None);
+      ct: CancellationToken.None);
 
     // Assert
     Assert.Equal(id1, id2);


### PR DESCRIPTION
## Summary
- `GetOrCreateMetricDefinitionIdAsync` was called **outside** the transaction lock in `SaveBucketsAsync`, so its `SqliteCommand` had no transaction attached
- When a concurrent flush had already begun a transaction on the shared connection, SQLite threw `"The transaction object is not associated with the same connection object as this command"`
- Fix: moved the call **inside** the lock after `BeginTransactionAsync` and passes the transaction object so the command is properly associated

## Test plan
- [ ] Deploy to Pi, run for 30+ seconds with metrics enabled — verify no "Error flushing metrics" in logs
- [ ] Existing MetricsDbContext unit tests pass (updated call sites for new parameter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)