### PR TITLE
fix: Declare custom namespace in CastReceiverOptions for CAF v3

### DIFF
--- a/docs/receiver-direct-channel.html
+++ b/docs/receiver-direct-channel.html
@@ -65,6 +65,12 @@
     const options = new cast.framework.CastReceiverOptions();
     options.disableIdleTimeout = true;
 
+    // CRITICAL: Declare custom namespaces in options. CAF v3 requires explicit
+    // namespace registration — without this, addCustomMessageListener silently
+    // receives nothing because the framework drops messages on unknown namespaces.
+    options.customNamespaces = {};
+    options.customNamespaces[NAMESPACE] = cast.framework.system.MessageType.JSON;
+
     // Listen for audio chunks on our custom namespace
     context.addCustomMessageListener(NAMESPACE, (event) => {
       const msg = event.data;


### PR DESCRIPTION
## Summary
- CAF v3 requires custom namespaces in `CastReceiverOptions.customNamespaces`
- Without this, `addCustomMessageListener` silently receives nothing
- Also includes test tone diagnostic from previous commit

## Test plan
- [ ] Reconnect to Cast device
- [ ] Listen for 440Hz test tone on startup
- [ ] Verify audio chunks play through speaker

🤖 Generated with [Claude Code](https://claude.com/claude-code)