### PR TITLE
fix: Source exclusivity, PipeWire BT auto-link cleanup, and default device selection

### DIFF
--- a/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
@@ -208,13 +208,14 @@ public class AudioManager : IAudioManager, IAsyncDisposable
 
       // Stop the old source immediately to prevent simultaneous playback.
       // Only one primary source should ever produce audio at a time.
-      if (oldSource != null && oldSource != source &&
-          (oldSource.State == AudioSourceState.Playing ||
-           oldSource.State == AudioSourceState.Paused))
+      // Always stop regardless of state — external events (e.g., AVRCP status)
+      // can set state to Stopped/Ready while the source's audio component
+      // (BufferedSoundGenerator, pw-record subprocess) is still in the mixer.
+      if (oldSource != null && oldSource != source)
       {
         _logger.LogInformation(
-          "Stopping old source {OldSource} before switching to {NewSource}",
-          oldSource.Name, source.Name);
+          "Stopping old source {OldSource} (State={OldState}) before switching to {NewSource}",
+          oldSource.Name, oldSource.State, source.Name);
 
         try
         {

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
@@ -181,23 +181,48 @@ public class SoundFlowAudioEngine : IAudioEngine
 
       if (playbackDevices.Length > 0)
       {
-        // Find the best playback device, skipping null/discard devices.
-        // MiniAudio often lists a null backend "Discard all samples" device at
-        // index 0, which silently drops all audio. We prefer a real device.
-        var deviceIndex = 0;
-        var deviceInfo = playbackDevices[0];
+        // Log all available devices for diagnostics
         for (int i = 0; i < playbackDevices.Length; i++)
         {
-          var name = playbackDevices[i].Name ?? "";
-          if (name.Contains("Discard all samples", StringComparison.OrdinalIgnoreCase) ||
-              name.Contains("generate zero samples", StringComparison.OrdinalIgnoreCase))
+          _logger.LogInformation("  Playback device [{Index}]: {Name} (IsDefault={IsDefault})",
+            i, playbackDevices[i].Name ?? "(null)", playbackDevices[i].IsDefault);
+        }
+
+        // Select the best playback device with this priority:
+        // 1. System default device (IsDefault=true)
+        // 2. First real device (skip null/discard backends)
+        // 3. First device as last resort
+        var deviceIndex = 0;
+        var deviceInfo = playbackDevices[0];
+
+        // Prefer the system default device
+        for (int i = 0; i < playbackDevices.Length; i++)
+        {
+          if (playbackDevices[i].IsDefault)
           {
-            _logger.LogDebug("Skipping null device at index {Index}: {Name}", i, name);
-            continue;
+            deviceIndex = i;
+            deviceInfo = playbackDevices[i];
+            _logger.LogInformation("Selected system default playback device at index {Index}: {Name}", i, deviceInfo.Name);
+            break;
           }
-          deviceIndex = i;
-          deviceInfo = playbackDevices[i];
-          break;
+        }
+
+        // If no default found, fall back to first non-discard device
+        if (!deviceInfo.IsDefault)
+        {
+          for (int i = 0; i < playbackDevices.Length; i++)
+          {
+            var name = playbackDevices[i].Name ?? "";
+            if (name.Contains("Discard all samples", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("generate zero samples", StringComparison.OrdinalIgnoreCase))
+            {
+              _logger.LogDebug("Skipping null device at index {Index}: {Name}", i, name);
+              continue;
+            }
+            deviceIndex = i;
+            deviceInfo = playbackDevices[i];
+            break;
+          }
         }
         _logger.LogInformation("Initializing playback device: {DeviceName} (index {Index} of {Total})",
           deviceInfo.Name, deviceIndex, playbackDevices.Length);

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowDeviceManager.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowDeviceManager.cs
@@ -427,7 +427,7 @@ public class SoundFlowDeviceManager : IAudioDeviceManager
             continue;
           }
 
-          var isDefault = outputDevices.Count == 0; // First non-hidden device is default
+          var isDefault = device.IsDefault; // Use the system's actual default device
           var displayName = ApplyFriendlyName(rawName);
           var isUsb = rawName.Contains("USB", StringComparison.OrdinalIgnoreCase);
 
@@ -465,7 +465,7 @@ public class SoundFlowDeviceManager : IAudioDeviceManager
           continue;
         }
 
-        var isDefault = inputDevices.Count == 0; // First non-hidden device is default
+        var isDefault = device.IsDefault; // Use the system's actual default device
         var displayName = ApplyFriendlyName(rawName);
         var isUsb = rawName.Contains("USB", StringComparison.OrdinalIgnoreCase);
 
@@ -605,7 +605,7 @@ public class SoundFlowDeviceManager : IAudioDeviceManager
             IsHidden = isHidden,
             FriendlyNameOverride = friendlyOverride,
             Type = AudioDeviceType.Output,
-            IsDefault = result.Count(r => r.Type == AudioDeviceType.Output && !r.IsHidden) == 0 && !isHidden,
+            IsDefault = device.IsDefault,
             IsUSBDevice = isUsb
           });
         }

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -34,6 +34,7 @@ namespace Radio.Infrastructure.Platform.Bluetooth
         private Process? _captureProcess;
         private CancellationTokenSource? _captureCts;
         private object? _activeGenerator;
+        private string? _activeNodeName;
         private DateTime? _connectionStartTime;
 
         // Player tracking
@@ -719,6 +720,7 @@ namespace Radio.Infrastructure.Platform.Bluetooth
                             "pw-record capture running (attempt {Attempt}/{Max}, PID {Pid}, target {Node})",
                             attempt, maxRetries, _captureProcess.Id, nodeName);
                         _activeGenerator = generator;
+                        _activeNodeName = nodeName;
 
                         // Set BT source node master volume to 1.0 AFTER pw-record is running
                         // and AVRCP volume sync has settled. BlueZ sets the PipeWire node volume
@@ -1030,6 +1032,120 @@ namespace Radio.Infrastructure.Platform.Bluetooth
                 }
                 _captureProcess.Dispose();
                 _captureProcess = null;
+            }
+
+            // Disconnect PipeWire's auto-link from the BT input node to the default
+            // output sink. PipeWire/WirePlumber automatically links bluez_input to the
+            // default audio output, which bypasses our application entirely. When we
+            // switch away from BT, we must sever this link so only the active source
+            // (routed through our SoundFlow mixer) reaches the speakers.
+            if (_activeNodeName != null)
+            {
+                DisconnectPipeWireBtAutoLinks(_activeNodeName);
+                _activeNodeName = null;
+            }
+        }
+
+        /// <summary>
+        /// Disconnects PipeWire's automatic links from a bluez_input node to the
+        /// default audio output sink, preventing BT audio from bypassing our mixer.
+        /// </summary>
+        private void DisconnectPipeWireBtAutoLinks(string btNodeName)
+        {
+            try
+            {
+                // Query current links and find ones from this BT node to any output sink
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "pw-link",
+                    Arguments = "-l",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(psi);
+                if (process == null) return;
+
+                var output = process.StandardOutput.ReadToEnd();
+                process.WaitForExit(3000);
+
+                // Parse links: find output ports of the BT node that connect to a sink
+                // Format: "  |-> alsa_output.xxx:playback_FL"
+                // We look for lines under the BT node's output ports
+                var lines = output.Split('\n');
+                var inBtNode = false;
+                string? currentBtPort = null;
+
+                foreach (var rawLine in lines)
+                {
+                    var line = rawLine.TrimEnd();
+
+                    // Detect BT node output port headers (no leading whitespace beyond node name)
+                    if (line.StartsWith(btNodeName + ":"))
+                    {
+                        inBtNode = true;
+                        currentBtPort = line.TrimEnd();
+                        continue;
+                    }
+
+                    // Lines under a different node reset the flag
+                    if (!line.StartsWith(" ") && line.Length > 0)
+                    {
+                        inBtNode = false;
+                        currentBtPort = null;
+                        continue;
+                    }
+
+                    // Under BT node, find links to output sinks
+                    if (inBtNode && currentBtPort != null && line.Contains("|->"))
+                    {
+                        var targetPort = line.Substring(line.IndexOf("|->") + 4).Trim();
+                        if (targetPort.StartsWith("alsa_output."))
+                        {
+                            // Disconnect this link
+                            DisconnectPipeWireLink(currentBtPort, targetPort);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to disconnect PipeWire BT auto-links for {NodeName}", btNodeName);
+            }
+        }
+
+        /// <summary>
+        /// Disconnects a single PipeWire link between two ports.
+        /// </summary>
+        private void DisconnectPipeWireLink(string outputPort, string inputPort)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "pw-link",
+                    Arguments = $"-d \"{outputPort}\" \"{inputPort}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(psi);
+                if (process == null) return;
+
+                process.WaitForExit(3000);
+
+                _logger.LogInformation(
+                    "Disconnected PipeWire auto-link: {Output} -> {Input}",
+                    outputPort, inputPort);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to disconnect PipeWire link {Output} -> {Input}",
+                    outputPort, inputPort);
             }
         }
 


### PR DESCRIPTION
## Summary

- **Source exclusivity**: Remove state guard in `SwitchSourceAsync()` so old sources are always stopped when switching, even if AVRCP events already set their state to Stopped/Ready while audio components remain active in the mixer
- **PipeWire BT auto-link cleanup**: Disconnect WirePlumber's automatic `bluez_input → alsa_output` links when stopping BT capture, preventing BT audio from bypassing the SoundFlow mixer and playing directly through speakers
- **Default device selection**: Use `DeviceInfo.IsDefault` from MiniAudio/SoundFlow in both `SoundFlowAudioEngine` and `SoundFlowDeviceManager` instead of "first non-hidden device" heuristic, so the correct system default appears in the Web UI on startup

## Test plan

- [x] Build passes (0 warnings)
- [x] All tests pass (1343 tests)
- [x] Deployed to Ubuntu and verified:
  - [x] Switching from BT to Radio stops BT audio (no dual playback)
  - [x] Switching from Radio to BT stops Radio audio
  - [x] Correct default output device shown in Web UI on startup
  - [x] PipeWire auto-links disconnected on BT capture stop (`pw-link -l` verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)