### PR TITLE
fix: Route USB capture audio to playback output

### DIFF
--- a/src/Radio.Infrastructure/Audio/Factories/RadioFactory.cs
+++ b/src/Radio.Infrastructure/Audio/Factories/RadioFactory.cs
@@ -209,7 +209,8 @@ public class RadioFactory : IRadioFactory
         _radioOptions,
         _deviceManager,
         _identificationService,
-        resolvedUSBPort);
+        resolvedUSBPort,
+        _playbackService);
 
       _logger.LogInformation("Successfully created RF320 radio source with USB port: {USBPort}", resolvedUSBPort);
       return source;

--- a/src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs
@@ -146,7 +146,8 @@ public class AudioSourceFactory : IAudioSourceFactory
       _deviceOptions,
       _deviceManager,
       _identificationService,
-      resolvedUSBPort);
+      resolvedUSBPort,
+      _playbackService);
   }
 
   /// <summary>
@@ -187,7 +188,8 @@ public class AudioSourceFactory : IAudioSourceFactory
       logger,
       _genericSourcePreferences,
       _deviceManager,
-      resolvedUSBPort);
+      resolvedUSBPort,
+      _playbackService);
   }
 
   /// <summary>

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/GenericUSBAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/GenericUSBAudioSource.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
 using Radio.Core.Exceptions;
 using Radio.Core.Interfaces.Audio;
+using Radio.Infrastructure.Audio.SoundFlow;
 
 namespace Radio.Infrastructure.Audio.Sources.Primary;
 
@@ -22,12 +23,14 @@ public class GenericUSBAudioSource : USBAudioSourceBase
   /// <param name="preferences">The generic source preferences.</param>
   /// <param name="deviceManager">The audio device manager.</param>
   /// <param name="resolvedUSBPort">USB port resolved from config store, overrides IOptionsMonitor value.</param>
+  /// <param name="playbackService">Optional SoundFlow playback service for routing captured audio to output.</param>
   public GenericUSBAudioSource(
     ILogger<GenericUSBAudioSource> logger,
     IOptionsMonitor<GenericSourcePreferences> preferences,
     IAudioDeviceManager deviceManager,
-    string? resolvedUSBPort = null)
-    : base(logger, deviceManager)
+    string? resolvedUSBPort = null,
+    SoundFlowPlaybackService? playbackService = null)
+    : base(logger, deviceManager, playbackService: playbackService)
   {
     _preferences = preferences;
     _resolvedUSBPort = resolvedUSBPort;

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/RadioAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/RadioAudioSource.cs
@@ -4,6 +4,7 @@ using Radio.Core.Configuration;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
+using Radio.Infrastructure.Audio.SoundFlow;
 
 namespace Radio.Infrastructure.Audio.Sources.Primary;
 
@@ -38,14 +39,16 @@ public class RadioAudioSource : USBAudioSourceBase, Radio.Core.Interfaces.Audio.
   /// <param name="deviceManager">The audio device manager.</param>
   /// <param name="identificationService">Optional fingerprinting service for track identification.</param>
   /// <param name="resolvedUSBPort">USB port resolved from config store, overrides IOptionsMonitor value.</param>
+  /// <param name="playbackService">Optional SoundFlow playback service for routing captured audio to output.</param>
   public RadioAudioSource(
     ILogger<RadioAudioSource> logger,
     IOptionsMonitor<DeviceOptions> deviceOptions,
     IOptionsMonitor<RadioOptions> radioOptions,
     IAudioDeviceManager deviceManager,
     BackgroundIdentificationService? identificationService = null,
-    string? resolvedUSBPort = null)
-    : base(logger, deviceManager, identificationService)
+    string? resolvedUSBPort = null,
+    SoundFlowPlaybackService? playbackService = null)
+    : base(logger, deviceManager, identificationService, playbackService: playbackService)
   {
     _deviceOptions = deviceOptions;
     _radioOptions = radioOptions;

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
@@ -4,6 +4,7 @@ using Radio.Core.Exceptions;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
+using Radio.Infrastructure.Audio.SoundFlow;
 using SoundFlow.Abstracts.Devices;
 using SoundFlow.Backends.MiniAudio;
 using SoundFlow.Enums;
@@ -15,17 +16,21 @@ namespace Radio.Infrastructure.Audio.Sources.Primary;
 /// Base class for USB audio sources that capture audio from USB audio input devices.
 /// Provides common functionality for USB port reservation, sound component management,
 /// live stream handling, and fingerprinting integration.
+/// Routes captured audio to the SoundFlow playback pipeline via a BufferedSoundGenerator.
 /// </summary>
 public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
 {
   private readonly IAudioDeviceManager _deviceManager;
   private readonly Dictionary<string, object> _metadata = new();
   private readonly BackgroundIdentificationService? _identificationService;
+  private readonly SoundFlowPlaybackService? _playbackService;
   private string? _reservedPort;
   private object? _soundComponent;
   private AudioCaptureDevice? _captureDevice;
   private MiniAudioEngine? _audioEngine;
   private int _audioCaptureCallCount = 0;
+  private BufferedSoundGenerator<float>? _soundGenerator;
+  private string? _playbackId;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="USBAudioSourceBase"/> class.
@@ -34,15 +39,18 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
   /// <param name="deviceManager">The audio device manager.</param>
   /// <param name="identificationService">Optional fingerprinting service for track identification.</param>
   /// <param name="metricsCollector">Optional metrics collector for tracking playback metrics.</param>
+  /// <param name="playbackService">Optional SoundFlow playback service for routing captured audio to output.</param>
   protected USBAudioSourceBase(
-    ILogger logger, 
+    ILogger logger,
     IAudioDeviceManager deviceManager,
     BackgroundIdentificationService? identificationService = null,
-    Radio.Core.Interfaces.IMetricsCollector? metricsCollector = null)
+    Radio.Core.Interfaces.IMetricsCollector? metricsCollector = null,
+    SoundFlowPlaybackService? playbackService = null)
     : base(logger, metricsCollector)
   {
     _deviceManager = deviceManager;
     _identificationService = identificationService;
+    _playbackService = playbackService;
 
     // Subscribe to track identification events if service is available
     if (_identificationService != null)
@@ -212,7 +220,7 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
 
   /// <summary>
   /// Called when audio samples are captured from the USB device.
-  /// Override in derived classes to process the captured audio.
+  /// Feeds captured samples into the BufferedSoundGenerator for playback output.
   /// </summary>
   /// <param name="samples">The captured audio samples.</param>
   /// <param name="capability">The device capability (should be Record for capture).</param>
@@ -226,9 +234,9 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
         "{SourceName} audio capture - Samples: {SampleCount}, Capability: {Capability}, State: {State}",
         Name, samples.Length, capability, State);
     }
-    
-    // Default implementation does nothing
-    // Derived classes can override to process audio samples
+
+    // Route captured audio to the playback pipeline via the buffered generator
+    _soundGenerator?.AddSamples(samples);
   }
 
   /// <summary>
@@ -251,7 +259,7 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
   }
 
   /// <inheritdoc/>
-  protected override Task PlayCoreAsync(CancellationToken cancellationToken)
+  protected override async Task PlayCoreAsync(CancellationToken cancellationToken)
   {
     if (_soundComponent == null)
     {
@@ -260,8 +268,8 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
     }
 
     Logger.LogInformation(
-      "Starting {SourceName} audio capture - Device: {Device}, USBPort: {USBPort}, State: {State}", 
-      Name, 
+      "Starting {SourceName} audio capture - Device: {Device}, USBPort: {USBPort}, State: {State}",
+      Name,
       MetadataInternal.TryGetValue("Device", out var device) ? device : "unknown",
       _reservedPort ?? "none",
       State);
@@ -272,11 +280,53 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
     }
     catch (Exception ex)
     {
-       Logger.LogError(ex, "Failed to start audio capture device for {SourceName}", Name);
-       throw;
+      Logger.LogError(ex, "Failed to start audio capture device for {SourceName}", Name);
+      throw;
     }
 
-    return Task.CompletedTask;
+    // Create a BufferedSoundGenerator to bridge captured audio to the SoundFlow playback pipeline
+    if (_playbackService != null)
+    {
+      var engine = _playbackService.GetUnderlyingEngine();
+      if (engine != null)
+      {
+        var format = _playbackService.GetAudioFormat();
+        _playbackId = $"usb-capture-{Id:N}";
+
+        if (_soundGenerator == null)
+        {
+          _soundGenerator = new BufferedSoundGenerator<float>(
+            engine, format, Logger, metricsCollector: MetricsCollector);
+        }
+
+        var success = await _playbackService.PlayComponentAsync(
+          _playbackId, _soundGenerator, Volume, cancellationToken);
+
+        if (success)
+        {
+          Logger.LogInformation(
+            "🔊 {SourceName} audio routed to playback output (PlaybackId={PlaybackId})",
+            Name, _playbackId);
+        }
+        else
+        {
+          Logger.LogError(
+            "Failed to route {SourceName} audio to playback output", Name);
+        }
+      }
+      else
+      {
+        Logger.LogWarning(
+          "{SourceName}: SoundFlow engine not available - captured audio will not play through speakers",
+          Name);
+      }
+    }
+    else
+    {
+      Logger.LogWarning(
+        "{SourceName}: SoundFlowPlaybackService not available - captured audio will not play through speakers",
+        Name);
+    }
   }
 
   /// <inheritdoc/>
@@ -306,20 +356,29 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
   }
 
   /// <inheritdoc/>
-  protected override Task StopCoreAsync(CancellationToken cancellationToken)
+  protected override async Task StopCoreAsync(CancellationToken cancellationToken)
   {
     Logger.LogInformation("Stopping {SourceName} audio capture", Name);
-    
+
     try
     {
       _captureDevice?.Stop();
     }
     catch (Exception ex)
     {
-       Logger.LogWarning(ex, "Failed to stop audio capture device for {SourceName}", Name);
+      Logger.LogWarning(ex, "Failed to stop audio capture device for {SourceName}", Name);
     }
 
-    return Task.CompletedTask;
+    // Disconnect from the playback pipeline
+    if (_playbackService != null && _playbackId != null)
+    {
+      Logger.LogDebug(
+        "Removing {SourceName} from SoundFlow mixer (PlaybackId={PlaybackId})",
+        Name, _playbackId);
+      await _playbackService.StopAsync(_playbackId, cancellationToken);
+      _playbackId = null;
+      _soundGenerator = null; // Disposed by StopAsync
+    }
   }
 
   /// <summary>
@@ -406,6 +465,19 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
     if (_identificationService != null)
     {
       _identificationService.TrackIdentified -= OnTrackIdentified;
+    }
+
+    // Disconnect from the playback pipeline
+    if (_playbackService != null && _playbackId != null)
+    {
+      await _playbackService.StopAsync(_playbackId);
+      _playbackId = null;
+      _soundGenerator = null; // Disposed by StopAsync
+    }
+    else
+    {
+      _soundGenerator?.Dispose();
+      _soundGenerator = null;
     }
 
     CleanupCaptureDevice();

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/VinylAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/VinylAudioSource.cs
@@ -4,6 +4,7 @@ using Radio.Core.Configuration;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
+using Radio.Infrastructure.Audio.SoundFlow;
 
 namespace Radio.Infrastructure.Audio.Sources.Primary;
 
@@ -25,13 +26,15 @@ public class VinylAudioSource : USBAudioSourceBase
   /// <param name="deviceManager">The audio device manager.</param>
   /// <param name="identificationService">Optional fingerprinting service for track identification.</param>
   /// <param name="resolvedUSBPort">USB port resolved from config store, overrides IOptionsMonitor value.</param>
+  /// <param name="playbackService">Optional SoundFlow playback service for routing captured audio to output.</param>
   public VinylAudioSource(
     ILogger<VinylAudioSource> logger,
     IOptionsMonitor<DeviceOptions> deviceOptions,
     IAudioDeviceManager deviceManager,
     BackgroundIdentificationService? identificationService = null,
-    string? resolvedUSBPort = null)
-    : base(logger, deviceManager, identificationService)
+    string? resolvedUSBPort = null,
+    SoundFlowPlaybackService? playbackService = null)
+    : base(logger, deviceManager, identificationService, playbackService: playbackService)
   {
     _deviceOptions = deviceOptions;
     _resolvedUSBPort = resolvedUSBPort;


### PR DESCRIPTION
## Summary
- USB capture sources (GenericUSB, Vinyl, RF320 Radio) were capturing audio via `AudioCaptureDevice.OnAudioProcessed` but not routing it to the SoundFlow playback pipeline — audio never reached speakers
- Adds a `BufferedSoundGenerator<float>` bridge in `USBAudioSourceBase` that feeds captured samples to the playback mixer via `PlayComponentAsync`, mirroring the working SDR pattern
- All three USB source constructors (`VinylAudioSource`, `GenericUSBAudioSource`, `RadioAudioSource`) updated to accept and pass through `SoundFlowPlaybackService`
- `AudioSourceFactory` and `RadioFactory` now pass the playback service to USB sources

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test --configuration Release` — 1,343 tests pass
- [x] Deploy to Ubuntu box, switch to GenericUSB (AB13X), verify visualization shows audio data
- [x] Verify logs show `AUDIO ROUTING COMPLETE: Component 'Buffered Generator (Single)' now connected to audio output`
- [x] Verify `PlaybackDeviceSwitched` re-attaches generator when output device changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)