### PR TITLE
fix: Queue add-to-queue and playlist load reliability

### DIFF
--- a/src/Radio.API/Controllers/FilesController.cs
+++ b/src/Radio.API/Controllers/FilesController.cs
@@ -272,8 +272,10 @@ public class FilesController : ControllerBase
 
       return Ok(new QueueFilesResponseDto
       {
-        Success = true,
-        Message = $"Added {addedCount} file(s) to queue",
+        Success = addedCount > 0,
+        Message = addedCount > 0
+          ? $"Added {addedCount} file(s) to queue"
+          : $"Failed to add files to queue ({failedPaths.Count} not found or not supported)",
         AddedCount = addedCount,
         FailedCount = failedPaths.Count,
         FailedPaths = failedPaths

--- a/src/Radio.Web/Components/App.razor
+++ b/src/Radio.Web/Components/App.razor
@@ -13,17 +13,71 @@
   <link href="css/design-system.css" rel="stylesheet" />
   <link href="css/virtual-keyboard.css" rel="stylesheet" />
   <HeadOutlet @rendermode="new InteractiveServerRenderMode(prerender: false)" />
+  <style>
+    /* Blazor circuit reconnect dialog visibility —
+       the framework looks for id="components-reconnect-modal" and toggles these classes */
+    #components-reconnect-modal.components-reconnect-show { display: flex !important; }
+    #components-reconnect-modal.components-reconnect-hide { display: none !important; }
+    #components-reconnect-modal.components-reconnect-failed { display: flex !important; }
+    #components-reconnect-modal.components-reconnect-rejected { display: flex !important; }
+  </style>
 </head>
 
 <body oncontextmenu="return false">
   <Routes @rendermode="new InteractiveServerRenderMode(prerender: false)" />
 
-  <script src="_framework/blazor.web.js"></script>
+  <!-- Blazor circuit reconnection overlay — shown when SignalR drops.
+       ID MUST be "components-reconnect-modal" for the framework to auto-manage visibility. -->
+  <div id="components-reconnect-modal" style="display:none; position:fixed; inset:0; z-index:99999; background:rgba(13,13,15,0.92); align-items:center; justify-content:center; font-family:var(--font-mono,'JetBrains Mono',monospace); color:#9CA3AF;">
+    <div style="text-align:center; padding:32px;">
+      <div style="font-size:1.1rem; margin-bottom:12px; color:#F0EFF4;">Reconnecting...</div>
+      <div style="font-size:0.85rem;">Connection to server lost. Attempting to reconnect.</div>
+    </div>
+  </div>
+
+  <!-- Load framework with autostart disabled so we can configure reconnection -->
+  <script src="_framework/blazor.web.js" autostart="false"></script>
+  <!-- Load all JS dependencies BEFORE starting Blazor circuit.
+       In autostart mode Blazor waits for DOMContentLoaded (after all scripts).
+       With manual start we must ensure the same ordering. -->
   <script src="_content/MudBlazor/MudBlazor.min.js"></script>
   <script src="js/fileDownload.js"></script>
   <script src="js/pageTransitions.js"></script>
   <!-- visualizer.js uses ES module exports and is loaded via import() in VisualizerPanel -->
   <script src="js/idle-dimmer.js"></script>
+  <script>
+    // Start Blazor AFTER all JS dependencies are loaded.
+    // Configure reconnection for kiosk reliability.
+    Blazor.start({
+      circuit: {
+        reconnectionOptions: {
+          maxRetries: 30,
+          retryIntervalMilliseconds: 2000
+        },
+        configureSignalR: function (builder) {
+          builder.withServerTimeout(60000);
+          builder.withKeepAliveInterval(15000);
+        }
+      }
+    }).then(function() {
+      console.log('[Blazor] Circuit started successfully');
+    }).catch(function(err) {
+      console.error('[Blazor] Circuit start FAILED:', err);
+    });
+
+    // Force full page reload when circuit is permanently lost
+    // (after max retries exhausted or server-rejected reconnect)
+    (function() {
+      var observer = new MutationObserver(function(mutations) {
+        var dialog = document.getElementById('components-reconnect-modal');
+        if (dialog && dialog.classList.contains('components-reconnect-failed')) {
+          console.warn('[Blazor] Circuit permanently lost — reloading page');
+          setTimeout(function() { location.reload(); }, 1000);
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
+    })();
+  </script>
 </body>
 
 </html>

--- a/src/Radio.Web/Components/Dialogs/LoadPlaylistDialog.razor
+++ b/src/Radio.Web/Components/Dialogs/LoadPlaylistDialog.razor
@@ -104,9 +104,13 @@
   private async Task LoadPlaylistAsync(Radio.Web.Models.PlaylistSummaryDto playlist)
   {
     _actionInProgress = true;
+    Logger.LogInformation("LoadPlaylistAsync called for: {Name} (Id: {Id})", playlist.Name, playlist.Id);
     try
     {
-      var success = await PlaylistApi.LoadAsync(playlist.Id);
+      using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+      Logger.LogInformation("Calling PlaylistApi.LoadAsync...");
+      var success = await PlaylistApi.LoadAsync(playlist.Id, cts.Token);
+      Logger.LogInformation("PlaylistApi.LoadAsync returned: {Success}", success);
       if (success)
       {
         Snackbar.Add($"Loaded '{playlist.Name}' ({playlist.ItemCount} tracks)", Severity.Success);
@@ -116,6 +120,11 @@
       {
         Snackbar.Add("Failed to load playlist", Severity.Error);
       }
+    }
+    catch (OperationCanceledException)
+    {
+      Logger.LogError("Timeout loading playlist {Id}", playlist.Id);
+      Snackbar.Add("Timed out loading playlist — is the API running?", Severity.Error);
     }
     catch (Exception ex)
     {

--- a/src/Radio.Web/Components/Pages/QueuePage.razor
+++ b/src/Radio.Web/Components/Pages/QueuePage.razor
@@ -595,16 +595,34 @@
 
   private async Task HandleBrowserAddToQueueAsync(string path)
   {
+    Logger.LogInformation("HandleBrowserAddToQueueAsync called with path: {Path}", path);
     try
     {
-      var success = await FileApi.AddFileToQueueAsync(path);
+      using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+      Logger.LogInformation("Calling FileApi.AddFileToQueueAsync...");
+      var (success, error) = await FileApi.AddFileToQueueAsync(path, cts.Token);
+      Logger.LogInformation("FileApi.AddFileToQueueAsync returned: Success={Success}, Error={Error}", success, error);
       if (success)
       {
         Snackbar.Add("Added to queue", Severity.Success);
         await RefreshQueueAsync();
       }
+      else
+      {
+        Logger.LogWarning("Failed to add file to queue: {Path} — {Error}", path, error);
+        Snackbar.Add($"Failed to add: {error}", Severity.Error);
+      }
     }
-    catch { }
+    catch (OperationCanceledException)
+    {
+      Logger.LogError("Timeout adding file to queue: {Path}", path);
+      Snackbar.Add("Timed out adding to queue — is the API running?", Severity.Error);
+    }
+    catch (Exception ex)
+    {
+      Logger.LogError(ex, "Error adding file to queue: {Path}", path);
+      Snackbar.Add("Failed to add to queue", Severity.Error);
+    }
   }
 
   private async Task LoadDrivesAsync()

--- a/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
+++ b/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
@@ -335,19 +335,30 @@
     if (filePaths == null || !filePaths.Any()) return;
 
     var addedCount = 0;
+    var failedCount = 0;
     foreach (var path in filePaths)
     {
       try
       {
-        if (await FileApi.AddFileToQueueAsync(path)) addedCount++;
+        var (success, _) = await FileApi.AddFileToQueueAsync(path);
+        if (success) addedCount++;
+        else failedCount++;
       }
-      catch (Exception ex) { Logger.LogError(ex, "Failed to add file to queue: {Path}", path); }
+      catch (Exception ex)
+      {
+        failedCount++;
+        Logger.LogError(ex, "Failed to add file to queue: {Path}", path);
+      }
     }
 
     if (addedCount > 0)
     {
       Snackbar.Add($"{addedCount} file{(addedCount != 1 ? "s" : "")} added", Severity.Success);
       await RefreshQueueAsync();
+    }
+    if (failedCount > 0)
+    {
+      Snackbar.Add($"{failedCount} file{(failedCount != 1 ? "s" : "")} failed to add", Severity.Error);
     }
   }
 

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -217,6 +217,14 @@ public record DriveInfoDto(
   string? DriveFormat
 );
 
+public record QueueFilesResponseDto(
+  bool Success,
+  string? Message,
+  int AddedCount,
+  int FailedCount,
+  List<string>? FailedPaths
+);
+
 // Play History API DTOs
 public record PlayHistoryListDto(
   int TotalCount,

--- a/src/Radio.Web/Program.cs
+++ b/src/Radio.Web/Program.cs
@@ -48,6 +48,11 @@ builder.Services.AddRazorComponents()
     {
       options.DetailedErrors = true;
     }
+
+    // Keep disconnected circuits alive longer for kiosk reliability.
+    // Default is 3 minutes — extend to 10 minutes so brief network blips
+    // or deploy restarts can reconnect without losing circuit state.
+    options.DisconnectedCircuitRetentionPeriod = TimeSpan.FromMinutes(10);
   });
 
 // Add MudBlazor services

--- a/src/Radio.Web/Services/ApiClients/FileApiService.cs
+++ b/src/Radio.Web/Services/ApiClients/FileApiService.cs
@@ -46,17 +46,28 @@ public class FileApiService
     }
   }
 
-  public async Task<bool> AddFileToQueueAsync(string filePath, CancellationToken cancellationToken = default)
+  public async Task<(bool Success, string? Error)> AddFileToQueueAsync(string filePath, CancellationToken cancellationToken = default)
   {
     try
     {
       var response = await _httpClient.PostAsJsonAsync("/api/files/queue", new { Paths = new List<string> { filePath } }, cancellationToken);
-      return response.IsSuccessStatusCode;
+      if (!response.IsSuccessStatusCode)
+        return (false, $"Server returned {response.StatusCode}");
+
+      var result = await response.Content.ReadFromJsonAsync<QueueFilesResponseDto>(cancellationToken: cancellationToken);
+      if (result == null)
+        return (false, "Empty response from server");
+
+      if (result.AddedCount > 0)
+        return (true, null);
+
+      var failedPath = result.FailedPaths?.FirstOrDefault() ?? filePath;
+      return (false, $"File not found or not supported: {failedPath}");
     }
     catch (Exception ex)
     {
       _logger.LogError(ex, "Failed to add file to queue {FilePath}", filePath);
-      return false;
+      return (false, ex.Message);
     }
   }
   
@@ -74,17 +85,27 @@ public class FileApiService
     }
   }
   
-  public async Task<bool> AddFilesToQueueAsync(List<string> filePaths, CancellationToken cancellationToken = default)
+  public async Task<(bool Success, int AddedCount, string? Error)> AddFilesToQueueAsync(List<string> filePaths, CancellationToken cancellationToken = default)
   {
     try
     {
       var response = await _httpClient.PostAsJsonAsync("/api/files/queue", new { Paths = filePaths }, cancellationToken);
-      return response.IsSuccessStatusCode;
+      if (!response.IsSuccessStatusCode)
+        return (false, 0, $"Server returned {response.StatusCode}");
+
+      var result = await response.Content.ReadFromJsonAsync<QueueFilesResponseDto>(cancellationToken: cancellationToken);
+      if (result == null)
+        return (false, 0, "Empty response from server");
+
+      if (result.AddedCount > 0)
+        return (true, result.AddedCount, result.FailedCount > 0 ? $"{result.FailedCount} files failed" : null);
+
+      return (false, 0, $"No files could be added ({result.FailedCount} failed)");
     }
     catch (Exception ex)
     {
       _logger.LogError(ex, "Failed to add files to queue");
-      return false;
+      return (false, 0, ex.Message);
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix false-positive success on queue add: API returned HTTP 200 with `addedCount: 0` but Web UI only checked `IsSuccessStatusCode` — now parses response body
- Fix API `QueueFilesResponseDto.Success` flag (was hardcoded `true`, now `addedCount > 0`)
- Fix Blazor circuit reconnection: correct dialog ID (`components-reconnect-modal`), move `Blazor.start()` after all JS dependencies to prevent race conditions
- Add 10s timeout to queue add and playlist load HTTP calls to prevent silent hangs
- Extend disconnected circuit retention to 10 minutes for kiosk reliability

## Test plan
- [x] Build: 0 warnings
- [x] Playwright: add-to-queue shows success snackbar and queue updates
- [x] Playwright: load playlist shows success snackbar and loads all tracks
- [x] Server logs confirm handler execution and API response parsing
- [x] Deployed to Ubuntu and verified

🤖 Generated with [Claude Code](https://claude.ai/code)