### PR TITLE
fix: Queue auto-advance plays next track when current ends

### DIFF
--- a/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
@@ -48,6 +48,7 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
   private string? _playbackId;
   private CancellationTokenSource? _playbackCts;
   private Task? _playbackMonitorTask;
+  private bool _trackEndedNaturally;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="FilePlayerAudioSource"/> class.
@@ -299,8 +300,9 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
   {
     ThrowIfDisposed();
 
-    // Track skip metric if moving from a playing track
-    var wasSkipped = State == AudioSourceState.Playing && _currentFile != null;
+    // Track skip metric only for user-initiated skips (not auto-advance from end-of-track)
+    var wasSkipped = State == AudioSourceState.Playing && _currentFile != null && !_trackEndedNaturally;
+    _trackEndedNaturally = false;
 
     // Handle RepeatMode.One - replay current track
     if (_preferences.CurrentValue.Repeat == RepeatMode.One && _currentFile != null)
@@ -752,10 +754,13 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
 
       if (!cancellationToken.IsCancellationRequested)
       {
-        State = AudioSourceState.Stopped;
+        Logger.LogInformation("🎵 FILE PLAYER: Track ended naturally, auto-advancing to next");
+        _trackEndedNaturally = true;
         OnPlaybackCompleted(PlaybackCompletionReason.EndOfContent);
 
-        // Always attempt to play next - NextAsync handles queue/repeat logic
+        // Auto-advance to next track. Keep state as Playing so NextAsync sees it
+        // and starts playback of the next file. If no more tracks exist, NextAsync
+        // calls StopAsync which sets state to Stopped.
         await NextAsync(CancellationToken.None);
       }
     }


### PR DESCRIPTION
## Summary
- Fixed queue auto-advance: when a track finishes naturally, the next track in queue now starts automatically
- Root cause: `MonitorPlaybackAsync` set `State=Stopped` before calling `NextAsync`, but `NextAsync` checked `State==Playing` to decide whether to call `PlayCoreAsync` — so the next track was loaded but never played
- Added `_trackEndedNaturally` flag to distinguish auto-advance from user-initiated skips in metrics

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings
- [x] `dotnet test --configuration Release` — all tests pass (75 FilePlayer tests)
- [x] Deployed to Ubuntu, queued 3 short audio files (10s, 22s, 26s)
- [x] Verified auto-advance: Track 1 → Track 2 → Track 3 seamlessly
- [x] Verified end-of-queue: last track finishes → state goes to Stopped (repeat Off)
- [x] Logs confirm: "Track ended naturally, auto-advancing to next"

🤖 Generated with [Claude Code](https://claude.com/claude-code)