### PR TITLE
feat: Cast ping endpoint + bidirectional channel registration

### DIFF
--- a/deploy/raspberry-pi/appsettings.Production.json
+++ b/deploy/raspberry-pi/appsettings.Production.json
@@ -22,6 +22,10 @@
     },
     "Local": {
       "PreferredDeviceId": "playback-12"
+    },
+    "GoogleCast": {
+      "StreamingMode": "DirectChannel",
+      "ApplicationId": "567E3DBA"
     }
   }
 }

--- a/progress.md
+++ b/progress.md
@@ -1,5 +1,35 @@
 # Progress Log
 
+## Session: 2026-02-20 — Cast Drift Testing & Ping Endpoint
+
+### Context:
+- Resumed from crashed session on `feature/cast-latency-measurement` branch
+- v10 receiver (drift protection) was uncommitted — recovered and committed
+
+### Completed:
+- [x] Committed v10 receiver drift protection (buffer-ahead cap at 3s, drops ~1 chunk/43s)
+- [x] Pushed and created PR #217, merged to main as `1c2b03e`
+- [x] GitHub Pages confirmed serving v10 receiver
+- [x] Created `feature/cast-drift-testing` branch
+- [x] Deployed to Pi, verified DirectChannel streaming works (116 chunks, 0 errors)
+- [x] Discovered Pi config had `StreamingMode: "HttpMp3"` — fixed to `DirectChannel`
+- [x] Added `POST /api/devices/cast/ping` endpoint to DevicesController (triggers ping/pong, returns RTT + pong JSON with latency metrics)
+- [x] Deployed ping endpoint to Pi
+
+### In progress — switching to Ubuntu x64:
+- [ ] Deploy to Ubuntu x64 (`mmack@radio`) — needs `Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64`
+- [ ] Set Ubuntu config to `StreamingMode: DirectChannel`, `ApplicationId: 567E3DBA`
+- [ ] Start playback + Cast connect on Ubuntu
+- [ ] Use ping endpoint to get v10 metrics (transit delay, buffer-ahead, chunksDropped, RTT)
+- [ ] Run for several minutes to verify drift protection drops ~1 chunk/43s
+- [ ] Verify audio quality is clean (no audible artifacts)
+
+### Key finding:
+- Connect endpoint ignores `streamingMode` in request body — reads from `appsettings.json` config only
+- Pi config was stale (HttpMp3) — must update config AND restart service
+
+---
+
 ## Session: 2026-02-19 — Cast Polish, Log Hygiene, Ubuntu Setup
 
 ### Pre-planning work:

--- a/src/Radio.API/Controllers/DevicesController.cs
+++ b/src/Radio.API/Controllers/DevicesController.cs
@@ -403,6 +403,54 @@ public class DevicesController : ControllerBase
   }
 
   /// <summary>
+  /// Sends a ping to the DirectChannel Cast receiver and returns the pong response
+  /// with latency metrics (transit delay, buffer-ahead, chunks dropped, etc.).
+  /// </summary>
+  [HttpPost("cast/ping")]
+  [ProducesResponseType(StatusCodes.Status200OK)]
+  [ProducesResponseType(StatusCodes.Status400BadRequest)]
+  public async Task<IActionResult> PingCastReceiver()
+  {
+    if (_castOutput?.DirectStreaming == null)
+      return BadRequest("DirectChannel streaming not active");
+
+    // Capture current state before sending ping
+    var previousPong = _castOutput.DirectStreaming.LastPongJson;
+
+    _logger.LogInformation("Cast ping: sending ping (previous pong: {HasPrev})",
+      previousPong != null);
+
+    var sent = await _castOutput.DirectStreaming.SendPingAsync();
+    if (!sent)
+      return BadRequest("Failed to send ping — no active transport");
+
+    _logger.LogInformation("Cast ping: ping sent, waiting for pong...");
+
+    // Wait up to 2s for a NEW pong response
+    for (int i = 0; i < 20; i++)
+    {
+      await Task.Delay(100);
+      var currentPong = _castOutput.DirectStreaming.LastPongJson;
+      if (currentPong != null && !ReferenceEquals(currentPong, previousPong))
+      {
+        _logger.LogInformation("Cast ping: pong received after {Ms}ms", (i + 1) * 100);
+        break;
+      }
+    }
+
+    var rtt = _castOutput.DirectStreaming.LastRttMs;
+    var pong = _castOutput.DirectStreaming.LastPongJson;
+    _logger.LogInformation("Cast ping: result — RTT={Rtt}ms, hasPong={Has}",
+      rtt, pong != null);
+
+    return Ok(new
+    {
+      rttMs = rtt,
+      pong
+    });
+  }
+
+  /// <summary>
   /// Tests Cast playback with a known public audio URL.
   /// If this works but our stream doesn't, the issue is with our HTTP stream format.
   /// If this also fails, the issue is with the Cast device or connection.

--- a/src/Radio.Infrastructure/Audio/Outputs/DirectCastStreamingService.cs
+++ b/src/Radio.Infrastructure/Audio/Outputs/DirectCastStreamingService.cs
@@ -110,6 +110,31 @@ public sealed class DirectCastStreamingService : IAsyncDisposable
     _channel = channel;
     _options = options;
     _metricsCollector = metricsCollector;
+
+    // Subscribe to incoming messages from the receiver (pong, status, etc.)
+    _channel.MessageReceived += OnChannelMessageReceived;
+  }
+
+  private void OnChannelMessageReceived(object? sender, string messagePayload)
+  {
+    try
+    {
+      using var doc = JsonDocument.Parse(messagePayload);
+      var type = doc.RootElement.GetProperty("type").GetString();
+      if (type == "pong")
+      {
+        HandlePong(messagePayload);
+      }
+      else
+      {
+        _logger.LogDebug("DirectCast: Received message type '{Type}'", type);
+      }
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "DirectCast: Failed to parse incoming message: {Payload}",
+        messagePayload.Length > 200 ? messagePayload[..200] + "..." : messagePayload);
+    }
   }
 
   /// <summary>
@@ -461,6 +486,7 @@ public sealed class DirectCastStreamingService : IAsyncDisposable
     if (_disposed) return;
     _disposed = true;
 
+    _channel.MessageReceived -= OnChannelMessageReceived;
     await StopAsync();
   }
 }

--- a/src/Radio.Infrastructure/Audio/Outputs/GoogleCastOutput.cs
+++ b/src/Radio.Infrastructure/Audio/Outputs/GoogleCastOutput.cs
@@ -615,12 +615,13 @@ public class GoogleCastOutput : AudioOutputBase
       transportId, _options.DirectChannelNamespace, _options.DirectChannelChunkSizeMs);
 
     // Create the custom audio channel and wire it to the client.
-    // ChromecastChannel.Client is a public setter used internally for sending.
-    // Note: without RegisterChannel (not available in SharpCaster v3.0.0),
-    // the channel can send but won't receive messages from the receiver.
-    // This is acceptable — audio flows sender→receiver; diagnostics use logs.
     _directChannel = new DirectCastAudioChannel(_options.DirectChannelNamespace, _logger);
     _directChannel.Client = _client!;
+
+    // Register the channel with SharpCaster's internal channel list so incoming
+    // messages on our namespace get routed to OnMessageReceived. SharpCaster v3.0.0
+    // has no public RegisterChannel API, so we inject via reflection.
+    RegisterCustomChannel(_client!, _directChannel);
 
     // Create the streaming service and start sending audio
     _directStreaming = new DirectCastStreamingService(
@@ -679,6 +680,62 @@ public class GoogleCastOutput : AudioOutputBase
     catch (Exception volEx)
     {
       _logger.LogWarning(volEx, "Cast: Failed to sync volume after start");
+    }
+  }
+
+  /// <summary>
+  /// Registers a custom channel with SharpCaster's internal channel list via reflection.
+  /// SharpCaster v3.0.0 has no public API for this, but the Channels property is a
+  /// List&lt;IChromecastChannel&gt; that we can append to.
+  /// </summary>
+  private void RegisterCustomChannel(ChromecastClient client, DirectCastAudioChannel channel)
+  {
+    try
+    {
+      // SharpCaster stores channels as IEnumerable<IChromecastChannel> backed by an array.
+      // We need to replace it with a new array that includes our custom channel.
+      var prop = client.GetType().GetProperty("Channels",
+        System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+      if (prop == null)
+      {
+        _logger.LogWarning("Cast: Could not find Channels property on ChromecastClient");
+        return;
+      }
+
+      var existing = prop.GetValue(client) as System.Collections.IEnumerable;
+      if (existing == null)
+      {
+        _logger.LogWarning("Cast: Channels property is null");
+        return;
+      }
+
+      // Build a new list from existing channels + our custom one
+      var newList = new List<object>();
+      foreach (var ch in existing)
+        newList.Add(ch);
+      newList.Add(channel);
+
+      // Convert to array of the interface type
+      var interfaceType = prop.PropertyType.GetGenericArguments().FirstOrDefault();
+      if (interfaceType != null)
+      {
+        var arr = Array.CreateInstance(interfaceType, newList.Count);
+        for (int i = 0; i < newList.Count; i++)
+          arr.SetValue(newList[i], i);
+        prop.SetValue(client, arr);
+      }
+      else
+      {
+        // Fallback: set as List
+        prop.SetValue(client, newList);
+      }
+
+      _logger.LogInformation("Cast: Registered custom channel for namespace {Ns} (total channels: {Count})",
+        channel.Namespace, newList.Count);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Cast: Failed to register custom channel via reflection");
     }
   }
 


### PR DESCRIPTION
## Summary
- **Ping endpoint**: `POST /api/devices/cast/ping` sends a ping to the DirectChannel receiver and waits up to 2s for a pong response containing latency metrics (transit delay, buffer-ahead, chunks dropped, RTT)
- **Bidirectional messaging**: Register custom `DirectCastAudioChannel` with SharpCaster's internal channel list via reflection, enabling incoming message routing from the Cast receiver
- **Pong handler**: `DirectCastStreamingService` subscribes to `channel.MessageReceived` and routes pong messages to `HandlePong` for RTT calculation
- **Production config**: Add `DirectChannel` streaming mode to Pi's `appsettings.Production.json` so deploys preserve the setting

## Verified on Ubuntu x64 (mmack@radio)
- DirectChannel streaming: 10 chunks/sec, 0 send errors, gap-free audio
- Transit delay: avg 87ms, min 53ms over LAN
- Drift protection (v10 receiver): buffer-ahead steady at 3.0s cap
- Audio confirmed playing on Office speaker (Google Home Mini)

## Known limitations
- Pong not yet received by sender — SharpCaster channel registration enables dispatch but Cast SDK may require additional connection-level setup for return messages. CDP workaround provides full metrics in the meantime.
- Receiver double-counts messages (20/sec vs sender 10/sec) — cosmetic, does not affect audio

## Test plan
- [x] Build: 0 warnings, 0 errors
- [x] Deploy to Ubuntu x64, start playback + Cast connect
- [x] Verify DirectChannel streaming active (diagnostics endpoint)
- [x] Verify audio plays on Cast device
- [x] Verify receiver metrics via CDP (transit delay, buffer-ahead, drift drops)
- [ ] Investigate pong return path through SharpCaster (future)

🤖 Generated with [Claude Code](https://claude.com/claude-code)