### PR TITLE
fix: Pass audio validator to BT ring buffer + enhance BtSender

### DIFF
--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -711,7 +711,8 @@ namespace Radio.Infrastructure.Platform.Bluetooth
 
                     var generator = new BufferedSoundGenerator<float>(
                         engine, format, _logger, maxBufferSeconds: 2.0f,
-                        metricsCollector: _metricsCollector);
+                        metricsCollector: _metricsCollector,
+                        audioValidator: _audioValidator);
 
                     StartCaptureSubprocess(generator, format, nodeName);
 

--- a/tools/Radio.Tools.BtSender/Program.cs
+++ b/tools/Radio.Tools.BtSender/Program.cs
@@ -1,10 +1,14 @@
+using System.Management;
 using NAudio.CoreAudioApi;
 using NAudio.Wave;
+using Windows.Devices.Enumeration;
+using Windows.Media.Audio;
 
 namespace Radio.Tools.BtSender;
 
 /// <summary>
 /// Sends a diagnostic tone (200Hz L / 300Hz R) to a Bluetooth audio device via WASAPI.
+/// Automatically connects the BT A2DP profile if needed.
 /// Usage: dotnet run --project tools/Radio.Tools.BtSender "Grandpas Radio"
 /// </summary>
 public static class Program
@@ -15,34 +19,59 @@ public static class Program
   private const int RightHz = 300;
   private const float Amplitude = 0.8f;
 
-  public static int Main(string[] args)
+  public static async Task<int> Main(string[] args)
   {
     if (args.Length == 0)
     {
       Console.WriteLine("BT Diagnostic Tone Sender");
-      Console.WriteLine("Usage: Radio.Tools.BtSender <device-name-substring>");
+      Console.WriteLine("Usage: Radio.Tools.BtSender <device-name-substring> [--duration <seconds>]");
       Console.WriteLine();
       Console.WriteLine("Available render devices:");
       ListDevices();
+      Console.WriteLine();
+      Console.WriteLine("Paired BT audio devices:");
+      await ListBluetoothDevicesAsync();
       return 1;
     }
 
     var searchTerm = args[0];
+    var duration = ParseDuration(args);
+
     Console.WriteLine($"Searching for render device matching: \"{searchTerm}\"");
 
     var device = FindDevice(searchTerm);
     if (device == null)
     {
-      Console.Error.WriteLine($"No render device found matching \"{searchTerm}\".");
-      Console.WriteLine();
-      Console.WriteLine("Available render devices:");
-      ListDevices();
-      return 1;
+      Console.WriteLine($"Device not active as WASAPI endpoint. Attempting BT connect...");
+      var connected = await TryConnectBluetoothAsync(searchTerm);
+      if (connected)
+      {
+        // Wait for WASAPI endpoint to appear
+        Console.WriteLine("Waiting for audio endpoint to become active...");
+        for (var i = 0; i < 30; i++)
+        {
+          await Task.Delay(500);
+          device = FindDevice(searchTerm);
+          if (device != null) break;
+        }
+      }
+
+      if (device == null)
+      {
+        Console.Error.WriteLine($"No render device found matching \"{searchTerm}\" after BT connect attempt.");
+        Console.WriteLine();
+        Console.WriteLine("Available render devices:");
+        ListDevices();
+        return 1;
+      }
     }
 
     Console.WriteLine($"Found device: {device.FriendlyName}");
     Console.WriteLine($"Sending {LeftHz}Hz (L) / {RightHz}Hz (R) diagnostic tone at {SampleRate}Hz");
-    Console.WriteLine("Press Ctrl+C to stop.");
+    if (duration.HasValue)
+      Console.WriteLine($"Duration: {duration.Value} seconds");
+    else
+      Console.WriteLine("Press Ctrl+C to stop.");
     Console.WriteLine();
 
     using var cts = new CancellationTokenSource();
@@ -52,9 +81,22 @@ public static class Program
       cts.Cancel();
     };
 
+    if (duration.HasValue)
+      cts.CancelAfter(TimeSpan.FromSeconds(duration.Value));
+
     PlayDiagnosticTone(device, cts.Token);
     Console.WriteLine("Stopped.");
     return 0;
+  }
+
+  private static int? ParseDuration(string[] args)
+  {
+    for (var i = 0; i < args.Length - 1; i++)
+    {
+      if (args[i] == "--duration" && int.TryParse(args[i + 1], out var seconds))
+        return seconds;
+    }
+    return null;
   }
 
   private static void ListDevices()
@@ -64,6 +106,31 @@ public static class Program
     for (var i = 0; i < devices.Count; i++)
     {
       Console.WriteLine($"  [{i}] {devices[i].FriendlyName}");
+    }
+
+    if (devices.Count == 0)
+      Console.WriteLine("  (none)");
+  }
+
+  private static async Task ListBluetoothDevicesAsync()
+  {
+    try
+    {
+      // Find paired BT audio devices that support AudioPlaybackConnection
+      var selector = AudioPlaybackConnection.GetDeviceSelector();
+      var devices = await DeviceInformation.FindAllAsync(selector);
+
+      foreach (var d in devices)
+      {
+        Console.WriteLine($"  {d.Name} (id: {d.Id[..Math.Min(40, d.Id.Length)]}...)");
+      }
+
+      if (devices.Count == 0)
+        Console.WriteLine("  (none — ensure BT device is paired)");
+    }
+    catch (Exception ex)
+    {
+      Console.WriteLine($"  (error listing BT devices: {ex.Message})");
     }
   }
 
@@ -76,9 +143,129 @@ public static class Program
       d.FriendlyName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
   }
 
+  /// <summary>
+  /// Attempts to connect to a BT device using AudioPlaybackConnection WinRT API.
+  /// This establishes an A2DP source connection so audio can be sent to the device.
+  /// Note: Requires the app to have MSIX identity or be running on Windows 10 20H1+.
+  /// </summary>
+  private static async Task<bool> TryConnectBluetoothAsync(string searchTerm)
+  {
+    try
+    {
+      var selector = AudioPlaybackConnection.GetDeviceSelector();
+      var devices = await DeviceInformation.FindAllAsync(selector);
+
+      var target = devices.FirstOrDefault(d =>
+        d.Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
+
+      if (target == null)
+      {
+        Console.WriteLine($"No paired BT audio device matching \"{searchTerm}\".");
+        Console.WriteLine("Paired BT audio devices:");
+        foreach (var d in devices)
+          Console.WriteLine($"  {d.Name}");
+        return false;
+      }
+
+      Console.WriteLine($"Found paired BT device: {target.Name}");
+      Console.WriteLine("Opening AudioPlaybackConnection...");
+
+      var connection = AudioPlaybackConnection.TryCreateFromId(target.Id);
+      if (connection == null)
+      {
+        Console.WriteLine("Failed to create AudioPlaybackConnection (may need MSIX identity).");
+        Console.WriteLine("Falling back to manual connection check...");
+        return await TryConnectViaDeviceManagerAsync(searchTerm);
+      }
+
+      // Start the A2DP connection
+      connection.Start();
+      var result = await connection.OpenAsync();
+      Console.WriteLine($"AudioPlaybackConnection status: {result.Status}");
+
+      if (result.Status == AudioPlaybackConnectionOpenResultStatus.Success)
+      {
+        Console.WriteLine("BT A2DP connection established successfully.");
+        return true;
+      }
+
+      Console.WriteLine($"AudioPlaybackConnection failed. Extended error: {result.ExtendedError?.Message}");
+      Console.WriteLine("Falling back to device enable approach...");
+      return await TryConnectViaDeviceManagerAsync(searchTerm);
+    }
+    catch (Exception ex)
+    {
+      Console.WriteLine($"AudioPlaybackConnection error: {ex.Message}");
+      Console.WriteLine("Falling back to device enable approach...");
+      return await TryConnectViaDeviceManagerAsync(searchTerm);
+    }
+  }
+
+  /// <summary>
+  /// Fallback: uses WMI to enable the BT audio endpoint device.
+  /// </summary>
+  private static async Task<bool> TryConnectViaDeviceManagerAsync(string searchTerm)
+  {
+    try
+    {
+      // Find the BT audio endpoint that's currently disconnected
+      using var enumerator = new MMDeviceEnumerator();
+      var allDevices = enumerator.EnumerateAudioEndPoints(DataFlow.Render,
+        DeviceState.Active | DeviceState.Unplugged | DeviceState.Disabled);
+
+      var btDevice = allDevices.FirstOrDefault(d =>
+        d.FriendlyName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
+
+      if (btDevice == null)
+      {
+        Console.WriteLine("BT device not found in any audio endpoint state.");
+        return false;
+      }
+
+      Console.WriteLine($"Found endpoint: {btDevice.FriendlyName} (State: {btDevice.State})");
+
+      if (btDevice.State == DeviceState.Active)
+        return true;
+
+      // The device exists but is not active. Windows needs a BT profile connection.
+      // Try using pnputil / devcon approach via WMI
+      Console.WriteLine("Device is not active. Attempting to trigger BT connection via WMI...");
+
+      var query = new SelectQuery("Win32_PnPEntity",
+        $"Name LIKE '%{searchTerm.Replace("'", "''")}%' AND PNPClass = 'MEDIA'");
+      using var searcher = new ManagementObjectSearcher(query);
+      foreach (ManagementObject obj in searcher.Get())
+      {
+        var name = obj["Name"]?.ToString();
+        var deviceId = obj["DeviceID"]?.ToString();
+        Console.WriteLine($"  Found PnP device: {name} ({deviceId})");
+
+        // Try to enable the device
+        try
+        {
+          var result = obj.InvokeMethod("Enable", null);
+          Console.WriteLine($"  Enable result: {result}");
+          await Task.Delay(2000);
+          return true;
+        }
+        catch (Exception ex)
+        {
+          Console.WriteLine($"  Enable failed: {ex.Message}");
+        }
+      }
+
+      Console.WriteLine("Could not auto-connect. Please connect the device manually via Windows BT settings.");
+      return false;
+    }
+    catch (Exception ex)
+    {
+      Console.WriteLine($"Device manager fallback error: {ex.Message}");
+      return false;
+    }
+  }
+
   private static void PlayDiagnosticTone(MMDevice device, CancellationToken ct)
   {
-    // Generate 1 second of loopable diagnostic tone
     var toneProvider = new DiagnosticToneProvider(SampleRate, Channels, LeftHz, RightHz, Amplitude);
 
     using var wasapiOut = new WasapiOut(device, AudioClientShareMode.Shared, useEventSync: true, latency: 200);

--- a/tools/Radio.Tools.BtSender/Radio.Tools.BtSender.csproj
+++ b/tools/Radio.Tools.BtSender/Radio.Tools.BtSender.csproj
@@ -10,5 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- **V2 validator fix**: `LinuxBluetoothService` was creating `BufferedSoundGenerator` without passing `_audioValidator`, so V2-Producer/V2-Consumer hooks never fired. Now all 3 validator stages (V1-BTCapture, V2-Producer/Consumer, V3-Mixer) report correctly.
- **BtSender enhancements**: Auto-connect attempts via `AudioPlaybackConnection` WinRT API + WMI fallback, `--duration` flag for automated testing, lists paired BT audio devices.

## Test plan
- [x] Full solution builds with 0 warnings, 0 errors
- [x] All tests pass (82 passed, 3 skipped)
- [x] Deployed to Ubuntu, verified all 3 validator stages log during BT diagnostic tone
- [x] V3-Mixer shows correct 200Hz L / 300Hz R detection
- [x] BtSender --duration flag works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)