### PR TITLE
feat: Improve Bluetooth album art lookup pipeline

### DIFF
--- a/src/Radio.Core/Interfaces/Audio/IMetadataLookupService.cs
+++ b/src/Radio.Core/Interfaces/Audio/IMetadataLookupService.cs
@@ -40,4 +40,15 @@ public interface IMetadataLookupService
   Task<string?> SearchCoverArtByTextAsync(
     string title, string artist, string? album = null,
     CancellationToken ct = default);
+
+  /// <summary>
+  /// Gets cover art directly from the Cover Art Archive by MusicBrainz release ID.
+  /// Faster than text search when the release ID is already known (e.g., from fingerprinting).
+  /// </summary>
+  /// <param name="releaseId">The MusicBrainz release ID.</param>
+  /// <param name="ct">Cancellation token.</param>
+  /// <returns>The cover art URL, or null if not found.</returns>
+  Task<string?> GetCoverArtByReleaseIdAsync(
+    string releaseId,
+    CancellationToken ct = default);
 }

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/MetadataLookupService.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/MetadataLookupService.cs
@@ -611,6 +611,15 @@ public sealed class MetadataLookupService : IMetadataLookupService
     return title.Trim();
   }
 
+  /// <inheritdoc/>
+  public async Task<string?> GetCoverArtByReleaseIdAsync(string releaseId, CancellationToken ct = default)
+  {
+    if (string.IsNullOrWhiteSpace(releaseId))
+      return null;
+
+    return await GetCoverArtUrlAsync(releaseId, ct);
+  }
+
   /// <summary>
   /// Queries the Cover Art Archive for a release's front cover image URL.
   /// Uses a separate HttpClient to avoid sending the MusicBrainz User-Agent to archive.org.

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -29,6 +29,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
   private readonly IOptionsMonitor<BluetoothOptions> _options;
   private readonly SoundFlowPlaybackService? _playbackService;
   private readonly SemaphoreSlim _routeLock = new(1, 1);
+  private readonly HashSet<string> _failedArtLookups = new();
   private string? _playbackId;
   private string? _lastCoverArtLookupKey;
   private AudioCaptureDevice? _captureDevice;
@@ -520,7 +521,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
     {
       // AVRCP rarely provides album art — look it up via MusicBrainz text search
       var lookupKey = $"{e.Title}|{e.Artist}";
-      if (lookupKey != _lastCoverArtLookupKey)
+      if (lookupKey != _lastCoverArtLookupKey && !_failedArtLookups.Contains(lookupKey))
       {
         _lastCoverArtLookupKey = lookupKey;
         _ = LookupCoverArtAsync(e.Title, e.Artist, e.Album);
@@ -539,6 +540,34 @@ public class BluetoothAudioSource : USBAudioSourceBase
         "Track identified via fingerprinting: '{Title}' by '{Artist}' — skipping further fingerprinting",
         e.Track.Title, e.Track.Artist);
     }
+
+    // Use fingerprint-identified cover art if we don't already have art
+    var hasArt = MetadataInternal.TryGetValue(StandardMetadataKeys.AlbumArtUrl, out var existingArt)
+      && existingArt is string artStr && !string.IsNullOrEmpty(artStr);
+
+    if (!hasArt && _serviceScopeFactory != null)
+    {
+      if (!string.IsNullOrEmpty(e.Track.CoverArtUrl))
+      {
+        // Fingerprint pipeline already found cover art — cache it locally
+        _ = CacheAndSetCoverArtAsync(e.Track.CoverArtUrl, e.Track.Title, e.Track.Artist);
+      }
+      else if (!string.IsNullOrEmpty(e.Track.MusicBrainzReleaseId))
+      {
+        // Have a release ID but no art yet — query Cover Art Archive directly
+        _ = LookupCoverArtByReleaseIdAsync(e.Track.MusicBrainzReleaseId, e.Track.Title, e.Track.Artist);
+      }
+      else if (!string.IsNullOrEmpty(e.Track.Title) && !string.IsNullOrEmpty(e.Track.Artist))
+      {
+        // Fingerprint gave us better metadata — retry text search with it
+        var lookupKey = $"{e.Track.Title}|{e.Track.Artist}";
+        if (lookupKey != _lastCoverArtLookupKey && !_failedArtLookups.Contains(lookupKey))
+        {
+          _lastCoverArtLookupKey = lookupKey;
+          _ = LookupCoverArtAsync(e.Track.Title, e.Track.Artist, e.Track.Album);
+        }
+      }
+    }
   }
 
   private async Task LookupCoverArtAsync(string title, string artist, string? album)
@@ -547,8 +576,6 @@ public class BluetoothAudioSource : USBAudioSourceBase
     {
       Logger.LogInformation("Looking up cover art for '{Title}' by '{Artist}' (Album: '{Album}')", title, artist, album);
 
-      // Resolve IMetadataLookupService from a scope (it's registered as scoped,
-      // but BluetoothAudioSource is a long-lived singleton-created instance)
       using var scope = _serviceScopeFactory!.CreateScope();
       var lookupService = scope.ServiceProvider.GetService<IMetadataLookupService>();
       if (lookupService == null)
@@ -558,23 +585,23 @@ public class BluetoothAudioSource : USBAudioSourceBase
       }
 
       var coverArtUrl = await lookupService.SearchCoverArtByTextAsync(title, artist, album);
+
+      // If album was specified but no results, retry without album constraint —
+      // streaming services append edition info that may not match MusicBrainz
+      if (string.IsNullOrEmpty(coverArtUrl) && !string.IsNullOrEmpty(album))
+      {
+        Logger.LogDebug("Retrying cover art search without album for '{Title}' by '{Artist}'", title, artist);
+        coverArtUrl = await lookupService.SearchCoverArtByTextAsync(title, artist);
+      }
+
       if (!string.IsNullOrEmpty(coverArtUrl))
       {
-        // Cache the external URL locally so the Web UI can serve it via /api/albumart/
-        if (_albumArtCache != null)
-        {
-          var localUrl = await _albumArtCache.SaveFromUrlAsync(coverArtUrl);
-          if (!string.IsNullOrEmpty(localUrl))
-          {
-            coverArtUrl = localUrl;
-          }
-        }
-
-        MetadataInternal[StandardMetadataKeys.AlbumArtUrl] = coverArtUrl;
-        Logger.LogInformation("Cover art found for '{Title}' by '{Artist}': {Url}", title, artist, coverArtUrl);
+        await CacheAndSetCoverArtUrlAsync(coverArtUrl, title, artist);
       }
       else
       {
+        // Track this failure to avoid re-querying for the same track
+        _failedArtLookups.Add($"{title}|{artist}");
         Logger.LogInformation("No cover art found for '{Title}' by '{Artist}'", title, artist);
       }
     }
@@ -582,6 +609,61 @@ public class BluetoothAudioSource : USBAudioSourceBase
     {
       Logger.LogWarning(ex, "Cover art lookup failed for '{Title}' by '{Artist}'", title, artist);
     }
+  }
+
+  private async Task CacheAndSetCoverArtAsync(string coverArtUrl, string title, string artist)
+  {
+    try
+    {
+      await CacheAndSetCoverArtUrlAsync(coverArtUrl, title, artist);
+    }
+    catch (Exception ex)
+    {
+      Logger.LogWarning(ex, "Failed to cache cover art from fingerprint for '{Title}' by '{Artist}'", title, artist);
+    }
+  }
+
+  private async Task LookupCoverArtByReleaseIdAsync(string releaseId, string title, string artist)
+  {
+    try
+    {
+      Logger.LogInformation(
+        "Looking up cover art by release ID {ReleaseId} for '{Title}' by '{Artist}'",
+        releaseId, title, artist);
+
+      using var scope = _serviceScopeFactory!.CreateScope();
+      var lookupService = scope.ServiceProvider.GetService<IMetadataLookupService>();
+      if (lookupService == null) return;
+
+      var coverArtUrl = await lookupService.GetCoverArtByReleaseIdAsync(releaseId);
+      if (!string.IsNullOrEmpty(coverArtUrl))
+      {
+        await CacheAndSetCoverArtUrlAsync(coverArtUrl, title, artist);
+      }
+      else
+      {
+        Logger.LogDebug("No cover art at Cover Art Archive for release {ReleaseId}", releaseId);
+      }
+    }
+    catch (Exception ex)
+    {
+      Logger.LogWarning(ex, "Cover art lookup by release ID failed for '{Title}' by '{Artist}'", title, artist);
+    }
+  }
+
+  private async Task CacheAndSetCoverArtUrlAsync(string coverArtUrl, string title, string artist)
+  {
+    if (_albumArtCache != null)
+    {
+      var localUrl = await _albumArtCache.SaveFromUrlAsync(coverArtUrl);
+      if (!string.IsNullOrEmpty(localUrl))
+      {
+        coverArtUrl = localUrl;
+      }
+    }
+
+    MetadataInternal[StandardMetadataKeys.AlbumArtUrl] = coverArtUrl;
+    Logger.LogInformation("Cover art found for '{Title}' by '{Artist}': {Url}", title, artist, coverArtUrl);
   }
 
   /// <summary>

--- a/task_plan.md
+++ b/task_plan.md
@@ -276,21 +276,17 @@ Four root causes identified and fixed:
 
 **Approach:** Use frontend-design skill to holistically adjust the topbar proportions and ensure downstream layout (content-area, panels) remains balanced.
 
-### F.18 Bluetooth Album Art: Prefer BT Metadata Over Online Lookup 🟡
-**Status:** pending
+### F.18 Bluetooth Album Art: Improve Album Art Lookup Pipeline ✅
+**Status:** complete
 
-**Problem:** Bluetooth connections used to provide album art directly via AVRCP metadata, but the current code falls back to MusicBrainz lookup based on song/artist/album name. BT-provided album art is almost always higher quality (the source app sends the actual cover art) compared to MusicBrainz which may return lower-res or mismatched art.
+**Investigation findings:** BlueZ AVRCP does NOT provide album art via D-Bus on this system (confirmed via live dbus-send queries). The Track metadata dict has Title, Artist, TrackNumber, Duration — but no ArtUrl, no Album art data. BlueZ doesn't support AVRCP BIP (Basic Imaging Profile). The task was reframed to improve the online lookup pipeline instead.
 
-**Requirements:**
-1. **First** attempt to retrieve album art from the BT AVRCP metadata (image property on the media player interface)
-2. **Only if BT art is unavailable**, fall back to MusicBrainz/Cover Art Archive online lookup
-3. Cache BT-provided art the same way online art is cached (in `data/albumart/`)
-
-**Investigation approach:**
-- [ ] Check BlueZ D-Bus `org.bluez.MediaPlayer1` for image/art property availability
-- [ ] Review current album art flow in `BluetoothAudioSource` and `AlbumArtService`
-- [ ] Determine if AVRCP art comes as a file path, URL, or binary blob
-- [ ] Wire BT art into the existing album art pipeline with priority over online lookup
+**Changes made:**
+1. **Fingerprint-identified cover art**: `OnTrackIdentified` now uses `e.Track.CoverArtUrl` from the fingerprint pipeline (already looked up via MusicBrainz + Cover Art Archive), caches it, and updates source metadata
+2. **Direct Cover Art Archive lookup**: If fingerprinting has `MusicBrainzReleaseId` but no `CoverArtUrl`, queries Cover Art Archive directly (skipping text search)
+3. **Retry without album**: If album-constrained MusicBrainz search returns null, retries without album constraint (streaming apps append edition info that doesn't match)
+4. **Negative caching**: Failed art lookups tracked in `_failedArtLookups` HashSet to avoid re-querying MusicBrainz for same title/artist within a session
+5. **New interface method**: `IMetadataLookupService.GetCoverArtByReleaseIdAsync()` for direct Cover Art Archive access by release ID
 
 ---
 

--- a/tests/Radio.IntegrationTests/TestSupport/MockMetadataLookupService.cs
+++ b/tests/Radio.IntegrationTests/TestSupport/MockMetadataLookupService.cs
@@ -127,4 +127,9 @@ public class MockMetadataLookupService : IMetadataLookupService
   {
     return Task.FromResult<string?>(null);
   }
+
+  public Task<string?> GetCoverArtByReleaseIdAsync(string releaseId, CancellationToken ct = default)
+  {
+    return Task.FromResult<string?>(null);
+  }
 }


### PR DESCRIPTION
## Summary
- AVRCP doesn't provide album art via BlueZ D-Bus (confirmed via live dbus-send queries)
- Reframed F.18 to improve the existing MusicBrainz/Cover Art Archive lookup pipeline
- Use fingerprint-identified cover art when available (skip MusicBrainz text search)
- Direct Cover Art Archive lookup by MusicBrainz release ID from fingerprinting
- Retry without album constraint when album-qualified search fails
- Negative cache for failed lookups to avoid redundant MusicBrainz API calls
- New `IMetadataLookupService.GetCoverArtByReleaseIdAsync()` interface method

## Test plan
- [x] Build: 0 warnings, 0 errors
- [x] Tests: 1382 pass, 0 fail
- [x] Deployed to Ubuntu and verified album art lookup works (The Hooters - And We Danced -> cover art found and cached)
- [ ] Verify fingerprint-identified cover art path (requires track with incomplete AVRCP metadata)
- [ ] Verify negative cache prevents re-querying same failed track

🤖 Generated with [Claude Code](https://claude.com/claude-code)