### PR TITLE
Fix: Route sleep/wake through server-side to bypass CORS

### DIFF
--- a/src/Radio.Web/Components/Layout/MainLayout.razor
+++ b/src/Radio.Web/Components/Layout/MainLayout.razor
@@ -123,6 +123,7 @@
 
   private int _queueCount = 0;
   private Color _distortionMarkerColor = Color.Default;
+  private DotNetObjectReference<MainLayout>? _selfReference;
 
   private readonly MudTheme _customTheme = new()
   {
@@ -209,9 +210,30 @@
   {
     if (firstRender)
     {
-      // Set API base URL for idle-dimmer.js sleep/wake fetch calls
+      // Set API base URL for idle-dimmer.js (still used by other JS callers)
       var apiBaseUrl = Configuration["ApiBaseUrl"] ?? WebConstants.DefaultApiBaseUrl;
       await JSRuntime.InvokeVoidAsync("radioSetApiBaseUrl", apiBaseUrl);
+
+      // Register .NET reference so JS sleep/wake can call back into Blazor
+      _selfReference = DotNetObjectReference.Create(this);
+      await JSRuntime.InvokeVoidAsync("radioSleepManager.setBlazorRef", _selfReference);
+    }
+  }
+
+  /// <summary>
+  /// Called from JS (idle-dimmer.js) when user interaction triggers sleep or wake.
+  /// Routes through Blazor server-side HttpClient to avoid browser CORS issues.
+  /// </summary>
+  [JSInvokable]
+  public async Task OnJsSleepRequested(bool sleep)
+  {
+    try
+    {
+      await SystemApi.SetSleepAsync(sleep);
+    }
+    catch (Exception ex)
+    {
+      Logger.LogWarning(ex, "Error setting sleep state to {Sleep} from JS callback", sleep);
     }
   }
 
@@ -722,7 +744,10 @@
   {
     try
     {
-      await JSRuntime.InvokeVoidAsync("radioSleepManager.enterSleep", "button");
+      // Show black overlay immediately via JS
+      await JSRuntime.InvokeVoidAsync("radioSleepManager.enterSleep", "server");
+      // Call API server-side to pause audio (avoids browser CORS issues)
+      await SystemApi.SetSleepAsync(true);
     }
     catch (Exception ex)
     {
@@ -762,6 +787,7 @@
 
     _timer?.Stop();
     _timer?.Dispose();
+    _selfReference?.Dispose();
   }
 
   public ValueTask DisposeAsync()

--- a/src/Radio.Web/Services/ApiClients/SystemApiService.cs
+++ b/src/Radio.Web/Services/ApiClients/SystemApiService.cs
@@ -58,6 +58,20 @@ public class SystemApiService
     }
   }
 
+  public async Task<bool> SetSleepAsync(bool sleep, CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      var response = await _httpClient.PostAsJsonAsync("/api/system/sleep", new { sleep }, cancellationToken);
+      return response.IsSuccessStatusCode;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to set sleep state to {Sleep}", sleep);
+      return false;
+    }
+  }
+
   public async Task<bool> PowerOffSystemAsync(CancellationToken cancellationToken = default)
   {
     try

--- a/src/Radio.Web/wwwroot/js/idle-dimmer.js
+++ b/src/Radio.Web/wwwroot/js/idle-dimmer.js
@@ -1,7 +1,7 @@
 // Screen idle dimmer + sleep manager for kiosk mode
 // - Dim: reduces brightness after 5 minutes of no interaction
-// - Sleep: black overlay + mutes audio after 30 minutes of no interaction
-// - Wake: touch/pointer/key restores screen + unmutes audio
+// - Sleep: black overlay, notifies Blazor to pause audio
+// - Wake: touch/pointer/key restores screen, notifies Blazor to resume audio
 // Exposes window.radioSleepManager for JS interop from Blazor
 
 // Safe setter for API base URL (called from Blazor JS interop instead of eval)
@@ -14,14 +14,12 @@ window.radioSetApiBaseUrl = function (url) {
   const SLEEP_TIMEOUT = 30 * 60 * 1000; // 30 minutes → sleep
   const DIM_BRIGHTNESS = 0.3;
 
-  function apiUrl(path) {
-    return (window.radioApiBaseUrl || '') + path;
-  }
   let dimTimer = null;
   let sleepTimer = null;
   let dimmed = false;
   let sleeping = false;
   let overlay = null;
+  let blazorRef = null;
 
   function createOverlay() {
     if (overlay) return overlay;
@@ -72,13 +70,10 @@ window.radioSetApiBaseUrl = function (url) {
     document.body.style.filter = 'brightness(0)';
     dimmed = true;
 
-    // Notify API to mute audio (unless triggered by server)
-    if (source !== 'server') {
-      fetch(apiUrl('/api/system/sleep'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sleep: true })
-      }).catch(function () { /* ignore */ });
+    // Notify Blazor to call API server-side (unless triggered by server)
+    if (source !== 'server' && blazorRef) {
+      blazorRef.invokeMethodAsync('OnJsSleepRequested', true)
+        .catch(function () { /* ignore */ });
     }
 
     clearTimeout(dimTimer);
@@ -102,13 +97,10 @@ window.radioSetApiBaseUrl = function (url) {
       overlay.style.pointerEvents = 'none';
     }
 
-    // Notify API to unmute (unless triggered by server)
-    if (source !== 'server') {
-      fetch(apiUrl('/api/system/sleep'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sleep: false })
-      }).catch(function () { /* ignore */ });
+    // Notify Blazor to call API server-side (unless triggered by server)
+    if (source !== 'server' && blazorRef) {
+      blazorRef.invokeMethodAsync('OnJsSleepRequested', false)
+        .catch(function () { /* ignore */ });
     }
 
     resetTimers();
@@ -137,7 +129,8 @@ window.radioSetApiBaseUrl = function (url) {
   window.radioSleepManager = {
     enterSleep: enterSleep,
     wake: wake,
-    isSleeping: function () { return sleeping; }
+    isSleeping: function () { return sleeping; },
+    setBlazorRef: function (ref) { blazorRef = ref; }
   };
 
   resetTimers();


### PR DESCRIPTION
## Summary
- Sleep/wake API calls now route through Blazor server-side instead of browser-side fetch
- Fixes the root cause: JS fetch from port 5002 to port 5000 was blocked by CORS in production
- Added `SystemApiService.SetSleepAsync()` for server-side API calls
- JS idle-dimmer now uses `DotNetObjectReference` callback to invoke Blazor `[JSInvokable]` method

## Root cause
The JS `idle-dimmer.js` was calling `fetch('/api/system/sleep')` directly from the browser. Since the Web UI runs on port 5002 and the API on port 5000, this is a cross-origin request. CORS is only configured for Development mode, so in production the fetch silently failed (`.catch(function () { /* ignore */ })`). The overlay appeared but the API never received the sleep command.

## What changed
- `idle-dimmer.js`: Replaced direct API fetch with `blazorRef.invokeMethodAsync('OnJsSleepRequested', bool)` callback
- `MainLayout.razor`: Registers `DotNetObjectReference<MainLayout>` with JS, adds `[JSInvokable] OnJsSleepRequested` that calls `SystemApi.SetSleepAsync()`
- `SystemApiService.cs`: Added `SetSleepAsync(bool)` method

## Test plan
- [ ] Play FM radio, press sleep button — audio should pause, screen should blank
- [ ] Touch screen to wake — audio should resume
- [ ] Play file, press sleep — audio should pause
- [ ] Let idle timeout trigger sleep (5 min idle → dim, 30 min → sleep) — audio should pause
- [ ] Encoder wake should also resume audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)