### PR TITLE
fix: Remove dead config defaults and fix Set As Default device buttons

### DIFF
--- a/design/appsettings.example.json
+++ b/design/appsettings.example.json
@@ -4,8 +4,6 @@
     "RootPath": "./data",
     "ConfigurationSubdirectory": "config",
     "ConfigurationFileName": "configuration.db",
-    "MetricsSubdirectory": "metrics",
-    "MetricsFileName": "metrics.db",
     "FingerprintingSubdirectory": "fingerprints",
     "FingerprintingFileName": "fingerprints.db",
     "BackupSubdirectory": "backups",

--- a/src/Radio.API/Controllers/DevicesController.cs
+++ b/src/Radio.API/Controllers/DevicesController.cs
@@ -72,7 +72,14 @@ public class DevicesController : ControllerBase
     {
       var devices = await _deviceManager.GetOutputDevicesAsync();
       var activeId = _deviceManager.GetSelectedOutputDeviceId();
-      return Ok(devices.Select(d => MapToDeviceDto(d, d.Id == activeId)).ToList());
+      var hasUserSelection = !string.IsNullOrEmpty(activeId);
+      return Ok(devices.Select(d =>
+      {
+        var isActive = d.Id == activeId;
+        // If user has selected a device, that one is "default"; otherwise use system default
+        var isDefault = hasUserSelection ? isActive : (bool?)null;
+        return MapToDeviceDto(d, isActive, isDefault);
+      }).ToList());
     }
     catch (Exception ex)
     {
@@ -93,7 +100,13 @@ public class DevicesController : ControllerBase
     {
       var devices = await _deviceManager.GetInputDevicesAsync();
       var activeInputId = _deviceManager.GetSelectedInputDeviceId();
-      return Ok(devices.Select(d => MapToDeviceDto(d, d.Id == activeInputId)).ToList());
+      var hasUserSelection = !string.IsNullOrEmpty(activeInputId);
+      return Ok(devices.Select(d =>
+      {
+        var isActive = d.Id == activeInputId;
+        var isDefault = hasUserSelection ? isActive : (bool?)null;
+        return MapToDeviceDto(d, isActive, isDefault);
+      }).ToList());
     }
     catch (Exception ex)
     {
@@ -149,7 +162,7 @@ public class DevicesController : ControllerBase
         return NotFound(new { error = "No default output device found" });
       }
       var activeId = _deviceManager.GetSelectedOutputDeviceId();
-      return Ok(MapToDeviceDto(device, device.Id == activeId));
+      return Ok(MapToDeviceDto(device, device.Id == activeId, isUserDefault: true));
     }
     catch (Exception ex)
     {
@@ -1423,14 +1436,15 @@ public class DevicesController : ControllerBase
     _castOutput.SetNowPlayingMetadata(title, artist, album, albumArtUrl);
   }
 
-  private static AudioDeviceDto MapToDeviceDto(AudioDeviceInfo device, bool isActive = false)
+  private static AudioDeviceDto MapToDeviceDto(
+    AudioDeviceInfo device, bool isActive = false, bool? isUserDefault = null)
   {
     return new AudioDeviceDto
     {
       Id = device.Id,
       Name = device.Name,
       Type = device.Type.ToString(),
-      IsDefault = device.IsDefault,
+      IsDefault = isUserDefault ?? device.IsDefault,
       IsActive = isActive,
       IsUSBDevice = device.IsUSBDevice,
       USBPort = device.USBPort,

--- a/src/Radio.API/Models/ConfigurationModels.cs
+++ b/src/Radio.API/Models/ConfigurationModels.cs
@@ -230,10 +230,6 @@ public class DeviceOptionsDto
   /// </summary>
   public VinylDeviceOptionsDto Vinyl { get; set; } = new();
 
-  /// <summary>
-  /// Gets or sets the cast device options.
-  /// </summary>
-  public CastDeviceOptionsDto Cast { get; set; } = new();
 }
 
 /// <summary>
@@ -256,17 +252,6 @@ public class VinylDeviceOptionsDto
   /// Gets or sets the USB port path for the vinyl device.
   /// </summary>
   public string USBPort { get; set; } = "/dev/ttyUSB1";
-}
-
-/// <summary>
-/// Chromecast device configuration.
-/// </summary>
-public class CastDeviceOptionsDto
-{
-  /// <summary>
-  /// Gets or sets the default Chromecast device name.
-  /// </summary>
-  public string DefaultDevice { get; set; } = "";
 }
 
 // ==================== Preferences DTOs (Phase 2) ====================

--- a/src/Radio.API/appsettings.json
+++ b/src/Radio.API/appsettings.json
@@ -42,16 +42,11 @@
     "Vinyl": {
       "USBPort": ""
     },
-    "Cast": {
-      "DefaultDevice": "AudioCast1"
-    }
   },
   "Database": {
     "RootPath": "./data",
     "ConfigurationSubdirectory": "config",
     "ConfigurationFileName": "configuration.db",
-    "MetricsSubdirectory": "metrics",
-    "MetricsFileName": "metrics.db",
     "FingerprintingSubdirectory": "fingerprints",
     "FingerprintingFileName": "fingerprints.db",
     "SecretsSubdirectory": "secrets",
@@ -120,10 +115,7 @@
       "Enabled": true,
       "ApplicationId": "567E3DBA",
       "DiscoveryTimeoutSeconds": 10,
-      "PreferredDeviceName": "Office speaker",
       "DefaultVolume": 0.7,
-      "AutoReconnect": true,
-      "ReconnectDelaySeconds": 5,
       "StreamingMode": "HttpMp3",
       "DirectChannelChunkSizeMs": 100,
       "DirectChannelNamespace": "urn:x-cast:com.radioconsole.audio"

--- a/src/Radio.Core/Configuration/AudioOutputOptions.cs
+++ b/src/Radio.Core/Configuration/AudioOutputOptions.cs
@@ -132,25 +132,9 @@ public class GoogleCastOutputOptions
   public int DiscoveryTimeoutSeconds { get; set; } = 10;
 
   /// <summary>
-  /// Gets or sets the preferred cast device name.
-  /// If empty, uses the first discovered device.
-  /// </summary>
-  public string PreferredDeviceName { get; set; } = "";
-
-  /// <summary>
   /// Gets or sets the default volume level for cast (0.0 to 1.0).
   /// </summary>
   public float DefaultVolume { get; set; } = 0.7f;
-
-  /// <summary>
-  /// Gets or sets whether to automatically reconnect on disconnect.
-  /// </summary>
-  public bool AutoReconnect { get; set; } = true;
-
-  /// <summary>
-  /// Gets or sets the reconnect delay in seconds.
-  /// </summary>
-  public int ReconnectDelaySeconds { get; set; } = 5;
 
   /// <summary>
   /// Gets or sets the file path for caching discovered Cast devices.

--- a/src/Radio.Core/Configuration/DeviceOptions.cs
+++ b/src/Radio.Core/Configuration/DeviceOptions.cs
@@ -21,11 +21,6 @@ public class DeviceOptions
   /// </summary>
   public VinylDeviceOptions Vinyl { get; set; } = new();
 
-  /// <summary>
-  /// Gets or sets the cast device options.
-  /// </summary>
-  public CastDeviceOptions Cast { get; set; } = new();
-
 }
 
 /// <summary>
@@ -53,14 +48,4 @@ public class VinylDeviceOptions
   public string USBPort { get; set; } = "";
 }
 
-/// <summary>
-/// Configuration options for Chromecast audio output.
-/// </summary>
-public class CastDeviceOptions
-{
-  /// <summary>
-  /// Gets or sets the default Chromecast device name.
-  /// </summary>
-  public string DefaultDevice { get; set; } = "";
-}
 

--- a/src/Radio.Infrastructure/Configuration/DeviceOptionsResolver.cs
+++ b/src/Radio.Infrastructure/Configuration/DeviceOptionsResolver.cs
@@ -58,8 +58,6 @@ public class DeviceOptionsResolver
                 ?? fallback.Radio ?? new RadioDeviceOptions(),
         Vinyl = await ResolveNestedAsync<VinylDeviceOptions>(storeId, "devices:Vinyl", ct)
                 ?? fallback.Vinyl ?? new VinylDeviceOptions(),
-        Cast = await ResolveNestedAsync<CastDeviceOptions>(storeId, "devices:Cast", ct)
-               ?? fallback.Cast ?? new CastDeviceOptions(),
       };
 
       return result;

--- a/src/Radio.Infrastructure/Configuration/Models/ConfigurationOptions.cs
+++ b/src/Radio.Infrastructure/Configuration/Models/ConfigurationOptions.cs
@@ -34,10 +34,4 @@ public sealed class ConfigurationOptions
 
   /// <summary>Whether to auto-save changes.</summary>
   public bool AutoSave { get; set; } = true;
-
-  /// <summary>Number of days to retain backups.</summary>
-  public int BackupRetentionDays { get; set; } = 30;
-
-  /// <summary>Debounce delay for auto-save in milliseconds.</summary>
-  public int AutoSaveDebounceMs { get; set; } = 5000;
 }

--- a/src/Radio.Web/Components/Pages/SystemConfigPage.razor
+++ b/src/Radio.Web/Components/Pages/SystemConfigPage.razor
@@ -368,13 +368,6 @@
                               Variant="Variant.Outlined"
                               HelperText="USB audio device name pattern for turntable (e.g., USB Microphone)" />
               </MudItem>
-              <MudItem xs="12" md="6">
-                <MudTextField T="string" @bind-Value="_deviceOptions.Cast.DefaultDevice"
-                              Label="Default Cast Device"
-                              Variant="Variant.Outlined"
-                              HelperText="Default Chromecast device name (optional)" />
-              </MudItem>
-
               <MudItem xs="12">
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveDeviceOptionsAsync"
                            StartIcon="@Icons.Material.Filled.Save" Disabled="@_isSaving">

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -518,7 +518,6 @@ public class DeviceOptionsDto
 {
   public RadioDeviceOptionsDto Radio { get; set; } = new();
   public VinylDeviceOptionsDto Vinyl { get; set; } = new();
-  public CastDeviceOptionsDto Cast { get; set; } = new();
 }
 
 public class RadioDeviceOptionsDto
@@ -529,11 +528,6 @@ public class RadioDeviceOptionsDto
 public class VinylDeviceOptionsDto
 {
   public string USBPort { get; set; } = "/dev/ttyUSB1";
-}
-
-public class CastDeviceOptionsDto
-{
-  public string DefaultDevice { get; set; } = "";
 }
 
 // Preferences DTOs (Phase 2)

--- a/tests/Radio.Infrastructure.Tests/Audio/Outputs/GoogleCastOutputTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Outputs/GoogleCastOutputTests.cs
@@ -24,10 +24,7 @@ public class GoogleCastOutputTests
       {
         Enabled = false,
         DiscoveryTimeoutSeconds = 5,
-        PreferredDeviceName = "",
-        DefaultVolume = 0.7f,
-        AutoReconnect = true,
-        ReconnectDelaySeconds = 5
+        DefaultVolume = 0.7f
       }
     };
 

--- a/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/USBAudioSourceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/USBAudioSourceTests.cs
@@ -33,8 +33,7 @@ public class USBAudioSourceTests
     _deviceOptions = new DeviceOptions
     {
       Radio = new RadioDeviceOptions { USBPort = "/dev/ttyUSB0" },
-      Vinyl = new VinylDeviceOptions { USBPort = "/dev/ttyUSB1" },
-      Cast = new CastDeviceOptions { DefaultDevice = "" }
+      Vinyl = new VinylDeviceOptions { USBPort = "/dev/ttyUSB1" }
     };
 
     _radioOptions = new RadioOptions

--- a/tests/Radio.Infrastructure.Tests/Configuration/DeviceOptionsResolverTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Configuration/DeviceOptionsResolverTests.cs
@@ -22,7 +22,6 @@ public class DeviceOptionsResolverTests
     {
       Radio = new RadioDeviceOptions { USBPort = "fallback-radio" },
       Vinyl = new VinylDeviceOptions { USBPort = "fallback-vinyl" },
-      Cast = new CastDeviceOptions { DefaultDevice = "fallback-cast" },
     });
 
     _configManager = new Mock<IConfigurationManager>();
@@ -38,8 +37,6 @@ public class DeviceOptionsResolverTests
       .ReturnsAsync("{\"usbPort\":\"AB13X\"}");
     _configManager.Setup(x => x.GetValueAsync<string>("sqlite", "devices:Vinyl", It.IsAny<ConfigurationReadMode>(), It.IsAny<CancellationToken>()))
       .ReturnsAsync("{\"usbPort\":\"TurntableUSB\"}");
-    _configManager.Setup(x => x.GetValueAsync<string>("sqlite", "devices:Cast", It.IsAny<ConfigurationReadMode>(), It.IsAny<CancellationToken>()))
-      .ReturnsAsync("{\"defaultDevice\":\"Office speaker\"}");
 
     var resolver = new DeviceOptionsResolver(_logger, _optionsMonitor.Object, _configManager.Object);
 
@@ -47,7 +44,6 @@ public class DeviceOptionsResolverTests
 
     Assert.Equal("AB13X", result.Radio.USBPort);
     Assert.Equal("TurntableUSB", result.Vinyl.USBPort);
-    Assert.Equal("Office speaker", result.Cast.DefaultDevice);
   }
 
   [Fact]
@@ -62,7 +58,6 @@ public class DeviceOptionsResolverTests
 
     Assert.Equal("fallback-radio", result.Radio.USBPort);
     Assert.Equal("fallback-vinyl", result.Vinyl.USBPort);
-    Assert.Equal("fallback-cast", result.Cast.DefaultDevice);
   }
 
   [Fact]

--- a/tests/Radio.IntegrationTests/appsettings.IntegrationTests.json
+++ b/tests/Radio.IntegrationTests/appsettings.IntegrationTests.json
@@ -9,8 +9,6 @@
     "RootPath": "",
     "ConfigurationSubdirectory": "config",
     "ConfigurationFileName": "configuration.db",
-    "MetricsSubdirectory": "metrics",
-    "MetricsFileName": "metrics.db",
     "FingerprintsSubdirectory": "fingerprints",
     "FingerprintsFileName": "fingerprints.db"
   },

--- a/tools/Radio.Tools.AudioUAT/appsettings.json
+++ b/tools/Radio.Tools.AudioUAT/appsettings.json
@@ -3,8 +3,6 @@
     "RootPath": "./data",
     "ConfigurationSubdirectory": "config",
     "ConfigurationFileName": "configuration.db",
-    "MetricsSubdirectory": "metrics",
-    "MetricsFileName": "metrics.db",
     "FingerprintingSubdirectory": "fingerprints",
     "FingerprintingFileName": "fingerprints.db",
     "BackupSubdirectory": "backups",


### PR DESCRIPTION
## Summary

- **Remove 8 dead configuration properties** that were defined in Options classes/appsettings but never consumed at runtime:
  - `GoogleCast.PreferredDeviceName` — superseded by `AudioPreferences.DefaultCastDeviceId/Name`
  - `GoogleCast.AutoReconnect` / `ReconnectDelaySeconds` — no auto-reconnect logic exists
  - `Devices.Cast.DefaultDevice` (entire `CastDeviceOptions` class) — only shown in SystemConfigPage UI, never used at runtime
  - `Database.MetricsSubdirectory` / `MetricsFileName` — orphaned appsettings keys with no matching class property (metrics uses `MetricsOptions.DatabasePath`)
  - `ConfigurationOptions.BackupRetentionDays` — duplicate of `DatabaseOptions.BackupRetentionDays` (the one actually consumed)
  - `ConfigurationOptions.AutoSaveDebounceMs` — defined but never read

- **Fix "Set As Default" buttons on Devices page** (Outputs/Inputs tabs) — pressing the button showed a green snackbar but the UI didn't update. Root cause: `IsDefault` was hardcoded to the first non-hidden device in `EnumerateDevices()`, not the user's selection. Now the API reflects the user's persisted selection (`AudioPreferences.CurrentOutput/CurrentInput`), falling back to system default when no selection exists.

## Test plan
- [x] Build: 0 warnings, 0 errors
- [x] Tests: 1382 pass, 0 fail
- [x] Deployed to Ubuntu — verified API returns correct `isDefault` flag
- [x] Verified round-trip: POST set-default → GET devices → `isDefault` moves to selected device
- [ ] Manual: Open Devices page, click "Set as Default" on a non-default output, verify star icon and chip update

🤖 Generated with [Claude Code](https://claude.com/claude-code)