### PR TITLE
fix: Offload tap modifier processing from RT audio thread

### DIFF
--- a/src/Radio.Infrastructure/Audio/SoundFlow/FingerprintTapModifier.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/FingerprintTapModifier.cs
@@ -19,6 +19,7 @@ public class FingerprintTapModifier : SoundModifier
   private readonly ILogger? _logger;
   private readonly IMetricsCollector? _metricsCollector;
   private readonly float[] _sampleBuffer;
+  private readonly float[] _flushBuffer;
   private readonly int _bufferSize;
   private int _bufferIndex;
   private readonly object _lock = new();
@@ -30,6 +31,7 @@ public class FingerprintTapModifier : SoundModifier
   private bool _loggedFirstBatch;
   private DateTime _lastLogTime = DateTime.MinValue;
   private DateTime _lastProcessedTime = DateTime.MinValue;
+  private volatile bool _flushInProgress;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="FingerprintTapModifier"/> class.
@@ -49,6 +51,7 @@ public class FingerprintTapModifier : SoundModifier
     _metricsCollector = metricsCollector;
     _bufferSize = bufferSize;
     _sampleBuffer = new float[bufferSize];
+    _flushBuffer = new float[bufferSize];
     _bufferIndex = 0;
     Name = "Fingerprint Tap";
   }
@@ -57,7 +60,9 @@ public class FingerprintTapModifier : SoundModifier
   public override float ProcessSample(float sample, int channel)
   {
     // Hot path: called 96,000 times/second for stereo 48kHz.
-    // Minimize work inside the lock — no DateTime, no allocations.
+    // Only buffer samples on the audio thread — all heavy processing
+    // (PCM conversion, ring buffer writes) is offloaded to ThreadPool.
+    bool shouldFlush = false;
     lock (_lock)
     {
       _totalSamplesProcessed++;
@@ -67,22 +72,32 @@ public class FingerprintTapModifier : SoundModifier
         _sampleBuffer[_bufferIndex++] = sample;
       }
 
-      // When buffer is full, write to output tap and reset
+      // When buffer is full, copy to flush buffer and reset
       if (_bufferIndex >= _bufferSize)
       {
-        _lastProcessedTime = DateTime.UtcNow;
+        if (!_flushInProgress)
+        {
+          Array.Copy(_sampleBuffer, _flushBuffer, _bufferSize);
+          shouldFlush = true;
+        }
+        _bufferIndex = 0;
+      }
+    }
 
+    // Heavy work runs on ThreadPool, not the real-time audio thread.
+    // WriteToOutputTap does per-sample float→PCM conversion (4096 iterations)
+    // which would block the audio callback and cause periodic distortion.
+    if (shouldFlush)
+    {
+      _flushInProgress = true;
+      ThreadPool.QueueUserWorkItem(_ =>
+      {
         try
         {
-          // Create a copy to write to the tap
-          var samplesForTap = new float[_bufferSize];
-          Array.Copy(_sampleBuffer, samplesForTap, _bufferSize);
-
-          // Write to the output tap for fingerprinting/streaming
-          _audioEngine.WriteToOutputTap(samplesForTap);
+          _audioEngine.WriteToOutputTap(_flushBuffer);
           _batchCount++;
+          _lastProcessedTime = DateTime.UtcNow;
 
-          // Log first batch at Information level for diagnostics
           if (!_loggedFirstBatch)
           {
             _loggedFirstBatch = true;
@@ -91,7 +106,6 @@ public class FingerprintTapModifier : SoundModifier
               _bufferSize, _totalSamplesProcessed);
           }
 
-          // Log periodically (every 10 seconds)
           if ((_lastProcessedTime - _lastLogTime).TotalSeconds >= 10)
           {
             _logger?.LogDebug(
@@ -99,7 +113,6 @@ public class FingerprintTapModifier : SoundModifier
               _totalSamplesProcessed, _bufferSize);
             _lastLogTime = _lastProcessedTime;
 
-            // Report metrics
             if (_metricsCollector != null)
             {
               var batchDelta = _batchCount - _lastReportedBatches;
@@ -123,9 +136,11 @@ public class FingerprintTapModifier : SoundModifier
           _writeErrorCount++;
           _logger?.LogWarning(ex, "Error writing samples to output tap");
         }
-
-        _bufferIndex = 0;
-      }
+        finally
+        {
+          _flushInProgress = false;
+        }
+      });
     }
 
     // Pass through unchanged - this is a tap, not an effect

--- a/src/Radio.Infrastructure/Audio/SoundFlow/VisualizationTapModifier.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/VisualizationTapModifier.cs
@@ -14,9 +14,11 @@ public class VisualizationTapModifier : SoundModifier
   private readonly IVisualizerService _visualizerService;
   private readonly AudioFormat _format;
   private readonly float[] _sampleBuffer;
+  private readonly float[] _flushBuffer;
   private readonly int _bufferSize;
   private int _bufferIndex;
   private readonly object _lock = new();
+  private volatile bool _flushInProgress;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="VisualizationTapModifier"/> class.
@@ -33,6 +35,7 @@ public class VisualizationTapModifier : SoundModifier
     _format = format;
     _bufferSize = bufferSize;
     _sampleBuffer = new float[bufferSize];
+    _flushBuffer = new float[bufferSize];
     _bufferIndex = 0;
     Name = "Visualization Tap";
   }
@@ -40,7 +43,10 @@ public class VisualizationTapModifier : SoundModifier
   /// <inheritdoc/>
   public override float ProcessSample(float sample, int channel)
   {
-    // Collect samples in the buffer
+    // Hot path: called 96,000 times/second for stereo 48kHz.
+    // Only buffer samples on the audio thread — FFT, RMS, and waveform
+    // analysis are offloaded to ThreadPool to avoid blocking the callback.
+    bool shouldFlush = false;
     lock (_lock)
     {
       if (_bufferIndex < _bufferSize)
@@ -48,25 +54,39 @@ public class VisualizationTapModifier : SoundModifier
         _sampleBuffer[_bufferIndex++] = sample;
       }
 
-      // When buffer is full, send to visualizer and reset
+      // When buffer is full, copy to flush buffer and reset
       if (_bufferIndex >= _bufferSize)
+      {
+        if (!_flushInProgress)
+        {
+          Array.Copy(_sampleBuffer, _flushBuffer, _bufferSize);
+          shouldFlush = true;
+        }
+        _bufferIndex = 0;
+      }
+    }
+
+    // Heavy work (mono conversion, FFT, RMS, waveform) runs on ThreadPool.
+    // Previously this ran synchronously on the audio thread, causing
+    // periodic distortion every ~21ms (2048 samples at 48kHz stereo).
+    if (shouldFlush)
+    {
+      _flushInProgress = true;
+      ThreadPool.QueueUserWorkItem(_ =>
       {
         try
         {
-          // Create a copy to avoid issues with the lock
-          var samplesForVisualizer = new float[_bufferSize];
-          Array.Copy(_sampleBuffer, samplesForVisualizer, _bufferSize);
-
-          // Process samples synchronously to ensure they reach the visualizer
-          _visualizerService.ProcessSamples(samplesForVisualizer);
+          _visualizerService.ProcessSamples(_flushBuffer);
         }
         catch (Exception)
         {
           // Ignore visualization errors — best-effort tap
         }
-
-        _bufferIndex = 0;
-      }
+        finally
+        {
+          _flushInProgress = false;
+        }
+      });
     }
 
     // Pass through unchanged - this is a tap, not an effect


### PR DESCRIPTION
## Summary
- **FingerprintTapModifier** and **VisualizationTapModifier** were doing heavy processing synchronously on the real-time audio callback thread, causing periodic audio glitches
- FingerprintTap: every 4096 samples (~42ms), allocated a float array, copied data, then called `WriteFromEngine` which iterates 4096 samples doing float→PCM conversion — all blocking the audio thread
- VisualizationTap: every 2048 samples (~21ms), allocated a float array, copied data, then ran FFT, RMS computation, and waveform analysis on the audio thread
- Fix: pre-allocate flush buffers, offload all heavy processing to `ThreadPool.QueueUserWorkItem`, keep only fast buffering (lock + array store + Array.Copy) on the audio thread

## Test plan
- [x] Build passes with 0 warnings
- [x] All tests pass
- [x] Deployed to Ubuntu, BT audio plays with stable buffer (~58% fill)
- [x] All PipeWire nodes at ERR=0
- [x] Zero buffer underruns, drops, or clock drift compensations
- [x] Fingerprinting pipeline still captures and processes audio correctly
- [x] Visualization still works via SignalR hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)