### PR TITLE
feat: Audio source exclusivity, system actions, and icon sizing

### DIFF
--- a/src/Radio.API/Controllers/SystemController.cs
+++ b/src/Radio.API/Controllers/SystemController.cs
@@ -500,4 +500,104 @@ public class SystemController : ControllerBase
     
     return Ok(new { message = "Shutdown initiated" });
   }
+
+  /// <summary>
+  /// Powers off the entire system (Linux only).
+  /// Requires the service user to have passwordless sudo for systemctl poweroff,
+  /// or polkit authorization for org.freedesktop.login1.power-off.
+  /// </summary>
+  [HttpPost("poweroff")]
+  [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(object), StatusCodes.Status400BadRequest)]
+  public IActionResult PowerOff()
+  {
+    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+    {
+      return BadRequest(new { error = "System power off is only supported on Linux" });
+    }
+
+    _logger.LogWarning("System power off requested via API");
+
+    Task.Run(async () =>
+    {
+      try
+      {
+        await Task.Delay(1500); // Allow response to be sent
+        _logger.LogInformation("Executing system power off...");
+
+        var psi = new ProcessStartInfo("systemctl", "poweroff")
+        {
+          RedirectStandardOutput = true,
+          RedirectStandardError = true,
+          UseShellExecute = false,
+        };
+
+        using var proc = Process.Start(psi);
+        if (proc != null)
+        {
+          await proc.WaitForExitAsync();
+          if (proc.ExitCode != 0)
+          {
+            var stderr = await proc.StandardError.ReadToEndAsync();
+            _logger.LogError("systemctl poweroff failed (exit {ExitCode}): {Error}", proc.ExitCode, stderr);
+          }
+        }
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "Failed to execute system power off");
+      }
+    });
+
+    return Ok(new { message = "System power off initiated" });
+  }
+
+  /// <summary>
+  /// Restarts the radio-api and radio-web systemd services (Linux only).
+  /// </summary>
+  [HttpPost("restart-services")]
+  [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(object), StatusCodes.Status400BadRequest)]
+  public IActionResult RestartServices()
+  {
+    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+    {
+      return BadRequest(new { error = "Service restart is only supported on Linux" });
+    }
+
+    _logger.LogWarning("Service restart requested via API");
+
+    Task.Run(async () =>
+    {
+      try
+      {
+        await Task.Delay(1500); // Allow response to be sent
+        _logger.LogInformation("Restarting radio services...");
+
+        var psi = new ProcessStartInfo("sudo", "systemctl restart radio-api radio-web")
+        {
+          RedirectStandardOutput = true,
+          RedirectStandardError = true,
+          UseShellExecute = false,
+        };
+
+        using var proc = Process.Start(psi);
+        if (proc != null)
+        {
+          await proc.WaitForExitAsync();
+          if (proc.ExitCode != 0)
+          {
+            var stderr = await proc.StandardError.ReadToEndAsync();
+            _logger.LogError("Service restart failed (exit {ExitCode}): {Error}", proc.ExitCode, stderr);
+          }
+        }
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "Failed to restart services");
+      }
+    });
+
+    return Ok(new { message = "Service restart initiated" });
+  }
 }

--- a/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
@@ -23,7 +23,6 @@ public class AudioManager : IAudioManager, IAsyncDisposable
 
   // State
   private IAudioSource? _activeSource;
-  private IAudioSource? _previousSource; // Track previous source for delayed cleanup
   private readonly Dictionary<AudioSourceType, IAudioSource> _sourceCache = new();
   private readonly SemaphoreSlim _switchLock = new(1, 1);
   private readonly SemaphoreSlim _createLock = new(1, 1);
@@ -207,18 +206,34 @@ public class AudioManager : IAudioManager, IAsyncDisposable
       var mixer = _audioEngine.GetMasterMixer();
       var oldSource = _activeSource;
 
-      // Determine if old source should keep playing during transition
-      bool shouldKeepOldSourcePlaying = oldSource != null &&
-                                         oldSource != source &&
-                                         (oldSource.State == AudioSourceState.Playing ||
-                                          oldSource.State == AudioSourceState.Paused);
-
-      if (shouldKeepOldSourcePlaying)
+      // Stop the old source immediately to prevent simultaneous playback.
+      // Only one primary source should ever produce audio at a time.
+      if (oldSource != null && oldSource != source &&
+          (oldSource.State == AudioSourceState.Playing ||
+           oldSource.State == AudioSourceState.Paused))
       {
         _logger.LogInformation(
-          "Keeping old source {OldSource} playing during transition to {NewSource}",
-          oldSource!.Name, source.Name);
-        _previousSource = oldSource;
+          "Stopping old source {OldSource} before switching to {NewSource}",
+          oldSource.Name, source.Name);
+
+        try
+        {
+          if (oldSource is IPrimaryAudioSource oldPrimary)
+          {
+            await oldPrimary.StopAsync(cancellationToken);
+          }
+
+          // Remove from mixer so its audio components are disconnected
+          if (mixer.GetActiveSources().Contains(oldSource))
+          {
+            mixer.RemoveSource(oldSource);
+            _logger.LogInformation("Removed old source {SourceName} from mixer", oldSource.Name);
+          }
+        }
+        catch (Exception ex)
+        {
+          _logger.LogWarning(ex, "Error stopping old source {SourceName} during switch", oldSource.Name);
+        }
       }
 
       // Ensure the new source is in the mixer
@@ -229,7 +244,7 @@ public class AudioManager : IAudioManager, IAsyncDisposable
         mixer.AddSource(source);
       }
 
-      // Update the active source reference early so new source becomes "active"
+      // Update the active source reference
       _activeSource = source;
 
       // Reset song change detection state for the new source
@@ -260,15 +275,11 @@ public class AudioManager : IAudioManager, IAsyncDisposable
             "Starting playback on new source: {SourceName}",
             source.Name);
           await newPrimary.PlayAsync(cancellationToken);
-
-          // Cleanup of the old source (stop + mixer removal) is handled centrally
-          // in the StateChanged event handler when the new source transitions to Playing.
-          // This avoids duplicate cleanup paths and potential race conditions.
         }
         else if (!canAutoPlay)
         {
           _logger.LogInformation(
-            "Source {SourceName} requires content selection before playback. Old source will keep playing until new content starts.",
+            "Source {SourceName} requires content selection before playback",
             source.Name);
         }
       }
@@ -457,10 +468,10 @@ public class AudioManager : IAudioManager, IAsyncDisposable
   }
 
   /// <summary>
-  /// Handles source state changes for previous source cleanup when a new source starts playing.
+  /// Handles source state changes. Logs state transitions for diagnostics.
   /// Play history recording is handled separately by PlayHistoryTracker.
   /// </summary>
-  private async void OnSourceStateChanged(object? sender, AudioSourceStateChangedEventArgs e)
+  private void OnSourceStateChanged(object? sender, AudioSourceStateChangedEventArgs e)
   {
     if (sender is not IAudioSource source)
       return;
@@ -468,59 +479,6 @@ public class AudioManager : IAudioManager, IAsyncDisposable
     _logger.LogInformation(
       "Source state changed: {SourceName} ({SourceType}) {OldState} -> {NewState}, IsActiveSource={IsActive}",
       source.Name, source.Type, e.PreviousState, e.NewState, source == _activeSource);
-
-    // Clean up previous source when active source starts playing
-    if (e.NewState == AudioSourceState.Playing && source == _activeSource && _previousSource != null)
-    {
-      await _switchLock.WaitAsync();
-      try
-      {
-        // Double-check after acquiring lock (state may have changed)
-        if (source != _activeSource || _previousSource == null)
-          return;
-
-        // Guard: Prevent cleaning up the active source if it was also tracked as previous
-        if (_previousSource == _activeSource || _previousSource.Id == _activeSource.Id)
-        {
-          _logger.LogInformation("Active source and previous source are the same. Skipping cleanup.");
-          _previousSource = null;
-          return;
-        }
-
-        _logger.LogInformation(
-          "Active source {ActiveSource} is now playing. Cleaning up previous source {PreviousSource}",
-          source.Name, _previousSource.Name);
-
-        try
-        {
-          var mixer = _audioEngine.GetMasterMixer();
-
-          // Stop the previous source
-          if (_previousSource is IPrimaryAudioSource previousPrimary)
-          {
-            await previousPrimary.StopAsync();
-            _logger.LogInformation("Stopped previous source: {SourceName}", _previousSource.Name);
-          }
-
-          // Remove previous source from mixer
-          if (mixer.GetActiveSources().Contains(_previousSource))
-          {
-            mixer.RemoveSource(_previousSource);
-            _logger.LogInformation("Removed previous source {SourceName} from mixer", _previousSource.Name);
-          }
-
-          _previousSource = null;
-        }
-        catch (Exception ex)
-        {
-          _logger.LogError(ex, "Failed to clean up previous source");
-        }
-      }
-      finally
-      {
-        _switchLock.Release();
-      }
-    }
   }
 
   /// <inheritdoc/>

--- a/src/Radio.Web/Components/Pages/SystemConfigPage.razor
+++ b/src/Radio.Web/Components/Pages/SystemConfigPage.razor
@@ -122,6 +122,28 @@
           </MudCard>
         </MudItem>
       </MudGrid>
+
+      @if (OperatingSystem.IsLinux())
+      {
+        <MudDivider Class="my-4" />
+        <MudGrid Spacing="3">
+          <MudItem xs="12">
+            <MudText Typo="Typo.h6" Class="mb-2">System Actions</MudText>
+          </MudItem>
+          <MudItem xs="6" md="3">
+            <MudButton Variant="Variant.Filled" Color="Color.Warning" FullWidth="true" Size="Size.Large"
+                       StartIcon="@Icons.Material.Filled.Refresh" OnClick="RestartServicesAsync">
+              Restart Services
+            </MudButton>
+          </MudItem>
+          <MudItem xs="6" md="3">
+            <MudButton Variant="Variant.Filled" Color="Color.Error" FullWidth="true" Size="Size.Large"
+                       StartIcon="@Icons.Material.Filled.PowerSettingsNew" OnClick="ShutdownSystemAsync">
+              Shutdown System
+            </MudButton>
+          </MudItem>
+        </MudGrid>
+      }
     </MudTabPanel>
 
     <!-- Tab 2: Configuration Management -->
@@ -2992,6 +3014,38 @@
         Logger.LogError(ex, "Error importing configuration");
         Snackbar.Add($"Error importing: {ex.Message}", Severity.Error);
       }
+    }
+  }
+
+  private async Task RestartServicesAsync()
+  {
+    var confirmed = await DialogService.ShowMessageBox(
+      "Restart Services",
+      "Restart radio-api and radio-web services? The UI will disconnect briefly.",
+      yesText: "Restart", cancelText: "Cancel");
+
+    if (confirmed == true)
+    {
+      Snackbar.Add("Restarting services...", Severity.Info);
+      var ok = await SystemApi.RestartServicesAsync();
+      if (!ok)
+        Snackbar.Add("Failed to restart services", Severity.Error);
+    }
+  }
+
+  private async Task ShutdownSystemAsync()
+  {
+    var confirmed = await DialogService.ShowMessageBox(
+      "Shutdown System",
+      "Power off the system? You will need physical access to turn it back on.",
+      yesText: "Shutdown", cancelText: "Cancel");
+
+    if (confirmed == true)
+    {
+      Snackbar.Add("System shutting down...", Severity.Warning);
+      var ok = await SystemApi.PowerOffSystemAsync();
+      if (!ok)
+        Snackbar.Add("Failed to power off system", Severity.Error);
     }
   }
 

--- a/src/Radio.Web/Services/ApiClients/SystemApiService.cs
+++ b/src/Radio.Web/Services/ApiClients/SystemApiService.cs
@@ -57,4 +57,32 @@ public class SystemApiService
       return null;
     }
   }
+
+  public async Task<bool> PowerOffSystemAsync(CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      var response = await _httpClient.PostAsync("/api/system/poweroff", null, cancellationToken);
+      return response.IsSuccessStatusCode;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to power off system");
+      return false;
+    }
+  }
+
+  public async Task<bool> RestartServicesAsync(CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      var response = await _httpClient.PostAsync("/api/system/restart-services", null, cancellationToken);
+      return response.IsSuccessStatusCode;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to restart services");
+      return false;
+    }
+  }
 }

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -187,7 +187,7 @@ html, body {
 
 .topbar-separator {
   width: 1px;
-  height: 44px;
+  height: 48px;
   background: var(--surface-separator);
   margin: 0 4px;
 }
@@ -205,10 +205,10 @@ html, body {
 .route-group {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   background: var(--surface-inset);
-  border-radius: 32px;
-  padding: 4px 10px;
+  border-radius: 36px;
+  padding: 4px 12px;
   border: 1px solid var(--surface-separator);
 }
 
@@ -224,9 +224,9 @@ html, body {
 
 .route-toggle {
   position: relative;
-  width: 56px;
-  height: 56px;
-  border-radius: 28px;
+  width: 64px;
+  height: 64px;
+  border-radius: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -236,6 +236,12 @@ html, body {
   border: none;
   background: transparent;
   -webkit-tap-highlight-color: transparent;
+}
+
+.route-toggle .mud-icon-root {
+  font-size: 30px !important;
+  width: 30px;
+  height: 30px;
 }
 
 .route-toggle:hover:not(.route-disabled) {
@@ -318,9 +324,9 @@ html, body {
 
 .nav-icon {
   position: relative;
-  width: 44px;
-  height: 48px;
-  border-radius: 12px;
+  width: 52px;
+  height: 56px;
+  border-radius: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -328,6 +334,13 @@ html, body {
   cursor: pointer;
   transition: color 100ms ease, background 100ms ease;
   -webkit-tap-highlight-color: transparent;
+}
+
+.nav-icon .mud-icon-button-label .mud-icon-root,
+.topbar-nav .mud-icon-root {
+  font-size: 30px !important;
+  width: 30px;
+  height: 30px;
 }
 
 .nav-icon:hover {


### PR DESCRIPTION
## Summary

- **F.14**: Fix audio source exclusivity — immediately stop old source when switching instead of relying on delayed cleanup via StateChanged event. Prevents simultaneous playback, especially when switching to FilePlayer (which doesn't auto-play and never triggered cleanup).
- **F.15**: Verified output exclusivity (Cast + local muting) is correctly implemented — no code changes needed.
- **F.16**: Add "Restart Services" and "Shutdown System" buttons to System Stats page (Linux only). New API endpoints: `POST /api/system/poweroff` and `POST /api/system/restart-services`.
- **F.19**: Increase topbar icons ~15-20% for better touch-screen usability (source/output toggles: 56px→64px, nav icons: 44x48→52x56, SVG icons: 24px→30px).

## Test plan

- [x] Build: 0 warnings, 0 errors
- [x] Tests: All 1343+ tests pass
- [x] Deployed to Ubuntu x64 and verified visually
- [x] System Actions buttons visible on System Stats page (Linux only)
- [x] Topbar icons visually larger and touch-friendly at 1920x720 kiosk resolution
- [ ] Manual test: Switch between sources rapidly — verify no simultaneous playback
- [ ] Manual test: Shutdown System button triggers system poweroff
- [ ] Manual test: Restart Services button restarts radio-api/radio-web

🤖 Generated with [Claude Code](https://claude.com/claude-code)