### PR TITLE
fix: Cast audio stops immediately — add reader lag and reduce tap latency

### DIFF
--- a/src/Radio.Infrastructure/Audio/Outputs/HttpStreamOutput.cs
+++ b/src/Radio.Infrastructure/Audio/Outputs/HttpStreamOutput.cs
@@ -394,11 +394,14 @@ public class HttpStreamOutput : AudioOutputBase
       try
       {
         // Create an independent stream reader for this client so multiple
-        // clients (and fingerprinting) don't compete for the same read position
+        // clients (and fingerprinting) don't compete for the same read position.
+        // The reader starts with a 1-second lag behind the write position,
+        // giving Cast devices an immediate burst of audio data.
         using var audioStream = _audioEngine.CreateStreamReader($"http-client-{clientId}");
         var buffer = new byte[_options.ClientBufferSize];
         var firstDataSent = false;
         var zeroBytesSince = DateTime.UtcNow;
+        var consecutiveZeroReads = 0;
 
         while (!cancellationToken.IsCancellationRequested && client.IsConnected)
         {
@@ -406,6 +409,7 @@ public class HttpStreamOutput : AudioOutputBase
 
           if (bytesRead == 0)
           {
+            consecutiveZeroReads++;
             // Warn if no data for > 5 seconds (throttled to every 5s)
             var now = DateTime.UtcNow;
             if ((now - zeroBytesSince).TotalSeconds > 5 &&
@@ -420,6 +424,7 @@ public class HttpStreamOutput : AudioOutputBase
             continue;
           }
 
+          consecutiveZeroReads = 0;
           zeroBytesSince = DateTime.UtcNow;
 
           if (!firstDataSent)
@@ -452,11 +457,13 @@ public class HttpStreamOutput : AudioOutputBase
           catch (HttpListenerException)
           {
             // Client disconnected
+            _logger.LogDebug("HttpStream: Client {ClientId} disconnected (HttpListenerException)", clientId);
             break;
           }
-          catch (InvalidOperationException)
+          catch (InvalidOperationException ex)
           {
             // Output stream closed or encoder disposed — Cast client disconnected mid-encode
+            _logger.LogDebug(ex, "HttpStream: Output stream closed for client {ClientId}", clientId);
             break;
           }
         }

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
@@ -199,8 +199,10 @@ public class SoundFlowAudioEngine : IAudioEngine
         _playbackDevice.MasterMixer.AddModifier(_balanceModifier);
         _logger.LogInformation("Balance modifier added to MasterMixer");
 
-        // Add fingerprint tap modifier after balance
-        _fingerprintTap = new FingerprintTapModifier(this, _logger, metricsCollector: _metricsCollector);
+        // Add fingerprint tap modifier after balance.
+        // Use 2048-sample buffer (~21ms at 48kHz stereo) instead of default 4096 (~42ms)
+        // to reduce latency for HTTP streaming to Cast devices.
+        _fingerprintTap = new FingerprintTapModifier(this, _logger, bufferSize: 2048, metricsCollector: _metricsCollector);
         _playbackDevice.MasterMixer.AddModifier(_fingerprintTap);
         _logger.LogInformation("Fingerprint tap modifier added to MasterMixer");
 
@@ -341,7 +343,12 @@ public class SoundFlowAudioEngine : IAudioEngine
         "Audio engine not initialized. Call InitializeAsync first.");
     }
 
-    return _outputTap.CreateReader(readerId);
+    // Start the reader 1 second behind the write position so Cast/HTTP clients
+    // get an immediate burst of audio data instead of waiting for new writes.
+    // Without this lag, Cast devices timeout before the first FingerprintTapModifier
+    // batch arrives (~42ms) and the LAME encoder produces its first MP3 frames.
+    var lagBytes = _options.SampleRate * _options.Channels * 2; // 1 second of 16-bit PCM
+    return _outputTap.CreateReader(readerId, lagBytes);
   }
 
   /// <summary>

--- a/src/Radio.Infrastructure/Audio/SoundFlow/TappedOutputStream.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/TappedOutputStream.cs
@@ -97,13 +97,27 @@ internal sealed class TappedOutputStream : Stream
   /// Each reader receives all data written after creation, independent of other readers.
   /// </summary>
   /// <param name="readerId">A unique identifier for this reader.</param>
+  /// <param name="lagBytes">Number of bytes to start behind the write position,
+  /// giving the reader immediate access to recently written audio data.
+  /// Clamped to the lesser of total bytes written and buffer capacity.
+  /// Use 0 (default) for real-time only (no historical data).</param>
   /// <returns>A <see cref="TappedOutputStreamReader"/> with an independent read position.</returns>
-  public TappedOutputStreamReader CreateReader(string readerId)
+  public TappedOutputStreamReader CreateReader(string readerId, int lagBytes = 0)
   {
     lock (_lock)
     {
-      // Start reading from current write position (only new data)
-      _readerPositions[readerId] = _writePosition;
+      if (lagBytes > 0)
+      {
+        // Clamp lag to what's actually available in the ring buffer
+        var maxLag = (int)Math.Min(_totalBytesWritten, _bufferSize - 1);
+        var actualLag = Math.Min(lagBytes, maxLag);
+        _readerPositions[readerId] = (_writePosition - actualLag + _bufferSize) % _bufferSize;
+      }
+      else
+      {
+        // Start reading from current write position (only new data)
+        _readerPositions[readerId] = _writePosition;
+      }
     }
     return new TappedOutputStreamReader(this, readerId);
   }

--- a/tests/Radio.Infrastructure.Tests/Audio/TappedOutputStreamTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/TappedOutputStreamTests.cs
@@ -44,11 +44,11 @@ public class TappedOutputStreamTests
     return (int)method.Invoke(stream, [readerId])!;
   }
 
-  private static Stream CreateReader(Stream stream, string readerId)
+  private static Stream CreateReader(Stream stream, string readerId, int lagBytes = 0)
   {
     var type = stream.GetType();
     var method = type.GetMethod("CreateReader")!;
-    return (Stream)method.Invoke(stream, [readerId])!;
+    return (Stream)method.Invoke(stream, [readerId, lagBytes])!;
   }
 
   private static int GetSampleRate(Stream stream)
@@ -354,7 +354,7 @@ public class TappedOutputStreamTests
     var samplesBeforeReader = new float[] { 1.0f, -1.0f };
     InvokeWriteFromEngine(stream, samplesBeforeReader);
 
-    // Create reader AFTER data was written
+    // Create reader AFTER data was written (no lag)
     var reader = CreateReader(stream, "late-reader");
 
     // Write new data
@@ -367,5 +367,66 @@ public class TappedOutputStreamTests
 
     // Assert - only gets data written after reader was created
     Assert.Equal(2, bytesRead); // 1 sample * 2 bytes
+  }
+
+  [Fact]
+  public void Reader_WithLag_GetsHistoricalData()
+  {
+    // Arrange
+    var stream = CreateTappedOutputStream(1000, 1, 1); // 1kHz, mono, 1s buffer = 2000 bytes
+    var samples = new float[100]; // 200 bytes of PCM
+    for (var i = 0; i < samples.Length; i++)
+      samples[i] = 0.5f;
+    InvokeWriteFromEngine(stream, samples);
+
+    // Create reader with 100-byte lag — should start behind write position
+    var reader = CreateReader(stream, "lag-reader", lagBytes: 100);
+
+    // Act
+    var buffer = new byte[200];
+    var bytesRead = reader.Read(buffer, 0, buffer.Length);
+
+    // Assert — reader should get 100 bytes of historical data immediately
+    Assert.Equal(100, bytesRead);
+  }
+
+  [Fact]
+  public void Reader_WithLag_ClampedToTotalBytesWritten()
+  {
+    // Arrange
+    var stream = CreateTappedOutputStream(1000, 1, 1);
+    var samples = new float[10]; // 20 bytes of PCM
+    for (var i = 0; i < samples.Length; i++)
+      samples[i] = 0.5f;
+    InvokeWriteFromEngine(stream, samples);
+
+    // Create reader requesting more lag than what's been written
+    var reader = CreateReader(stream, "lag-reader", lagBytes: 1000);
+
+    // Act
+    var buffer = new byte[200];
+    var bytesRead = reader.Read(buffer, 0, buffer.Length);
+
+    // Assert — lag clamped to 20 bytes (total written)
+    Assert.Equal(20, bytesRead);
+  }
+
+  [Fact]
+  public void Reader_WithZeroLag_BehavesLikeDefault()
+  {
+    // Arrange
+    var stream = CreateTappedOutputStream();
+    var samplesBeforeReader = new float[] { 1.0f, -1.0f };
+    InvokeWriteFromEngine(stream, samplesBeforeReader);
+
+    // Create reader with explicit zero lag
+    var reader = CreateReader(stream, "no-lag-reader", lagBytes: 0);
+
+    // Act
+    var buffer = new byte[10];
+    var bytesRead = reader.Read(buffer, 0, buffer.Length);
+
+    // Assert — no historical data, same as default
+    Assert.Equal(0, bytesRead);
   }
 }


### PR DESCRIPTION
## Summary
- Cast devices hear a few milliseconds of audio then silence because the HTTP stream reader starts at the write position with no buffered data — by the time the first FingerprintTapModifier batch arrives (~42ms), Cast has already timed out
- `TappedOutputStream.CreateReader` now supports a `lagBytes` parameter to start readers behind the write position, giving immediate access to recently written audio
- `SoundFlowAudioEngine` uses a 1-second lag for HTTP stream readers so Cast gets an instant burst of audio data on connection
- `FingerprintTapModifier` buffer reduced from 4096 to 2048 samples (~21ms vs ~42ms) for lower streaming latency
- Added debug logging for LAME encoder disconnects

## Root Cause
Pi logs showed `InvalidOperationException: Output stream closed` at `LameMP3FileWriter.Flush()` — Cast connected, got nothing (reader at write position = 0 available bytes), timed out, and disconnected. Our Flush then failed because the HTTP response stream was already closed.

## Test plan
- [x] Build passes (0 warnings)
- [x] All 692 Infrastructure tests pass (including 3 new lag tests)
- [ ] Deploy to Pi and test Cast audio with file player
- [ ] Test Cast audio with BT source
- [ ] Verify local playback unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)