### PR TITLE
Fix: Pause SoundFlow playback for USB capture sources on sleep

### DIFF
--- a/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
@@ -336,17 +336,21 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
   /// <inheritdoc/>
   protected override Task PauseCoreAsync(CancellationToken cancellationToken)
   {
-    Logger.LogInformation("Pausing {SourceName} audio (stopping capture)", Name);
-    
-    // For live inputs, pause implies stopping the capture stream to release resources
-    // or simply stopping data flow.
+    Logger.LogInformation("Pausing {SourceName} audio (stopping capture + playback)", Name);
+
     try
     {
       _captureDevice?.Stop();
     }
     catch (Exception ex)
     {
-       Logger.LogWarning(ex, "Failed to stop audio capture device during pause for {SourceName}", Name);
+      Logger.LogWarning(ex, "Failed to stop audio capture device during pause for {SourceName}", Name);
+    }
+
+    // Pause the SoundFlow playback component so buffered audio stops flowing to output
+    if (_playbackId != null && _playbackService != null)
+    {
+      _playbackService.Pause(_playbackId);
     }
 
     return Task.CompletedTask;
@@ -356,6 +360,13 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
   protected override Task ResumeCoreAsync(CancellationToken cancellationToken)
   {
     Logger.LogInformation("Resuming {SourceName} audio", Name);
+
+    // Resume the SoundFlow playback component before restarting capture
+    if (_playbackId != null && _playbackService != null)
+    {
+      _playbackService.Resume(_playbackId);
+    }
+
     return PlayCoreAsync(cancellationToken);
   }
 


### PR DESCRIPTION
## Summary
- USB capture sources (FM Radio, Vinyl, GenericUSB) now fully pause on sleep
- `PauseCoreAsync()` calls `PlaybackService.Pause()` to stop the `BufferedSoundGenerator` in the SoundFlow mixer
- `ResumeCoreAsync()` calls `PlaybackService.Resume()` before restarting capture

## Root cause
`USBAudioSourceBase.PauseCoreAsync()` stopped the USB capture device but not the `BufferedSoundGenerator` feeding the SoundFlow mixer. Buffered audio continued flowing to speakers even after capture stopped.

## Test plan
- [ ] Play FM radio, press sleep — audio should stop immediately
- [ ] Wake — radio audio should resume
- [ ] Repeat with Vinyl and GenericUSB sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)