### PR TITLE
feat: UI/UX audit polish for kiosk touch targets and layout

### DIFF
--- a/deploy/Deploy-ToLinux.ps1
+++ b/deploy/Deploy-ToLinux.ps1
@@ -166,7 +166,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # Move files into place, preserving data, logs, and Production config
-ssh $SshTarget "sudo mkdir -p $TargetPath/api $TargetPath/web $TargetPath/data $TargetPath/logs && sudo rsync -a --delete --exclude='appsettings.Production.json' /tmp/radio-deploy-api/ $TargetPath/api/ && sudo rsync -a --delete --exclude='appsettings.Production.json' /tmp/radio-deploy-web/ $TargetPath/web/ && sudo chown -R radio:radio $TargetPath && sudo chmod +x $TargetPath/api/Radio.API $TargetPath/web/Radio.Web && rm -rf /tmp/radio-deploy-api /tmp/radio-deploy-web"
+ssh $SshTarget "sudo mkdir -p $TargetPath/api $TargetPath/web $TargetPath/data $TargetPath/logs && sudo rsync -a --delete --exclude='appsettings.Production.json' /tmp/radio-deploy-api/ $TargetPath/api/ && sudo rsync -a --delete --exclude='appsettings.Production.json' /tmp/radio-deploy-web/ $TargetPath/web/ && sudo chown -R ${TargetUser}:${TargetUser} $TargetPath && sudo chmod +x $TargetPath/api/Radio.API $TargetPath/web/Radio.Web && rm -rf /tmp/radio-deploy-api /tmp/radio-deploy-web"
 
 # Deploy target-specific Production config if not already present
 $targetConfigPath = Join-Path $RepoRoot "deploy\$configDir\appsettings.Production.json"
@@ -175,7 +175,7 @@ if (Test-Path $targetConfigPath) {
   if ($LASTEXITCODE -ne 0) {
     Write-Host "  Deploying Production config from deploy/$configDir/..." -ForegroundColor DarkGray
     scp $targetConfigPath "${SshTarget}:/tmp/appsettings.Production.json"
-    ssh $SshTarget "sudo cp /tmp/appsettings.Production.json $TargetPath/api/ && sudo cp /tmp/appsettings.Production.json $TargetPath/web/ && sudo chown radio:radio $TargetPath/api/appsettings.Production.json $TargetPath/web/appsettings.Production.json && rm /tmp/appsettings.Production.json"
+    ssh $SshTarget "sudo cp /tmp/appsettings.Production.json $TargetPath/api/ && sudo cp /tmp/appsettings.Production.json $TargetPath/web/ && sudo chown ${TargetUser}:${TargetUser} $TargetPath/api/appsettings.Production.json $TargetPath/web/appsettings.Production.json && rm /tmp/appsettings.Production.json"
   }
 }
 

--- a/src/Radio.Web/Components/Layout/MainLayout.razor
+++ b/src/Radio.Web/Components/Layout/MainLayout.razor
@@ -37,13 +37,13 @@
              data-source="@GetSourceDataAttr(source.Type)"
              @onclick="@(() => HandleSourceToggleAsync(source))"
              title="@source.Name">
-          <MudIcon Icon="@GetSourceIcon(source.Type)" Size="Size.Small" />
+          <MudIcon Icon="@GetSourceIcon(source.Type)" Size="Size.Medium" />
         </div>
       }
       @if (IsBluetoothSourceSelected())
       {
         <div class="route-toggle" @onclick="@(() => NavigationManager.NavigateTo("/bluetooth"))" title="Bluetooth Settings">
-          <MudIcon Icon="@Icons.Material.Filled.SettingsBluetooth" Size="Size.Small" />
+          <MudIcon Icon="@Icons.Material.Filled.SettingsBluetooth" Size="Size.Medium" />
         </div>
       }
     </div>
@@ -59,7 +59,7 @@
              @onclick="@(() => HandleOutputChangeAsync(output.Id))"
              title="@output.Name"
              style="position: relative;">
-          <MudIcon Icon="@GetOutputIcon(output)" Size="Size.Small" />
+          <MudIcon Icon="@GetOutputIcon(output)" Size="Size.Medium" />
           @if (output.Id == "google-cast" && _isCastConnecting)
           {
             <div class="cast-connecting" style="position:absolute; inset:0; border-radius:inherit; border: 2px solid var(--accent-primary);"></div>
@@ -75,39 +75,25 @@
       @if (_selectedOutputId == "google-cast")
       {
         <div class="route-toggle" @onclick="@OpenCastDeviceDialog" title="Select Cast Device">
-          <MudIcon Icon="@Icons.Material.Filled.Settings" Size="Size.Small" />
+          <MudIcon Icon="@Icons.Material.Filled.Settings" Size="Size.Medium" />
         </div>
       }
     </div>
 
-    <div class="topbar-separator"></div>
-
-    <!-- Volume Control -->
-    <div class="volume-control">
-      <MudIconButton Icon="@(_isMuted ? Icons.Material.Filled.VolumeOff : Icons.Material.Filled.VolumeUp)"
-                     Color="Color.Default" Size="Size.Small"
-                     Style="min-width:44px; min-height:44px;"
-                     OnClick="@HandleMuteAsync" />
-      <MudSlider T="double" Value="_volume" ValueChanged="@OnVolumeChanged"
-                 Min="0" Max="1" Step="0.01" Size="Size.Small"
-                 Color="Color.Primary" Style="width: 160px;" />
-      <span class="volume-label">@((_volume * 100).ToString("F0"))%</span>
-    </div>
-
     <!-- Navigation Icons (right-aligned) -->
     <div class="topbar-nav">
-      <MudIconButton Icon="@Icons.Material.Filled.Home" Class="@NavClass("/")" Href="/" Size="Size.Medium" title="Home" />
+      <MudIconButton Icon="@Icons.Material.Filled.Home" Class="@NavClass("/")" Href="/" Size="Size.Large" title="Home" />
       <MudBadge Content="@_queueCount" Overlap="true" Color="Color.Primary" Visible="@(_queueCount > 0)">
-        <MudIconButton Icon="@Icons.Material.Filled.QueueMusic" Class="@NavClass("/queue")" Href="/queue" Size="Size.Medium" title="Queue" />
+        <MudIconButton Icon="@Icons.Material.Filled.QueueMusic" Class="@NavClass("/queue")" Href="/queue" Size="Size.Large" title="Queue" />
       </MudBadge>
-      <MudIconButton Icon="@Icons.Material.Filled.Dashboard" Class="@NavClass("/metrics")" Href="/metrics" Size="Size.Medium" title="Metrics" />
-      <MudIconButton Icon="@Icons.Material.Filled.Devices" Class="@NavClass("/devices")" Href="/devices" Size="Size.Medium" title="Devices" />
-      <MudIconButton Icon="@Icons.Material.Filled.History" Class="@NavClass("/history")" Href="/history" Size="Size.Medium" title="History" />
-      <MudIconButton Icon="@Icons.Material.Filled.Settings" Class="@NavClass("/system")" Href="/system" Size="Size.Medium" title="Settings" />
+      <MudIconButton Icon="@Icons.Material.Filled.Dashboard" Class="@NavClass("/metrics")" Href="/metrics" Size="Size.Large" title="Metrics" />
+      <MudIconButton Icon="@Icons.Material.Filled.Devices" Class="@NavClass("/devices")" Href="/devices" Size="Size.Large" title="Devices" />
+      <MudIconButton Icon="@Icons.Material.Filled.History" Class="@NavClass("/history")" Href="/history" Size="Size.Large" title="History" />
+      <MudIconButton Icon="@Icons.Material.Filled.Settings" Class="@NavClass("/system")" Href="/system" Size="Size.Large" title="Settings" />
     </div>
   </div>
 
-  <!-- Main Content Area — 524px (576 - 52) -->
+  <!-- Main Content Area — 640px (720 - 80) -->
   <div class="content-area">
     <div class="page-transition">
       @Body
@@ -128,15 +114,7 @@
   private CastDeviceDto? _defaultCastDevice;
   private bool _isCastConnecting;
 
-  // Audio state for title bar volume control
-  private bool _isMuted = false;
-  private double _volume = 0.75;
   private int _queueCount = 0;
-  
-  // Volume debouncing
-  private System.Threading.Timer? _volumeDebounceTimer;
-  private double _pendingVolume;
-  private readonly object _volumeLock = new();
 
   private readonly MudTheme _customTheme = new()
   {
@@ -198,8 +176,7 @@
       DeviceDisplayState.DisplaySettingsChanged += OnDeviceDisplaySettingsChanged;
       Logger.LogDebug("MainLayout - Subscribed to audio state events");
 
-      // Load initial audio state
-      await RefreshAudioStateAsync();
+      // Load initial state
       await RefreshQueueCountAsync();
 
       // Update time immediately
@@ -681,13 +658,11 @@
 
   private async Task OnPlaybackStateChanged()
   {
-    await RefreshAudioStateAsync();
     await InvokeAsync(StateHasChanged);
   }
 
   private async Task OnNowPlayingChanged()
   {
-    await RefreshAudioStateAsync();
     await InvokeAsync(StateHasChanged);
   }
 
@@ -715,23 +690,6 @@
     await InvokeAsync(StateHasChanged);
   }
 
-  private async Task RefreshAudioStateAsync()
-  {
-    try
-    {
-      var state = await AudioApi.GetPlaybackStateAsync();
-      if (state != null)
-      {
-        _isMuted = state.IsMuted;
-        _volume = state.Volume;
-      }
-    }
-    catch (Exception ex)
-    {
-      Logger.LogError(ex, "Error refreshing audio state in MainLayout");
-    }
-  }
-
   private async Task RefreshQueueCountAsync()
   {
     try
@@ -746,44 +704,6 @@
     }
   }
 
-  private async Task HandleMuteAsync()
-  {
-    try
-    {
-      await AudioApi.ToggleMuteAsync(!_isMuted);
-      await RefreshAudioStateAsync();
-    }
-    catch (Exception ex)
-    {
-      Logger.LogError(ex, "Error in HandleMuteAsync");
-    }
-  }
-
-  private async Task OnVolumeChanged(double newVolume)
-  {
-    // Update UI immediately but debounce API call
-    _volume = newVolume;
-    
-    lock (_volumeLock)
-    {
-      _pendingVolume = newVolume;
-      
-      // Cancel existing timer and start new one
-      _volumeDebounceTimer?.Dispose();
-      _volumeDebounceTimer = new System.Threading.Timer(async _ =>
-      {
-        try
-        {
-          await AudioApi.SetVolumeAsync((float)_pendingVolume);
-        }
-        catch (Exception ex)
-        {
-          Logger.LogError(ex, "Error in debounced volume change");
-        }
-      }, null, TimeSpan.FromMilliseconds(300), Timeout.InfiniteTimeSpan);
-    }
-  }
-
   public void Dispose()
   {
     // Unsubscribe from events to prevent memory leaks
@@ -795,7 +715,6 @@
 
     _timer?.Stop();
     _timer?.Dispose();
-    _volumeDebounceTimer?.Dispose();
   }
 
   public ValueTask DisposeAsync()

--- a/src/Radio.Web/Components/Pages/PlayHistoryPage.razor
+++ b/src/Radio.Web/Components/Pages/PlayHistoryPage.razor
@@ -12,7 +12,7 @@
 <div style="height: 100%; display: flex; gap: 2px; overflow: hidden;">
   <!-- Left: Filters & Statistics -->
   <div class="panel surface-raised" style="width: 360px; flex-shrink: 0; overflow: hidden; padding: 16px; display: flex; flex-direction: column;">
-    <MudStack Spacing="3" Style="overflow-y: auto; flex: 1;">
+    <MudStack Spacing="3" Style="overflow-y: auto; overflow-x: hidden; flex: 1; min-height: 0;">
       <MudText Typo="Typo.h6">Play History</MudText>
 
       <MudDatePicker Label="Filter by Date" @bind-Date="_selectedDate" Clearable="true" />

--- a/src/Radio.Web/Components/Pages/QueuePage.razor
+++ b/src/Radio.Web/Components/Pages/QueuePage.razor
@@ -235,7 +235,7 @@
           <MudText Typo="Typo.body2" Color="Color.Secondary">1 track in queue</MudText>
         </div>
       }
-      <MudTable Items="@_queueItems" Hover="true" Dense="false" FixedHeader="true" Height="400px" Style="overflow-y: auto;">
+      <MudTable Items="@_queueItems" Hover="true" Dense="false" FixedHeader="true" Style="flex: 1; overflow-y: auto;">
         <HeaderContent>
           <MudTh Style="width: 60px; font-size: 1rem;">#</MudTh>
           <MudTh Style="font-size: 1rem;">Title</MudTh>

--- a/src/Radio.Web/Components/Pages/SystemConfigPage.razor
+++ b/src/Radio.Web/Components/Pages/SystemConfigPage.razor
@@ -126,7 +126,7 @@
 
     <!-- Tab 2: Configuration Management -->
     <MudTabPanel Text="Configuration" Icon="@Icons.Material.Filled.Tune">
-      <MudTabs Elevation="1" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-2">
+      <MudTabs Elevation="1" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-2" Style="max-width: 900px;">
         
         <!-- Audio Configuration -->
         <MudTabPanel Text="Audio">
@@ -1260,11 +1260,12 @@
 
     <!-- Tab 6: Secrets -->
     <MudTabPanel Text="Secrets" Icon="@Icons.Material.Filled.Lock">
+      <div style="max-width: 720px;">
       <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-3">
         <strong>Security Notice:</strong> Secrets are sensitive credentials. Values are masked by default and encrypted server-side. Only enter secrets in secure environments.
         Secrets must be explicitly saved using the "Save Secrets" button (not auto-saved).
       </MudAlert>
-      
+
       <MudTabs Elevation="1" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-2">
         
         <!-- TTS Secrets -->
@@ -1364,6 +1365,7 @@
         </MudTabPanel>
 
       </MudTabs>
+      </div>
     </MudTabPanel>
 
     <!-- Tab 7: Store Management -->

--- a/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
@@ -225,6 +225,18 @@
       </div>
     }
 
+    <!-- Volume Control -->
+    <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 4px;">
+      <MudIconButton Icon="@(_isMuted ? Icons.Material.Filled.VolumeOff : Icons.Material.Filled.VolumeUp)"
+                     Color="Color.Default" Size="Size.Medium"
+                     Style="min-width: 44px; min-height: 44px;"
+                     OnClick="@HandleMuteAsync" />
+      <MudSlider T="double" Value="_volume" ValueChanged="@OnVolumeChanged"
+                 Min="0" Max="1" Step="0.01" Size="Size.Small"
+                 Color="Color.Primary" Style="flex: 1;" />
+      <span style="font-family: var(--font-mono); font-size: 14px; color: var(--text-medium); min-width: 40px; text-align: right;">@((_volume * 100).ToString("F0"))%</span>
+    </div>
+
     <!-- Transport Controls -->
     <div class="transport-group">
       <MudIconButton Icon="@Icons.Material.Filled.Shuffle"

--- a/src/Radio.Web/Components/Shared/VisualizerPanel.razor
+++ b/src/Radio.Web/Components/Shared/VisualizerPanel.razor
@@ -86,7 +86,7 @@
       {
         _jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/visualizer.js");
 
-        var success = await _jsModule.InvokeAsync<bool>("visualizer.init", "visualizer-panel-canvas", 650, 400);
+        var success = await _jsModule.InvokeAsync<bool>("visualizer.init", "visualizer-panel-canvas", 0, 0);
         if (success)
         {
           _isInitialized = true;

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -92,8 +92,8 @@
   /* ── Fixed Dimensions ── */
   --viewport-width:         1920px;
   --viewport-height:        720px;
-  --topbar-height:          52px;
-  --content-height:         668px;
+  --topbar-height:          80px;
+  --content-height:         640px;
 
   /* ── Touch Targets ── */
   --touch-min:              48px;
@@ -172,10 +172,10 @@ html, body {
 
 .topbar-clock {
   font-family: var(--font-led);
-  font-size: 20px;
+  font-size: 28px;
   color: var(--signal-amber);
   text-shadow: 0 0 8px var(--signal-amber-glow);
-  min-width: 80px;
+  min-width: 100px;
   letter-spacing: 2px;
 }
 
@@ -187,7 +187,7 @@ html, body {
 
 .topbar-separator {
   width: 1px;
-  height: 28px;
+  height: 44px;
   background: var(--surface-separator);
   margin: 0 4px;
 }
@@ -205,15 +205,15 @@ html, body {
 .route-group {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 4px;
   background: var(--surface-inset);
-  border-radius: 24px;
-  padding: 3px 6px;
+  border-radius: 32px;
+  padding: 4px 10px;
   border: 1px solid var(--surface-separator);
 }
 
 .route-label {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
   text-transform: uppercase;
   color: var(--text-low);
@@ -224,9 +224,9 @@ html, body {
 
 .route-toggle {
   position: relative;
-  width: 44px;
-  height: 44px;
-  border-radius: 20px;
+  width: 56px;
+  height: 56px;
+  border-radius: 28px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -970,8 +970,12 @@ html, body {
 /* Vertical tabs — left-align text, scrollable panels */
 .mud-tabs-vertical .mud-tab { justify-content: flex-start !important; text-align: left; }
 .mud-tabs-vertical .mud-tab-content { justify-content: flex-start; }
-.mud-tabs-vertical > .mud-tabs-panels { overflow-y: auto; }
-.mud-tabs-vertical > .mud-tabs-header { overflow: hidden; }
+.mud-tabs-vertical > .mud-tabs-panels { overflow-y: auto; overflow-x: hidden; }
+.mud-tabs-vertical > .mud-tabs-header { overflow: hidden; min-width: 160px; }
+
+/* Nested horizontal config tabs — compact scrollable */
+.mud-tabs-vertical .mud-tabs:not(.mud-tabs-vertical) .mud-tab { min-height: 36px; font-size: 13px; padding: 0 10px; }
+.mud-tabs-vertical .mud-tabs:not(.mud-tabs-vertical) .mud-tabs-header { overflow-x: auto; flex-wrap: nowrap; }
 
 /* Switches — normalize thumb to fit track */
 .mud-switch .mud-switch-thumb { width: 20px; height: 20px; }

--- a/src/Radio.Web/wwwroot/js/visualizer.js
+++ b/src/Radio.Web/wwwroot/js/visualizer.js
@@ -4,7 +4,6 @@
 export const visualizer = {
   canvases: {},
   animationFrames: {},
-  upsTracking: {}, // Track updates per second for each canvas
 
   // Initialize a canvas for visualization
   init: function (canvasId, width, height) {
@@ -20,8 +19,14 @@ export const visualizer = {
       return false;
     }
 
-    canvas.width = width;
-    canvas.height = height;
+    // Auto-size from container if dimensions not provided (fallback to known panel size)
+    const parent = canvas.parentElement;
+    const actualWidth = width || (parent && parent.clientWidth > 0 ? parent.clientWidth : 710);
+    const actualHeight = height || (parent && parent.clientHeight > 0 ? parent.clientHeight : 640);
+    canvas.width = actualWidth;
+    canvas.height = actualHeight;
+    width = actualWidth;
+    height = actualHeight;
 
     this.canvases[canvasId] = {
       canvas: canvas,
@@ -35,13 +40,6 @@ export const visualizer = {
       targetScaleFactor: 1.0
     };
 
-    // Initialize UPS tracking for this canvas
-    this.upsTracking[canvasId] = {
-      timestamps: [],
-      currentUPS: 0,
-      lastUPSUpdate: Date.now()
-    };
-
     console.log(`Initialized canvas ${canvasId} (${width}x${height})`);
     return true;
   },
@@ -53,51 +51,6 @@ export const visualizer = {
 
     const { ctx, width, height } = canvasData;
     ctx.clearRect(0, 0, width, height);
-  },
-
-  // Track update and calculate UPS
-  trackUpdate: function (canvasId) {
-    const tracking = this.upsTracking[canvasId];
-    if (!tracking) return;
-
-    const now = Date.now();
-    tracking.timestamps.push(now);
-
-    // Keep only last 60 timestamps (enough for 1 second of data at high rates)
-    if (tracking.timestamps.length > 60) {
-      tracking.timestamps.shift();
-    }
-
-    // Update UPS calculation every second
-    if (now - tracking.lastUPSUpdate >= 1000) {
-      // Calculate UPS from timestamps in the last second
-      const oneSecondAgo = now - 1000;
-      const recentTimestamps = tracking.timestamps.filter(t => t >= oneSecondAgo);
-      tracking.currentUPS = recentTimestamps.length;
-      tracking.lastUPSUpdate = now;
-    }
-  },
-
-  // Draw UPS indicator
-  drawUPSIndicator: function (ctx, width, height, ups) {
-    // Determine color based on performance
-    let color;
-    if (ups > 30) {
-      color = '#4ADE80'; // Green
-    } else if (ups >= 15) {
-      color = '#F0A830'; // Amber
-    } else {
-      color = '#F87171'; // Red
-    }
-
-    // Draw in bottom-left corner
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
-    ctx.fillRect(5, height - 25, 120, 20);
-    
-    ctx.fillStyle = color;
-    ctx.font = '14px Inter, sans-serif';
-    ctx.textAlign = 'left';
-    ctx.fillText(`Updates: ${ups}/sec`, 10, height - 10);
   },
 
   // Update dynamic VU meter scaling
@@ -140,14 +93,24 @@ export const visualizer = {
     canvasData.scaleFactor += (canvasData.targetScaleFactor - canvasData.scaleFactor) * transitionSpeed;
   },
 
+  // Lazy-resize: fix canvas if it was initialized before parent had layout
+  ensureCanvasSize: function (canvasData) {
+    if (canvasData.width > 0 && canvasData.height > 0) return;
+    const parent = canvasData.canvas.parentElement;
+    const w = parent && parent.clientWidth > 0 ? parent.clientWidth : 710;
+    const h = parent && parent.clientHeight > 0 ? parent.clientHeight : 640;
+    canvasData.canvas.width = w;
+    canvasData.canvas.height = h;
+    canvasData.width = w;
+    canvasData.height = h;
+  },
+
   // Draw VU meter
   drawVUMeter: function (canvasId, leftPeak, rightPeak, leftRms, rightRms, isClipping) {
     const canvasData = this.canvases[canvasId];
     if (!canvasData) return;
-    
-    // Track this update for UPS calculation
-    this.trackUpdate(canvasId);
-    
+    this.ensureCanvasSize(canvasData);
+
     // Validate and clamp inputs
     leftPeak = Math.max(0, Math.min(1, leftPeak || 0));
     rightPeak = Math.max(0, Math.min(1, rightPeak || 0));
@@ -183,22 +146,6 @@ export const visualizer = {
     // Draw right meter
     this.drawMeter(ctx, meterX + meterWidth + spacing, meterY, meterWidth, meterHeight, rightPeak, rightRms, isClipping, 'Right');
     
-    // Draw scale factor indicator (top-right corner)
-    if (scaleFactor > 1.01) { // Only show if scaled
-      ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
-      ctx.fillRect(width - 85, 5, 80, 25);
-      
-      ctx.fillStyle = '#5CD4E8';
-      ctx.font = '14px Inter, sans-serif';
-      ctx.textAlign = 'right';
-      ctx.fillText(`×${scaleFactor.toFixed(2)}`, width - 10, 22);
-    }
-    
-    // Draw UPS indicator
-    const tracking = this.upsTracking[canvasId];
-    if (tracking) {
-      this.drawUPSIndicator(ctx, width, height, tracking.currentUPS);
-    }
   },
 
   drawMeter: function (ctx, x, y, width, height, peak, rms, isClipping, label) {
@@ -290,9 +237,7 @@ export const visualizer = {
   drawWaveform: function (canvasId, leftSamples, rightSamples) {
     const canvasData = this.canvases[canvasId];
     if (!canvasData) return;
-
-    // Track this update for UPS calculation
-    this.trackUpdate(canvasId);
+    this.ensureCanvasSize(canvasData);
 
     const { ctx, width, height } = canvasData;
     
@@ -327,12 +272,6 @@ export const visualizer = {
     ctx.textAlign = 'left';
     ctx.fillText('Left', 10, 20);
     ctx.fillText('Right', 10, channelHeight + 20);
-    
-    // Draw UPS indicator
-    const tracking = this.upsTracking[canvasId];
-    if (tracking) {
-      this.drawUPSIndicator(ctx, width, height, tracking.currentUPS);
-    }
   },
 
   drawWaveformChannel: function (ctx, samples, x, y, width, height, colorPositive, colorNegative) {
@@ -383,9 +322,7 @@ export const visualizer = {
   drawSpectrum: function (canvasId, magnitudes, frequencies) {
     const canvasData = this.canvases[canvasId];
     if (!canvasData) return;
-
-    // Track this update for UPS calculation
-    this.trackUpdate(canvasId);
+    this.ensureCanvasSize(canvasData);
 
     const { ctx, width, height } = canvasData;
     
@@ -438,12 +375,6 @@ export const visualizer = {
         ctx.fillText(label, labelX, height - 5);
       }
     });
-    
-    // Draw UPS indicator
-    const tracking = this.upsTracking[canvasId];
-    if (tracking) {
-      this.drawUPSIndicator(ctx, width, height, tracking.currentUPS);
-    }
   },
 
   interpolateColor: function (color1, color2, t) {


### PR DESCRIPTION
## Summary
- Enlarged topbar icons for kiosk touch (Source/Output to Medium, Nav to Large), increased topbar from 52px to 80px and viewport from 576px to 720px
- Moved volume control from topbar to NowPlayingPanel for better contextual grouping
- Removed all debug overlays from visualizer (UPS counter, scale factor) and added canvas auto-sizing from container with lazy-resize fallback
- Fixed Queue page MudTable hardcoded 400px height (now flex-fills available space)
- Fixed History page left-panel horizontal scrollbar overflow
- Fixed System Config nested tab overflow and Secrets field width stretching
- Fixed deploy script hardcoded `radio:radio` ownership — now uses `$TargetUser` variable

## Test plan
- [x] Build: 0 warnings, 0 errors
- [x] Tests: 82 passed, 3 skipped, 0 failures (IntegrationTests)
- [x] Deployed to Ubuntu x64 and visually verified all pages at 1920x720
- [ ] Verify visualizer canvas auto-sizes on first draw call when audio plays
- [ ] Verify deploy script ownership works on fresh deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)