### PR TITLE
fix: Address high-priority architectural review findings

### DIFF
--- a/comprehensive-review.md
+++ b/comprehensive-review.md
@@ -1,0 +1,435 @@
+# Comprehensive Architectural Review
+
+## HIGH Priority
+
+---
+
+### 1. [PRIORITY: High] [DIFFICULTY: Easy]
+- **Category:** Security
+- **Location:** `src/Radio.API/Controllers/SecretsController.cs:46-67`
+- **Issue:** The `GET /api/secrets/{section}?raw=true` endpoint returns unmasked plaintext secrets (API keys for Google TTS, Azure TTS, AcoustID) with no authentication or authorization. Anyone on the network can retrieve all secrets.
+- **Recommendation:** Remove the `?raw=true` option entirely, or gate it behind authentication. At minimum, add `[Authorize]` to this controller. Consider removing the raw endpoint and only allowing secret writes.
+
+---
+
+### 2. [PRIORITY: High] [DIFFICULTY: Easy]
+- **Category:** Security
+- **Location:** `src/Radio.API/Controllers/FilesController.cs:55-63, 130-237`
+- **Issue:** The `absolutePath` query parameter on `GET /api/files` is passed directly to `Directory.Exists()`, `Directory.GetDirectories()`, and `Directory.GetFiles()` with zero path validation. An attacker can enumerate the entire filesystem (`/etc`, `/home`, `C:\Windows\System32`).
+- **Recommendation:** Whitelist allowed base directories (e.g., the configured media root). Reject any `absolutePath` that does not start with an allowed prefix. Add `Path.GetFullPath()` + prefix check to prevent `..` traversal.
+
+---
+
+### 3. [PRIORITY: High] [DIFFICULTY: Easy]
+- **Category:** Security
+- **Location:** `src/Radio.API/Controllers/FilesController.cs:266-323`; `src/Radio.Infrastructure/Audio/Services/FileBrowser.cs:300-317`
+- **Issue:** The `PlayFile` endpoint accepts an arbitrary file path from the POST body and passes it to `LoadFileAsync()`. The `GetFullPath` helper uses `Path.Combine` without `..` traversal protection. An attacker can play any audio file on the system or probe for file existence.
+- **Recommendation:** Validate that resolved paths fall within the configured media root using `Path.GetFullPath()` + `StartsWith()` check. Reject paths containing `..` segments.
+
+---
+
+### 4. [PRIORITY: High] [DIFFICULTY: Easy]
+- **Category:** Security
+- **Location:** `src/Radio.Web/Components/Layout/MainLayout.razor:215`
+- **Issue:** `eval()` is used to set a global JS variable: `await JSRuntime.InvokeVoidAsync("eval", $"window.radioApiBaseUrl = '{apiBaseUrl}'")`. Since `apiBaseUrl` comes from `IConfiguration` and the configuration API is unauthenticated, an attacker could inject JavaScript via a chained attack (write malicious config → trigger UI reload).
+- **Recommendation:** Replace `eval()` with a safe JS interop call, e.g., `await JSRuntime.InvokeVoidAsync("Object.assign", DotNetObjectReference.Create(...))` or write a tiny JS function that accepts the URL as a parameter and sets the global.
+
+---
+
+### 5. [PRIORITY: High] [DIFFICULTY: Easy]
+- **Category:** Error Handling
+- **Location:** `src/Radio.Web/Components/Pages/RadioPage.razor` (8 instances: lines ~258, ~316, ~399, ~530, ~547, ~563, ~580, ~597)
+- **Issue:** Eight separate `catch (Exception) { // Silently fail }` blocks swallow all exceptions including unexpected ones (NullReferenceException, InvalidOperationException, etc.) with no logging. Bugs in radio control logic will be invisible.
+- **Recommendation:** At minimum, add `Logger.LogWarning(ex, "...")` to each catch block. Better: extract a shared error-handling helper that logs and optionally shows a Snackbar notification.
+
+---
+
+### 6. [PRIORITY: High] [DIFFICULTY: Easy]
+- **Category:** Error Handling
+- **Location:** `src/Radio.Infrastructure/Audio/Outputs/GoogleCastOutput.cs:142, 436`; `src/Radio.Web/Components/Pages/MetricsDashboardPage.razor:218, 228, 254`
+- **Issue:** Bare `catch { }` blocks (no exception type, no body) silently swallow all exceptions including critical ones. The Cast disconnect failure at line 142 can mask network issues; the metrics page catches at lines 218/228/254 hide data loading failures.
+- **Recommendation:** Replace bare `catch { }` with typed catches (`catch (Exception ex)`) and add at minimum `_logger.LogDebug(ex, "...")`. For Cast disconnect, log at Warning level since it indicates a network state problem.
+
+---
+
+### 7. [PRIORITY: High] [DIFFICULTY: Easy]
+- **Category:** Dead Code
+- **Location:** `src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs:498-527` (TryRecoverPlaybackDevice)
+- **Issue:** `TryRecoverPlaybackDevice()` re-attaches Balance, Limiter, and FingerprintTap modifiers but does NOT re-attach `_visualizationTap`. `SwitchPlaybackDevice()` (lines 594-645) correctly attaches all four. After a device recovery, visualization will silently stop working.
+- **Recommendation:** Add the `_visualizationTap` re-attachment block to `TryRecoverPlaybackDevice()`, matching the pattern in `SwitchPlaybackDevice()`. Better: extract a shared `ReattachModifiers()` helper (see item #19).
+
+---
+
+### 8. [PRIORITY: High] [DIFFICULTY: Medium]
+- **Category:** Security
+- **Location:** `src/Radio.API/` (all 18 controllers); `src/Radio.API/Program.cs`
+- **Issue:** No authentication or authorization is configured. All endpoints are publicly accessible to anyone on the network, including secrets retrieval, configuration writes, file browsing, audio control, and system administration. No rate limiting exists.
+- **Recommendation:** Implement API key authentication (simplest for a single-user appliance) or JWT bearer tokens. Add `[Authorize]` to sensitive controllers (Secrets, Configuration, System, Files). Add rate limiting middleware for discovery/scan endpoints.
+
+---
+
+### 9. [PRIORITY: High] [DIFFICULTY: Medium]
+- **Category:** Duplication / Base Class
+- **Location:** `src/Radio.Infrastructure/Audio/Sources/Primary/PrimaryAudioSourceBase.cs` and `src/Radio.Infrastructure/Audio/Sources/Events/EventAudioSourceBase.cs`
+- **Issue:** ~13 methods/properties are duplicated nearly verbatim across both base classes: `Id`, `State`, `Volume`, `PlayAsync`, `StopAsync`, `DisposeAsync`, `InitializeAsync`, `OnStateChanged`, `OnPlaybackCompleted`, `ThrowIfDisposed`, etc. Any bug fix must be applied in two places. The `ThrowIfDisposed` implementations even use different patterns (`ObjectDisposedException.ThrowIf` vs manual throw).
+- **Recommendation:** Extract a common `AudioSourceBase` abstract class containing shared state management, volume, disposal, and event patterns. `PrimaryAudioSourceBase` inherits from it and adds pause/resume/seek/capability methods. `EventAudioSourceBase` inherits directly with no additions.
+
+---
+
+### 10. [PRIORITY: High] [DIFFICULTY: Medium]
+- **Category:** Concurrency
+- **Location:** `src/Radio.Infrastructure/Audio/Services/AudioManager.cs:319-328`
+- **Issue:** `GetOrCreateSourceAsync` calls `SwitchSourceAsync` while holding `_createLock` (line 328), creating a lock ordering of `_createLock → _switchLock`. But the main code path at line 388 intentionally calls `SwitchSourceAsync` *outside* `_createLock` with a comment noting deadlock avoidance. If two threads hit the cache-after-lock path vs. a direct `SwitchSourceAsync`, the inconsistent ordering can deadlock.
+- **Recommendation:** Move the `SwitchSourceAsync` call at line 328 outside the `_createLock` scope, matching the pattern at line 388. Store the cached source reference, release `_createLock`, then call `SwitchSourceAsync`.
+
+---
+
+### 11. [PRIORITY: High] [DIFFICULTY: Medium]
+- **Category:** Error Handling / Concurrency
+- **Location:** Multiple files in `src/Radio.Infrastructure/` — 19+ instances of `_ =` fire-and-forget async in infrastructure code (see list below)
+- **Issue:** Fire-and-forget async calls (`_ = SomeMethodAsync()`) silently lose exceptions. Key instances: `GoogleCastOutput.cs:118,125` (Cast volume/mute), `LinuxBluetoothService.cs:338,382,387,392` (BT device watching), `BluetoothAudioSource.cs:296,452,783` (audio capture), `SoundFlowPlaybackService.cs:693` (stop), `AudioPreferencePersistence.cs:53,274` (persist). A failed Cast volume set or BT capture acquisition will never be noticed.
+- **Recommendation:** Create a `SafeFireAndForget(Task task, ILogger logger, string context)` extension method that logs exceptions. Replace all `_ = MethodAsync()` with `MethodAsync().SafeFireAndForget(_logger, "context")`. For critical operations (Cast, BT capture), consider awaiting with a timeout instead.
+
+---
+
+### 12. [PRIORITY: High] [DIFFICULTY: Medium]
+- **Category:** Testing
+- **Location:** `src/Radio.Infrastructure/Audio/Services/AudioManager.cs`
+- **Issue:** `AudioManager` is the central orchestrator for source switching, volume control, gain management, and ducking coordination. It has no direct unit tests despite being the most critical service in the system. The lock ordering bug (item #10) would have been caught by concurrency tests.
+- **Recommendation:** Create `tests/Radio.Infrastructure.Tests/Audio/Services/AudioManagerTests.cs` covering: source switching (including concurrent switches), volume/balance/mute operations, source gain offsets, cached source retrieval, and error handling during source creation.
+
+---
+
+### 13. [PRIORITY: High] [DIFFICULTY: Medium]
+- **Category:** Testing
+- **Location:** `src/Radio.API/Controllers/` — 5 controllers have no tests
+- **Issue:** `IntegrationsController`, `NotificationsController`, `PlaylistsController`, `RadioBandsController`, and `AudioDiagnosticsController` have no corresponding test files. These endpoints handle hardware integration, user playlists, and system diagnostics.
+- **Recommendation:** Create test files for each missing controller. Priority order: PlaylistsController (user data), IntegrationsController (hardware), then the others. Use the existing `CustomWebApplicationFactory` pattern from other controller tests.
+
+---
+
+### 14. [PRIORITY: High] [DIFFICULTY: Hard]
+- **Category:** Architecture / Separation of Concerns
+- **Location:** `src/Radio.Web/Components/Shared/RadioControlPanel.razor` (1185 lines); `src/Radio.Web/Components/Shared/NowPlayingPanel.razor` (760 lines); `src/Radio.Web/Components/Layout/MainLayout.razor` (790 lines)
+- **Issue:** Three components exceed 750 lines each, mixing multiple responsibilities. `RadioControlPanel` combines tuner display, frequency input dialogs, preset management, SDR controls, and 856+ lines of scoped CSS. `NowPlayingPanel` combines album art, fingerprint status, transport controls, volume, and gain popover. `MainLayout` manages source routing, output routing, Cast device selection, clock, navigation, and sleep mode.
+- **Recommendation:** Extract subcomponents: `RadioTunerDisplay`, `RadioPresetBank`, `RadioFrequencyDialog` from RadioControlPanel; `TransportControls`, `GainPopover`, `FingerprintBadge` from NowPlayingPanel; `SourceRouting`, `OutputRouting` from MainLayout. Target <300 lines per component.
+
+---
+
+## MEDIUM Priority
+
+---
+
+### 15. [PRIORITY: Medium] [DIFFICULTY: Easy]
+- **Category:** Duplication
+- **Location:** `src/Radio.Web/Components/Layout/MainLayout.razor:517-525` and `src/Radio.Web/Components/Shared/NowPlayingPanel.razor:520-528`
+- **Issue:** Source icon mapping (`GetSourceIcon` / `GetFpSourceIcon`) is duplicated with subtle inconsistencies: MainLayout handles `"FilePlayer"` while NowPlayingPanel uses `"File"`; MainLayout handles `"RTLSDRCore" or "RF320"` while NowPlayingPanel only handles `"Radio"`. A third copy exists at MainLayout:528-536 for CSS data attributes.
+- **Recommendation:** Create `Components/Shared/SourceTypeHelper.cs` with static methods `GetIcon(string sourceType)` and `GetDataAttribute(string sourceType)`. Normalize source type strings in one place.
+
+---
+
+### 16. [PRIORITY: Medium] [DIFFICULTY: Easy]
+- **Category:** Duplication
+- **Location:** `src/Radio.Web/Components/Pages/RadioPage.razor:603-674` and `src/Radio.Web/Components/Shared/RadioControlPanel.razor:1119-1177`
+- **Issue:** Five frequency-related methods are duplicated verbatim between these two files: `FormatFrequency()`, `FormatStep()`, `GetDialogStep()`, `GetMinFrequency()`, `GetMaxFrequency()`. The RadioPage versions have inline comments; the RadioControlPanel versions are compressed. Both do identical Hz→MHz/kHz conversions.
+- **Recommendation:** Create `Components/Shared/FrequencyFormatter.cs` with static methods for all frequency formatting/conversion. Both components call the shared class.
+
+---
+
+### 17. [PRIORITY: Medium] [DIFFICULTY: Easy]
+- **Category:** Observability
+- **Location:** `src/Radio.API/Middleware/ApiMetricsMiddleware.cs:34-41`
+- **Issue:** The metrics middleware only increments a single `api.requests_total` counter. It tracks no request latency, no error rates, no per-endpoint breakdown, no concurrent request count, and no exception tracking. This provides almost zero operational insight.
+- **Recommendation:** Add `Stopwatch` around `_next(context)` for latency, check `context.Response.StatusCode` for error counting, wrap in try/catch for exception counting, and include path tags for per-endpoint breakdown.
+
+---
+
+### 18. [PRIORITY: Medium] [DIFFICULTY: Easy]
+- **Category:** Observability / Logging
+- **Location:** `src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs:348,319`; `src/Radio.API/Controllers/FilesController.cs:68,108,136,221`; `src/Radio.API/Controllers/QueueController.cs:83,117,155,186,225,293`
+- **Issue:** Periodic operational telemetry and routine per-request API logs use `LogInformation` instead of `LogDebug`. The buffer stats log fires every 10 seconds during playback; file browse and queue CRUD logs fire on every user interaction. This creates excessive log noise in production.
+- **Recommendation:** Change periodic telemetry (`BufferedSoundGenerator` stats, clock drift) and routine CRUD logs (file browse, queue operations) to `LogDebug`. Keep `LogInformation` for significant state changes (source switches, device changes, errors).
+
+---
+
+### 19. [PRIORITY: Medium] [DIFFICULTY: Easy]
+- **Category:** Duplication
+- **Location:** `src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs:268-292` (InitializeAsync), `498-527` (TryRecoverPlaybackDevice), `594-645` (SwitchPlaybackDevice)
+- **Issue:** Modifier re-attachment logic (create-or-reuse then AddModifier for Balance, Limiter, FingerprintTap, VisualizationTap) is duplicated across three methods. The `TryRecoverPlaybackDevice` copy is missing `_visualizationTap` (bug, see item #7).
+- **Recommendation:** Extract `private void AttachModifiersToDevice(AudioPlaybackDevice device)` that handles all four modifiers with the create-or-reuse pattern. Call from all three locations.
+
+---
+
+### 20. [PRIORITY: Medium] [DIFFICULTY: Easy]
+- **Category:** Readability / Magic Strings
+- **Location:** `src/Radio.Web/Components/Layout/MainLayout.razor` (source types: "Radio", "RTLSDRCore", "RF320", "Bluetooth", etc.); `src/Radio.Web/Components/Shared/RadioControlPanel.razor` (band types: "FM", "AM", "AIR", "SW", "WB", "VHF"); `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor` (queue states: "Current", "Played")
+- **Issue:** String literals for source types, radio bands, and queue item states are scattered across multiple Razor components with no central definition. Typos would cause silent failures (wrong icon, wrong formatting).
+- **Recommendation:** Create `Radio.Web/Constants/SourceTypes.cs`, `RadioBands.cs`, and `QueueItemStates.cs` with `const string` fields. Reference these constants from all components.
+
+---
+
+### 21. [PRIORITY: Medium] [DIFFICULTY: Easy]
+- **Category:** Dependencies
+- **Location:** `tests/*.csproj` files across 7 test projects
+- **Issue:** xUnit version is inconsistent across test projects: 2.5.3, 2.6.3, and 2.9.3 appear in different `.csproj` files. This can cause subtle test behavior differences and makes dependency management harder.
+- **Recommendation:** Consolidate all test projects to xUnit 2.9.3 (latest). Use `Directory.Build.props` to centralize the version.
+
+---
+
+### 22. [PRIORITY: Medium] [DIFFICULTY: Easy]
+- **Category:** Performance
+- **Location:** `src/Radio.Infrastructure/Audio/Services/AudioPreferencePersistence.cs:239-250`
+- **Issue:** `RestoreSourceGainOffsets()` executes a synchronous blocking DB query (`store.GetEntryAsync(key).GetAwaiter().GetResult()`) inside a foreach loop over all `AudioSourceType` enum values. This is N sequential blocking queries during startup.
+- **Recommendation:** Add a `GetEntriesByPrefixAsync("AudioPreferences:SourceGain")` method to the config store and use it to batch-read all gain values in a single query. Make the method async and await it from the caller.
+
+---
+
+### 23. [PRIORITY: Medium] [DIFFICULTY: Easy]
+- **Category:** Error Handling
+- **Location:** `src/Radio.API/Services/PhoneCallIntegrationService.cs:54-68`; `src/Radio.API/Services/RotaryEncoderHostedService.cs:43-53`
+- **Issue:** Both hosted services exit `ExecuteAsync()` permanently if their initial `StartAsync()` call throws. If the RotaryPhone hub or HID device is temporarily unavailable at startup, the integration silently never starts with no retry.
+- **Recommendation:** Add a retry loop with exponential backoff (e.g., 5s, 15s, 30s, 60s) around the start call, similar to the pattern in `AudioStateUpdateService` which retries on error with a 1-second backoff.
+
+---
+
+### 24. [PRIORITY: Medium] [DIFFICULTY: Easy]
+- **Category:** Concurrency
+- **Location:** Multiple files — 18 `async void` event handlers (e.g., `AudioStateUpdateService.cs:678,692,707,755,769,816,829`; `PlayHistoryTracker.cs:76,421,475,549`; `BluetoothAudioSource.cs:521`)
+- **Issue:** `async void` event handlers that throw unhandled exceptions will crash the entire process. While using `async void` for event handlers is the accepted .NET pattern, each handler must have a top-level try/catch to prevent process termination.
+- **Recommendation:** Audit all 18 `async void` methods to verify each has a top-level `try { ... } catch (Exception ex) { _logger.LogError(ex, "..."); }` wrapping the entire body. Add missing try/catch blocks.
+
+---
+
+### 25. [PRIORITY: Medium] [DIFFICULTY: Medium]
+- **Category:** Duplication / Base Class
+- **Location:** `src/Radio.Infrastructure/Audio/SoundFlow/FingerprintTapModifier.cs:21-25,60-85,90-144,153-173,178-185` and `src/Radio.Infrastructure/Audio/SoundFlow/VisualizationTapModifier.cs:16-21,44-67,72-89,99-119,124-131`
+- **Issue:** Both tap modifiers implement an identical double-buffered, lock-protected, ThreadPool-offloaded sample processing pattern. The field declarations, `ProcessSample` buffering logic, `ThreadPool.QueueUserWorkItem` dispatch, `Flush()`, and `Reset()` methods are character-for-character identical. Only the flush target differs (`WriteToOutputTap` vs `ProcessSamples`).
+- **Recommendation:** Extract an abstract `BufferedTapModifier : SoundModifier` base class with a virtual `OnFlushBuffer(float[] buffer, int count)` method. Both modifiers inherit and override only the flush target. This eliminates ~120 lines of duplication.
+
+---
+
+### 26. [PRIORITY: Medium] [DIFFICULTY: Medium]
+- **Category:** Architecture / Separation of Concerns
+- **Location:** `src/Radio.Core/Interfaces/Audio/IAudioManager.cs`
+- **Issue:** `IAudioManager` is a "God Interface" with 40+ members mixing source switching, engine lifecycle, ducking coordination, per-source gain control, and master volume/balance/mute. This makes it difficult to mock in tests and violates Interface Segregation Principle.
+- **Recommendation:** Split into focused interfaces: `IAudioSourceManager` (source switching, creation, caching), `IAudioMixerControl` (volume, balance, mute, gain), and keep `IAudioManager` as a facade that implements both for backward compatibility.
+
+---
+
+### 27. [PRIORITY: Medium] [DIFFICULTY: Medium]
+- **Category:** Performance
+- **Location:** `src/Radio.Web/Components/Shared/NowPlayingPanel.razor:328-341` (5-second timer); SignalR subscription at lines ~290-310
+- **Issue:** `NowPlayingPanel` both polls playback state every 5 seconds via a timer AND subscribes to SignalR `PlaybackStateChanged` events. This creates redundant API calls when SignalR is connected and working properly.
+- **Recommendation:** Remove the polling timer. Use SignalR exclusively for state updates. Add a "disconnected" visual indicator when the SignalR connection is lost, and only fall back to polling during disconnection.
+
+---
+
+### 28. [PRIORITY: Medium] [DIFFICULTY: Medium]
+- **Category:** Performance
+- **Location:** `src/Radio.Infrastructure/Audio/SoundFlow/TappedOutputStream.cs:173-178`
+- **Issue:** `ReadForReader()` copies data byte-by-byte from the ring buffer. For HTTP audio streaming reads of 4096+ bytes, this is significantly slower than bulk copy. This runs on every HTTP stream client read request.
+- **Recommendation:** Replace the byte-by-byte loop with `Buffer.BlockCopy` or `Span<byte>` bulk copies, handling the ring buffer wrap-around with at most two copy operations (before wrap + after wrap).
+
+---
+
+### 29. [PRIORITY: Medium] [DIFFICULTY: Medium]
+- **Category:** Performance
+- **Location:** `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor`
+- **Issue:** The queue list renders all items without virtualization. Queues can contain 1000+ items, and each render cycle processes the entire list. No `MudVirtualize` or similar virtual scrolling is used.
+- **Recommendation:** Replace the queue item list with `MudVirtualize<QueueItemDto>` for queues exceeding ~50 items. This renders only visible items and dramatically improves render performance for large playlists.
+
+---
+
+### 30. [PRIORITY: Medium] [DIFFICULTY: Medium]
+- **Category:** Error Handling
+- **Location:** `src/Radio.Web/` (all API service clients in `Services/`)
+- **Issue:** All 14 API client services return `null` on any exception (logged but silent in UI). Components receiving `null` show empty states with no distinction between "no data" and "API error". No Snackbar notifications, no retry buttons, no error badges.
+- **Recommendation:** Create a `Result<T>` wrapper type with `Success`, `Error(message)`, and `Disconnected` states. Update API services to return `Result<T>`. Update components to show error states with retry buttons when appropriate.
+
+---
+
+### 31. [PRIORITY: Medium] [DIFFICULTY: Medium]
+- **Category:** Performance
+- **Location:** `src/Radio.Infrastructure/Metrics/Repositories/SqliteMetricsRepository.cs:257-273`
+- **Issue:** `GetCurrentSnapshotsAsync()` iterates over each metric key and calls `GetAggregateAsync()` individually, each executing 2 SQL queries. For N keys, this is 2N database round-trips. `SaveBucketsAsync()` (lines 104-129) creates a new `SqliteCommand` per bucket in a loop.
+- **Recommendation:** Consolidate `GetCurrentSnapshotsAsync` into a single `SELECT ... WHERE Key IN (...)` query. For `SaveBucketsAsync`, reuse a prepared statement across iterations or use `INSERT ... VALUES (...), (...), (...)` batch syntax.
+
+---
+
+### 32. [PRIORITY: Medium] [DIFFICULTY: Medium]
+- **Category:** Testing
+- **Location:** `src/Radio.Web/` — no unit or bUnit tests for several pages
+- **Issue:** `BluetoothPage` and `DiagnosticPage` have no component tests. The Web project overall has ~40 tests but the critical `MainLayout`, `RadioControlPanel`, and `NowPlayingPanel` components have limited coverage for their complex state management and event handling.
+- **Recommendation:** Add bUnit tests for BluetoothPage and DiagnosticPage. Add targeted tests for MainLayout source/output routing state transitions and RadioControlPanel frequency conversion logic.
+
+---
+
+### 33. [PRIORITY: Medium] [DIFFICULTY: Medium]
+- **Category:** Testing
+- **Location:** `src/Radio.Infrastructure/Audio/Services/` — multiple services untested
+- **Issue:** `AnnouncementService`, `AudioSourceFactory`, `AudioFileEventSourceFactory`, `VisualizationModeService`, `PlayHistoryTracker`, and `AccurateDurationReader` have no direct unit tests. `PlayHistoryTracker` has complex state machine logic for song change detection that is particularly test-worthy.
+- **Recommendation:** Prioritize `PlayHistoryTracker` tests (song change detection state machine), then `AudioSourceFactory` (factory logic with device resolution), then `AnnouncementService` (ducking coordination).
+
+---
+
+### 34. [PRIORITY: Medium] [DIFFICULTY: Medium]
+- **Category:** Architecture
+- **Location:** `src/Radio.Core/Models/Audio/` — `AudioSourceState` enum and `AudioOutputState` enum
+- **Issue:** `AudioSourceState` and `AudioOutputState` share 7 of their values (Created, Initializing, Ready, Stopping, Stopped, Error, Disposed). The duplication means state transition logic is implemented twice with potential for divergence.
+- **Recommendation:** Extract a common `AudioComponentState` enum for shared states. If source-specific states (Playing, Paused) and output-specific states (Connecting, Streaming) are needed, use separate extension enums or a composite pattern.
+
+---
+
+### 35. [PRIORITY: Medium] [DIFFICULTY: Medium]
+- **Category:** Separation of Concerns
+- **Location:** `src/Radio.API/Controllers/SystemController.cs`; `src/Radio.API/Controllers/ConfigurationController.cs:239-261`
+- **Issue:** `SystemController` contains CPU usage caching logic, log file path resolution, regex-based log parsing, and temperature zone reading — all business logic that belongs in an Infrastructure service. `ConfigurationController` has conditional store selection logic (lines 239-261) that should be in a configuration management service.
+- **Recommendation:** Extract `SystemInfoService` (CPU, memory, disk, temperature, log parsing) and `ConfigurationManagementService` (store selection, reconciliation) into Infrastructure. Controllers should only delegate and map responses.
+
+---
+
+### 36. [PRIORITY: Medium] [DIFFICULTY: Hard]
+- **Category:** Architecture / State Management
+- **Location:** `src/Radio.Web/Components/Layout/MainLayout.razor` (8 state fields); `src/Radio.Web/Services/RadioPanelToggleService.cs`; scattered state across `NowPlayingPanel`, `RadioControlPanel`, `QueueHistoryPanel`
+- **Issue:** Audio state (active source, selected output, volume, mute, Cast connection) is scattered across multiple components with no centralized store. MainLayout alone has 8 state fields (`_availableSources`, `_selectedSourceId`, `_availableOutputs`, `_selectedOutputId`, `_defaultCastDevice`, `_isCastConnecting`, `_showCastDropdown`, etc.). `RadioPanelToggleService` is a singleton just for panel visibility. State synchronization bugs are inevitable.
+- **Recommendation:** Create a centralized `AudioStateStore` service (similar to Fluxor or a simple observable store pattern) that holds all audio-related state. Components subscribe to specific state slices. SignalR events update the store, and the store notifies subscribers. This eliminates duplicate state and sync bugs.
+
+---
+
+## LOW Priority
+
+---
+
+### 37. [PRIORITY: Low] [DIFFICULTY: Easy]
+- **Category:** Dead Code
+- **Location:** `src/Radio.Infrastructure/Audio/Sources/Primary/PrimaryAudioSourceBase.cs:197-201, 208-212, 219-223, 229-234`
+- **Issue:** Four virtual methods (`NextAsync`, `PreviousAsync`, `SetShuffleAsync`, `SetRepeatModeAsync`) throw `NotSupportedException` if the capability property is false, then have an unreachable `return Task.CompletedTask` after the throw. While technically a valid pattern for subclasses that override, the structure is confusing — the throw and return serve different code paths but read as sequential.
+- **Recommendation:** Add a comment above each `return Task.CompletedTask` clarifying it's the default for subclasses that support the capability but don't need custom logic. Or restructure: `if (!Supports) throw; return await CoreAsync();` with a virtual `CoreAsync` that returns `Task.CompletedTask`.
+
+---
+
+### 38. [PRIORITY: Low] [DIFFICULTY: Easy]
+- **Category:** Readability / Magic Numbers
+- **Location:** `src/Radio.Infrastructure/Audio/SoundFlow/FingerprintTapModifier.cs:53-54` (buffer size 4096); `VisualizationTapModifier.cs:37-38` (buffer size 2048); `BufferedSoundGenerator.cs:101-102` (drift thresholds 15%, 25%); `TappedOutputStream.cs:47` (bytes per sample = 2)
+- **Issue:** Buffer sizes, drift thresholds, and format constants are hardcoded as magic numbers throughout the audio pipeline. Tuning requires finding and modifying scattered literals.
+- **Recommendation:** Define named constants: `const int FingerprintBufferSamples = 4096`, `const int VisualizationBufferSamples = 2048`, `const float DriftWarningThreshold = 0.15f`, `const float DriftCriticalThreshold = 0.25f`, `const int PcmBytesPerSample = 2`.
+
+---
+
+### 39. [PRIORITY: Low] [DIFFICULTY: Easy]
+- **Category:** Observability
+- **Location:** `src/Radio.Infrastructure/External/PhoneContactLookupService.cs:52`
+- **Issue:** `_logger.LogInformation("Resolved {PhoneNumber} -> {Name}")` logs caller phone numbers and names at Information level. This is personally identifiable information (PII) appearing in production logs.
+- **Recommendation:** Change to `LogDebug` and consider masking: `"Resolved {PhoneNumber} -> {Name}"` → `"Resolved ***{LastFour} -> {Name}"` with partial phone number masking.
+
+---
+
+### 40. [PRIORITY: Low] [DIFFICULTY: Easy]
+- **Category:** Configuration
+- **Location:** `src/Radio.API/Program.cs`; `src/Radio.Web/Program.cs`
+- **Issue:** SignalR hub paths (`/hubs/audio`, `/hubs/visualization`) and stream paths (`/stream/audio`, `/stream/audio/mp3`) are hardcoded string literals in both projects. If a path changes, both projects must be updated.
+- **Recommendation:** Define hub/stream paths as constants in `Radio.Core` (e.g., `HubPaths.Audio`, `HubPaths.Visualization`, `StreamPaths.RawAudio`, `StreamPaths.Mp3Audio`) and reference from both projects.
+
+---
+
+### 41. [PRIORITY: Low] [DIFFICULTY: Easy]
+- **Category:** Error Handling
+- **Location:** `src/Radio.API/Hubs/AudioStateHub.cs:20-21`; `src/Radio.API/Hubs/AudioVisualizationHub.cs:22-23`
+- **Issue:** The static `_connectedClients` counter can go negative if `OnDisconnectedAsync` is called without a matching `OnConnectedAsync` (e.g., during abnormal shutdown). No lower-bound clamp exists.
+- **Recommendation:** Add `_connectedClients = Math.Max(0, _connectedClients - 1)` in the decrement path. Consider replacing `lock` + manual increment with `Interlocked.Increment`/`Interlocked.Decrement` since the lock also protects a metrics gauge update.
+
+---
+
+### 42. [PRIORITY: Low] [DIFFICULTY: Easy]
+- **Category:** Documentation
+- **Location:** `src/Radio.Web/Services/` (all 14 API client services); `src/Radio.Web/Services/RadioPanelToggleService.cs`; `src/Radio.Web/Services/DeviceDisplayStateService.cs`
+- **Issue:** Web service classes have no XML doc comments on public methods. `RadioPanelToggleService` and `DeviceDisplayStateService` have no comments at all. A new developer cannot understand the purpose of these services without reading their implementation.
+- **Recommendation:** Add `/// <summary>` comments to all public methods in Web services. At minimum, document the purpose and return values of each API client method.
+
+---
+
+### 43. [PRIORITY: Low] [DIFFICULTY: Easy]
+- **Category:** Consistency
+- **Location:** `src/Radio.Web/Components/` — various components
+- **Issue:** Some components implement `IDisposable`, others implement `IAsyncDisposable`. Some unsubscribe from events in Dispose, others forget. Some use try/catch in event handlers, others don't. No base component class enforces cleanup patterns.
+- **Recommendation:** Standardize on `IAsyncDisposable` for all components that subscribe to events or hold timers. Consider a `RadioComponentBase : ComponentBase, IAsyncDisposable` base class with a virtual `OnDisposeAsync()` and automatic event unsubscription tracking.
+
+---
+
+### 44. [PRIORITY: Low] [DIFFICULTY: Easy]
+- **Category:** Dependencies
+- **Location:** `src/Radio.Infrastructure/Audio/Services/AlbumArtCacheService.cs:127` (registered as concrete type)
+- **Issue:** `AlbumArtCacheService` is registered as `AddSingleton<AlbumArtCacheService>()` without an interface, breaking the Dependency Inversion Principle. All other services in the audio pipeline use interface-based registration.
+- **Recommendation:** Extract `IAlbumArtCacheService` interface and register via `AddSingleton<IAlbumArtCacheService, AlbumArtCacheService>()`. This enables testing with mocks and maintains consistency.
+
+---
+
+### 45. [PRIORITY: Low] [DIFFICULTY: Easy]
+- **Category:** Performance
+- **Location:** `src/Radio.Infrastructure/Audio/Services/AudioPreferencePersistence.cs:81-88`
+- **Issue:** `RestoreVolumePreferences()` is synchronous but calls three `GetAwaiter().GetResult()` blocking calls sequentially during startup. While this runs once, it sets a bad pattern and blocks the thread pool thread.
+- **Recommendation:** Make the method `async Task RestoreVolumePreferencesAsync()` and `await` the config store calls. Update the caller to await it. This aligns with the rest of the codebase's async patterns.
+
+---
+
+### 46. [PRIORITY: Low] [DIFFICULTY: Easy]
+- **Category:** Dead Code / Bloat
+- **Location:** `src/Radio.Web/Components/Shared/RadioControlPanel.razor` — 856+ lines of scoped CSS
+- **Issue:** The component has more CSS than C#/Razor code. Much of the scoped CSS could be extracted to a shared stylesheet or use existing design system classes from `design-system.css`. The sheer volume makes the component file unwieldy.
+- **Recommendation:** Extract the scoped CSS to `RadioControlPanel.razor.css` (Blazor CSS isolation file) or factor common patterns into `design-system.css` utility classes. Keep only component-specific overrides in scoped styles.
+
+---
+
+### 47. [PRIORITY: Low] [DIFFICULTY: Medium]
+- **Category:** Architecture
+- **Location:** `src/Radio.Core/Interfaces/Audio/IAudioSource.cs` — `GetSoundComponent()` returns `object`
+- **Issue:** `IAudioSource.GetSoundComponent()` returns an untyped `object` (a SoundFlow component). Consumers must cast to the expected type, which is fragile and undiscoverable. The Core layer leaks an implicit dependency on SoundFlow's type system.
+- **Recommendation:** Define an `ISoundComponent` marker interface in Core that SoundFlow components implement via adapter. Return `ISoundComponent` instead of `object`. This makes the contract explicit and type-safe.
+
+---
+
+### 48. [PRIORITY: Low] [DIFFICULTY: Medium]
+- **Category:** Configuration
+- **Location:** `src/Radio.Core/Configuration/` — 20 option POCOs
+- **Issue:** Configuration option classes have no default values defined in Core. Defaults are scattered across `appsettings.json` files and Infrastructure code. If `appsettings.json` is missing a section, the application may get unexpected `null` or `0` values.
+- **Recommendation:** Add sensible defaults directly in the option POCOs (e.g., `public int SampleRate { get; set; } = 48000;`, `public float DuckingPercentage { get; set; } = 0.3f;`). This makes the system resilient to missing configuration and self-documenting.
+
+---
+
+### 49. [PRIORITY: Low] [DIFFICULTY: Medium]
+- **Category:** Observability
+- **Location:** `src/Radio.API/` — no health check endpoint
+- **Issue:** There is no `/health` or `/ready` endpoint. The systemd services have no way to verify the API is healthy beyond checking if the process is running. If the audio engine crashes internally but the HTTP server stays up, the system appears healthy when it isn't.
+- **Recommendation:** Add ASP.NET Core health checks: `builder.Services.AddHealthChecks().AddCheck<AudioEngineHealthCheck>("audio-engine")`. Map to `/health`. Configure systemd to poll it.
+
+---
+
+### 50. [PRIORITY: Low] [DIFFICULTY: Medium]
+- **Category:** Architecture
+- **Location:** `src/Radio.Core/Models/Audio/RadioPreset.cs` — `Frequency` property is `double`; `src/Radio.Core/Interfaces/Audio/IRadioControl.cs` — `CurrentFrequency` is `Frequency` struct
+- **Issue:** `RadioPreset.Frequency` is a raw `double` (ambiguous unit — MHz? kHz? Hz?) while `IRadioControl.CurrentFrequency` uses the type-safe `Frequency` struct that stores Hz internally. This dual representation invites unit conversion bugs.
+- **Recommendation:** Change `RadioPreset.Frequency` to use the `Frequency` struct. Update serialization and database schema accordingly. The `Frequency` struct already has `FromMegahertz()` and `FromKilohertz()` factory methods for backward-compatible deserialization.
+
+---
+
+### 51. [PRIORITY: Low] [DIFFICULTY: Medium]
+- **Category:** Testing
+- **Location:** `tests/` — hardcoded test constants across projects
+- **Issue:** Sample rates (48000), frequencies (440Hz), buffer sizes, and other test constants are hardcoded independently in each test file. No shared test constants exist.
+- **Recommendation:** Create `tests/Radio.TestCommon/TestAudioConstants.cs` (or add to an existing shared project) with `const int SampleRate = 48000`, `const double TestFrequencyHz = 440.0`, etc. Reference from all test projects.
+
+---
+
+### 52. [PRIORITY: Low] [DIFFICULTY: Medium]
+- **Category:** Performance
+- **Location:** `src/Radio.Web/Components/Shared/RadioControlPanel.razor` — `OnInitializedAsync`; `src/Radio.Web/Components/Layout/MainLayout.razor` — `OnInitializedAsync`
+- **Issue:** Both components make 3+ sequential API calls during initialization (e.g., `LoadRadioStateAsync()` → `LoadPresetsAsync()` → `LoadBandsAsync()`). These are independent operations that could run concurrently.
+- **Recommendation:** Use `await Task.WhenAll(LoadRadioStateAsync(), LoadPresetsAsync(), LoadBandsAsync())` for independent initialization calls. This reduces perceived startup latency by running API calls in parallel.
+
+---
+
+### 53. [PRIORITY: Low] [DIFFICULTY: Hard]
+- **Category:** Architecture
+- **Location:** `src/Radio.Infrastructure/Audio/` — no documented lock ordering
+- **Issue:** The audio subsystem has 25+ lock objects across ~15 files (see: `_switchLock`, `_createLock` in AudioManager; `_stateLock` in AudioEngine; `_playersLock` in PlaybackService; `_sourcesLock` in MasterMixer; `_bufferLock` in BufferedSoundGenerator; etc.). There is no documented lock hierarchy or ordering convention. The existing deadlock risk in AudioManager (item #10) demonstrates the practical danger.
+- **Recommendation:** Document a lock ordering hierarchy in `design/AUDIO_ARCHITECTURE.md` (e.g., "Engine locks → Manager locks → Source locks → Buffer locks"). Add comments at each lock declaration specifying its position in the hierarchy. Consider using `System.Threading.Lock` (if on .NET 9+) or a debug-mode lock ordering validator.

--- a/src/Radio.API/Controllers/FilesController.cs
+++ b/src/Radio.API/Controllers/FilesController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Radio.API.Extensions;
+using Radio.Core.Configuration;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.API.Models;
@@ -19,6 +21,7 @@ public class FilesController : ControllerBase
   private readonly IFileBrowser _fileBrowser;
   private readonly IAudioEngine _audioEngine;
   private readonly IAudioManager? _audioManager;
+  private readonly IOptionsMonitor<FilePlayerOptions> _filePlayerOptions;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="FilesController"/> class.
@@ -27,11 +30,13 @@ public class FilesController : ControllerBase
     ILogger<FilesController> logger,
     IFileBrowser fileBrowser,
     IAudioEngine audioEngine,
+    IOptionsMonitor<FilePlayerOptions> filePlayerOptions,
     IAudioManager? audioManager = null)
   {
     _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     _fileBrowser = fileBrowser ?? throw new ArgumentNullException(nameof(fileBrowser));
     _audioEngine = audioEngine ?? throw new ArgumentNullException(nameof(audioEngine));
+    _filePlayerOptions = filePlayerOptions ?? throw new ArgumentNullException(nameof(filePlayerOptions));
     _audioManager = audioManager;
   }
 
@@ -59,6 +64,11 @@ public class FilesController : ControllerBase
     // Absolute path mode: bypass _fileBrowser and enumerate directly
     if (!string.IsNullOrWhiteSpace(absolutePath))
     {
+      if (!IsPathAllowed(absolutePath))
+      {
+        _logger.LogWarning("Rejected absolute path access: {Path}", absolutePath);
+        return BadRequest(new { error = "Path is not within an allowed directory" });
+      }
       return await ListFilesAbsolute(absolutePath, cancellationToken);
     }
 
@@ -270,6 +280,13 @@ public class FilesController : ControllerBase
     if (string.IsNullOrWhiteSpace(request.Path))
     {
       return BadRequest(new { error = "File path is required" });
+    }
+
+    // Validate absolute paths against allowed directories
+    if (Path.IsPathRooted(request.Path) && !IsPathAllowed(request.Path))
+    {
+      _logger.LogWarning("Rejected play file path: {Path}", request.Path);
+      return BadRequest(new { error = "Path is not within an allowed directory" });
     }
 
     try
@@ -520,6 +537,42 @@ public class FilesController : ControllerBase
     // Fallback: AudioManager not available
     _logger.LogWarning("IAudioManager not available, cannot activate File Player source");
     return null;
+  }
+
+  /// <summary>
+  /// Validates that a path falls within an allowed directory (media root or configured browse directories).
+  /// Prevents path traversal attacks via ".." segments or symlinks.
+  /// </summary>
+  private bool IsPathAllowed(string path)
+  {
+    try
+    {
+      // Resolve to absolute path, eliminating ".." segments and symlinks
+      var resolvedPath = Path.GetFullPath(path);
+
+      // Check against configured media root
+      var options = _filePlayerOptions.CurrentValue;
+      var mediaRoot = Path.GetFullPath(
+        string.IsNullOrEmpty(options.RootDirectory) ? "." : options.RootDirectory);
+      if (resolvedPath.StartsWith(mediaRoot, StringComparison.OrdinalIgnoreCase))
+        return true;
+
+      // Check against additional allowed browse directories
+      foreach (var allowedDir in options.AllowedBrowseDirectories)
+      {
+        if (string.IsNullOrWhiteSpace(allowedDir)) continue;
+        var resolvedAllowed = Path.GetFullPath(allowedDir);
+        if (resolvedPath.StartsWith(resolvedAllowed, StringComparison.OrdinalIgnoreCase))
+          return true;
+      }
+
+      return false;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Error validating path: {Path}", path);
+      return false;
+    }
   }
 
   /// <summary>

--- a/src/Radio.API/Controllers/SecretsController.cs
+++ b/src/Radio.API/Controllers/SecretsController.cs
@@ -36,15 +36,14 @@ public class SecretsController : ControllerBase
   }
 
   /// <summary>
-  /// Gets all secrets for a section, with values masked by default.
+  /// Gets all secrets for a section, with values always masked.
   /// </summary>
   /// <param name="section">The section name (e.g., "tts", "acoustid").</param>
-  /// <param name="raw">If true, returns raw (unmasked) values.</param>
   [HttpGet("{section}")]
   [ProducesResponseType(typeof(Dictionary<string, string>), StatusCodes.Status200OK)]
   [ProducesResponseType(StatusCodes.Status400BadRequest)]
   public async Task<ActionResult<Dictionary<string, string>>> GetSectionSecrets(
-    string section, [FromQuery] bool raw = false)
+    string section)
   {
     if (!SectionTagMappings.TryGetValue(section, out var tagMap))
       return BadRequest(new { error = $"Unknown secrets section '{section}'" });
@@ -53,14 +52,7 @@ public class SecretsController : ControllerBase
     foreach (var (property, tag) in tagMap)
     {
       var value = await _secrets.GetSecretAsync(tag);
-      if (raw)
-      {
-        result[property] = value ?? "";
-      }
-      else
-      {
-        result[property] = MaskValue(value);
-      }
+      result[property] = MaskValue(value);
     }
 
     return Ok(result);

--- a/src/Radio.Core/Configuration/FilePlayerOptions.cs
+++ b/src/Radio.Core/Configuration/FilePlayerOptions.cs
@@ -20,4 +20,11 @@ public class FilePlayerOptions
   /// Gets or sets the supported audio file extensions.
   /// </summary>
   public string[] SupportedExtensions { get; set; } = [".mp3", ".flac", ".wav", ".ogg", ".aac", ".m4a", ".wma"];
+
+  /// <summary>
+  /// Gets or sets additional directories that may be browsed via absolute path
+  /// (e.g., NAS mounts, USB drives). Paths outside RootDirectory and these
+  /// directories will be rejected. Empty array means only RootDirectory is allowed.
+  /// </summary>
+  public string[] AllowedBrowseDirectories { get; set; } = [];
 }

--- a/src/Radio.Core/Extensions/TaskExtensions.cs
+++ b/src/Radio.Core/Extensions/TaskExtensions.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Logging;
+
+namespace Radio.Core.Extensions;
+
+/// <summary>
+/// Extension methods for Task to handle fire-and-forget patterns safely.
+/// </summary>
+public static class TaskExtensions
+{
+  /// <summary>
+  /// Observes a fire-and-forget task, logging any exceptions that occur.
+  /// Use this instead of <c>_ = SomeMethodAsync()</c> to prevent silent exception loss.
+  /// </summary>
+  /// <param name="task">The task to observe.</param>
+  /// <param name="logger">Logger to record any exceptions.</param>
+  /// <param name="context">A short description of what the task does, for log messages.</param>
+  public static async void SafeFireAndForget(this Task task, ILogger logger, string context)
+  {
+    try
+    {
+      await task;
+    }
+    catch (OperationCanceledException)
+    {
+      // Expected during shutdown — don't log as error
+      logger.LogDebug("Fire-and-forget task cancelled: {Context}", context);
+    }
+    catch (ObjectDisposedException)
+    {
+      // Expected during disposal — don't log as error
+      logger.LogDebug("Fire-and-forget task hit disposed object: {Context}", context);
+    }
+    catch (Exception ex)
+    {
+      logger.LogError(ex, "Unhandled exception in fire-and-forget task: {Context}", context);
+    }
+  }
+}

--- a/src/Radio.Infrastructure/Audio/Outputs/GoogleCastOutput.cs
+++ b/src/Radio.Infrastructure/Audio/Outputs/GoogleCastOutput.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
+using Radio.Core.Extensions;
 using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
 using Sharpcaster;
@@ -115,14 +116,14 @@ public class GoogleCastOutput : AudioOutputBase
   protected override void OnVolumeChanged(float volume)
   {
     // Apply volume to connected device if available
-    _ = SetCastVolumeAsync(volume);
+    SetCastVolumeAsync(volume).SafeFireAndForget(_logger, "SetCastVolume");
   }
 
   /// <inheritdoc />
   protected override void OnMuteChanged(bool muted)
   {
     // Apply mute state to connected device if available
-    _ = SetCastMuteAsync(muted);
+    SetCastMuteAsync(muted).SafeFireAndForget(_logger, "SetCastMute");
   }
 
   /// <inheritdoc />
@@ -139,7 +140,8 @@ public class GoogleCastOutput : AudioOutputBase
       // Dispose old client if reinitializing after error
       if (_client != null)
       {
-        try { await _client.DisconnectAsync(); } catch { }
+        try { await _client.DisconnectAsync(); }
+        catch (Exception ex) { _logger.LogDebug(ex, "Error disconnecting previous Cast client during reinit"); }
       }
 
       // Create a fresh ChromecastClient
@@ -433,7 +435,8 @@ public class GoogleCastOutput : AudioOutputBase
         // Create a fresh ChromecastClient for cached connections to avoid stale socket state
         if (_client != null)
         {
-          try { await _client.DisconnectAsync(); } catch { }
+          try { await _client.DisconnectAsync(); }
+          catch (Exception ex) { _logger.LogDebug(ex, "Error disconnecting previous Cast client for cached connection"); }
         }
         _client = new ChromecastClient();
 

--- a/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
@@ -314,7 +314,9 @@ public class AudioManager : IAudioManager, IAsyncDisposable
     }
 
     // Serialize source creation to prevent duplicate instances (e.g., two Radio
-    // requests arriving simultaneously, both trying to open the RTL-SDR device)
+    // requests arriving simultaneously, both trying to open the RTL-SDR device).
+    // IMPORTANT: Never call SwitchSourceAsync while holding _createLock — it
+    // acquires _switchLock and would create an inconsistent lock ordering.
     IAudioSource? source = null;
     await _createLock.WaitAsync(cancellationToken);
     try
@@ -323,62 +325,61 @@ public class AudioManager : IAudioManager, IAsyncDisposable
       if (_sourceCache.TryGetValue(sourceType, out cachedSource))
       {
         _logger.LogDebug("Returning cached source for type (after lock): {SourceType}", sourceType);
-        if (switchToSource && cachedSource != _activeSource)
+        source = cachedSource;
+        // Don't return here — fall through to switch logic after lock release
+      }
+      else
+      {
+        _logger.LogInformation("Creating new source for type: {SourceType}", sourceType);
+
+        try
         {
-          await SwitchSourceAsync(cachedSource, cancellationToken);
+          source = _sourceFactory.CreateSource(sourceType);
         }
-        return cachedSource;
-      }
-
-      _logger.LogInformation("Creating new source for type: {SourceType}", sourceType);
-
-      try
-      {
-        source = _sourceFactory.CreateSource(sourceType);
-      }
-      catch (ArgumentOutOfRangeException)
-      {
-        _logger.LogWarning("Source type {SourceType} is not supported", sourceType);
-        return null;
-      }
-      catch (Exception ex)
-      {
-        _logger.LogError(ex, "Failed to create source for type: {SourceType}", sourceType);
-        return null;
-      }
-
-      if (source == null)
-      {
-        _logger.LogWarning("Source type {SourceType} is not supported", sourceType);
-        return null;
-      }
-
-      // Initialize the source before adding to mixer
-      if (source is IPrimaryAudioSource primarySource)
-      {
-        _logger.LogDebug("Initializing source: {SourceName}", source.Name);
-        await primarySource.InitializeAsync(cancellationToken);
-
-        if (source.State == AudioSourceState.Error)
+        catch (ArgumentOutOfRangeException)
         {
-          _logger.LogWarning("Source {SourceName} failed to initialize", source.Name);
+          _logger.LogWarning("Source type {SourceType} is not supported", sourceType);
           return null;
         }
+        catch (Exception ex)
+        {
+          _logger.LogError(ex, "Failed to create source for type: {SourceType}", sourceType);
+          return null;
+        }
+
+        if (source == null)
+        {
+          _logger.LogWarning("Source type {SourceType} is not supported", sourceType);
+          return null;
+        }
+
+        // Initialize the source before adding to mixer
+        if (source is IPrimaryAudioSource primarySource)
+        {
+          _logger.LogDebug("Initializing source: {SourceName}", source.Name);
+          await primarySource.InitializeAsync(cancellationToken);
+
+          if (source.State == AudioSourceState.Error)
+          {
+            _logger.LogWarning("Source {SourceName} failed to initialize", source.Name);
+            return null;
+          }
+        }
+
+        // Cache the source for reuse
+        _sourceCache[sourceType] = source;
+
+        // Subscribe to state changes for source cleanup and play history tracking
+        SubscribeToSourceStateChanges(source);
+
+        // Add to mixer
+        var mixer = _audioEngine.GetMasterMixer();
+        mixer.AddSource(source);
+
+        _logger.LogInformation(
+          "Created and registered source: {SourceName} ({SourceType})",
+          source.Name, source.Type);
       }
-
-      // Cache the source for reuse
-      _sourceCache[sourceType] = source;
-
-      // Subscribe to state changes for source cleanup and play history tracking
-      SubscribeToSourceStateChanges(source);
-
-      // Add to mixer
-      var mixer = _audioEngine.GetMasterMixer();
-      mixer.AddSource(source);
-
-      _logger.LogInformation(
-        "Created and registered source: {SourceName} ({SourceType})",
-        source.Name, source.Type);
     }
     finally
     {
@@ -386,7 +387,7 @@ public class AudioManager : IAudioManager, IAsyncDisposable
     }
 
     // Switch to the source if requested (outside _createLock to avoid deadlock with _switchLock)
-    if (switchToSource && source != null)
+    if (switchToSource && source != null && source != _activeSource)
     {
       await SwitchSourceAsync(source, cancellationToken);
     }

--- a/src/Radio.Infrastructure/Audio/Services/AudioPreferencePersistence.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioPreferencePersistence.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
+using Radio.Core.Extensions;
 using Radio.Core.Interfaces.Audio;
 using Radio.Infrastructure.Configuration.Abstractions;
 using Radio.Infrastructure.Configuration.Models;
@@ -50,7 +51,7 @@ public class AudioPreferencePersistence : IDisposable
     {
       _volumePersistTimer?.Dispose();
       _volumePersistTimer = new Timer(
-        _ => _ = PersistVolumePreferencesAsync(),
+        _ => PersistVolumePreferencesAsync().SafeFireAndForget(_logger, "PersistVolumePreferences"),
         null,
         TimeSpan.FromMilliseconds(500),
         Timeout.InfiniteTimeSpan);
@@ -271,7 +272,7 @@ public class AudioPreferencePersistence : IDisposable
     {
       _sourceGainPersistTimer?.Dispose();
       _sourceGainPersistTimer = new Timer(
-        _ => _ = PersistSourceGainAsync(),
+        _ => PersistSourceGainAsync().SafeFireAndForget(_logger, "PersistSourceGain"),
         null,
         TimeSpan.FromMilliseconds(500),
         Timeout.InfiniteTimeSpan);

--- a/src/Radio.Infrastructure/Audio/Services/FileBrowser.cs
+++ b/src/Radio.Infrastructure/Audio/Services/FileBrowser.cs
@@ -296,6 +296,7 @@ public class FileBrowser : IFileBrowser
 
   /// <summary>
   /// Gets the full file system path from a relative path.
+  /// Validates that the resolved path stays within the media root to prevent path traversal.
   /// </summary>
   private string GetFullPath(string? relativePath)
   {
@@ -314,7 +315,18 @@ public class FileBrowser : IFileBrowser
       return basePath;
     }
 
-    return Path.Combine(basePath, relativePath);
+    // Resolve the combined path and verify it stays within the base
+    var combined = Path.GetFullPath(Path.Combine(basePath, relativePath));
+    var resolvedBase = Path.GetFullPath(basePath);
+
+    if (!combined.StartsWith(resolvedBase, StringComparison.OrdinalIgnoreCase))
+    {
+      _logger.LogWarning("Path traversal attempt blocked: {RelativePath} resolved to {FullPath} (outside {Base})",
+        relativePath, combined, resolvedBase);
+      throw new UnauthorizedAccessException($"Path '{relativePath}' is outside the allowed media directory");
+    }
+
+    return combined;
   }
 
   /// <summary>

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
@@ -262,38 +262,13 @@ public class SoundFlowAudioEngine : IAudioEngine
         _options.OutputBufferSizeSeconds,
         _metricsCollector);
 
-      // Add modifiers to capture mixed audio for fingerprinting/streaming
+      // Add modifiers to capture mixed audio for fingerprinting/streaming.
+      // Start the playback device AFTER all modifiers are attached.
+      // SoundFlow's audio callback must see the full modifier chain from
+      // the first callback invocation, otherwise modifiers receive silence.
       if (_playbackDevice != null)
       {
-        // Add balance modifier first (before limiter/fingerprint tap)
-        _balanceModifier = new BalanceModifier(_masterMixer);
-        _playbackDevice.MasterMixer.AddModifier(_balanceModifier);
-        _logger.LogInformation("Balance modifier added to MasterMixer");
-
-        // Add limiter after balance to prevent clipping before downstream taps
-        _limiterModifier = new LimiterModifier();
-        _playbackDevice.MasterMixer.AddModifier(_limiterModifier);
-        _logger.LogInformation("Limiter modifier added to MasterMixer (threshold={Threshold:F3})",
-          LimiterModifier.DefaultThreshold);
-
-        // Add fingerprint tap modifier after limiter.
-        // Use 2048-sample buffer (~21ms at 48kHz stereo) instead of default 4096 (~42ms)
-        // to reduce latency for HTTP streaming to Cast devices.
-        _fingerprintTap = new FingerprintTapModifier(this, _logger, bufferSize: 2048, metricsCollector: _metricsCollector);
-        _playbackDevice.MasterMixer.AddModifier(_fingerprintTap);
-        _logger.LogInformation("Fingerprint tap modifier added to MasterMixer");
-
-        // Add visualization tap modifier for real-time spectrum/level/waveform data
-        if (_visualizerService != null)
-        {
-          _visualizationTap = new VisualizationTapModifier(_visualizerService, _audioFormat);
-          _playbackDevice.MasterMixer.AddModifier(_visualizationTap);
-          _logger.LogInformation("Visualization tap modifier added to MasterMixer");
-        }
-
-        // Start the playback device AFTER all modifiers are attached.
-        // SoundFlow's audio callback must see the full modifier chain from
-        // the first callback invocation, otherwise modifiers receive silence.
+        AttachModifiersToPlaybackDevice();
         _playbackDevice.Start();
         _logger.LogInformation("Playback device started with all modifiers attached");
       }
@@ -495,36 +470,8 @@ public class SoundFlowAudioEngine : IAudioEngine
       _playbackDevice.MasterMixer.Volume = _localOutputMuted ? 0f : _masterMixer.GetEffectiveVolume();
       _playbackDevice.Start();
 
-      // Re-attach modifiers
-      if (_balanceModifier != null)
-      {
-        _playbackDevice.MasterMixer.AddModifier(_balanceModifier);
-      }
-      else
-      {
-        _balanceModifier = new BalanceModifier(_masterMixer);
-        _playbackDevice.MasterMixer.AddModifier(_balanceModifier);
-      }
-
-      if (_limiterModifier != null)
-      {
-        _playbackDevice.MasterMixer.AddModifier(_limiterModifier);
-      }
-      else
-      {
-        _limiterModifier = new LimiterModifier();
-        _playbackDevice.MasterMixer.AddModifier(_limiterModifier);
-      }
-
-      if (_fingerprintTap != null)
-      {
-        _playbackDevice.MasterMixer.AddModifier(_fingerprintTap);
-      }
-      else
-      {
-        _fingerprintTap = new FingerprintTapModifier(this, _logger, metricsCollector: _metricsCollector);
-        _playbackDevice.MasterMixer.AddModifier(_fingerprintTap);
-      }
+      // Re-attach all modifiers (including visualization tap, which was previously missing here)
+      AttachModifiersToPlaybackDevice();
 
       _logger.LogInformation("Recovery successful: playback device {Name} initialized with modifiers", deviceInfo.Name);
     }
@@ -591,58 +538,8 @@ public class SoundFlowAudioEngine : IAudioEngine
       // Apply current volume/mute state
       _playbackDevice.MasterMixer.Volume = _localOutputMuted ? 0f : _masterMixer.GetEffectiveVolume();
 
-      // Re-attach balance modifier (before limiter/fingerprint tap)
-      if (_balanceModifier != null)
-      {
-        _playbackDevice.MasterMixer.AddModifier(_balanceModifier);
-        _logger.LogInformation("Balance modifier re-attached to new playback device");
-      }
-      else
-      {
-        _balanceModifier = new BalanceModifier(_masterMixer);
-        _playbackDevice.MasterMixer.AddModifier(_balanceModifier);
-        _logger.LogInformation("Balance modifier created and attached to new playback device");
-      }
-
-      // Re-attach limiter (after balance, before fingerprint tap)
-      if (_limiterModifier != null)
-      {
-        _playbackDevice.MasterMixer.AddModifier(_limiterModifier);
-        _logger.LogInformation("Limiter modifier re-attached to new playback device");
-      }
-      else
-      {
-        _limiterModifier = new LimiterModifier();
-        _playbackDevice.MasterMixer.AddModifier(_limiterModifier);
-        _logger.LogInformation("Limiter modifier created and attached to new playback device");
-      }
-
-      // Re-attach fingerprint tap if it exists
-      if (_fingerprintTap != null)
-      {
-        _playbackDevice.MasterMixer.AddModifier(_fingerprintTap);
-        _logger.LogInformation("Fingerprint tap re-attached to new playback device");
-      }
-      // If it didn't exist (e.g. started with no device), create it now
-      else
-      {
-        _fingerprintTap = new FingerprintTapModifier(this, _logger, metricsCollector: _metricsCollector);
-        _playbackDevice.MasterMixer.AddModifier(_fingerprintTap);
-        _logger.LogInformation("Fingerprint tap created and attached to new playback device");
-      }
-
-      // Re-attach visualization tap
-      if (_visualizationTap != null)
-      {
-        _playbackDevice.MasterMixer.AddModifier(_visualizationTap);
-        _logger.LogInformation("Visualization tap re-attached to new playback device");
-      }
-      else if (_visualizerService != null)
-      {
-        _visualizationTap = new VisualizationTapModifier(_visualizerService, _audioFormat);
-        _playbackDevice.MasterMixer.AddModifier(_visualizationTap);
-        _logger.LogInformation("Visualization tap created and attached to new playback device");
-      }
+      // Re-attach all modifiers to the new device
+      AttachModifiersToPlaybackDevice();
 
       _playbackDevice.Start();
 
@@ -667,6 +564,61 @@ public class SoundFlowAudioEngine : IAudioEngine
       _currentDeviceIndex = -1;
       return false;
     }
+  }
+
+  /// <summary>
+  /// Attaches all audio modifiers (balance, limiter, fingerprint tap, visualization tap)
+  /// to the current playback device's mixer. Creates modifiers if they don't exist yet.
+  /// </summary>
+  private void AttachModifiersToPlaybackDevice()
+  {
+    if (_playbackDevice == null) return;
+
+    // Balance modifier (first in chain)
+    if (_balanceModifier != null)
+    {
+      _playbackDevice.MasterMixer.AddModifier(_balanceModifier);
+    }
+    else
+    {
+      _balanceModifier = new BalanceModifier(_masterMixer);
+      _playbackDevice.MasterMixer.AddModifier(_balanceModifier);
+    }
+
+    // Limiter (after balance, before taps)
+    if (_limiterModifier != null)
+    {
+      _playbackDevice.MasterMixer.AddModifier(_limiterModifier);
+    }
+    else
+    {
+      _limiterModifier = new LimiterModifier();
+      _playbackDevice.MasterMixer.AddModifier(_limiterModifier);
+    }
+
+    // Fingerprint tap (after limiter)
+    if (_fingerprintTap != null)
+    {
+      _playbackDevice.MasterMixer.AddModifier(_fingerprintTap);
+    }
+    else
+    {
+      _fingerprintTap = new FingerprintTapModifier(this, _logger, bufferSize: 2048, metricsCollector: _metricsCollector);
+      _playbackDevice.MasterMixer.AddModifier(_fingerprintTap);
+    }
+
+    // Visualization tap (last in chain)
+    if (_visualizationTap != null)
+    {
+      _playbackDevice.MasterMixer.AddModifier(_visualizationTap);
+    }
+    else if (_visualizerService != null)
+    {
+      _visualizationTap = new VisualizationTapModifier(_visualizerService, _audioFormat);
+      _playbackDevice.MasterMixer.AddModifier(_visualizationTap);
+    }
+
+    _logger.LogDebug("All modifiers attached to playback device");
   }
 
   /// <summary>

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowPlaybackService.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowPlaybackService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Radio.Core.Extensions;
 using Radio.Infrastructure.Audio.Services;
 using SoundFlow.Abstracts;
 using SoundFlow.Abstracts.Devices;
@@ -690,7 +691,7 @@ public class SoundFlowPlaybackService : IDisposable
 
     foreach (var sourceId in sourceIds)
     {
-      _ = StopAsync(sourceId);
+      StopAsync(sourceId).SafeFireAndForget(_logger, $"StopAsync({sourceId})");
     }
   }
 

--- a/src/Radio.Infrastructure/Audio/Sources/AudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/AudioSourceBase.cs
@@ -1,0 +1,218 @@
+using Microsoft.Extensions.Logging;
+using Radio.Core.Interfaces.Audio;
+
+namespace Radio.Infrastructure.Audio.Sources;
+
+/// <summary>
+/// Base abstract class for all audio sources (primary and event).
+/// Provides common state management, lifecycle methods, and event infrastructure.
+/// </summary>
+public abstract class AudioSourceBase : IAudioSource, IAsyncDisposable
+{
+  private readonly ILogger _logger;
+  private AudioSourceState _state = AudioSourceState.Created;
+  private float _volume = 1.0f;
+  private bool _disposed;
+  private string? _id;
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="AudioSourceBase"/> class.
+  /// </summary>
+  /// <param name="logger">The logger instance.</param>
+  protected AudioSourceBase(ILogger logger)
+  {
+    _logger = logger;
+  }
+
+  /// <inheritdoc/>
+  public string Id => _id ??= $"{Type}-{Guid.NewGuid():N}";
+
+  /// <inheritdoc/>
+  public abstract string Name { get; }
+
+  /// <inheritdoc/>
+  public abstract AudioSourceType Type { get; }
+
+  /// <inheritdoc/>
+  public abstract AudioSourceCategory Category { get; }
+
+  /// <inheritdoc/>
+  public AudioSourceState State
+  {
+    get => _state;
+    protected set
+    {
+      if (_state == value) return;
+      var previousState = _state;
+      _state = value;
+      LogStateChange(previousState, value);
+      OnStateChanged(previousState, value);
+    }
+  }
+
+  /// <inheritdoc/>
+  public float Volume
+  {
+    get => _volume;
+    set
+    {
+      _volume = Math.Clamp(value, 0.0f, 1.0f);
+      OnVolumeChanged(_volume);
+    }
+  }
+
+  /// <inheritdoc/>
+  public event EventHandler<AudioSourceStateChangedEventArgs>? StateChanged;
+
+  /// <summary>
+  /// Raised when playback completes (end of content, error, or user stop).
+  /// </summary>
+  public event EventHandler<AudioSourceCompletedEventArgs>? PlaybackCompleted;
+
+  /// <inheritdoc/>
+  public abstract object GetSoundComponent();
+
+  /// <summary>
+  /// Starts playback. Auto-initializes if source is in Created state.
+  /// </summary>
+  public virtual async Task PlayAsync(CancellationToken cancellationToken = default)
+  {
+    ThrowIfDisposed();
+    if (State == AudioSourceState.Created)
+    {
+      await InitializeAsync(cancellationToken);
+    }
+
+    // Check if initialization failed
+    if (State == AudioSourceState.Error)
+    {
+      return;
+    }
+
+    await PlayCoreAsync(cancellationToken);
+    State = AudioSourceState.Playing;
+  }
+
+  /// <summary>
+  /// Stops playback if the source is currently playing or paused.
+  /// </summary>
+  public virtual async Task StopAsync(CancellationToken cancellationToken = default)
+  {
+    ThrowIfDisposed();
+    if (State != AudioSourceState.Playing && State != AudioSourceState.Paused)
+    {
+      return;
+    }
+
+    await StopCoreAsync(cancellationToken);
+    State = AudioSourceState.Stopped;
+  }
+
+  /// <inheritdoc/>
+  public async ValueTask DisposeAsync()
+  {
+    if (_disposed) return;
+
+    await DisposeAsyncCore();
+    State = AudioSourceState.Disposed;
+    _disposed = true;
+    GC.SuppressFinalize(this);
+  }
+
+  /// <summary>
+  /// Initializes the audio source. Override in derived classes for source-specific setup.
+  /// </summary>
+  /// <param name="cancellationToken">Cancellation token.</param>
+  /// <returns>A task representing the async operation.</returns>
+  public virtual Task InitializeAsync(CancellationToken cancellationToken = default)
+  {
+    State = AudioSourceState.Initializing;
+    return Task.CompletedTask;
+  }
+
+  /// <summary>
+  /// Core implementation for starting playback.
+  /// </summary>
+  /// <param name="cancellationToken">Cancellation token.</param>
+  /// <returns>A task representing the async operation.</returns>
+  protected abstract Task PlayCoreAsync(CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Core implementation for stopping playback.
+  /// </summary>
+  /// <param name="cancellationToken">Cancellation token.</param>
+  /// <returns>A task representing the async operation.</returns>
+  protected abstract Task StopCoreAsync(CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Core implementation for async disposal.
+  /// </summary>
+  /// <returns>A task representing the async operation.</returns>
+  protected virtual ValueTask DisposeAsyncCore()
+  {
+    return ValueTask.CompletedTask;
+  }
+
+  /// <summary>
+  /// Called when the volume changes. Override to apply volume to the sound component.
+  /// </summary>
+  /// <param name="volume">The new volume level (0.0 to 1.0).</param>
+  protected virtual void OnVolumeChanged(float volume)
+  {
+  }
+
+  /// <summary>
+  /// Logs a state change. Override to change log level or message format.
+  /// Default logs at Debug level.
+  /// </summary>
+  /// <param name="previousState">The previous state.</param>
+  /// <param name="newState">The new state.</param>
+  protected virtual void LogStateChange(AudioSourceState previousState, AudioSourceState newState)
+  {
+    _logger.LogDebug("Audio source {Id} state changed from {PreviousState} to {NewState}",
+      Id, previousState, newState);
+  }
+
+  /// <summary>
+  /// Raises the <see cref="StateChanged"/> event.
+  /// </summary>
+  /// <param name="previousState">The previous state.</param>
+  /// <param name="newState">The new state.</param>
+  protected virtual void OnStateChanged(AudioSourceState previousState, AudioSourceState newState)
+  {
+    StateChanged?.Invoke(this, new AudioSourceStateChangedEventArgs
+    {
+      PreviousState = previousState,
+      NewState = newState,
+      SourceId = Id
+    });
+  }
+
+  /// <summary>
+  /// Raises the <see cref="PlaybackCompleted"/> event.
+  /// </summary>
+  /// <param name="reason">The reason for completion.</param>
+  /// <param name="error">Any error that occurred, if applicable.</param>
+  protected virtual void OnPlaybackCompleted(PlaybackCompletionReason reason, Exception? error = null)
+  {
+    PlaybackCompleted?.Invoke(this, new AudioSourceCompletedEventArgs
+    {
+      SourceId = Id,
+      Reason = reason,
+      Error = error
+    });
+  }
+
+  /// <summary>
+  /// Throws an <see cref="ObjectDisposedException"/> if this instance has been disposed.
+  /// </summary>
+  protected void ThrowIfDisposed()
+  {
+    ObjectDisposedException.ThrowIf(_disposed, this);
+  }
+
+  /// <summary>
+  /// Gets the logger for this instance.
+  /// </summary>
+  protected ILogger Logger => _logger;
+}

--- a/src/Radio.Infrastructure/Audio/Sources/Events/AudioFileEventSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Events/AudioFileEventSource.cs
@@ -90,7 +90,7 @@ public class AudioFileEventSource : EventAudioSourceBase
   }
 
   /// <inheritdoc/>
-  protected override async Task InitializeAsync(CancellationToken cancellationToken = default)
+  public override async Task InitializeAsync(CancellationToken cancellationToken = default)
   {
     await base.InitializeAsync(cancellationToken);
 

--- a/src/Radio.Infrastructure/Audio/Sources/Events/EventAudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Events/EventAudioSourceBase.cs
@@ -5,200 +5,30 @@ namespace Radio.Infrastructure.Audio.Sources.Events;
 
 /// <summary>
 /// Base abstract class for event audio sources.
-/// Provides common functionality for state management and events.
+/// Extends <see cref="AudioSourceBase"/> with event-specific category and log level.
 /// </summary>
-public abstract class EventAudioSourceBase : IEventAudioSource
+public abstract class EventAudioSourceBase : AudioSourceBase, IEventAudioSource
 {
-  private readonly ILogger _logger;
-  private AudioSourceState _state = AudioSourceState.Created;
-  private float _volume = 1.0f;
-  private bool _disposed;
-  private string? _id;
-
   /// <summary>
   /// Initializes a new instance of the <see cref="EventAudioSourceBase"/> class.
   /// </summary>
   /// <param name="logger">The logger instance.</param>
-  protected EventAudioSourceBase(ILogger logger)
+  protected EventAudioSourceBase(ILogger logger) : base(logger)
   {
-    _logger = logger;
   }
 
   /// <inheritdoc/>
-  public string Id => _id ??= $"{Type}-{Guid.NewGuid():N}";
-
-  /// <inheritdoc/>
-  public abstract string Name { get; }
-
-  /// <inheritdoc/>
-  public abstract AudioSourceType Type { get; }
-
-  /// <inheritdoc/>
-  public AudioSourceCategory Category => AudioSourceCategory.Event;
-
-  /// <inheritdoc/>
-  public AudioSourceState State
-  {
-    get => _state;
-    protected set
-    {
-      if (_state == value) return;
-      var previousState = _state;
-      _state = value;
-      _logger.LogDebug("Event audio source {Id} state changed from {PreviousState} to {NewState}",
-        Id, previousState, value);
-      OnStateChanged(previousState, value);
-    }
-  }
-
-  /// <inheritdoc/>
-  public float Volume
-  {
-    get => _volume;
-    set
-    {
-      _volume = Math.Clamp(value, 0.0f, 1.0f);
-      OnVolumeChanged(_volume);
-    }
-  }
+  public override AudioSourceCategory Category => AudioSourceCategory.Event;
 
   /// <inheritdoc/>
   public abstract TimeSpan Duration { get; }
 
-  /// <inheritdoc/>
-  public event EventHandler<AudioSourceStateChangedEventArgs>? StateChanged;
-
-  /// <inheritdoc/>
-  public event EventHandler<AudioSourceCompletedEventArgs>? PlaybackCompleted;
-
-  /// <inheritdoc/>
-  public abstract object GetSoundComponent();
-
-  /// <inheritdoc/>
-  public virtual async Task PlayAsync(CancellationToken cancellationToken = default)
-  {
-    ThrowIfDisposed();
-    if (State == AudioSourceState.Created)
-    {
-      await InitializeAsync(cancellationToken);
-    }
-
-    // Check if initialization failed
-    if (State == AudioSourceState.Error)
-    {
-      return;
-    }
-
-    await PlayCoreAsync(cancellationToken);
-    State = AudioSourceState.Playing;
-  }
-
-  /// <inheritdoc/>
-  public virtual async Task StopAsync(CancellationToken cancellationToken = default)
-  {
-    ThrowIfDisposed();
-    if (State != AudioSourceState.Playing)
-    {
-      return;
-    }
-
-    await StopCoreAsync(cancellationToken);
-    State = AudioSourceState.Stopped;
-  }
-
-  /// <inheritdoc/>
-  public async ValueTask DisposeAsync()
-  {
-    if (_disposed) return;
-
-    await DisposeAsyncCore();
-    State = AudioSourceState.Disposed;
-    _disposed = true;
-    GC.SuppressFinalize(this);
-  }
-
   /// <summary>
-  /// Initializes the audio source.
+  /// Logs state changes at Debug level for event sources.
   /// </summary>
-  /// <param name="cancellationToken">Cancellation token.</param>
-  /// <returns>A task representing the async operation.</returns>
-  protected virtual Task InitializeAsync(CancellationToken cancellationToken = default)
+  protected override void LogStateChange(AudioSourceState previousState, AudioSourceState newState)
   {
-    State = AudioSourceState.Initializing;
-    return Task.CompletedTask;
+    Logger.LogDebug("Event audio source {Id} state changed from {PreviousState} to {NewState}",
+      Id, previousState, newState);
   }
-
-  /// <summary>
-  /// Core implementation for starting playback.
-  /// </summary>
-  /// <param name="cancellationToken">Cancellation token.</param>
-  /// <returns>A task representing the async operation.</returns>
-  protected abstract Task PlayCoreAsync(CancellationToken cancellationToken);
-
-  /// <summary>
-  /// Core implementation for stopping playback.
-  /// </summary>
-  /// <param name="cancellationToken">Cancellation token.</param>
-  /// <returns>A task representing the async operation.</returns>
-  protected abstract Task StopCoreAsync(CancellationToken cancellationToken);
-
-  /// <summary>
-  /// Core implementation for async disposal.
-  /// </summary>
-  /// <returns>A task representing the async operation.</returns>
-  protected virtual ValueTask DisposeAsyncCore()
-  {
-    return ValueTask.CompletedTask;
-  }
-
-  /// <summary>
-  /// Called when the volume changes. Override to apply volume to the sound component.
-  /// </summary>
-  /// <param name="volume">The new volume level (0.0 to 1.0).</param>
-  protected virtual void OnVolumeChanged(float volume)
-  {
-  }
-
-  /// <summary>
-  /// Raises the <see cref="StateChanged"/> event.
-  /// </summary>
-  /// <param name="previousState">The previous state.</param>
-  /// <param name="newState">The new state.</param>
-  protected virtual void OnStateChanged(AudioSourceState previousState, AudioSourceState newState)
-  {
-    StateChanged?.Invoke(this, new AudioSourceStateChangedEventArgs
-    {
-      PreviousState = previousState,
-      NewState = newState,
-      SourceId = Id
-    });
-  }
-
-  /// <summary>
-  /// Raises the <see cref="PlaybackCompleted"/> event.
-  /// </summary>
-  /// <param name="reason">The reason for completion.</param>
-  /// <param name="error">Any error that occurred, if applicable.</param>
-  protected virtual void OnPlaybackCompleted(PlaybackCompletionReason reason, Exception? error = null)
-  {
-    PlaybackCompleted?.Invoke(this, new AudioSourceCompletedEventArgs
-    {
-      SourceId = Id,
-      Reason = reason,
-      Error = error
-    });
-  }
-
-  /// <summary>
-  /// Throws an <see cref="ObjectDisposedException"/> if this instance has been disposed.
-  /// </summary>
-  protected void ThrowIfDisposed()
-  {
-    ObjectDisposedException.ThrowIf(_disposed, this);
-  }
-
-  /// <summary>
-  /// Gets the logger for this instance.
-  /// </summary>
-  protected ILogger Logger => _logger;
 }

--- a/src/Radio.Infrastructure/Audio/Sources/Events/TTSEventSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Events/TTSEventSource.cs
@@ -75,7 +75,7 @@ public class TTSEventSource : EventAudioSourceBase
   }
 
   /// <inheritdoc/>
-  protected override async Task InitializeAsync(CancellationToken cancellationToken = default)
+  public override async Task InitializeAsync(CancellationToken cancellationToken = default)
   {
     await base.InitializeAsync(cancellationToken);
 

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/PrimaryAudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/PrimaryAudioSourceBase.cs
@@ -7,16 +7,12 @@ namespace Radio.Infrastructure.Audio.Sources.Primary;
 
 /// <summary>
 /// Base abstract class for primary audio sources.
-/// Provides common functionality for state management and events.
+/// Extends <see cref="AudioSourceBase"/> with pause/resume, seeking, track navigation,
+/// shuffle/repeat support, and playback metrics.
 /// </summary>
-public abstract class PrimaryAudioSourceBase : IPrimaryAudioSource
+public abstract class PrimaryAudioSourceBase : AudioSourceBase, IPrimaryAudioSource
 {
-  private readonly ILogger _logger;
   private readonly IMetricsCollector? _metricsCollector;
-  private AudioSourceState _state = AudioSourceState.Created;
-  private float _volume = 1.0f;
-  private bool _disposed;
-  private string? _id;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="PrimaryAudioSourceBase"/> class.
@@ -24,8 +20,8 @@ public abstract class PrimaryAudioSourceBase : IPrimaryAudioSource
   /// <param name="logger">The logger instance.</param>
   /// <param name="metricsCollector">Optional metrics collector for tracking playback metrics.</param>
   protected PrimaryAudioSourceBase(ILogger logger, IMetricsCollector? metricsCollector = null)
+    : base(logger)
   {
-    _logger = logger;
     _metricsCollector = metricsCollector;
   }
 
@@ -35,42 +31,7 @@ public abstract class PrimaryAudioSourceBase : IPrimaryAudioSource
   protected IMetricsCollector? MetricsCollector => _metricsCollector;
 
   /// <inheritdoc/>
-  public string Id => _id ??= $"{Type}-{Guid.NewGuid():N}";
-
-  /// <inheritdoc/>
-  public abstract string Name { get; }
-
-  /// <inheritdoc/>
-  public abstract AudioSourceType Type { get; }
-
-  /// <inheritdoc/>
-  public AudioSourceCategory Category => AudioSourceCategory.Primary;
-
-  /// <inheritdoc/>
-  public AudioSourceState State
-  {
-    get => _state;
-    protected set
-    {
-      if (_state == value) return;
-      var previousState = _state;
-      _state = value;
-      _logger.LogInformation("Audio source {Id} state changed from {PreviousState} to {NewState}",
-        Id, previousState, value);
-      OnStateChanged(previousState, value);
-    }
-  }
-
-  /// <inheritdoc/>
-  public float Volume
-  {
-    get => _volume;
-    set
-    {
-      _volume = Math.Clamp(value, 0.0f, 1.0f);
-      OnVolumeChanged(_volume);
-    }
-  }
+  public override AudioSourceCategory Category => AudioSourceCategory.Primary;
 
   /// <inheritdoc/>
   public abstract TimeSpan? Duration { get; }
@@ -109,32 +70,13 @@ public abstract class PrimaryAudioSourceBase : IPrimaryAudioSource
   /// <inheritdoc/>
   public virtual RepeatMode RepeatMode => RepeatMode.Off;
 
-  /// <inheritdoc/>
-  public event EventHandler<AudioSourceStateChangedEventArgs>? StateChanged;
-
-  /// <inheritdoc/>
-  public event EventHandler<AudioSourceCompletedEventArgs>? PlaybackCompleted;
-
-  /// <inheritdoc/>
-  public abstract object GetSoundComponent();
-
-  /// <inheritdoc/>
-  public virtual async Task PlayAsync(CancellationToken cancellationToken = default)
+  /// <summary>
+  /// Logs state changes at Information level for primary sources.
+  /// </summary>
+  protected override void LogStateChange(AudioSourceState previousState, AudioSourceState newState)
   {
-    ThrowIfDisposed();
-    if (State == AudioSourceState.Created)
-    {
-      await InitializeAsync(cancellationToken);
-    }
-
-    // Check if initialization failed
-    if (State == AudioSourceState.Error)
-    {
-      return;
-    }
-
-    await PlayCoreAsync(cancellationToken);
-    State = AudioSourceState.Playing;
+    Logger.LogInformation("Audio source {Id} state changed from {PreviousState} to {NewState}",
+      Id, previousState, newState);
   }
 
   /// <inheritdoc/>
@@ -143,7 +85,7 @@ public abstract class PrimaryAudioSourceBase : IPrimaryAudioSource
     ThrowIfDisposed();
     if (State != AudioSourceState.Playing)
     {
-      _logger.LogWarning("Cannot pause {SourceId} - not playing (state: {State})", Id, State);
+      Logger.LogWarning("Cannot pause {SourceId} - not playing (state: {State})", Id, State);
       return;
     }
 
@@ -157,25 +99,12 @@ public abstract class PrimaryAudioSourceBase : IPrimaryAudioSource
     ThrowIfDisposed();
     if (State != AudioSourceState.Paused)
     {
-      _logger.LogWarning("Cannot resume {SourceId} - not paused (state: {State})", Id, State);
+      Logger.LogWarning("Cannot resume {SourceId} - not paused (state: {State})", Id, State);
       return;
     }
 
     await ResumeCoreAsync(cancellationToken);
     State = AudioSourceState.Playing;
-  }
-
-  /// <inheritdoc/>
-  public virtual async Task StopAsync(CancellationToken cancellationToken = default)
-  {
-    ThrowIfDisposed();
-    if (State != AudioSourceState.Playing && State != AudioSourceState.Paused)
-    {
-      return;
-    }
-
-    await StopCoreAsync(cancellationToken);
-    State = AudioSourceState.Stopped;
   }
 
   /// <inheritdoc/>
@@ -234,31 +163,6 @@ public abstract class PrimaryAudioSourceBase : IPrimaryAudioSource
     return Task.CompletedTask;
   }
 
-  /// <inheritdoc/>
-  public async ValueTask DisposeAsync()
-  {
-    if (_disposed) return;
-
-    await DisposeAsyncCore();
-    State = AudioSourceState.Disposed;
-    _disposed = true;
-    GC.SuppressFinalize(this);
-  }
-
-  /// <inheritdoc/>
-  public virtual Task InitializeAsync(CancellationToken cancellationToken = default)
-  {
-    State = AudioSourceState.Initializing;
-    return Task.CompletedTask;
-  }
-
-  /// <summary>
-  /// Core implementation for starting playback.
-  /// </summary>
-  /// <param name="cancellationToken">Cancellation token.</param>
-  /// <returns>A task representing the async operation.</returns>
-  protected abstract Task PlayCoreAsync(CancellationToken cancellationToken);
-
   /// <summary>
   /// Core implementation for pausing playback.
   /// </summary>
@@ -274,13 +178,6 @@ public abstract class PrimaryAudioSourceBase : IPrimaryAudioSource
   protected abstract Task ResumeCoreAsync(CancellationToken cancellationToken);
 
   /// <summary>
-  /// Core implementation for stopping playback.
-  /// </summary>
-  /// <param name="cancellationToken">Cancellation token.</param>
-  /// <returns>A task representing the async operation.</returns>
-  protected abstract Task StopCoreAsync(CancellationToken cancellationToken);
-
-  /// <summary>
   /// Core implementation for seeking.
   /// </summary>
   /// <param name="position">The position to seek to.</param>
@@ -292,43 +189,10 @@ public abstract class PrimaryAudioSourceBase : IPrimaryAudioSource
   }
 
   /// <summary>
-  /// Core implementation for async disposal.
+  /// Raises the <see cref="AudioSourceBase.PlaybackCompleted"/> event
+  /// and tracks metrics for natural completion.
   /// </summary>
-  /// <returns>A task representing the async operation.</returns>
-  protected virtual ValueTask DisposeAsyncCore()
-  {
-    return ValueTask.CompletedTask;
-  }
-
-  /// <summary>
-  /// Called when the volume changes. Override to apply volume to the sound component.
-  /// </summary>
-  /// <param name="volume">The new volume level (0.0 to 1.0).</param>
-  protected virtual void OnVolumeChanged(float volume)
-  {
-  }
-
-  /// <summary>
-  /// Raises the <see cref="StateChanged"/> event.
-  /// </summary>
-  /// <param name="previousState">The previous state.</param>
-  /// <param name="newState">The new state.</param>
-  protected virtual void OnStateChanged(AudioSourceState previousState, AudioSourceState newState)
-  {
-    StateChanged?.Invoke(this, new AudioSourceStateChangedEventArgs
-    {
-      PreviousState = previousState,
-      NewState = newState,
-      SourceId = Id
-    });
-  }
-
-  /// <summary>
-  /// Raises the <see cref="PlaybackCompleted"/> event.
-  /// </summary>
-  /// <param name="reason">The reason for completion.</param>
-  /// <param name="error">Any error that occurred, if applicable.</param>
-  protected virtual void OnPlaybackCompleted(PlaybackCompletionReason reason, Exception? error = null)
+  protected override void OnPlaybackCompleted(PlaybackCompletionReason reason, Exception? error = null)
   {
     // Track metrics for natural completion
     if (reason == PlaybackCompletionReason.EndOfContent)
@@ -336,12 +200,7 @@ public abstract class PrimaryAudioSourceBase : IPrimaryAudioSource
       _metricsCollector?.Increment("audio.songs_played_total");
     }
 
-    PlaybackCompleted?.Invoke(this, new AudioSourceCompletedEventArgs
-    {
-      SourceId = Id,
-      Reason = reason,
-      Error = error
-    });
+    base.OnPlaybackCompleted(reason, error);
   }
 
   /// <summary>
@@ -361,20 +220,4 @@ public abstract class PrimaryAudioSourceBase : IPrimaryAudioSource
   {
     _metricsCollector?.Increment("audio.playback_errors");
   }
-
-  /// <summary>
-  /// Throws an <see cref="ObjectDisposedException"/> if this instance has been disposed.
-  /// </summary>
-  protected void ThrowIfDisposed()
-  {
-    if (_disposed)
-    {
-      throw new ObjectDisposedException(GetType().Name);
-    }
-  }
-
-  /// <summary>
-  /// Gets the logger for this instance.
-  /// </summary>
-  protected ILogger Logger => _logger;
 }

--- a/src/Radio.Web/Components/Layout/MainLayout.razor
+++ b/src/Radio.Web/Components/Layout/MainLayout.razor
@@ -212,7 +212,7 @@
     {
       // Set API base URL for idle-dimmer.js sleep/wake fetch calls
       var apiBaseUrl = Configuration["ApiBaseUrl"] ?? "http://localhost:5000";
-      await JSRuntime.InvokeVoidAsync("eval", $"window.radioApiBaseUrl = '{apiBaseUrl}'");
+      await JSRuntime.InvokeVoidAsync("radioSetApiBaseUrl", apiBaseUrl);
     }
   }
 

--- a/src/Radio.Web/Components/Pages/MetricsDashboardPage.razor
+++ b/src/Radio.Web/Components/Pages/MetricsDashboardPage.razor
@@ -215,7 +215,7 @@
   private async Task LoadAvailableMetricsAsync()
   {
     try { _availableMetrics = await MetricsApi.GetMetricKeysAsync(); }
-    catch { }
+    catch (Exception ex) { Logger.LogWarning(ex, "Failed to load available metrics"); }
   }
 
   private async Task LoadSnapshotsAsync()
@@ -225,7 +225,7 @@
       if (_availableMetrics != null && _availableMetrics.Count > 0)
         _snapshots = await MetricsApi.GetMetricSnapshotsAsync(_availableMetrics);
     }
-    catch { }
+    catch (Exception ex) { Logger.LogWarning(ex, "Failed to load metric snapshots"); }
   }
 
   private async Task LoadSparklineDataAsync()
@@ -251,7 +251,7 @@
         if (history != null && history.Count > 1)
           return (key, points: history.Select(h => h.Value).ToList(), history: (List<MetricHistoryDto>?)history);
       }
-      catch { }
+      catch (Exception ex) { Logger.LogDebug(ex, "Failed to load sparkline data for metric {Key}", key); }
       return (key, points: (List<double>?)null, history: (List<MetricHistoryDto>?)null);
     });
 

--- a/src/Radio.Web/Components/Pages/RadioPage.razor
+++ b/src/Radio.Web/Components/Pages/RadioPage.razor
@@ -255,9 +255,9 @@
     {
       _availableBands = await RadioApi.GetBandsAsync();
     }
-    catch (Exception)
+    catch (Exception ex)
     {
-      // Silently fail
+      Logger.LogWarning(ex, "Failed to load radio bands");
     }
   }
 
@@ -313,9 +313,9 @@
     {
       _presets = await RadioApi.GetPresetsAsync();
     }
-    catch (Exception)
+    catch (Exception ex)
     {
-      // Silently fail
+      Logger.LogWarning(ex, "Failed to load radio presets");
     }
   }
   
@@ -527,9 +527,9 @@
         }
       }
     }
-    catch (Exception)
+    catch (Exception ex)
     {
-      // Silently fail
+      Logger.LogWarning(ex, "Failed to save radio preset");
     }
   }
 
@@ -544,9 +544,9 @@
         await InvokeAsync(StateHasChanged);
       }
     }
-    catch (Exception)
+    catch (Exception ex)
     {
-      // Silently fail
+      Logger.LogWarning(ex, "Failed to load radio preset {PresetId}", id);
     }
   }
 
@@ -560,9 +560,9 @@
         await LoadPresetsAsync();
       }
     }
-    catch (Exception)
+    catch (Exception ex)
     {
-      // Silently fail
+      Logger.LogWarning(ex, "Failed to delete radio preset {PresetId}", id);
     }
   }
   
@@ -577,9 +577,9 @@
         await InvokeAsync(StateHasChanged);
       }
     }
-    catch (Exception)
+    catch (Exception ex)
     {
-      // Silently fail
+      Logger.LogWarning(ex, "Failed to set auto gain to {Enabled}", enabled);
     }
   }
 
@@ -594,9 +594,9 @@
         await InvokeAsync(StateHasChanged);
       }
     }
-    catch (Exception)
+    catch (Exception ex)
     {
-      // Silently fail
+      Logger.LogWarning(ex, "Failed to set gain to {Gain}", gain);
     }
   }
   

--- a/src/Radio.Web/wwwroot/js/idle-dimmer.js
+++ b/src/Radio.Web/wwwroot/js/idle-dimmer.js
@@ -3,6 +3,12 @@
 // - Sleep: black overlay + mutes audio after 30 minutes of no interaction
 // - Wake: touch/pointer/key restores screen + unmutes audio
 // Exposes window.radioSleepManager for JS interop from Blazor
+
+// Safe setter for API base URL (called from Blazor JS interop instead of eval)
+window.radioSetApiBaseUrl = function (url) {
+  window.radioApiBaseUrl = url;
+};
+
 (function () {
   const IDLE_TIMEOUT = 5 * 60 * 1000; // 5 minutes → dim
   const SLEEP_TIMEOUT = 30 * 60 * 1000; // 30 minutes → sleep

--- a/tests/Radio.API.Tests/Controllers/FilesControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/FilesControllerTests.cs
@@ -94,13 +94,13 @@ public class FilesControllerTests : IClassFixture<CustomWebApplicationFactory<Pr
   }
 
   [Fact]
-  public async Task GetFiles_WithAbsolutePath_NonExistent_ReturnsNotFound()
+  public async Task GetFiles_WithAbsolutePath_NonExistent_ReturnsBadRequest()
   {
-    // Act
+    // Act - absolute path outside allowed directories is rejected by path traversal protection
     var response = await _client.GetAsync("/api/files?absolutePath=%2Fno%2Fsuch%2Fpath");
 
     // Assert
-    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
   }
 
   [Fact]

--- a/tests/Radio.API.Tests/Controllers/SecretsControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/SecretsControllerTests.cs
@@ -50,13 +50,16 @@ public class SecretsControllerTests : IClassFixture<CustomWebApplicationFactory<
     var postResponse = await _client.PostAsJsonAsync("/api/secrets/tts", data);
     Assert.True(postResponse.IsSuccessStatusCode);
 
-    // Act - retrieve raw
-    var getResponse = await _client.GetAsync("/api/secrets/tts?raw=true");
+    // Act - retrieve (always masked, raw=true was removed for security)
+    var getResponse = await _client.GetAsync("/api/secrets/tts");
     Assert.True(getResponse.IsSuccessStatusCode);
 
     var result = await getResponse.Content.ReadFromJsonAsync<Dictionary<string, string>>();
     Assert.NotNull(result);
-    Assert.Equal("test-google-key-12345", result!["GoogleAPIKey"]);
+    // Value should be masked (contains "..." and preserves first/last 4 chars)
+    Assert.Contains("...", result!["GoogleAPIKey"]);
+    Assert.StartsWith("test", result["GoogleAPIKey"]);
+    Assert.EndsWith("2345", result["GoogleAPIKey"]);
   }
 
   [Fact]
@@ -78,8 +81,8 @@ public class SecretsControllerTests : IClassFixture<CustomWebApplicationFactory<
     var response = await _client.DeleteAsync("/api/secrets/acoustid");
     Assert.True(response.IsSuccessStatusCode);
 
-    // Verify deleted
-    var getResponse = await _client.GetAsync("/api/secrets/acoustid?raw=true");
+    // Verify deleted (always masked now)
+    var getResponse = await _client.GetAsync("/api/secrets/acoustid");
     var result = await getResponse.Content.ReadFromJsonAsync<Dictionary<string, string>>();
     Assert.NotNull(result);
     Assert.Equal("", result!["ApiKey"]);

--- a/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/SDRRadioAudioSourceFingerprintingTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/SDRRadioAudioSourceFingerprintingTests.cs
@@ -7,6 +7,7 @@ using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
+using Radio.Infrastructure.Audio.Sources;
 using Radio.Infrastructure.Audio.Sources.Primary;
 using RTLSDRCore;
 using RTLSDRCore.Hardware;
@@ -312,7 +313,7 @@ public class SDRRadioAudioSourceFingerprintingTests
     var source = CreateSource(identificationService: identificationService);
     
     // Manually set the state to Playing using reflection to bypass hardware requirement
-    var stateField = typeof(PrimaryAudioSourceBase).GetField(
+    var stateField = typeof(AudioSourceBase).GetField(
       "_state",
       System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
     stateField?.SetValue(source, AudioSourceState.Playing);
@@ -343,7 +344,7 @@ public class SDRRadioAudioSourceFingerprintingTests
     var source = CreateSource(identificationService: identificationService);
     
     // Manually set the state to Paused using reflection to bypass hardware requirement
-    var stateField = typeof(PrimaryAudioSourceBase).GetField(
+    var stateField = typeof(AudioSourceBase).GetField(
       "_state",
       System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
     stateField?.SetValue(source, AudioSourceState.Paused);


### PR DESCRIPTION
## Summary
- **Security**: Remove raw secret retrieval, replace `eval()` XSS vector, add path traversal protection for file browsing
- **Error handling**: Add `SafeFireAndForget` extension for fire-and-forget async, add logging to 13 empty/bare catch blocks
- **Architecture**: Extract `AudioSourceBase` from Primary/Event bases (eliminates ~13 duplicated methods), extract `AttachModifiersToPlaybackDevice` helper (fixes missing visualization tap in device recovery)
- **Concurrency**: Fix lock ordering in `AudioManager.GetOrCreateSourceAsync` to prevent potential deadlock

## Details

### Security fixes
| Fix | Files |
|-----|-------|
| Remove `?raw=true` secret endpoint | `SecretsController.cs` |
| Replace `eval()` with safe JS interop | `MainLayout.razor`, `idle-dimmer.js` |
| Path traversal protection | `FilesController.cs`, `FileBrowser.cs`, `FilePlayerOptions.cs` |

### Error handling
| Fix | Files |
|-----|-------|
| `SafeFireAndForget` extension | New `TaskExtensions.cs` + 3 infrastructure call sites |
| Empty catch block logging | `RadioPage.razor` (8 blocks) |
| Bare catch block fixes | `GoogleCastOutput.cs` (2), `MetricsDashboardPage.razor` (3) |

### Architecture
| Fix | Files |
|-----|-------|
| Extract `AudioSourceBase` | New base class, refactored `PrimaryAudioSourceBase` and `EventAudioSourceBase` |
| Extract modifier attachment helper | `SoundFlowAudioEngine.cs` — 3 locations consolidated + bug fix |
| Lock ordering fix | `AudioManager.cs` — release `_createLock` before `SwitchSourceAsync` |

## Test plan
- [x] Full build: 0 warnings, 0 errors
- [x] All 1,391 tests pass across 7 projects
- [x] Updated 3 tests affected by security/architecture changes
- [ ] Deploy and smoke test on Ubuntu target

🤖 Generated with [Claude Code](https://claude.com/claude-code)