### PR TITLE
refactor: Extract AudioSourceFactory from AudioManager

### DIFF
--- a/src/Radio.Core/Interfaces/Audio/IAudioManager.cs
+++ b/src/Radio.Core/Interfaces/Audio/IAudioManager.cs
@@ -12,11 +12,6 @@ public interface IAudioManager : IAsyncDisposable
   IAudioEngine Engine { get; }
 
   /// <summary>
-  /// Gets the audio device manager.
-  /// </summary>
-  IAudioDeviceManager DeviceManager { get; }
-
-  /// <summary>
   /// Gets the currently active primary audio source.
   /// </summary>
   IAudioSource? ActiveSource { get; }

--- a/src/Radio.Core/Interfaces/Audio/IAudioSourceFactory.cs
+++ b/src/Radio.Core/Interfaces/Audio/IAudioSourceFactory.cs
@@ -1,0 +1,17 @@
+namespace Radio.Core.Interfaces.Audio;
+
+/// <summary>
+/// Factory for creating audio sources by type.
+/// Encapsulates all source-specific dependencies and configuration.
+/// </summary>
+public interface IAudioSourceFactory
+{
+  /// <summary>
+  /// Creates an audio source for the specified type.
+  /// </summary>
+  /// <param name="sourceType">The type of audio source to create.</param>
+  /// <returns>The created audio source.</returns>
+  /// <exception cref="InvalidOperationException">Thrown when the source cannot be created (e.g., missing configuration).</exception>
+  /// <exception cref="ArgumentOutOfRangeException">Thrown when the source type is not supported.</exception>
+  IAudioSource CreateSource(AudioSourceType sourceType);
+}

--- a/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
@@ -8,7 +6,6 @@ using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
-using Radio.Infrastructure.Audio.Sources.Primary;
 using Radio.Infrastructure.Configuration.Abstractions;
 using Radio.Infrastructure.Configuration.Models;
 
@@ -21,28 +18,13 @@ namespace Radio.Infrastructure.Audio.Services;
 public class AudioManager : IAudioManager, IAsyncDisposable
 {
   private readonly ILogger<AudioManager> _logger;
-  private readonly ILoggerFactory _loggerFactory;
   private readonly IAudioEngine _audioEngine;
-  private readonly IAudioDeviceManager _deviceManager;
-  private readonly IRadioFactory _radioFactory;
+  private readonly IAudioSourceFactory _sourceFactory;
   private readonly IBluetoothService _bluetoothService;
   private readonly IOptionsMonitor<BluetoothOptions> _bluetoothOptions;
-
-  // Options for source creation
-  private readonly IOptionsMonitor<FilePlayerOptions> _filePlayerOptions;
-  private readonly IOptionsMonitor<FilePlayerPreferences> _filePlayerPreferences;
-  private readonly IOptionsMonitor<DeviceOptions> _deviceOptions;
-  private readonly IOptionsMonitor<GenericSourcePreferences> _genericSourcePreferences;
   private readonly IOptionsMonitor<AudioPreferences> _audioPreferences;
-  private readonly IConfiguration _configuration;
-
-  // Optional services
   private readonly BackgroundIdentificationService? _identificationService;
-  private readonly IMetricsCollector? _metricsCollector;
   private readonly Configuration.Abstractions.IConfigurationManager? _configurationManager;
-  private readonly SoundFlow.SoundFlowPlaybackService? _playbackService;
-  private readonly IServiceScopeFactory? _serviceScopeFactory;
-  private readonly AlbumArtCacheService? _albumArtCache;
 
   // Play history tracking (extracted to PlayHistoryTracker)
   private readonly PlayHistoryTracker? _playHistoryTracker;
@@ -65,45 +47,23 @@ public class AudioManager : IAudioManager, IAsyncDisposable
   /// </summary>
   public AudioManager(
     ILogger<AudioManager> logger,
-    ILoggerFactory loggerFactory,
     IAudioEngine audioEngine,
-    IAudioDeviceManager deviceManager,
-    IRadioFactory radioFactory,
+    IAudioSourceFactory sourceFactory,
     IBluetoothService bluetoothService,
     IOptionsMonitor<BluetoothOptions> bluetoothOptions,
-    IOptionsMonitor<FilePlayerOptions> filePlayerOptions,
-    IOptionsMonitor<FilePlayerPreferences> filePlayerPreferences,
-    IOptionsMonitor<DeviceOptions> deviceOptions,
-    IOptionsMonitor<GenericSourcePreferences> genericSourcePreferences,
     IOptionsMonitor<AudioPreferences> audioPreferences,
-    IConfiguration configuration,
     BackgroundIdentificationService? identificationService = null,
-    IMetricsCollector? metricsCollector = null,
     Configuration.Abstractions.IConfigurationManager? configurationManager = null,
-    SoundFlow.SoundFlowPlaybackService? playbackService = null,
-    IServiceScopeFactory? serviceScopeFactory = null,
-    AlbumArtCacheService? albumArtCache = null,
     PlayHistoryTracker? playHistoryTracker = null)
   {
     _logger = logger;
-    _loggerFactory = loggerFactory;
     _audioEngine = audioEngine;
-    _deviceManager = deviceManager;
-    _radioFactory = radioFactory;
+    _sourceFactory = sourceFactory;
     _bluetoothService = bluetoothService;
     _bluetoothOptions = bluetoothOptions;
-    _filePlayerOptions = filePlayerOptions;
-    _filePlayerPreferences = filePlayerPreferences;
-    _deviceOptions = deviceOptions;
-    _genericSourcePreferences = genericSourcePreferences;
     _audioPreferences = audioPreferences;
-    _configuration = configuration;
     _identificationService = identificationService;
-    _metricsCollector = metricsCollector;
     _configurationManager = configurationManager;
-    _playbackService = playbackService;
-    _serviceScopeFactory = serviceScopeFactory;
-    _albumArtCache = albumArtCache;
     _playHistoryTracker = playHistoryTracker;
 
     _bluetoothService.DeviceConnected += OnBluetoothDeviceConnected;
@@ -111,9 +71,6 @@ public class AudioManager : IAudioManager, IAsyncDisposable
 
   /// <inheritdoc/>
   public IAudioEngine Engine => _audioEngine;
-
-  /// <inheritdoc/>
-  public IAudioDeviceManager DeviceManager => _deviceManager;
 
   /// <inheritdoc/>
   public IAudioSource? ActiveSource => _activeSource;
@@ -346,15 +303,12 @@ public class AudioManager : IAudioManager, IAsyncDisposable
 
       try
       {
-        source = sourceType switch
-        {
-          AudioSourceType.Radio => CreateRadioSource(),
-          AudioSourceType.FilePlayer => CreateFilePlayerSource(),
-          AudioSourceType.Vinyl => CreateVinylSource(),
-          AudioSourceType.GenericUSB => CreateGenericUSBSource(),
-          AudioSourceType.Bluetooth => CreateBluetoothSource(),
-          _ => null
-        };
+        source = _sourceFactory.CreateSource(sourceType);
+      }
+      catch (ArgumentOutOfRangeException)
+      {
+        _logger.LogWarning("Source type {SourceType} is not supported", sourceType);
+        return null;
       }
       catch (Exception ex)
       {
@@ -598,99 +552,6 @@ public class AudioManager : IAudioManager, IAsyncDisposable
     {
       _logger.LogWarning(ex, "Failed to restore volume preferences");
     }
-  }
-
-  /// <summary>
-  /// Creates a Bluetooth audio source.
-  /// </summary>
-  private IAudioSource CreateBluetoothSource()
-  {
-    var logger = _loggerFactory.CreateLogger<BluetoothAudioSource>();
-    return new BluetoothAudioSource(
-      logger,
-      _deviceManager,
-      _bluetoothService,
-      _bluetoothOptions,
-      _identificationService,
-      _metricsCollector,
-      _playbackService,
-      _serviceScopeFactory,
-      _albumArtCache);
-  }
-
-  /// <summary>
-  /// Creates a radio audio source using the RadioFactory.
-  /// </summary>
-  private IAudioSource CreateRadioSource()
-  {
-    var deviceType = _radioFactory.GetDefaultDeviceType();
-    _logger.LogDebug("Creating radio source with device type: {DeviceType}", deviceType);
-    return _radioFactory.CreateRadioSource(deviceType);
-  }
-
-  /// <summary>
-  /// Creates a file player audio source.
-  /// </summary>
-  private IAudioSource CreateFilePlayerSource()
-  {
-    // Use the same root directory logic as FileBrowser for consistency
-    // The FilePlayerOptions.RootDirectory is a subdirectory relative to this root
-    var rootDir = _configuration["RootDir"] ?? Directory.GetCurrentDirectory();
-
-    var logger = _loggerFactory.CreateLogger<FilePlayerAudioSource>();
-    return new FilePlayerAudioSource(
-      logger,
-      _filePlayerOptions,
-      _filePlayerPreferences,
-      rootDir,
-      _identificationService,
-      _metricsCollector,
-      _playbackService,
-      _configurationManager,
-      _albumArtCache);
-  }
-
-  /// <summary>
-  /// Creates a vinyl turntable audio source.
-  /// </summary>
-  /// <exception cref="InvalidOperationException">Thrown if vinyl USB port is not configured.</exception>
-  private IAudioSource CreateVinylSource()
-  {
-    var vinylConfig = _deviceOptions.CurrentValue.Vinyl;
-
-    if (vinylConfig == null || string.IsNullOrWhiteSpace(vinylConfig.USBPort))
-    {
-      throw new InvalidOperationException(
-        "Vinyl source is not configured. Please configure the USB port in DeviceOptions.Vinyl section.");
-    }
-
-    var logger = _loggerFactory.CreateLogger<VinylAudioSource>();
-    return new VinylAudioSource(
-      logger,
-      _deviceOptions,
-      _deviceManager,
-      _identificationService);
-  }
-
-  /// <summary>
-  /// Creates a generic USB audio source.
-  /// </summary>
-  /// <exception cref="InvalidOperationException">Thrown if generic USB port is not configured.</exception>
-  private IAudioSource CreateGenericUSBSource()
-  {
-    var prefs = _genericSourcePreferences.CurrentValue;
-
-    if (string.IsNullOrWhiteSpace(prefs.USBPort))
-    {
-      throw new InvalidOperationException(
-        "Generic USB source is not configured. Please configure the USB port in GenericSourcePreferences section.");
-    }
-
-    var logger = _loggerFactory.CreateLogger<GenericUSBAudioSource>();
-    return new GenericUSBAudioSource(
-      logger,
-      _genericSourcePreferences,
-      _deviceManager);
   }
 
   /// <summary>

--- a/src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs
@@ -1,0 +1,161 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Radio.Core.Configuration;
+using Radio.Core.Interfaces;
+using Radio.Core.Interfaces.Audio;
+using Radio.Core.Models.Audio;
+using Radio.Infrastructure.Audio.Fingerprinting;
+using Radio.Infrastructure.Audio.Sources.Primary;
+using Radio.Infrastructure.Configuration.Abstractions;
+
+namespace Radio.Infrastructure.Audio.Services;
+
+/// <summary>
+/// Creates audio sources with all required dependencies.
+/// Consolidates source creation logic that was spread across AudioManager.
+/// </summary>
+public class AudioSourceFactory : IAudioSourceFactory
+{
+  private readonly ILogger<AudioSourceFactory> _logger;
+  private readonly ILoggerFactory _loggerFactory;
+  private readonly IAudioDeviceManager _deviceManager;
+  private readonly IRadioFactory _radioFactory;
+  private readonly IBluetoothService _bluetoothService;
+  private readonly IOptionsMonitor<BluetoothOptions> _bluetoothOptions;
+  private readonly IOptionsMonitor<FilePlayerOptions> _filePlayerOptions;
+  private readonly IOptionsMonitor<FilePlayerPreferences> _filePlayerPreferences;
+  private readonly IOptionsMonitor<DeviceOptions> _deviceOptions;
+  private readonly IOptionsMonitor<GenericSourcePreferences> _genericSourcePreferences;
+  private readonly IConfiguration _configuration;
+  private readonly BackgroundIdentificationService? _identificationService;
+  private readonly IMetricsCollector? _metricsCollector;
+  private readonly Configuration.Abstractions.IConfigurationManager? _configurationManager;
+  private readonly SoundFlow.SoundFlowPlaybackService? _playbackService;
+  private readonly IServiceScopeFactory? _serviceScopeFactory;
+  private readonly AlbumArtCacheService? _albumArtCache;
+
+  public AudioSourceFactory(
+    ILogger<AudioSourceFactory> logger,
+    ILoggerFactory loggerFactory,
+    IAudioDeviceManager deviceManager,
+    IRadioFactory radioFactory,
+    IBluetoothService bluetoothService,
+    IOptionsMonitor<BluetoothOptions> bluetoothOptions,
+    IOptionsMonitor<FilePlayerOptions> filePlayerOptions,
+    IOptionsMonitor<FilePlayerPreferences> filePlayerPreferences,
+    IOptionsMonitor<DeviceOptions> deviceOptions,
+    IOptionsMonitor<GenericSourcePreferences> genericSourcePreferences,
+    IConfiguration configuration,
+    BackgroundIdentificationService? identificationService = null,
+    IMetricsCollector? metricsCollector = null,
+    Configuration.Abstractions.IConfigurationManager? configurationManager = null,
+    SoundFlow.SoundFlowPlaybackService? playbackService = null,
+    IServiceScopeFactory? serviceScopeFactory = null,
+    AlbumArtCacheService? albumArtCache = null)
+  {
+    _logger = logger;
+    _loggerFactory = loggerFactory;
+    _deviceManager = deviceManager;
+    _radioFactory = radioFactory;
+    _bluetoothService = bluetoothService;
+    _bluetoothOptions = bluetoothOptions;
+    _filePlayerOptions = filePlayerOptions;
+    _filePlayerPreferences = filePlayerPreferences;
+    _deviceOptions = deviceOptions;
+    _genericSourcePreferences = genericSourcePreferences;
+    _configuration = configuration;
+    _identificationService = identificationService;
+    _metricsCollector = metricsCollector;
+    _configurationManager = configurationManager;
+    _playbackService = playbackService;
+    _serviceScopeFactory = serviceScopeFactory;
+    _albumArtCache = albumArtCache;
+  }
+
+  /// <inheritdoc/>
+  public IAudioSource CreateSource(AudioSourceType sourceType)
+  {
+    return sourceType switch
+    {
+      AudioSourceType.Radio => CreateRadioSource(),
+      AudioSourceType.FilePlayer => CreateFilePlayerSource(),
+      AudioSourceType.Vinyl => CreateVinylSource(),
+      AudioSourceType.GenericUSB => CreateGenericUSBSource(),
+      AudioSourceType.Bluetooth => CreateBluetoothSource(),
+      _ => throw new ArgumentOutOfRangeException(nameof(sourceType), sourceType, "Unsupported source type")
+    };
+  }
+
+  private IAudioSource CreateRadioSource()
+  {
+    var deviceType = _radioFactory.GetDefaultDeviceType();
+    _logger.LogDebug("Creating radio source with device type: {DeviceType}", deviceType);
+    return _radioFactory.CreateRadioSource(deviceType);
+  }
+
+  private IAudioSource CreateBluetoothSource()
+  {
+    var logger = _loggerFactory.CreateLogger<BluetoothAudioSource>();
+    return new BluetoothAudioSource(
+      logger,
+      _deviceManager,
+      _bluetoothService,
+      _bluetoothOptions,
+      _identificationService,
+      _metricsCollector,
+      _playbackService,
+      _serviceScopeFactory,
+      _albumArtCache);
+  }
+
+  private IAudioSource CreateFilePlayerSource()
+  {
+    var rootDir = _configuration["RootDir"] ?? Directory.GetCurrentDirectory();
+    var logger = _loggerFactory.CreateLogger<FilePlayerAudioSource>();
+    return new FilePlayerAudioSource(
+      logger,
+      _filePlayerOptions,
+      _filePlayerPreferences,
+      rootDir,
+      _identificationService,
+      _metricsCollector,
+      _playbackService,
+      _configurationManager,
+      _albumArtCache);
+  }
+
+  private IAudioSource CreateVinylSource()
+  {
+    var vinylConfig = _deviceOptions.CurrentValue.Vinyl;
+    if (vinylConfig == null || string.IsNullOrWhiteSpace(vinylConfig.USBPort))
+    {
+      throw new InvalidOperationException(
+        "Vinyl source is not configured. Please configure the USB port in DeviceOptions.Vinyl section.");
+    }
+
+    var logger = _loggerFactory.CreateLogger<VinylAudioSource>();
+    return new VinylAudioSource(
+      logger,
+      _deviceOptions,
+      _deviceManager,
+      _identificationService);
+  }
+
+  private IAudioSource CreateGenericUSBSource()
+  {
+    var prefs = _genericSourcePreferences.CurrentValue;
+    if (string.IsNullOrWhiteSpace(prefs.USBPort))
+    {
+      throw new InvalidOperationException(
+        "Generic USB source is not configured. Please configure the USB port in GenericSourcePreferences section.");
+    }
+
+    var logger = _loggerFactory.CreateLogger<GenericUSBAudioSource>();
+    return new GenericUSBAudioSource(
+      logger,
+      _genericSourcePreferences,
+      _deviceManager);
+  }
+}

--- a/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
+++ b/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
@@ -119,28 +119,21 @@ public static class AudioServiceExtensions
     // Register album art cache service (singleton for disk-backed image cache)
     services.AddSingleton<AlbumArtCacheService>();
 
+    // Register audio source factory (encapsulates all source-creation dependencies)
+    services.AddSingleton<AudioSourceFactory>();
+    services.AddSingleton<IAudioSourceFactory>(sp => sp.GetRequiredService<AudioSourceFactory>());
+
     // Register audio manager (singleton to maintain state)
     // Use explicit factory to ensure all optional services are resolved.
     services.AddSingleton<AudioManager>(sp => new AudioManager(
       sp.GetRequiredService<ILogger<AudioManager>>(),
-      sp.GetRequiredService<ILoggerFactory>(),
       sp.GetRequiredService<IAudioEngine>(),
-      sp.GetRequiredService<IAudioDeviceManager>(),
-      sp.GetRequiredService<IRadioFactory>(),
+      sp.GetRequiredService<IAudioSourceFactory>(),
       sp.GetRequiredService<IBluetoothService>(),
       sp.GetRequiredService<IOptionsMonitor<BluetoothOptions>>(),
-      sp.GetRequiredService<IOptionsMonitor<FilePlayerOptions>>(),
-      sp.GetRequiredService<IOptionsMonitor<FilePlayerPreferences>>(),
-      sp.GetRequiredService<IOptionsMonitor<DeviceOptions>>(),
-      sp.GetRequiredService<IOptionsMonitor<GenericSourcePreferences>>(),
       sp.GetRequiredService<IOptionsMonitor<AudioPreferences>>(),
-      sp.GetRequiredService<IConfiguration>(),
       sp.GetService<BackgroundIdentificationService>(),
-      sp.GetService<IMetricsCollector>(),
       sp.GetService<Configuration.Abstractions.IConfigurationManager>(),
-      sp.GetService<SoundFlowPlaybackService>(),
-      sp.GetService<IServiceScopeFactory>(),
-      sp.GetService<AlbumArtCacheService>(),
       sp.GetRequiredService<PlayHistoryTracker>()));
     services.AddSingleton<IAudioManager>(sp => sp.GetRequiredService<AudioManager>());
 


### PR DESCRIPTION
## Summary
- Extract 5 source creation methods (`CreateRadioSource`, `CreateBluetoothSource`, `CreateFilePlayerSource`, `CreateVinylSource`, `CreateGenericUSBSource`) and their 12 DI dependencies into a new `AudioSourceFactory` class
- Reduce AudioManager constructor from 20 to 9 parameters (743 lines, down from 1302 pre-C.1)
- Add `IAudioSourceFactory` interface in Radio.Core for clean dependency inversion
- Remove unused `IAudioDeviceManager DeviceManager` property from `IAudioManager` interface (no consumers found)
- Register `AudioSourceFactory` as singleton in DI container

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] All 1313 tests pass (2 pre-existing CoverArt integration test failures from external API)
- [x] Deployed to Ubuntu x64 radio box — services start, API responds, audio working

🤖 Generated with [Claude Code](https://claude.com/claude-code)