### PR TITLE
feat: Add latency measurement to DirectChannel Cast streaming

### DIFF
--- a/docs/receiver-direct-channel.html
+++ b/docs/receiver-direct-channel.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!--
-  Direct Channel Cast Receiver for Radio Console (v8 — Raw PCM)
-  ==============================================================
+  Direct Channel Cast Receiver for Radio Console (v9 — Raw PCM + Latency)
+  ========================================================================
   Custom CAF receiver that receives raw PCM audio data directly over the
   Cast protocol's custom message bus and plays it using Web Audio API.
 
@@ -10,13 +10,13 @@
   - v6 Data URI: PlayerManager reports PLAYING but video element stays paused
   - v7 Web Audio + MP3: Works! But audible gaps at chunk boundaries due to
     MP3 encoder/decoder warmup delay per-chunk
+  - v8 Raw PCM: Works great! Zero encode/decode overhead.
 
-  v8 strategy: send raw Int16LE PCM, no encoding at all.
-  1. Sender reads 48kHz/16-bit/stereo PCM from the audio engine ring buffer
-  2. Sender Base64-encodes raw PCM bytes (no MP3 encoding)
-  3. Receiver decodes Base64, converts Int16LE → Float32 in JS
-  4. Creates AudioBuffer directly and schedules via AudioBufferSourceNode
-  5. Zero encode/decode overhead = zero gaps at chunk boundaries
+  v9 additions: Latency measurement support.
+  - Sender includes `ts` (Unix epoch ms) in each audio message
+  - Receiver tracks transit delay (Date.now() - msg.ts) and schedule-ahead time
+  - Ping/pong includes latency stats and supports RTT calculation
+  - All v8 audio functionality unchanged
 -->
 <html>
 <head>
@@ -28,7 +28,7 @@
   <cast-media-player></cast-media-player>
 
   <div id="status" style="color: #ccc; font-family: monospace; padding: 20px; position: absolute; top: 0; left: 0; z-index: 100;">
-    Radio Console — Direct Channel Receiver v8 (Raw PCM)<br>
+    Radio Console — Direct Channel Receiver v9 (Raw PCM + Latency)<br>
     <span id="info">Initializing...</span>
   </div>
 
@@ -59,6 +59,20 @@
     let decodeErrors = 0;
     let pendingChunks = [];
 
+    // --- Latency tracking ---
+    // transitDelay = Date.now() - msg.ts (subject to clock skew between sender/receiver)
+    // bufferAhead = nextPlayTime - audioCtx.currentTime (local, no skew)
+    // totalLatency ≈ transitDelay + bufferAhead (estimated end-to-end)
+    let latencySum = 0;         // Sum of transit delays (ms)
+    let latencyCount = 0;       // Number of samples
+    let latencyMin = Infinity;
+    let latencyMax = -Infinity;
+    let lastTransitDelay = 0;
+    let firstChunkReceiveTime = 0;  // Wall clock when first chunk arrived
+    let firstChunkPlayTime = 0;     // audioCtx time when first chunk was scheduled
+    // AudioContext start offset: maps audioCtx.currentTime=0 to a wall clock time
+    let audioCtxStartWallTime = 0;
+
     /**
      * Ensures AudioContext is initialized.
      */
@@ -68,6 +82,8 @@
         audioCtx = new (window.AudioContext || window.webkitAudioContext)({
           sampleRate: pcmSampleRate
         });
+        // Map audioCtx.currentTime=0 to wall clock for latency calculation
+        audioCtxStartWallTime = Date.now() - (audioCtx.currentTime * 1000);
         console.log('AudioContext created, sampleRate:', audioCtx.sampleRate, 'state:', audioCtx.state);
 
         if (audioCtx.state === 'suspended') {
@@ -180,6 +196,7 @@
       const msg = event.data;
 
       if (msg.type === 'audio' && msg.data) {
+        const receiveTime = Date.now();
         chunksReceived++;
         bytesReceived += atob(msg.data).length;
 
@@ -187,17 +204,32 @@
         if (msg.sr) pcmSampleRate = msg.sr;
         if (msg.ch) pcmChannels = msg.ch;
 
+        // Track latency from sender timestamp
+        if (msg.ts) {
+          const transitDelay = receiveTime - msg.ts;
+          lastTransitDelay = transitDelay;
+          latencySum += transitDelay;
+          latencyCount++;
+          if (transitDelay < latencyMin) latencyMin = transitDelay;
+          if (transitDelay > latencyMax) latencyMax = transitDelay;
+        }
+
+        if (chunksReceived === 1) {
+          firstChunkReceiveTime = receiveTime;
+        }
+
         // Sequence gap detection
         if (lastSeq >= 0 && msg.seq !== lastSeq + 1) {
           console.warn('Sequence gap: expected ' + (lastSeq + 1) + ', got ' + msg.seq);
         }
         lastSeq = msg.seq;
 
-        // Log first few chunks
+        // Log first few chunks with latency info
         if (chunksReceived <= 3) {
           const dataLen = atob(msg.data).length;
+          const transitInfo = msg.ts ? ', transit: ' + (receiveTime - msg.ts) + 'ms' : '';
           console.log('Chunk ' + msg.seq + ': ' + dataLen + ' bytes ' +
-            (msg.fmt || 'unknown') + ' (' + pcmSampleRate + 'Hz, ' + pcmChannels + 'ch)');
+            (msg.fmt || 'unknown') + ' (' + pcmSampleRate + 'Hz, ' + pcmChannels + 'ch)' + transitInfo);
         }
 
         if (!isPlaying && pendingChunks !== null) {
@@ -213,13 +245,17 @@
           scheduleChunk(msg.data);
         }
 
-        // Periodic stats
+        // Periodic stats with latency
         if (chunksReceived % 100 === 0) {
           const bufferAhead = audioCtx ? (nextPlayTime - audioCtx.currentTime) : 0;
+          const avgTransit = latencyCount > 0 ? (latencySum / latencyCount).toFixed(0) : '?';
           console.log('Stats: ' + chunksReceived + ' received, ' +
             chunksScheduled + ' scheduled, ' +
             (bytesReceived / 1024).toFixed(0) + 'KB, ' +
-            'buffer: ' + bufferAhead.toFixed(2) + 's, errors: ' + decodeErrors);
+            'buffer: ' + bufferAhead.toFixed(2) + 's, errors: ' + decodeErrors +
+            ', transit avg/min/max: ' + avgTransit + '/' +
+            (latencyMin === Infinity ? '?' : latencyMin) + '/' +
+            (latencyMax === -Infinity ? '?' : latencyMax) + 'ms');
         }
 
       } else if (msg.type === 'stop') {
@@ -236,13 +272,22 @@
         bytesReceived = 0;
         lastSeq = -1;
         decodeErrors = 0;
+        latencySum = 0;
+        latencyCount = 0;
+        latencyMin = Infinity;
+        latencyMax = -Infinity;
+        lastTransitDelay = 0;
+        firstChunkReceiveTime = 0;
+        firstChunkPlayTime = 0;
         updateStatus('Stopped — ready for new stream');
 
       } else if (msg.type === 'ping') {
+        const now = Date.now();
         const bufferAhead = audioCtx ? (nextPlayTime - audioCtx.currentTime) : 0;
+        const avgTransit = latencyCount > 0 ? Math.round(latencySum / latencyCount) : null;
         context.sendCustomMessage(NAMESPACE, event.senderId, {
           type: 'pong',
-          version: 8,
+          version: 9,
           chunksReceived,
           bytesReceived,
           chunksScheduled,
@@ -250,7 +295,23 @@
           isPlaying,
           bufferAhead: bufferAhead.toFixed(2),
           audioCtxState: audioCtx ? audioCtx.state : 'none',
-          audioCtxTime: audioCtx ? audioCtx.currentTime.toFixed(2) : '0'
+          audioCtxTime: audioCtx ? audioCtx.currentTime.toFixed(2) : '0',
+          // Latency metrics
+          latency: {
+            transitAvgMs: avgTransit,
+            transitMinMs: latencyMin === Infinity ? null : latencyMin,
+            transitMaxMs: latencyMax === -Infinity ? null : latencyMax,
+            lastTransitMs: lastTransitDelay,
+            bufferAheadMs: Math.round(bufferAhead * 1000),
+            samples: latencyCount,
+            // Estimated total pipeline latency:
+            // transit (sender→receiver) + buffer ahead (schedule→play)
+            estimatedTotalMs: avgTransit !== null
+              ? avgTransit + Math.round(bufferAhead * 1000) : null
+          },
+          // Echo back sender's timestamp for RTT calculation
+          pingTs: msg.ts || null,
+          pongTs: now
         });
       }
     });
@@ -267,7 +328,7 @@
     options.customNamespaces[NAMESPACE] = cast.framework.system.MessageType.JSON;
 
     context.start(options);
-    console.log('Direct Channel receiver v8 (Raw PCM) started, listening on', NAMESPACE);
+    console.log('Direct Channel receiver v9 (Raw PCM + Latency) started, listening on', NAMESPACE);
     updateStatus('Waiting for audio chunks...');
   </script>
 </body>

--- a/src/Radio.API/Controllers/DevicesController.cs
+++ b/src/Radio.API/Controllers/DevicesController.cs
@@ -382,6 +382,16 @@ public class DevicesController : ControllerBase
       {
         state = _castOutput?.State.ToString(),
         connectedDevice = _castOutput?.ConnectedDevice?.FriendlyName,
+        directChannel = _castOutput?.DirectStreaming != null ? new
+        {
+          isStreaming = _castOutput.DirectStreaming.IsStreaming,
+          totalChunksSent = _castOutput.DirectStreaming.TotalChunksSent,
+          totalBytesSent = _castOutput.DirectStreaming.TotalBytesSent,
+          sendErrors = _castOutput.DirectStreaming.SendErrors,
+          lastChunkTime = _castOutput.DirectStreaming.LastChunkTime,
+          lastRttMs = _castOutput.DirectStreaming.LastRttMs,
+          lastPongJson = _castOutput.DirectStreaming.LastPongJson,
+        } : null,
       },
       engine = new
       {

--- a/src/Radio.Infrastructure/Audio/Outputs/DirectCastStreamingService.cs
+++ b/src/Radio.Infrastructure/Audio/Outputs/DirectCastStreamingService.cs
@@ -55,6 +55,11 @@ public sealed class DirectCastStreamingService : IAsyncDisposable
   private DateTime _lastChunkTime;
   private bool _lastChunkWasSilence = true;
 
+  // Latency measurement
+  private long _lastPingSentMs;
+  private long _lastRttMs;
+  private string? _lastPongJson;
+
   /// <summary>
   /// Gets the total number of audio chunks sent to the Cast device.
   /// </summary>
@@ -108,6 +113,59 @@ public sealed class DirectCastStreamingService : IAsyncDisposable
   {
     _transportId = transportId;
     _logger.LogInformation("DirectCast: Transport ID set to {TransportId}", transportId);
+  }
+
+  /// <summary>
+  /// Sends a ping to the receiver to measure round-trip time and collect latency stats.
+  /// The receiver replies with a pong containing latency metrics.
+  /// </summary>
+  /// <returns>True if the ping was sent successfully.</returns>
+  public async Task<bool> SendPingAsync()
+  {
+    if (string.IsNullOrEmpty(_transportId))
+      return false;
+
+    try
+    {
+      _lastPingSentMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+      var message = JsonSerializer.Serialize(new
+      {
+        type = "ping",
+        ts = _lastPingSentMs
+      });
+      await _channel.SendMessageAsync(message, _transportId);
+      return true;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "DirectCast: Failed to send ping");
+      return false;
+    }
+  }
+
+  /// <summary>
+  /// Gets the last round-trip time from a ping/pong exchange.
+  /// </summary>
+  public long LastRttMs => _lastRttMs;
+
+  /// <summary>
+  /// Gets the last raw pong JSON for inspection.
+  /// </summary>
+  public string? LastPongJson => _lastPongJson;
+
+  /// <summary>
+  /// Called when a pong message is received from the receiver.
+  /// </summary>
+  internal void HandlePong(string pongJson)
+  {
+    _lastPongJson = pongJson;
+    var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+    if (_lastPingSentMs > 0)
+    {
+      _lastRttMs = now - _lastPingSentMs;
+      _logger.LogInformation("DirectCast: Pong received — RTT {Rtt}ms, payload: {Pong}",
+        _lastRttMs, pongJson);
+    }
   }
 
   /// <summary>
@@ -314,7 +372,8 @@ public sealed class DirectCastStreamingService : IAsyncDisposable
           seq,
           fmt = "pcm",
           sr = sampleRate,
-          ch = channels
+          ch = channels,
+          ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
         });
 
         // Send over the Cast channel

--- a/src/Radio.Infrastructure/Audio/Outputs/GoogleCastOutput.cs
+++ b/src/Radio.Infrastructure/Audio/Outputs/GoogleCastOutput.cs
@@ -542,13 +542,15 @@ public class GoogleCastOutput : AudioOutputBase
 
     try
     {
+      var startTimer = System.Diagnostics.Stopwatch.StartNew();
       _logger.LogInformation("Starting Google Cast output (mode: {Mode})", _options.StreamingMode);
 
       if (_client != null)
       {
         // Launch the receiver application (default CC1AD845 or custom receiver)
         var launchStatus = await _client.LaunchApplicationAsync(_options.ApplicationId);
-        _logger.LogInformation("Cast: Receiver launched on {Device}", ConnectedDevice?.FriendlyName);
+        _logger.LogInformation("Cast: Receiver launched on {Device} ({LaunchMs}ms)",
+          ConnectedDevice?.FriendlyName, startTimer.ElapsedMilliseconds);
 
         // Allow receiver to start initializing before sending commands
         await Task.Delay(250, cancellationToken);
@@ -567,8 +569,8 @@ public class GoogleCastOutput : AudioOutputBase
       IsEnabledInternal = true;
       State = AudioOutputState.Streaming;
 
-      _logger.LogInformation("Google Cast output started streaming to {Name} (mode: {Mode})",
-        ConnectedDevice?.FriendlyName, _options.StreamingMode);
+      _logger.LogInformation("Google Cast output started streaming to {Name} (mode: {Mode}, setupMs: {SetupMs})",
+        ConnectedDevice?.FriendlyName, _options.StreamingMode, startTimer.ElapsedMilliseconds);
     }
     catch (Exception ex)
     {
@@ -756,6 +758,12 @@ public class GoogleCastOutput : AudioOutputBase
     _streamUrl = streamUrl;
     _logger.LogDebug("Stream URL set to: {Url}", streamUrl);
   }
+
+  /// <summary>
+  /// Gets the active DirectChannel streaming service, if any.
+  /// Used for diagnostics and latency measurement.
+  /// </summary>
+  public DirectCastStreamingService? DirectStreaming => _directStreaming;
 
   /// <summary>
   /// Sets the audio engine reference for DirectChannel streaming mode.


### PR DESCRIPTION
## Summary
- Add Unix timestamp (`ts`) to DirectChannel audio messages for transit delay measurement
- Receiver v9 tracks transit avg/min/max, buffer-ahead, and estimated total pipeline latency
- Enhanced ping/pong with latency metrics and RTT calculation support
- Stopwatch timing on `GoogleCastOutput.StartAsync` for setup duration logging
- Expose DirectChannel stats in `/api/devices/cast/diagnostics` endpoint

## Test plan
- [ ] Deploy to Ubuntu server with DirectChannel mode
- [ ] Verify receiver v9 loads on Cast device
- [ ] Check latency stats via CDP console and `/api/devices/cast/diagnostics`
- [ ] Compare with HttpMp3 mode latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)