### PR TITLE
fix: Make BtSender resilient to WASAPI disconnects

### DIFF
--- a/tools/Radio.Tools.BtSender/Program.cs
+++ b/tools/Radio.Tools.BtSender/Program.cs
@@ -1,14 +1,11 @@
-using System.Management;
 using NAudio.CoreAudioApi;
 using NAudio.Wave;
-using Windows.Devices.Enumeration;
-using Windows.Media.Audio;
 
 namespace Radio.Tools.BtSender;
 
 /// <summary>
 /// Sends a diagnostic tone (200Hz L / 300Hz R) to a Bluetooth audio device via WASAPI.
-/// Automatically connects the BT A2DP profile if needed.
+/// Automatically reconnects on device loss or WASAPI errors.
 /// Usage: dotnet run --project tools/Radio.Tools.BtSender "Grandpas Radio"
 /// </summary>
 public static class Program
@@ -18,6 +15,8 @@ public static class Program
   private const int LeftHz = 200;
   private const int RightHz = 300;
   private const float Amplitude = 0.8f;
+  private const int ReconnectDelayMs = 3000;
+  private const int MaxReconnectAttempts = 120; // 6 minutes at 3s intervals
 
   public static async Task<int> Main(string[] args)
   {
@@ -28,51 +27,14 @@ public static class Program
       Console.WriteLine();
       Console.WriteLine("Available render devices:");
       ListDevices();
-      Console.WriteLine();
-      Console.WriteLine("Paired BT audio devices:");
-      await ListBluetoothDevicesAsync();
       return 1;
     }
 
     var searchTerm = args[0];
     var duration = ParseDuration(args);
 
+    Console.WriteLine($"BtSender started");
     Console.WriteLine($"Searching for render device matching: \"{searchTerm}\"");
-
-    var device = FindDevice(searchTerm);
-    if (device == null)
-    {
-      Console.WriteLine($"Device not active as WASAPI endpoint. Attempting BT connect...");
-      var connected = await TryConnectBluetoothAsync(searchTerm);
-      if (connected)
-      {
-        // Wait for WASAPI endpoint to appear
-        Console.WriteLine("Waiting for audio endpoint to become active...");
-        for (var i = 0; i < 30; i++)
-        {
-          await Task.Delay(500);
-          device = FindDevice(searchTerm);
-          if (device != null) break;
-        }
-      }
-
-      if (device == null)
-      {
-        Console.Error.WriteLine($"No render device found matching \"{searchTerm}\" after BT connect attempt.");
-        Console.WriteLine();
-        Console.WriteLine("Available render devices:");
-        ListDevices();
-        return 1;
-      }
-    }
-
-    Console.WriteLine($"Found device: {device.FriendlyName}");
-    Console.WriteLine($"Sending {LeftHz}Hz (L) / {RightHz}Hz (R) diagnostic tone at {SampleRate}Hz");
-    if (duration.HasValue)
-      Console.WriteLine($"Duration: {duration.Value} seconds");
-    else
-      Console.WriteLine("Press Ctrl+C to stop.");
-    Console.WriteLine();
 
     using var cts = new CancellationTokenSource();
     Console.CancelKeyPress += (_, e) =>
@@ -84,9 +46,126 @@ public static class Program
     if (duration.HasValue)
       cts.CancelAfter(TimeSpan.FromSeconds(duration.Value));
 
-    PlayDiagnosticTone(device, cts.Token);
+    // Main resilience loop: find device → play → on failure, wait and retry
+    await PlayWithReconnectAsync(searchTerm, cts.Token);
+
     Console.WriteLine("Stopped.");
     return 0;
+  }
+
+  /// <summary>
+  /// Outer resilience loop. Finds the WASAPI device, starts playback, and
+  /// automatically reconnects if the device disappears or WASAPI errors out.
+  /// </summary>
+  private static async Task PlayWithReconnectAsync(string searchTerm, CancellationToken ct)
+  {
+    var reconnectCount = 0;
+
+    while (!ct.IsCancellationRequested)
+    {
+      var device = FindDevice(searchTerm);
+      if (device == null)
+      {
+        if (reconnectCount == 0)
+          Console.WriteLine($"Device not found. Waiting for \"{searchTerm}\" to become available...");
+
+        reconnectCount++;
+        if (reconnectCount > MaxReconnectAttempts)
+        {
+          Console.Error.WriteLine($"Device not found after {MaxReconnectAttempts} attempts. Giving up.");
+          Console.WriteLine("Available render devices:");
+          ListDevices();
+          return;
+        }
+
+        try { await Task.Delay(ReconnectDelayMs, ct); }
+        catch (OperationCanceledException) { return; }
+        continue;
+      }
+
+      if (reconnectCount > 0)
+        Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Device recovered after {reconnectCount} retries");
+      else
+        Console.WriteLine($"Found device: {device.FriendlyName}");
+
+      reconnectCount = 0;
+      Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Sending {LeftHz}Hz (L) / {RightHz}Hz (R) diagnostic tone at {SampleRate}Hz");
+
+      var (exitReason, error) = PlayDiagnosticTone(device, ct);
+
+      if (ct.IsCancellationRequested)
+        return;
+
+      // Playback stopped unexpectedly — log and retry
+      Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Playback stopped: {exitReason}");
+      if (error != null)
+        Console.WriteLine($"  Error: {error.Message}");
+      Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Reconnecting in {ReconnectDelayMs}ms...");
+
+      try { await Task.Delay(ReconnectDelayMs, ct); }
+      catch (OperationCanceledException) { return; }
+    }
+  }
+
+  private static (string Reason, Exception? Error) PlayDiagnosticTone(MMDevice device, CancellationToken ct)
+  {
+    WasapiOut? wasapiOut = null;
+    Exception? playbackError = null;
+    var stoppedEvent = new ManualResetEventSlim(false);
+
+    try
+    {
+      var toneProvider = new DiagnosticToneProvider(SampleRate, Channels, LeftHz, RightHz, Amplitude);
+
+      wasapiOut = new WasapiOut(device, AudioClientShareMode.Shared, useEventSync: true, latency: 200);
+      wasapiOut.PlaybackStopped += (_, e) =>
+      {
+        playbackError = e.Exception;
+        stoppedEvent.Set();
+      };
+      wasapiOut.Init(toneProvider);
+      wasapiOut.Play();
+
+      // Wait for either cancellation or unexpected playback stop.
+      // Poll periodically so we can also detect device removal.
+      while (!ct.IsCancellationRequested)
+      {
+        if (stoppedEvent.Wait(500))
+        {
+          // PlaybackStopped fired
+          return playbackError != null
+            ? ("WASAPI error", playbackError)
+            : ("playback ended", null);
+        }
+
+        // Check if WASAPI is still in Playing state
+        if (wasapiOut.PlaybackState != PlaybackState.Playing)
+          return ("state changed to " + wasapiOut.PlaybackState, null);
+
+        // Check if the device is still active
+        try
+        {
+          // Accessing AudioSessionControl will throw if the device is gone
+          _ = device.AudioEndpointVolume.MasterVolumeLevelScalar;
+        }
+        catch (Exception ex)
+        {
+          return ("device lost", ex);
+        }
+      }
+
+      return ("cancelled", null);
+    }
+    catch (Exception ex)
+    {
+      return ("exception during setup/play", ex);
+    }
+    finally
+    {
+      try { wasapiOut?.Stop(); } catch { /* ignore */ }
+      try { wasapiOut?.Dispose(); } catch { /* ignore */ }
+      stoppedEvent.Dispose();
+    }
   }
 
   private static int? ParseDuration(string[] args)
@@ -112,176 +191,20 @@ public static class Program
       Console.WriteLine("  (none)");
   }
 
-  private static async Task ListBluetoothDevicesAsync()
-  {
-    try
-    {
-      // Find paired BT audio devices that support AudioPlaybackConnection
-      var selector = AudioPlaybackConnection.GetDeviceSelector();
-      var devices = await DeviceInformation.FindAllAsync(selector);
-
-      foreach (var d in devices)
-      {
-        Console.WriteLine($"  {d.Name} (id: {d.Id[..Math.Min(40, d.Id.Length)]}...)");
-      }
-
-      if (devices.Count == 0)
-        Console.WriteLine("  (none — ensure BT device is paired)");
-    }
-    catch (Exception ex)
-    {
-      Console.WriteLine($"  (error listing BT devices: {ex.Message})");
-    }
-  }
-
   private static MMDevice? FindDevice(string searchTerm)
   {
-    using var enumerator = new MMDeviceEnumerator();
-    var devices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
-
-    return devices.FirstOrDefault(d =>
-      d.FriendlyName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
-  }
-
-  /// <summary>
-  /// Attempts to connect to a BT device using AudioPlaybackConnection WinRT API.
-  /// This establishes an A2DP source connection so audio can be sent to the device.
-  /// Note: Requires the app to have MSIX identity or be running on Windows 10 20H1+.
-  /// </summary>
-  private static async Task<bool> TryConnectBluetoothAsync(string searchTerm)
-  {
     try
     {
-      var selector = AudioPlaybackConnection.GetDeviceSelector();
-      var devices = await DeviceInformation.FindAllAsync(selector);
-
-      var target = devices.FirstOrDefault(d =>
-        d.Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
-
-      if (target == null)
-      {
-        Console.WriteLine($"No paired BT audio device matching \"{searchTerm}\".");
-        Console.WriteLine("Paired BT audio devices:");
-        foreach (var d in devices)
-          Console.WriteLine($"  {d.Name}");
-        return false;
-      }
-
-      Console.WriteLine($"Found paired BT device: {target.Name}");
-      Console.WriteLine("Opening AudioPlaybackConnection...");
-
-      var connection = AudioPlaybackConnection.TryCreateFromId(target.Id);
-      if (connection == null)
-      {
-        Console.WriteLine("Failed to create AudioPlaybackConnection (may need MSIX identity).");
-        Console.WriteLine("Falling back to manual connection check...");
-        return await TryConnectViaDeviceManagerAsync(searchTerm);
-      }
-
-      // Start the A2DP connection
-      connection.Start();
-      var result = await connection.OpenAsync();
-      Console.WriteLine($"AudioPlaybackConnection status: {result.Status}");
-
-      if (result.Status == AudioPlaybackConnectionOpenResultStatus.Success)
-      {
-        Console.WriteLine("BT A2DP connection established successfully.");
-        return true;
-      }
-
-      Console.WriteLine($"AudioPlaybackConnection failed. Extended error: {result.ExtendedError?.Message}");
-      Console.WriteLine("Falling back to device enable approach...");
-      return await TryConnectViaDeviceManagerAsync(searchTerm);
-    }
-    catch (Exception ex)
-    {
-      Console.WriteLine($"AudioPlaybackConnection error: {ex.Message}");
-      Console.WriteLine("Falling back to device enable approach...");
-      return await TryConnectViaDeviceManagerAsync(searchTerm);
-    }
-  }
-
-  /// <summary>
-  /// Fallback: uses WMI to enable the BT audio endpoint device.
-  /// </summary>
-  private static async Task<bool> TryConnectViaDeviceManagerAsync(string searchTerm)
-  {
-    try
-    {
-      // Find the BT audio endpoint that's currently disconnected
       using var enumerator = new MMDeviceEnumerator();
-      var allDevices = enumerator.EnumerateAudioEndPoints(DataFlow.Render,
-        DeviceState.Active | DeviceState.Unplugged | DeviceState.Disabled);
+      var devices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
 
-      var btDevice = allDevices.FirstOrDefault(d =>
+      return devices.FirstOrDefault(d =>
         d.FriendlyName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
-
-      if (btDevice == null)
-      {
-        Console.WriteLine("BT device not found in any audio endpoint state.");
-        return false;
-      }
-
-      Console.WriteLine($"Found endpoint: {btDevice.FriendlyName} (State: {btDevice.State})");
-
-      if (btDevice.State == DeviceState.Active)
-        return true;
-
-      // The device exists but is not active. Windows needs a BT profile connection.
-      // Try using pnputil / devcon approach via WMI
-      Console.WriteLine("Device is not active. Attempting to trigger BT connection via WMI...");
-
-      var query = new SelectQuery("Win32_PnPEntity",
-        $"Name LIKE '%{searchTerm.Replace("'", "''")}%' AND PNPClass = 'MEDIA'");
-      using var searcher = new ManagementObjectSearcher(query);
-      foreach (ManagementObject obj in searcher.Get())
-      {
-        var name = obj["Name"]?.ToString();
-        var deviceId = obj["DeviceID"]?.ToString();
-        Console.WriteLine($"  Found PnP device: {name} ({deviceId})");
-
-        // Try to enable the device
-        try
-        {
-          var result = obj.InvokeMethod("Enable", null);
-          Console.WriteLine($"  Enable result: {result}");
-          await Task.Delay(2000);
-          return true;
-        }
-        catch (Exception ex)
-        {
-          Console.WriteLine($"  Enable failed: {ex.Message}");
-        }
-      }
-
-      Console.WriteLine("Could not auto-connect. Please connect the device manually via Windows BT settings.");
-      return false;
     }
-    catch (Exception ex)
+    catch
     {
-      Console.WriteLine($"Device manager fallback error: {ex.Message}");
-      return false;
+      return null;
     }
-  }
-
-  private static void PlayDiagnosticTone(MMDevice device, CancellationToken ct)
-  {
-    var toneProvider = new DiagnosticToneProvider(SampleRate, Channels, LeftHz, RightHz, Amplitude);
-
-    using var wasapiOut = new WasapiOut(device, AudioClientShareMode.Shared, useEventSync: true, latency: 200);
-    wasapiOut.Init(toneProvider);
-    wasapiOut.Play();
-
-    try
-    {
-      while (wasapiOut.PlaybackState == PlaybackState.Playing && !ct.IsCancellationRequested)
-      {
-        Thread.Sleep(100);
-      }
-    }
-    catch (OperationCanceledException) { }
-
-    wasapiOut.Stop();
   }
 
   /// <summary>

--- a/tools/Radio.Tools.BtSender/Radio.Tools.BtSender.csproj
+++ b/tools/Radio.Tools.BtSender/Radio.Tools.BtSender.csproj
@@ -10,6 +10,5 @@
 
   <ItemGroup>
     <PackageReference Include="NAudio" Version="2.2.1" />
-    <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- BtSender's WASAPI playback silently died when backgrounded, making long-running automated BT diagnostic tests impossible
- Added `PlayWithReconnectAsync` loop that detects WASAPI failures (PlaybackStopped event, device health checks) and automatically reconnects
- Waits up to 6 minutes for device to reappear on disconnect, with timestamped logging
- Removed dead BT auto-connect code (AudioPlaybackConnection/WMI) and `System.Management` dependency

## Verified
- BtSender running in background for 1+ minutes with stable WASAPI output
- All 3 Ubuntu validator stages (V1-BTCapture, V2-Producer/Consumer, V3-Mixer) reporting OK continuously
- No reconnect messages = WASAPI staying healthy in background mode

## Test plan
- [x] Quick foreground test (8s duration) — clean start/stop
- [x] Missing device test — waits and respects duration timeout
- [x] Background mode with `run_in_background` — stays alive, audio flows to Ubuntu
- [x] All validators stable at -5dB/-8dB for 30+ seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)