### PR TITLE
Remaining medium-priority review fixes (#22, #27, #29, #31)

### DIFF
--- a/comprehensive-review.md
+++ b/comprehensive-review.md
@@ -1,6 +1,6 @@
 # Comprehensive Architectural Review
 
-> **Last updated:** 2026-03-04 — PR #273 (high) + PR #274 (medium)
+> **Last updated:** 2026-03-04 — PR #273 (high) + PR #274 (medium) + PR #275 (medium)
 
 ## HIGH Priority
 
@@ -178,7 +178,7 @@
 
 ---
 
-### 22. [PRIORITY: Medium] [DIFFICULTY: Easy]
+### 22. [PRIORITY: Medium] [DIFFICULTY: Easy] --- DONE (PR #275)
 - **Category:** Performance
 - **Location:** `src/Radio.Infrastructure/Audio/Services/AudioPreferencePersistence.cs:239-250`
 - **Issue:** `RestoreSourceGainOffsets()` executes a synchronous blocking DB query (`store.GetEntryAsync(key).GetAwaiter().GetResult()`) inside a foreach loop over all `AudioSourceType` enum values. This is N sequential blocking queries during startup.
@@ -218,7 +218,7 @@
 
 ---
 
-### 27. [PRIORITY: Medium] [DIFFICULTY: Medium]
+### 27. [PRIORITY: Medium] [DIFFICULTY: Medium] --- DONE (PR #275)
 - **Category:** Performance
 - **Location:** `src/Radio.Web/Components/Shared/NowPlayingPanel.razor:328-341` (5-second timer); SignalR subscription at lines ~290-310
 - **Issue:** `NowPlayingPanel` both polls playback state every 5 seconds via a timer AND subscribes to SignalR `PlaybackStateChanged` events. This creates redundant API calls when SignalR is connected and working properly.
@@ -234,7 +234,7 @@
 
 ---
 
-### 29. [PRIORITY: Medium] [DIFFICULTY: Medium]
+### 29. [PRIORITY: Medium] [DIFFICULTY: Medium] --- DONE (PR #275)
 - **Category:** Performance
 - **Location:** `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor`
 - **Issue:** The queue list renders all items without virtualization. Queues can contain 1000+ items, and each render cycle processes the entire list. No `MudVirtualize` or similar virtual scrolling is used.
@@ -250,7 +250,7 @@
 
 ---
 
-### 31. [PRIORITY: Medium] [DIFFICULTY: Medium]
+### 31. [PRIORITY: Medium] [DIFFICULTY: Medium] --- DONE (PR #275)
 - **Category:** Performance
 - **Location:** `src/Radio.Infrastructure/Metrics/Repositories/SqliteMetricsRepository.cs:257-273`
 - **Issue:** `GetCurrentSnapshotsAsync()` iterates over each metric key and calls `GetAggregateAsync()` individually, each executing 2 SQL queries. For N keys, this is 2N database round-trips. `SaveBucketsAsync()` (lines 104-129) creates a new `SqliteCommand` per bucket in a loop.

--- a/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
@@ -140,10 +140,12 @@ public class AudioManager : IAudioManager, IAsyncDisposable
     }
 
     // Restore volume/mute/balance from persisted preferences
-    _preferencePersistence?.RestoreVolumePreferences();
+    if (_preferencePersistence != null)
+      await _preferencePersistence.RestoreVolumePreferencesAsync();
 
     // Restore per-source gain offsets from persisted preferences
-    _preferencePersistence?.RestoreSourceGainOffsets();
+    if (_preferencePersistence != null)
+      await _preferencePersistence.RestoreSourceGainOffsetsAsync();
 
     _initialized = true;
     _logger.LogInformation("AudioManager initialized successfully");

--- a/src/Radio.Infrastructure/Audio/Services/AudioPreferencePersistence.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioPreferencePersistence.cs
@@ -63,7 +63,7 @@ public class AudioPreferencePersistence : IDisposable
   /// Reads from the config store directly (SQLite) since IOptionsMonitor only reflects appsettings.json defaults.
   /// Sets the mixer directly to avoid triggering re-persistence.
   /// </summary>
-  public void RestoreVolumePreferences()
+  public async Task RestoreVolumePreferencesAsync()
   {
     try
     {
@@ -79,14 +79,14 @@ public class AudioPreferencePersistence : IDisposable
         {
           var storeId = _configurationManager.CurrentStoreType == ConfigurationStoreType.Sqlite ? "sqlite" : "config";
           _logger.LogDebug("Reading volume from config store '{StoreId}'", storeId);
-          var store = _configurationManager.GetStoreAsync(storeId).GetAwaiter().GetResult();
+          var store = await _configurationManager.GetStoreAsync(storeId);
 
-          var volEntry = store.GetEntryAsync("AudioPreferences:MasterVolume").GetAwaiter().GetResult();
+          var volEntry = await store.GetEntryAsync("AudioPreferences:MasterVolume");
           _logger.LogDebug("Config store volume entry: {Entry}", volEntry?.Value ?? "null");
           if (volEntry != null && int.TryParse(volEntry.Value, out var storedVol))
             volumePercent = storedVol;
 
-          var muteEntry = store.GetEntryAsync("AudioPreferences:IsMuted").GetAwaiter().GetResult();
+          var muteEntry = await store.GetEntryAsync("AudioPreferences:IsMuted");
           _logger.LogDebug("Config store mute entry: {Entry}", muteEntry?.Value ?? "null");
           if (muteEntry != null && bool.TryParse(muteEntry.Value, out var storedMuted))
             isMuted = storedMuted;
@@ -219,7 +219,7 @@ public class AudioPreferencePersistence : IDisposable
   /// <summary>
   /// Restores per-source gain offsets from the configuration store.
   /// </summary>
-  public void RestoreSourceGainOffsets()
+  public async Task RestoreSourceGainOffsetsAsync()
   {
     if (_configurationManager == null)
     {
@@ -230,17 +230,24 @@ public class AudioPreferencePersistence : IDisposable
     try
     {
       var storeId = _configurationManager.CurrentStoreType == ConfigurationStoreType.Sqlite ? "sqlite" : "config";
-      var store = _configurationManager.GetStoreAsync(storeId).GetAwaiter().GetResult();
+      var store = await _configurationManager.GetStoreAsync(storeId);
 
-      // Read all AudioPreferences:SourceGain:* keys
+      // Read all AudioPreferences:SourceGain:* keys concurrently
       var sourceTypes = Enum.GetValues<AudioSourceType>();
+      var tasks = sourceTypes.Select(async sourceType =>
+      {
+        var key = $"AudioPreferences:SourceGain:{sourceType}";
+        var entry = await store.GetEntryAsync(key);
+        return (sourceType, entry);
+      });
+
+      var results = await Task.WhenAll(tasks);
+
       var restored = 0;
       lock (_sourceGainPersistLock)
       {
-        foreach (var sourceType in sourceTypes)
+        foreach (var (sourceType, entry) in results)
         {
-          var key = $"AudioPreferences:SourceGain:{sourceType}";
-          var entry = store.GetEntryAsync(key).GetAwaiter().GetResult();
           if (entry != null && float.TryParse(entry.Value, CultureInfo.InvariantCulture, out var gain))
           {
             // Clamp handles migration from old MaxGain=25 values

--- a/src/Radio.Infrastructure/Metrics/Repositories/SqliteMetricsRepository.cs
+++ b/src/Radio.Infrastructure/Metrics/Repositories/SqliteMetricsRepository.cs
@@ -101,30 +101,41 @@ public sealed class SqliteMetricsRepository : IMetricsReader
           unit,
           transaction,
           ct);
+
+        // Reuse a single command for all buckets — avoids N command/parameter
+        // allocations per flush cycle.
+        await using var cmd = _dbContext.Connection.CreateCommand();
+        cmd.Transaction = transaction;
+
+        cmd.CommandText = $@"
+          INSERT INTO {tableName}
+            (MetricId, Timestamp, ValueSum, ValueCount, ValueMin, ValueMax, ValueLast)
+          VALUES
+            (@MetricId, @Timestamp, @ValueSum, @ValueCount, @ValueMin, @ValueMax, @ValueLast)
+          ON CONFLICT(MetricId, Timestamp) DO UPDATE SET
+            ValueSum = ValueSum + @ValueSum,
+            ValueCount = ValueCount + @ValueCount,
+            ValueMin = MIN(ValueMin, @ValueMin),
+            ValueMax = MAX(ValueMax, @ValueMax),
+            ValueLast = @ValueLast";
+
+        var pMetricId = cmd.Parameters.Add("@MetricId", SqliteType.Integer);
+        var pTimestamp = cmd.Parameters.Add("@Timestamp", SqliteType.Integer);
+        var pValueSum = cmd.Parameters.Add("@ValueSum", SqliteType.Real);
+        var pValueCount = cmd.Parameters.Add("@ValueCount", SqliteType.Integer);
+        var pValueMin = cmd.Parameters.Add("@ValueMin", SqliteType.Real);
+        var pValueMax = cmd.Parameters.Add("@ValueMax", SqliteType.Real);
+        var pValueLast = cmd.Parameters.Add("@ValueLast", SqliteType.Real);
+
         foreach (var bucket in buckets)
         {
-          await using var cmd = _dbContext.Connection.CreateCommand();
-          cmd.Transaction = transaction;
-
-          cmd.CommandText = $@"
-            INSERT INTO {tableName}
-              (MetricId, Timestamp, ValueSum, ValueCount, ValueMin, ValueMax, ValueLast)
-            VALUES
-              (@MetricId, @Timestamp, @ValueSum, @ValueCount, @ValueMin, @ValueMax, @ValueLast)
-            ON CONFLICT(MetricId, Timestamp) DO UPDATE SET
-              ValueSum = ValueSum + @ValueSum,
-              ValueCount = ValueCount + @ValueCount,
-              ValueMin = MIN(ValueMin, @ValueMin),
-              ValueMax = MAX(ValueMax, @ValueMax),
-              ValueLast = @ValueLast";
-
-          cmd.Parameters.AddWithValue("@MetricId", metricId);
-          cmd.Parameters.AddWithValue("@Timestamp", bucket.Timestamp);
-          cmd.Parameters.AddWithValue("@ValueSum", bucket.ValueSum);
-          cmd.Parameters.AddWithValue("@ValueCount", bucket.ValueCount);
-          cmd.Parameters.AddWithValue("@ValueMin", bucket.ValueMin ?? (object)DBNull.Value);
-          cmd.Parameters.AddWithValue("@ValueMax", bucket.ValueMax ?? (object)DBNull.Value);
-          cmd.Parameters.AddWithValue("@ValueLast", bucket.ValueLast ?? (object)DBNull.Value);
+          pMetricId.Value = metricId;
+          pTimestamp.Value = bucket.Timestamp;
+          pValueSum.Value = bucket.ValueSum;
+          pValueCount.Value = bucket.ValueCount;
+          pValueMin.Value = bucket.ValueMin ?? (object)DBNull.Value;
+          pValueMax.Value = bucket.ValueMax ?? (object)DBNull.Value;
+          pValueLast.Value = bucket.ValueLast ?? (object)DBNull.Value;
 
           await cmd.ExecuteNonQueryAsync(ct);
         }
@@ -258,15 +269,25 @@ public sealed class SqliteMetricsRepository : IMetricsReader
     IEnumerable<string> keys,
     CancellationToken ct = default)
   {
-    var result = new Dictionary<string, double>();
+    var keyList = keys.ToList();
+    if (keyList.Count == 0)
+      return new Dictionary<string, double>();
 
-    foreach (var key in keys)
+    // For small key lists, run individual queries concurrently is fine.
+    // Each GetAggregateAsync uses its own read connection.
+    var tasks = keyList.Select(async key =>
     {
       var value = await GetAggregateAsync(key, ct);
+      return (key, value);
+    });
+
+    var results = await Task.WhenAll(tasks);
+
+    var result = new Dictionary<string, double>();
+    foreach (var (key, value) in results)
+    {
       if (value.HasValue)
-      {
         result[key] = value.Value;
-      }
     }
 
     return result;

--- a/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
@@ -284,8 +284,6 @@
   private bool _canSeek;
   private double _progressPercent;
   private double _totalDurationSeconds;
-  private System.Threading.Timer? _timer;
-
   // Fingerprint status state
   private FingerprintStatusDto? _fpStatus;
   private bool _showFingerprintDetail;
@@ -316,27 +314,10 @@
       await RefreshPlaybackStateAsync();
       await RefreshFingerprintStatusAsync();
       await LoadSourceGainOffsetsAsync();
-
-      _timer = new System.Threading.Timer(TimerCallback, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
     }
     catch (Exception ex)
     {
       Logger.LogError(ex, "Error initializing NowPlayingPanel");
-    }
-  }
-
-  private async void TimerCallback(object? state)
-  {
-    try
-    {
-      await RefreshPlaybackStateAsync();
-
-      await InvokeAsync(StateHasChanged);
-    }
-    catch (ObjectDisposedException) { }
-    catch (Exception ex)
-    {
-      Logger.LogWarning(ex, "Error in NowPlayingPanel timer callback");
     }
   }
 
@@ -745,7 +726,6 @@
     HubService.NowPlayingChanged -= OnNowPlayingChanged;
     HubService.VolumeChanged -= OnVolumeChangedEvent;
     HubService.FingerprintStatusChanged -= OnFingerprintStatusChanged;
-    _timer?.Dispose();
     _gainDebounceTimer?.Dispose();
     await Task.CompletedTask;
   }

--- a/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
+++ b/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
@@ -72,13 +72,14 @@
         else
         {
           <div id="queue-scroll-container" class="scrollable" style="flex: 1; overflow-y: auto; min-height: 0;">
-            @foreach (var item in _queueItems)
-            {
-              var itemState = item.State ?? "Upcoming";
-              var isError = itemState == "Error";
-              var isCurrent = itemState == "Current";
-              var isPlayed = itemState == "Played";
-              var isClickable = !isError;
+            <MudVirtualize Items="@_queueItems" ItemSize="56" OverscanCount="5" Context="item">
+              @{
+                var itemState = item.State ?? "Upcoming";
+                var isError = itemState == "Error";
+                var isCurrent = itemState == "Current";
+                var isPlayed = itemState == "Played";
+                var isClickable = !isError;
+              }
 
               <div class="list-item-touch @(isCurrent ? "list-item-active" : "")"
                    style="cursor: @(isClickable ? "pointer" : "not-allowed");
@@ -132,7 +133,7 @@
                   </div>
                 }
               </div>
-            }
+            </MudVirtualize>
           </div>
         }
       </div>

--- a/tests/Radio.Infrastructure.Tests/Audio/Services/AudioPreferencePersistenceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Services/AudioPreferencePersistenceTests.cs
@@ -52,7 +52,7 @@ public class AudioPreferencePersistenceTests : IDisposable
   }
 
   [Fact]
-  public void RestoreVolumePreferences_SetsVolumeFromConfigStore()
+  public async Task RestoreVolumePreferencesAsync_SetsVolumeFromConfigStore()
   {
     // Arrange — stored volume is 50%
     _storeMock.Setup(s => s.GetEntryAsync("AudioPreferences:MasterVolume", It.IsAny<ConfigurationReadMode>(), It.IsAny<CancellationToken>()))
@@ -61,7 +61,7 @@ public class AudioPreferencePersistenceTests : IDisposable
       .ReturnsAsync(new ConfigurationEntry { Key = "AudioPreferences:IsMuted", Value = "False" });
 
     // Act
-    _sut.RestoreVolumePreferences();
+    await _sut.RestoreVolumePreferencesAsync();
 
     // Assert
     _mixerMock.VerifySet(m => m.MasterVolume = 0.5f, Times.Once);
@@ -70,7 +70,7 @@ public class AudioPreferencePersistenceTests : IDisposable
   }
 
   [Fact]
-  public void RestoreVolumePreferences_RestoresMutedState()
+  public async Task RestoreVolumePreferencesAsync_RestoresMutedState()
   {
     // Arrange
     _storeMock.Setup(s => s.GetEntryAsync("AudioPreferences:MasterVolume", It.IsAny<ConfigurationReadMode>(), It.IsAny<CancellationToken>()))
@@ -79,7 +79,7 @@ public class AudioPreferencePersistenceTests : IDisposable
       .ReturnsAsync(new ConfigurationEntry { Key = "AudioPreferences:IsMuted", Value = "True" });
 
     // Act
-    _sut.RestoreVolumePreferences();
+    await _sut.RestoreVolumePreferencesAsync();
 
     // Assert
     _mixerMock.VerifySet(m => m.MasterVolume = 0.3f, Times.Once);
@@ -87,14 +87,14 @@ public class AudioPreferencePersistenceTests : IDisposable
   }
 
   [Fact]
-  public void RestoreVolumePreferences_FallsBackToOptionsDefaults_WhenConfigStoreEmpty()
+  public async Task RestoreVolumePreferencesAsync_FallsBackToOptionsDefaults_WhenConfigStoreEmpty()
   {
     // Arrange — no entries in config store
     _storeMock.Setup(s => s.GetEntryAsync(It.IsAny<string>(), It.IsAny<ConfigurationReadMode>(), It.IsAny<CancellationToken>()))
       .ReturnsAsync((ConfigurationEntry?)null);
 
     // Act
-    _sut.RestoreVolumePreferences();
+    await _sut.RestoreVolumePreferencesAsync();
 
     // Assert — uses defaults from AudioPreferences (75%, not muted)
     _mixerMock.VerifySet(m => m.MasterVolume = 0.75f, Times.Once);
@@ -102,7 +102,7 @@ public class AudioPreferencePersistenceTests : IDisposable
   }
 
   [Fact]
-  public void RestoreVolumePreferences_HandlesNoConfigManager()
+  public async Task RestoreVolumePreferencesAsync_HandlesNoConfigManager()
   {
     // Arrange — create instance without config manager
     var sut = new AudioPreferencePersistence(
@@ -112,7 +112,7 @@ public class AudioPreferencePersistenceTests : IDisposable
       configurationManager: null);
 
     // Act — should not throw
-    sut.RestoreVolumePreferences();
+    await sut.RestoreVolumePreferencesAsync();
 
     // Assert — uses options defaults
     _mixerMock.VerifySet(m => m.MasterVolume = 0.75f, Times.Once);
@@ -120,14 +120,14 @@ public class AudioPreferencePersistenceTests : IDisposable
   }
 
   [Fact]
-  public void RestoreVolumePreferences_HandlesConfigStoreException()
+  public async Task RestoreVolumePreferencesAsync_HandlesConfigStoreException()
   {
     // Arrange
     _configManagerMock.Setup(m => m.GetStoreAsync("config", It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvalidOperationException("Store not found"));
 
     // Act — should not throw
-    _sut.RestoreVolumePreferences();
+    await _sut.RestoreVolumePreferencesAsync();
 
     // Assert — falls back to options defaults
     _mixerMock.VerifySet(m => m.MasterVolume = 0.75f, Times.Once);


### PR DESCRIPTION
## Summary
- **#22 Batch config reads**: Converted `AudioPreferencePersistence` from blocking `.GetAwaiter().GetResult()` to proper `async`/`await` with `Task.WhenAll` for concurrent config store reads
- **#27 Remove redundant polling**: Removed 5-second timer from `NowPlayingPanel` — SignalR events already provide real-time state updates
- **#29 Queue virtualization**: Replaced `@foreach` with `MudVirtualize` in `QueueHistoryPanel` for efficient rendering of large playlists
- **#31 Batch SQL**: Reused single SQLite command with typed parameters in `SaveBucketsAsync` (avoids N command allocations per flush); parallelized `GetCurrentSnapshotsAsync` with `Task.WhenAll`

Items #34 (shared state enum) and #35 (SystemInfoService extraction) were investigated and deferred — #34 requires DTO type changes that risk breaking JSON serialization, #35 is a large refactor better suited to its own PR.

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings
- [x] All ~1,391 tests pass
- [x] AudioPreferencePersistenceTests updated for new async method signatures
- [ ] Deploy and verify queue scrolling with large playlist
- [ ] Verify NowPlayingPanel updates without timer (source switch, play/pause, volume)

🤖 Generated with [Claude Code](https://claude.com/claude-code)