### PR TITLE
feat: SongRec (Shazam) fallback recognizer + Now Playing fix

### DIFF
--- a/findings.md
+++ b/findings.md
@@ -1,110 +1,73 @@
 # Findings
 
-## Research & Discoveries
+## Current Fingerprinting Architecture
 
-### Feature 1: RotaryUsb — Rotary Encoder Integration
-
-**Repo**: `mmackelprang/RotaryUsb` (C++/CircuitPython firmware, C# example)
-**Hardware**: 4x KY-040 rotary encoders on Raspberry Pi Pico (RP2040)
-**Communication**: USB HID (Generic HID mode recommended for dedicated apps)
-
-**Protocol (Generic HID mode)**:
-- VID `0xCAFE`, PID `0x4005` (C++ firmware)
-- Usage Page `0xFF00`, Usage `0x01`
-- 8-byte reports: `[ReportID=0x01, Enc1(int8), Enc2(int8), Enc3(int8), Enc4(int8), Buttons(bitmask), Reserved, Reserved]`
-- Encoder values are signed relative deltas: +1 CW, -1 CCW per detent
-- Buttons: bit0=Btn1, bit1=Btn2, bit2=Btn3, bit3=Btn4 (1=pressed)
-- Reports only sent on state change, 10ms minimum interval
-
-**Linux integration**: Use `HidSharp` NuGet (cross-platform, works via hidraw) — NOT `HidLibrary` (Windows-only)
-
-**Parsing (C#)**:
-```csharp
-sbyte enc1 = (sbyte)data[1]; // -127 to +127
-byte buttons = data[5];
-bool btn1 = (buttons & 0x01) != 0;
+### Pipeline
+```
+Sources (Radio/SDR/File/BT/USB)
+  → FingerprintTapModifier (captures float samples from mixer)
+  → SoundFlowAudioTap (15s capture, silence detection, normalization)
+  → ChromaprintFingerprintService (writes WAV, invokes fpcalc binary)
+  → MetadataLookupService (cache → AcoustID → MusicBrainz → Cover Art Archive)
+  → TrackMetadata (Title, Artist, Album, CoverArtUrl)
+  → UI (SignalR events, /api/audio/fingerprint/status)
 ```
 
----
+### Key Files
+- `Radio.Infrastructure/Audio/Fingerprinting/ChromaprintFingerprintService.cs` — fpcalc invocation, WAV generation, normalization
+- `Radio.Infrastructure/Audio/Fingerprinting/BackgroundIdentificationService.cs` — 15s interval loop, per-source logic, song change detection
+- `Radio.Infrastructure/Audio/Fingerprinting/MetadataLookupService.cs` — Cache → AcoustID → MusicBrainz chain
+- `Radio.Infrastructure/Audio/Fingerprinting/SoundFlowAudioTap.cs` — Audio capture, silence detection
+- `Radio.Infrastructure/Audio/SoundFlow/FingerprintTapModifier.cs` — Mixer-level audio tap
+- `Radio.Infrastructure/Audio/Fingerprinting/AcoustIdClient.cs` — HTTP client for AcoustID API
+- `Radio.Core/Configuration/FingerprintingOptions.cs` — All config options
 
-### Feature 2: RotaryPhone — Phone Call Announcements
+### Source-Specific Behavior Today
+- **File sources**: Fingerprints the actual file directly (bypasses capture). Works well.
+- **Live sources (Radio, Vinyl, BT, USB)**: Captures 15s of mixer output, normalizes, runs through fpcalc. AcoustID often fails to match because captured segment duration doesn't match full track. System retries with fallback durations (180s, 210s, 240s, 270s, 300s) — inaccurate.
+- **Bluetooth**: Can get AVRCP metadata (title/artist) directly. Falls back to fingerprinting if AVRCP unavailable.
 
-**Repo**: `mmackelprang/RotaryPhone` (.NET 9, ASP.NET Core + SignalR)
-**What it does**: Rotary phone-to-cell phone bridge via Bluetooth HFP
+### Current Limitations
+1. **Vinyl**: Surface noise, turntable rumble (confirmed via spectrum — strong sub-100Hz energy even with no music), and EQ differences confuse Chromaprint
+2. **FM Radio**: No RDS metadata extraction despite having RTL-SDR hardware. Relies entirely on acoustic fingerprinting, which is unreliable for live radio
+3. **No audio preprocessing**: Raw mixer output goes straight to fpcalc with only amplitude normalization
+4. **Single strategy**: All sources use the same Chromaprint/AcoustID pipeline. No way to swap in ACRCloud, SongRec, or RDS per source type
 
-**Integration point**: SignalR hub at `http://<host>:5555/hub`
-**Key events**:
-- `CallStateChanged(string phoneId, string state)` — states: "Idle", "Dialing", "Ringing", "InCall"
-- `IncomingCall(string phoneId, string phoneNumber)` — caller phone number
+## Vinyl Low-Frequency Noise (Observed)
+- Spectrum analyzer shows tall bars at sub-100Hz even with no music playing
+- Likely turntable rumble (motor/bearing resonance) — common even on direct-drive
+- This energy will pollute Chromaprint fingerprints
+- Fix: High-pass filter (80-100Hz cutoff) on audio samples before passing to fpcalc
+- Note: User's direct-drive turntable should NOT have wow/flutter issues, so pitch correction is unnecessary
 
-**Caller name resolution**: REST API `GET /api/contacts` to look up phone number → name
+## Alternative Metadata Sources
 
-**Note**: The `IncomingCall` SignalR event may need enhancement in RotaryPhone's `SignalRNotifierService` — currently only `CallStateChanged` is broadcast. The phone number may need to be fetched from call history API when state transitions to "Ringing".
+### 1. RDS (Radio Data System) for FM Radio
+- **redsea** (github.com/windytan/redsea): Decodes RDS from RTL-SDR raw IQ stream
+- Provides: Station name (PS), Radio Text (RT) — often contains song title/artist
+- Primary metadata source for FM; fingerprinting as fallback
+- Need to check if RTLSDRCore exposes raw IQ or RDS data
 
-**Integration sequence**:
-1. Connect SignalR client to RotaryPhone hub
-2. On `Ringing` state → play ring audio sample (looped event source with ducking)
-3. Resolve caller name via contacts API
-4. TTS: "Incoming call from [Name]" or "Unknown caller from [Number]"
-5. On state change away from `Ringing` → stop ring audio
+### 2. ACRCloud (acrcloud.com)
+- Cloud-based audio recognition service
+- Handles degraded audio (vinyl, radio) natively
+- User has API key + usage token
+- **Limitation: 5,000 calls/month** — must be used judiciously (not every 15s)
+- Best as fallback when Chromaprint/AcoustID fails
 
----
+### 3. SongRec (github.com/marin-m/SongRec)
+- Open-source Shazam client (unofficial API)
+- Handles degraded audio well (designed for noisy environments)
+- No call limits (unofficial, personal use OK per user)
+- Linux binary available, can be invoked like fpcalc
+- Good for vinyl and radio where AcoustID struggles
 
-### Feature 3: GoogleBroadcast — CRITICAL ISSUE
+## Strategy Per Source Type
 
-**Repo**: `mmackelprang/GoogleBroadcast` — **This is a simulation/scaffold. No actual functionality.**
-- All "broadcast" methods are `SimulateBroadcastCall` that just `Task.Delay(1000)` and log
-- Device discovery returns hardcoded fake devices
-- Google auth is initialized but never used
-- The code appears to be AI-generated boilerplate (single commit from Copilot)
-
-**Direction mismatch**: The repo is about SENDING broadcasts TO Google Home devices. The user wants to RECEIVE broadcasts. Neither direction has a public Google API:
-- **Sending**: Possible via Google Assistant gRPC API workaround (send "broadcast [message]" as assistant text command). Requires OAuth2 user credentials (not service accounts).
-- **Receiving**: No public API exists. Google Home broadcasts are closed-ecosystem — only played on Google Home/Nest speakers.
-
-**Possible alternatives**:
-1. Build a custom broadcast system using the existing Cast infrastructure
-2. Use MQTT or a webhook-based notification system
-3. Integrate with Home Assistant which has Google Assistant SDK integration
-4. Abandon Google broadcast, implement a custom "house intercom" via Cast devices
-
----
-
-## Existing Codebase Integration Points
-
-### Audio Sources
-- `IEventAudioSource` for ephemeral audio (TTS, ring sounds) with auto-ducking
-- `IDuckingService` reduces primary source volume (priority 1-10 scale, event default=8)
-- `ITTSFactory.CreateAsync(text, params)` → returns ready-to-play event source
-- Pattern: create event source → start ducking → play → stop ducking on completion
-
-### Input Devices
-- **NO existing HID/serial/GPIO abstraction** — entirely greenfield
-- USB handling is audio-only (capture devices via MiniAudio)
-- Would need new `IInputDevice` interface + implementations
-
-### System Config UI
-- MudBlazor Material 3 with MudTabs layout
-- Cards for metrics, dialogs for configuration
-- Pattern: Razor component + injected API service + SignalR for real-time updates
-
-### SignalR Infrastructure
-- `AudioStateHub` + `AudioVisualizationHub` already exist
-- `AudioStateUpdateService` broadcasts state changes
-- Well-established pattern for adding new real-time events
-
-## Key Files
-| File | Role |
-|------|------|
-| `src/Radio.Core/Interfaces/Audio/IAudioSource.cs` | Audio source interfaces |
-| `src/Radio.Core/Interfaces/Audio/IEventAudioSource.cs` | Event source (TTS, sounds) |
-| `src/Radio.Infrastructure/Audio/Sources/Event/TTSEventSource.cs` | TTS implementation |
-| `src/Radio.Infrastructure/Audio/Services/DuckingService.cs` | Audio ducking |
-| `src/Radio.Infrastructure/Audio/Sources/Event/AudioFileEventSource.cs` | Audio file playback |
-| `src/Radio.Web/Components/Pages/SystemConfigPage.razor` | System config UI pattern |
-| `src/Radio.API/Services/AudioStateUpdateService.cs` | SignalR state broadcasting |
-
-## Open Questions
-- What should we do about Google Broadcast? (see critical issue above)
-- Where will the RotaryPhone server be running? Same Ubuntu box or separate machine?
-- Which firmware mode for RotaryUsb? (Generic HID recommended)
+| Source | Primary | Fallback | Notes |
+|--------|---------|----------|-------|
+| File | Chromaprint/AcoustID (file) | — | Already works well |
+| Bluetooth | AVRCP metadata | Chromaprint/AcoustID | Already implemented |
+| FM Radio | RDS via redsea | ACRCloud or SongRec | RDS is free, instant |
+| Vinyl | Chromaprint + high-pass filter | SongRec or ACRCloud | Clean audio first |
+| Generic USB | Chromaprint/AcoustID | SongRec or ACRCloud | Same as vinyl approach |

--- a/progress.md
+++ b/progress.md
@@ -1,12 +1,32 @@
 # Progress Log
 
-## Session: 2026-03-03
+## Session: 2026-03-04
 
-### Completed
-- Reset planning files for new session
+- Explored current fingerprinting architecture (ChromaprintFingerprintService, BackgroundIdentificationService, MetadataLookupService, SoundFlowAudioTap)
+- Confirmed: File fingerprinting works well. Live sources (vinyl, radio) struggle with AcoustID
+- Observed vinyl low-frequency rumble on spectrum analyzer (strong sub-100Hz even during silence) — will add high-pass filter before fpcalc
+- User confirmed: direct-drive turntable, no wow/flutter — pitch correction unnecessary
+- Documented alternative metadata sources: RDS (FM), ACRCloud (cloud, 5K/month), SongRec (Shazam, unlimited)
+- Created 6-phase plan: preprocessing → SongRec → ACRCloud → RDS → strategy architecture → UI
+- Ready to begin Phase 1 (audio preprocessing)
+- Implemented 2nd-order Butterworth high-pass filter (80Hz cutoff) in ChromaprintFingerprintService
+- Filter applied to all live-source fingerprints (vinyl, radio, USB) before normalization + fpcalc
+- File-based fingerprinting (GenerateFingerprintFromFileAsync) is unaffected
+- Updated pipeline integration tests: assertions now check hash validity + similarity (common prefix) instead of exact match, since filter intentionally modifies audio
+- All 1,391 tests pass
+- Ready to deploy and test with vinyl
+- Tested vinyl with Cars Greatest Hits — 786-char hash (good) but AcoustID returned no results across all duration fallbacks
+- Confirmed: high-pass filter alone insufficient for vinyl — Phase 2 (SongRec) needed
 
-### Key Findings
-_None yet_
+## Session: 2026-03-04 (continued)
 
-### Errors / Blockers
-_None yet_
+- Phase 2: SongRec (Shazam) integration implemented
+- Created ISongRecRecognitionService interface in Radio.Core
+- Created SongRecRecognitionService: writes temp WAV, invokes `songrec audio-file-to-recognized-song`, parses Shazam JSON
+- Added SongRecOptions config (Enabled, SongRecPath, TimeoutSeconds)
+- Added MetadataSource.Shazam and LookupSource.SongRec enum values
+- Wired into BackgroundIdentificationService as AcoustID fallback for live sources
+- Registered in DI (FingerprintingServiceExtensions)
+- Added 9 unit tests for SongRec service (parsing, availability, edge cases)
+- Fixed Now Playing panel stuck on previous source (subscribed to SourceChanged event)
+- All 1,400 tests pass (9 new SongRec tests)

--- a/src/Radio.API/appsettings.json
+++ b/src/Radio.API/appsettings.json
@@ -94,6 +94,11 @@
       "ContactEmail": "mark@mackelprang.com",
       "MaxRequestsPerSecond": 1,
       "TimeoutSeconds": 10
+    },
+    "SongRec": {
+      "Enabled": true,
+      "SongRecPath": "",
+      "TimeoutSeconds": 15
     }
   },
   "AudioEngine": {

--- a/src/Radio.Core/Configuration/FingerprintingOptions.cs
+++ b/src/Radio.Core/Configuration/FingerprintingOptions.cs
@@ -50,6 +50,28 @@ public sealed class FingerprintingOptions
   /// On Windows: download from https://acoustid.org/chromaprint
   /// </summary>
   public string FpcalcPath { get; set; } = string.Empty;
+
+  /// <summary>SongRec (Shazam) fallback recognizer configuration.</summary>
+  public SongRecOptions SongRec { get; set; } = new();
+}
+
+/// <summary>
+/// Configuration options for SongRec (Shazam) audio recognition.
+/// SongRec is an open-source Shazam client used as a fallback when AcoustID fails.
+/// Install via: sudo add-apt-repository ppa:marin-m/songrec &amp;&amp; sudo apt install songrec
+/// </summary>
+public sealed class SongRecOptions
+{
+  /// <summary>Enable or disable SongRec fallback recognition.</summary>
+  public bool Enabled { get; set; } = false;
+
+  /// <summary>
+  /// Path to the songrec binary. If empty, searches PATH.
+  /// </summary>
+  public string SongRecPath { get; set; } = string.Empty;
+
+  /// <summary>Timeout in seconds for the songrec process.</summary>
+  public int TimeoutSeconds { get; set; } = 15;
 }
 
 /// <summary>

--- a/src/Radio.Core/Interfaces/Audio/ISongRecRecognitionService.cs
+++ b/src/Radio.Core/Interfaces/Audio/ISongRecRecognitionService.cs
@@ -1,0 +1,25 @@
+using Radio.Core.Models.Audio;
+
+namespace Radio.Core.Interfaces.Audio;
+
+/// <summary>
+/// Service for recognizing audio using SongRec (Shazam).
+/// Used as a fallback when AcoustID/Chromaprint fails to identify live audio sources.
+/// </summary>
+public interface ISongRecRecognitionService
+{
+  /// <summary>
+  /// Attempts to recognize audio from captured samples using SongRec (Shazam algorithm).
+  /// </summary>
+  /// <param name="samples">The audio sample buffer to recognize.</param>
+  /// <param name="ct">Cancellation token.</param>
+  /// <returns>Track metadata if recognized, null if no match or error.</returns>
+  Task<TrackMetadata?> RecognizeAsync(
+    AudioSampleBuffer samples,
+    CancellationToken ct = default);
+
+  /// <summary>
+  /// Gets whether the SongRec binary is available on this system.
+  /// </summary>
+  bool IsAvailable { get; }
+}

--- a/src/Radio.Core/Models/Audio/MetadataLookupResult.cs
+++ b/src/Radio.Core/Models/Audio/MetadataLookupResult.cs
@@ -38,6 +38,9 @@ public enum LookupSource
   /// <summary>Result came from AcoustID API.</summary>
   AcoustID,
 
+  /// <summary>Result came from SongRec (Shazam) recognition.</summary>
+  SongRec,
+
   /// <summary>Metadata was manually assigned.</summary>
   Manual
 }

--- a/src/Radio.Core/Models/Audio/TrackMetadata.cs
+++ b/src/Radio.Core/Models/Audio/TrackMetadata.cs
@@ -75,5 +75,8 @@ public enum MetadataSource
   Fingerprinting,
 
   /// <summary>Metadata obtained from Bluetooth AVRCP (track info from phone).</summary>
-  Avrcp
+  Avrcp,
+
+  /// <summary>Metadata obtained from SongRec (Shazam) recognition.</summary>
+  Shazam
 }

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/BackgroundIdentificationService.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/BackgroundIdentificationService.cs
@@ -208,6 +208,7 @@ public sealed class BackgroundIdentificationService : BackgroundService
     UpdatePhase(FingerprintPhase.Capturing);
 
     FingerprintData fingerprint;
+    AudioSampleBuffer? capturedSamples = null; // Kept for SongRec fallback on live sources
 
     // For file-based sources, fingerprint the actual file to get correct track duration.
     // AcoustID requires duration within ~3s of the real track length to match.
@@ -250,6 +251,7 @@ public sealed class BackgroundIdentificationService : BackgroundService
       }
 
       _logger.LogDebug("Captured {SampleCount} audio samples in {Elapsed}ms", samples.Samples.Length, captureElapsed);
+      capturedSamples = samples; // Save for SongRec fallback
 
       UpdatePhase(FingerprintPhase.Fingerprinting);
       var fingerprintStartTime = DateTime.UtcNow;
@@ -312,6 +314,48 @@ public sealed class BackgroundIdentificationService : BackgroundService
       }
 
       lookupElapsed = (DateTime.UtcNow - lookupStartTime).TotalMilliseconds;
+    }
+
+    // SongRec fallback: if AcoustID failed for a live source and we have captured audio
+    if (result?.IsMatch != true && capturedSamples != null)
+    {
+      var songRec = scope.ServiceProvider.GetService<ISongRecRecognitionService>();
+      if (songRec is { IsAvailable: true })
+      {
+        _logger.LogInformation("AcoustID returned no match, trying SongRec (Shazam) fallback");
+        UpdatePhase(FingerprintPhase.Querying);
+
+        try
+        {
+          RecordMetadataCall();
+          var songRecMetadata = await songRec.RecognizeAsync(capturedSamples, ct);
+          if (songRecMetadata != null)
+          {
+            _logger.LogInformation(
+              "SongRec identified: '{Title}' by '{Artist}' (album: {Album})",
+              songRecMetadata.Title, songRecMetadata.Artist, songRecMetadata.Album ?? "(none)");
+
+            result = new MetadataLookupResult
+            {
+              IsMatch = true,
+              Confidence = 0.8, // SongRec doesn't provide a numeric confidence score
+              FingerprintId = fingerprint.Id,
+              Metadata = songRecMetadata,
+              Source = LookupSource.SongRec
+            };
+          }
+          else
+          {
+            _logger.LogInformation("SongRec also returned no match");
+          }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+          _logger.LogWarning(ex, "SongRec fallback failed");
+        }
+
+        lookupElapsed = (DateTime.UtcNow - lookupStartTime).TotalMilliseconds;
+      }
     }
 
     // Update event record with result

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/SongRecRecognitionService.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/SongRecRecognitionService.cs
@@ -1,0 +1,385 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Radio.Core.Configuration;
+using Radio.Core.Interfaces.Audio;
+using Radio.Core.Models.Audio;
+
+namespace Radio.Infrastructure.Audio.Fingerprinting;
+
+/// <summary>
+/// Audio recognition service using SongRec (open-source Shazam client).
+/// Writes captured audio to a temp WAV file, invokes `songrec recognize --json`,
+/// and parses the Shazam response to extract track metadata.
+/// </summary>
+/// <remarks>
+/// SongRec internally downsamples to 16kHz and recognizes from the central 12s
+/// of the provided audio. It uses Shazam's algorithm which handles noisy/degraded
+/// audio (vinyl, radio) much better than Chromaprint/AcoustID.
+/// </remarks>
+public sealed class SongRecRecognitionService : ISongRecRecognitionService
+{
+  private readonly ILogger<SongRecRecognitionService> _logger;
+  private readonly string _songRecPath;
+  private readonly int _timeoutSeconds;
+
+  public SongRecRecognitionService(
+    ILogger<SongRecRecognitionService> logger,
+    IOptions<FingerprintingOptions> options)
+  {
+    _logger = logger;
+    var songRecOptions = options.Value.SongRec;
+    _timeoutSeconds = songRecOptions.TimeoutSeconds;
+
+    if (!songRecOptions.Enabled)
+    {
+      _logger.LogInformation("SongRec fallback recognition is disabled");
+      _songRecPath = "songrec";
+      IsAvailable = false;
+      return;
+    }
+
+    _songRecPath = ResolveSongRecPath(songRecOptions.SongRecPath);
+
+    if (IsAvailable)
+      _logger.LogInformation("SongRec available at: {SongRecPath}", _songRecPath);
+    else
+      _logger.LogWarning("SongRec binary not found. Install via: sudo add-apt-repository ppa:marin-m/songrec && sudo apt install songrec");
+  }
+
+  /// <inheritdoc/>
+  public bool IsAvailable { get; private set; }
+
+  /// <inheritdoc/>
+  public async Task<TrackMetadata?> RecognizeAsync(
+    AudioSampleBuffer samples,
+    CancellationToken ct = default)
+  {
+    if (!IsAvailable)
+    {
+      _logger.LogDebug("SongRec not available, skipping recognition");
+      return null;
+    }
+
+    if (samples.Samples.Length == 0)
+    {
+      _logger.LogWarning("Cannot recognize empty audio buffer");
+      return null;
+    }
+
+    _logger.LogDebug(
+      "SongRec recognition: {Duration}s audio ({SampleRate}Hz, {Channels}ch)",
+      samples.Duration.TotalSeconds, samples.SampleRate, samples.Channels);
+
+    var tempFile = Path.Combine(Path.GetTempPath(), $"songrec_{Guid.NewGuid():N}.wav");
+    try
+    {
+      // Write PCM samples as WAV file for songrec to process
+      await WriteWavFileAsync(tempFile, samples, ct);
+
+      // Run songrec recognize
+      var result = await RunSongRecAsync(tempFile, ct);
+      if (result == null)
+        return null;
+
+      // Parse track metadata from Shazam response
+      return ParseResult(result);
+    }
+    finally
+    {
+      try { File.Delete(tempFile); } catch { /* best effort cleanup */ }
+    }
+  }
+
+  /// <summary>
+  /// Runs the songrec recognize command and returns the parsed JSON result.
+  /// </summary>
+  internal async Task<SongRecResult?> RunSongRecAsync(string wavFilePath, CancellationToken ct)
+  {
+    try
+    {
+      var psi = new ProcessStartInfo
+      {
+        FileName = _songRecPath,
+        Arguments = $"audio-file-to-recognized-song \"{wavFilePath}\"",
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+      };
+
+      _logger.LogDebug("Running: {SongRecPath} {Arguments}", _songRecPath, psi.Arguments);
+
+      using var process = Process.Start(psi);
+      if (process == null)
+      {
+        _logger.LogError("Failed to start songrec process");
+        return null;
+      }
+
+      using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+      timeoutCts.CancelAfter(TimeSpan.FromSeconds(_timeoutSeconds));
+
+      var stdout = await process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+      var stderr = await process.StandardError.ReadToEndAsync(timeoutCts.Token);
+      await process.WaitForExitAsync(timeoutCts.Token);
+
+      if (process.ExitCode != 0)
+      {
+        _logger.LogWarning(
+          "songrec exited with code {ExitCode}: {StdErr}",
+          process.ExitCode, stderr.Length > 200 ? stderr[..200] : stderr);
+        return null;
+      }
+
+      if (string.IsNullOrWhiteSpace(stdout))
+      {
+        _logger.LogInformation("SongRec returned empty output (no match)");
+        return null;
+      }
+
+      _logger.LogDebug("SongRec raw output ({Length} chars): {Output}",
+        stdout.Length, stdout.Length > 300 ? stdout[..300] + "..." : stdout);
+
+      var result = JsonSerializer.Deserialize<SongRecResult>(stdout);
+      if (result?.Track == null)
+      {
+        _logger.LogInformation("SongRec returned no track match");
+        return null;
+      }
+
+      _logger.LogInformation(
+        "SongRec recognized: '{Title}' by '{Artist}'",
+        result.Track.Title, result.Track.Subtitle);
+
+      return result;
+    }
+    catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+    {
+      _logger.LogWarning("SongRec process timed out after {Timeout}s", _timeoutSeconds);
+      return null;
+    }
+    catch (Exception ex) when (ex is not OperationCanceledException)
+    {
+      _logger.LogError(ex, "Error running songrec");
+      return null;
+    }
+  }
+
+  /// <summary>
+  /// Converts SongRec/Shazam result to TrackMetadata.
+  /// </summary>
+  internal static TrackMetadata? ParseResult(SongRecResult result)
+  {
+    if (result.Track == null)
+      return null;
+
+    var track = result.Track;
+
+    // Extract album and genre from sections metadata
+    string? album = null;
+    string? genre = null;
+    int? releaseYear = null;
+    if (track.Sections != null)
+    {
+      foreach (var section in track.Sections)
+      {
+        if (section.Metadata == null) continue;
+        foreach (var meta in section.Metadata)
+        {
+          if (string.Equals(meta.Title, "Album", StringComparison.OrdinalIgnoreCase))
+            album = meta.Text;
+          else if (string.Equals(meta.Title, "Released", StringComparison.OrdinalIgnoreCase))
+          {
+            if (int.TryParse(meta.Text, out var year))
+              releaseYear = year;
+          }
+          else if (string.Equals(meta.Title, "Genre", StringComparison.OrdinalIgnoreCase))
+            genre = meta.Text;
+        }
+      }
+    }
+
+    // Cover art: prefer high-res, fall back to standard
+    string? coverArtUrl = track.Images?.CoverArtHq
+      ?? track.Images?.CoverArt;
+
+    return new TrackMetadata
+    {
+      Id = Guid.NewGuid().ToString(),
+      Title = track.Title ?? "Unknown Title",
+      Artist = track.Subtitle ?? "Unknown Artist",
+      Album = album,
+      Genre = genre,
+      ReleaseYear = releaseYear,
+      CoverArtUrl = coverArtUrl,
+      Source = MetadataSource.Shazam,
+      CreatedAt = DateTime.UtcNow,
+      UpdatedAt = DateTime.UtcNow
+    };
+  }
+
+  /// <summary>
+  /// Writes audio samples as a standard WAV file for songrec to process.
+  /// </summary>
+  private static async Task WriteWavFileAsync(
+    string path, AudioSampleBuffer samples, CancellationToken ct)
+  {
+    const int bitsPerSample = 16;
+    int byteRate = samples.SampleRate * samples.Channels * (bitsPerSample / 8);
+    short blockAlign = (short)(samples.Channels * (bitsPerSample / 8));
+
+    // Convert float samples to s16le bytes
+    var pcmDataLength = samples.Samples.Length * 2;
+    var byteBuffer = new byte[pcmDataLength];
+    for (int i = 0; i < samples.Samples.Length; i++)
+    {
+      float sample = Math.Clamp(samples.Samples[i], -1.0f, 1.0f);
+      short pcm = (short)(sample * 32767);
+      byteBuffer[i * 2] = (byte)(pcm & 0xFF);
+      byteBuffer[i * 2 + 1] = (byte)((pcm >> 8) & 0xFF);
+    }
+
+    int dataSize = byteBuffer.Length;
+    int fileSize = 36 + dataSize;
+
+    using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, useAsync: true);
+    var header = new byte[44];
+
+    // RIFF header
+    header[0] = (byte)'R'; header[1] = (byte)'I'; header[2] = (byte)'F'; header[3] = (byte)'F';
+    BitConverter.TryWriteBytes(header.AsSpan(4), fileSize);
+    header[8] = (byte)'W'; header[9] = (byte)'A'; header[10] = (byte)'V'; header[11] = (byte)'E';
+
+    // fmt sub-chunk
+    header[12] = (byte)'f'; header[13] = (byte)'m'; header[14] = (byte)'t'; header[15] = (byte)' ';
+    BitConverter.TryWriteBytes(header.AsSpan(16), 16); // sub-chunk size
+    BitConverter.TryWriteBytes(header.AsSpan(20), (short)1); // PCM format
+    BitConverter.TryWriteBytes(header.AsSpan(22), (short)samples.Channels);
+    BitConverter.TryWriteBytes(header.AsSpan(24), samples.SampleRate);
+    BitConverter.TryWriteBytes(header.AsSpan(28), byteRate);
+    BitConverter.TryWriteBytes(header.AsSpan(32), blockAlign);
+    BitConverter.TryWriteBytes(header.AsSpan(34), (short)bitsPerSample);
+
+    // data sub-chunk
+    header[36] = (byte)'d'; header[37] = (byte)'a'; header[38] = (byte)'t'; header[39] = (byte)'a';
+    BitConverter.TryWriteBytes(header.AsSpan(40), dataSize);
+
+    await fs.WriteAsync(header, ct);
+    await fs.WriteAsync(byteBuffer, ct);
+  }
+
+  private string ResolveSongRecPath(string configuredPath)
+  {
+    // Use configured path if provided
+    if (!string.IsNullOrEmpty(configuredPath))
+    {
+      if (File.Exists(configuredPath))
+      {
+        IsAvailable = true;
+        return configuredPath;
+      }
+
+      _logger.LogWarning(
+        "Configured songrec path not found: {Path}, searching alternatives",
+        configuredPath);
+    }
+
+    // Check if songrec is in PATH
+    var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+      ? "songrec.exe" : "songrec";
+
+    var pathDirs = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator) ?? [];
+    foreach (var dir in pathDirs)
+    {
+      var candidate = Path.Combine(dir, binaryName);
+      if (File.Exists(candidate))
+      {
+        IsAvailable = true;
+        return candidate;
+      }
+    }
+
+    // Check common installation locations (Linux)
+    string[] searchPaths = ["/usr/bin/songrec", "/usr/local/bin/songrec", "/snap/bin/songrec"];
+    foreach (var path in searchPaths)
+    {
+      if (File.Exists(path))
+      {
+        IsAvailable = true;
+        return path;
+      }
+    }
+
+    IsAvailable = false;
+    return binaryName;
+  }
+
+  // --- SongRec/Shazam JSON response DTOs ---
+
+  internal sealed class SongRecResult
+  {
+    [JsonPropertyName("track")]
+    public SongRecTrack? Track { get; set; }
+
+    [JsonPropertyName("matches")]
+    public List<SongRecMatch>? Matches { get; set; }
+  }
+
+  internal sealed class SongRecTrack
+  {
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonPropertyName("subtitle")]
+    public string? Subtitle { get; set; }
+
+    [JsonPropertyName("images")]
+    public SongRecImages? Images { get; set; }
+
+    [JsonPropertyName("sections")]
+    public List<SongRecSection>? Sections { get; set; }
+
+    [JsonPropertyName("key")]
+    public string? Key { get; set; }
+  }
+
+  internal sealed class SongRecImages
+  {
+    [JsonPropertyName("coverart")]
+    public string? CoverArt { get; set; }
+
+    [JsonPropertyName("coverarthq")]
+    public string? CoverArtHq { get; set; }
+  }
+
+  internal sealed class SongRecSection
+  {
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("metadata")]
+    public List<SongRecMetadataItem>? Metadata { get; set; }
+  }
+
+  internal sealed class SongRecMetadataItem
+  {
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonPropertyName("text")]
+    public string? Text { get; set; }
+  }
+
+  internal sealed class SongRecMatch
+  {
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("offset")]
+    public double Offset { get; set; }
+  }
+}

--- a/src/Radio.Infrastructure/DependencyInjection/FingerprintingServiceExtensions.cs
+++ b/src/Radio.Infrastructure/DependencyInjection/FingerprintingServiceExtensions.cs
@@ -101,6 +101,9 @@ public static class FingerprintingServiceExtensions
     // Register audio tap as scoped
     services.AddScoped<IAudioSampleProvider, SoundFlowAudioTap>();
 
+    // Register SongRec (Shazam) fallback recognizer — checks IsAvailable at runtime
+    services.AddSingleton<ISongRecRecognitionService, SongRecRecognitionService>();
+
     // Register background identification service as singleton so other components
     // (AudioManager, FilePlayerAudioSource, etc.) can subscribe to TrackIdentified events.
     // AddHostedService alone only registers as IHostedService, not as the concrete type.

--- a/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
@@ -308,6 +308,7 @@
 
       HubService.PlaybackStateChanged += OnPlaybackStateChanged;
       HubService.NowPlayingChanged += OnNowPlayingChanged;
+      HubService.SourceChanged += OnSourceChanged;
       HubService.VolumeChanged += OnVolumeChangedEvent;
       HubService.FingerprintStatusChanged += OnFingerprintStatusChanged;
 
@@ -330,6 +331,14 @@
   private async Task OnNowPlayingChanged()
   {
     await RefreshPlaybackStateAsync();
+    await InvokeAsync(StateHasChanged);
+  }
+
+  private async Task OnSourceChanged()
+  {
+    // Source switched — immediately refresh to show the new source's metadata
+    await RefreshPlaybackStateAsync();
+    await LoadSourceGainOffsetsAsync();
     await InvokeAsync(StateHasChanged);
   }
 
@@ -724,6 +733,7 @@
   {
     HubService.PlaybackStateChanged -= OnPlaybackStateChanged;
     HubService.NowPlayingChanged -= OnNowPlayingChanged;
+    HubService.SourceChanged -= OnSourceChanged;
     HubService.VolumeChanged -= OnVolumeChangedEvent;
     HubService.FingerprintStatusChanged -= OnFingerprintStatusChanged;
     _gainDebounceTimer?.Dispose();

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,61 +1,159 @@
 # Task Plan
 
-## Objective
-Integrate rotary encoders (Volume, Tuning, Source, Viz), phone call announcements (ring + TTS), and a generic notification receiver into the Radio Console.
+## Goal
+Test and validate alternative metadata identification approaches for non-file audio sources (vinyl, FM radio). Improve fingerprinting accuracy with audio preprocessing, add RDS metadata for FM, and integrate alternative recognition services (ACRCloud, SongRec) as fallbacks.
+
+## Current Phase
+Phase 2 — SongRec Integration (complete, needs deployment + vinyl testing)
 
 ## Phases
 
-### Phase 1: Core interfaces & configuration
-- [ ] RotaryEncoderOptions, PhoneIntegrationOptions config classes
-- [ ] IRotaryEncoderService, IPhoneIntegrationService, IAnnouncementService interfaces
-- [ ] Event args classes
+| # | Phase | Status | Notes |
+|---|-------|--------|-------|
+| 1 | Audio preprocessing for vinyl fingerprinting | complete | High-pass filter deployed, tested — AcoustID still can't match vinyl |
+| 2 | SongRec integration (Shazam) | complete | Fallback recognizer wired into BackgroundIdentificationService |
+| 3 | ACRCloud integration | pending | Cloud fallback, 5K/month limit |
+| 4 | RDS metadata for FM radio | pending | redsea + RTL-SDR investigation |
+| 5 | Strategy-per-source architecture | pending | Pluggable identification per source type |
+| 6 | Fingerprint UI enhancements | pending | Source type display, color-coded results |
 
-### Phase 2: Announcement Service (shared foundation)
-- [ ] AnnouncementService: TTS + ducking orchestration
-- [ ] First real consumer of IDuckingService
+---
 
-### Phase 3: Notification Controller
-- [ ] POST /api/notifications/announce endpoint
-- [ ] Validates + calls AnnouncementService
+## Phase 1: Audio Preprocessing for Vinyl Fingerprinting
 
-### Phase 4: Rotary Encoder Service
-- [ ] HidRotaryEncoderService: HidSharp USB HID reader
-- [ ] RotaryEncoderActionRouter: encoder events → audio actions
-- [ ] VisualizationModeService: tracks viz mode
-- [ ] RotaryEncoderHostedService: BackgroundService
+**Goal**: Add a high-pass filter to audio samples before fingerprinting to remove turntable rumble, then test if Chromaprint/AcoustID match rate improves for vinyl.
 
-### Phase 5: Phone Call Integration
-- [ ] PhoneCallClient: SignalR client to RotaryPhone hub
-- [ ] PhoneContactLookupService: REST client for contacts
-- [ ] PhoneCallIntegrationService: ring + TTS on incoming calls
+**Steps**:
+1. Add high-pass filter (Butterworth 2nd-order, ~80Hz cutoff) in `ChromaprintFingerprintService` applied to samples before WAV generation — only for non-file sources
+2. Deploy and test with vinyl playing known tracks
+3. Compare match rates: before (current) vs after (filtered)
+4. If significantly improved, ship it. If still poor, Phase 2 becomes higher priority.
 
-### Phase 6: Configuration & Wiring
-- [ ] NuGet packages (HidSharp, SignalR.Client)
-- [ ] DI registration in AudioServiceExtensions
-- [ ] Program.cs hosted services
-- [ ] appsettings.json config sections
+**Key insight**: Spectrum analyzer confirms strong sub-100Hz energy from vinyl even with silence. This rumble pollutes Chromaprint hashes.
 
-### Phase 7: Web UI Updates
-- [ ] SignalR handlers for new events
-- [ ] System config page tabs for encoder/phone status
+**Files to modify**:
+- `Radio.Infrastructure/Audio/Fingerprinting/ChromaprintFingerprintService.cs` — add filtering step
+- Possibly `SoundFlowAudioTap.cs` — if filtering should happen at capture time
 
-### Phase 8: Testing & Deployment
-- [ ] Build: 0 warnings
-- [ ] Tests: all pass
-- [ ] Deploy + functional testing
+**Validation**:
+- Play 5 known vinyl tracks, check if AcoustID matches
+- Compare fingerprint hash lengths (short = bad, 800+ chars = good)
+- Check logs for match confidence scores
+
+---
+
+## Phase 2: SongRec Integration (Shazam)
+
+**Goal**: Add SongRec as an alternative fingerprinting service for sources where AcoustID struggles.
+
+**Steps**:
+1. Research SongRec CLI interface — how to invoke, what audio format it needs, what it returns
+2. Install SongRec on Ubuntu deployment target
+3. Create `SongRecFingerprintService` implementing a new `IAlternativeLookupService` interface
+4. Wire into `BackgroundIdentificationService` as fallback when AcoustID returns no match
+5. Test with vinyl and radio sources
+
+**Key facts**:
+- SongRec is a CLI tool (like fpcalc) — can be invoked as a subprocess
+- Handles noisy/degraded audio natively (Shazam's algorithm is designed for it)
+- No API call limits (unofficial Shazam client, personal use)
+- Available on Linux (apt install or build from source)
+
+**Validation**:
+- Play 5 known vinyl tracks that AcoustID fails to match
+- Play FM radio and check recognition rate
+- Measure latency (SongRec vs AcoustID)
+
+---
+
+## Phase 3: ACRCloud Integration
+
+**Goal**: Add ACRCloud as a cloud-based recognition fallback with rate limiting.
+
+**Steps**:
+1. Research ACRCloud API — REST endpoint, auth, audio format requirements
+2. Create `ACRCloudLookupService` with rate limiting (budget: ~160 calls/day from 5K/month)
+3. Store API key in secrets store (existing `${secret:...}` infrastructure)
+4. Wire as final fallback after AcoustID + SongRec fail
+5. Add rate tracking to fingerprint status UI
+
+**Key constraints**:
+- 5,000 calls/month — must be used sparingly
+- Only call when other methods fail AND source is actively playing
+- Longer duplicate suppression window for ACRCloud matches (save quota)
+
+**Validation**:
+- Test with tracks that AcoustID and SongRec both miss
+- Verify rate limiting works (never exceeds budget)
+- Check that secrets store handles ACRCloud credentials
+
+---
+
+## Phase 4: RDS Metadata for FM Radio
+
+**Goal**: Extract Radio Data System (RDS) metadata from FM broadcasts as primary metadata source for radio.
+
+**Steps**:
+1. Investigate if RTLSDRCore exposes raw IQ data or RDS decoding
+2. Research redsea CLI — can it read from RTL-SDR while our app is using it?
+3. If RTLSDRCore has RDS: add RDS text parsing to SDRRadioAudioSource
+4. If not: evaluate running redsea as a sidecar process with shared SDR access
+5. Parse RDS Radio Text (RT) for "Artist - Title" patterns
+6. Use RDS as primary metadata, fingerprinting as fallback for stations without RDS
+
+**Key challenge**: RTL-SDR is a single-user device. If our app is using it for audio demodulation, redsea can't access it simultaneously unless RTLSDRCore exposes RDS data.
+
+**Validation**:
+- Tune to FM station known to broadcast RDS
+- Verify station name (PS) and radio text (RT) are captured
+- Check if song title/artist appears in RT field
+
+---
+
+## Phase 5: Strategy-Per-Source Architecture
+
+**Goal**: Refactor identification pipeline to support pluggable strategies per source type.
+
+**Steps**:
+1. Define `IIdentificationStrategy` interface with `IdentifyAsync(AudioSampleBuffer, AudioSourceType)` method
+2. Create strategy implementations: `ChromaprintStrategy`, `SongRecStrategy`, `ACRCloudStrategy`, `RDSStrategy`
+3. Create `IdentificationStrategyResolver` that selects strategy chain per source type
+4. Refactor `BackgroundIdentificationService` to use strategy resolver instead of hardcoded Chromaprint path
+5. Make strategy chains configurable via `appsettings.json`
+
+**Default chains**:
+- File: Chromaprint/AcoustID only
+- Bluetooth: AVRCP → Chromaprint/AcoustID
+- FM Radio: RDS → SongRec → ACRCloud
+- Vinyl: Chromaprint+filter → SongRec → ACRCloud
+- Generic USB: Chromaprint → SongRec → ACRCloud
+
+---
+
+## Phase 6: Fingerprint UI Enhancements
+
+**Goal**: Update fingerprint status UI to show identification method and color-code results.
+
+**Steps**:
+1. Add `IdentificationMethod` field to status events (Chromaprint, SongRec, ACRCloud, RDS, AVRCP)
+2. Color-code results: green = matched, orange = no match, red = error
+3. Show which strategy was used for each identification attempt
+4. Show rate limits for ACRCloud (calls used / remaining this month)
+
+---
 
 ## Decisions Log
-| # | Decision | Rationale | Date |
-|---|----------|-----------|------|
-| 1 | GoogleBroadcast → Generic notification receiver | GoogleBroadcast repo is simulated, no receive API exists | 2026-03-03 |
-| 2 | Encoder Layout A: Vol/Tune/Source/Viz | Most intuitive vintage radio UX | 2026-03-03 |
-| 3 | RotaryPhone on same Ubuntu box (localhost:5555) | Simplifies networking, single machine | 2026-03-03 |
-| 4 | AnnouncementService shared by phone + notifications | DRY: same TTS+ducking pattern | 2026-03-03 |
+
+| Decision | Rationale | Date |
+|----------|-----------|------|
+| Start with audio preprocessing (Phase 1) | Cheapest test — if high-pass filter fixes vinyl AcoustID, we may not need SongRec/ACRCloud for vinyl at all | 2026-03-04 |
+| SongRec before ACRCloud (Phase 2 before 3) | SongRec has no call limits; ACRCloud is limited to 5K/month. Test free option first. | 2026-03-04 |
+| RDS after SongRec (Phase 4) | RDS requires RTL-SDR investigation and may have device sharing constraints. SongRec is a simpler integration. | 2026-03-04 |
+| No pitch correction for vinyl | User's direct-drive turntable doesn't have wow/flutter issues | 2026-03-04 |
+| High-pass at ~80Hz for vinyl preprocessing | Spectrum shows strong sub-100Hz rumble energy even during silence | 2026-03-04 |
 
 ## Errors Encountered
-| # | Error | Resolution | Date |
-|---|-------|------------|------|
 
-## Current Status
-**Phase:** 0 (planning)
-**Blocked:** No
+| Error | Resolution | Phase |
+|-------|------------|-------|
+| | | |

--- a/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/SongRecRecognitionServiceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/SongRecRecognitionServiceTests.cs
@@ -1,0 +1,238 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Radio.Core.Configuration;
+using Radio.Core.Models.Audio;
+using Radio.Infrastructure.Audio.Fingerprinting;
+using Xunit;
+
+namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
+
+public class SongRecRecognitionServiceTests
+{
+  private readonly Mock<ILogger<SongRecRecognitionService>> _loggerMock;
+
+  public SongRecRecognitionServiceTests()
+  {
+    _loggerMock = new Mock<ILogger<SongRecRecognitionService>>();
+  }
+
+  [Fact]
+  public void Constructor_WhenDisabled_SetsIsAvailableFalse()
+  {
+    var options = Options.Create(new FingerprintingOptions
+    {
+      SongRec = new SongRecOptions { Enabled = false }
+    });
+
+    var service = new SongRecRecognitionService(_loggerMock.Object, options);
+
+    Assert.False(service.IsAvailable);
+  }
+
+  [Fact]
+  public async Task RecognizeAsync_WhenNotAvailable_ReturnsNull()
+  {
+    var options = Options.Create(new FingerprintingOptions
+    {
+      SongRec = new SongRecOptions { Enabled = false }
+    });
+    var service = new SongRecRecognitionService(_loggerMock.Object, options);
+
+    var samples = CreateTestSamples(5.0);
+    var result = await service.RecognizeAsync(samples);
+
+    Assert.Null(result);
+  }
+
+  [Fact]
+  public async Task RecognizeAsync_WithEmptySamples_ReturnsNull()
+  {
+    var options = Options.Create(new FingerprintingOptions
+    {
+      SongRec = new SongRecOptions { Enabled = true }
+    });
+    var service = new SongRecRecognitionService(_loggerMock.Object, options);
+
+    var samples = new AudioSampleBuffer
+    {
+      Samples = [],
+      SampleRate = 44100,
+      Channels = 2,
+      Duration = TimeSpan.Zero
+    };
+
+    var result = await service.RecognizeAsync(samples);
+
+    Assert.Null(result);
+  }
+
+  [Fact]
+  public void ParseResult_WithValidTrack_ReturnsMetadata()
+  {
+    var result = new SongRecRecognitionService.SongRecResult
+    {
+      Track = new SongRecRecognitionService.SongRecTrack
+      {
+        Title = "Just What I Needed",
+        Subtitle = "The Cars",
+        Images = new SongRecRecognitionService.SongRecImages
+        {
+          CoverArt = "https://example.com/cover.jpg",
+          CoverArtHq = "https://example.com/cover-hq.jpg"
+        },
+        Sections =
+        [
+          new SongRecRecognitionService.SongRecSection
+          {
+            Type = "SONG",
+            Metadata =
+            [
+              new SongRecRecognitionService.SongRecMetadataItem
+                { Title = "Album", Text = "The Cars" },
+              new SongRecRecognitionService.SongRecMetadataItem
+                { Title = "Released", Text = "1978" },
+              new SongRecRecognitionService.SongRecMetadataItem
+                { Title = "Genre", Text = "Rock" }
+            ]
+          }
+        ]
+      }
+    };
+
+    var metadata = SongRecRecognitionService.ParseResult(result);
+
+    Assert.NotNull(metadata);
+    Assert.Equal("Just What I Needed", metadata.Title);
+    Assert.Equal("The Cars", metadata.Artist);
+    Assert.Equal("The Cars", metadata.Album);
+    Assert.Equal(1978, metadata.ReleaseYear);
+    Assert.Equal("Rock", metadata.Genre);
+    Assert.Equal("https://example.com/cover-hq.jpg", metadata.CoverArtUrl);
+    Assert.Equal(MetadataSource.Shazam, metadata.Source);
+  }
+
+  [Fact]
+  public void ParseResult_PrefersCoverArtHq_OverCoverArt()
+  {
+    var result = new SongRecRecognitionService.SongRecResult
+    {
+      Track = new SongRecRecognitionService.SongRecTrack
+      {
+        Title = "Test Song",
+        Subtitle = "Test Artist",
+        Images = new SongRecRecognitionService.SongRecImages
+        {
+          CoverArt = "https://example.com/cover.jpg",
+          CoverArtHq = "https://example.com/cover-hq.jpg"
+        }
+      }
+    };
+
+    var metadata = SongRecRecognitionService.ParseResult(result);
+
+    Assert.NotNull(metadata);
+    Assert.Equal("https://example.com/cover-hq.jpg", metadata.CoverArtUrl);
+  }
+
+  [Fact]
+  public void ParseResult_FallsBackToCoverArt_WhenNoHq()
+  {
+    var result = new SongRecRecognitionService.SongRecResult
+    {
+      Track = new SongRecRecognitionService.SongRecTrack
+      {
+        Title = "Test Song",
+        Subtitle = "Test Artist",
+        Images = new SongRecRecognitionService.SongRecImages
+        {
+          CoverArt = "https://example.com/cover.jpg",
+          CoverArtHq = null
+        }
+      }
+    };
+
+    var metadata = SongRecRecognitionService.ParseResult(result);
+
+    Assert.NotNull(metadata);
+    Assert.Equal("https://example.com/cover.jpg", metadata.CoverArtUrl);
+  }
+
+  [Fact]
+  public void ParseResult_WithNoTrack_ReturnsNull()
+  {
+    var result = new SongRecRecognitionService.SongRecResult
+    {
+      Track = null
+    };
+
+    var metadata = SongRecRecognitionService.ParseResult(result);
+
+    Assert.Null(metadata);
+  }
+
+  [Fact]
+  public void ParseResult_WithNoMetadataSections_StillReturnsMetadata()
+  {
+    var result = new SongRecRecognitionService.SongRecResult
+    {
+      Track = new SongRecRecognitionService.SongRecTrack
+      {
+        Title = "Minimal Track",
+        Subtitle = "Unknown Artist"
+      }
+    };
+
+    var metadata = SongRecRecognitionService.ParseResult(result);
+
+    Assert.NotNull(metadata);
+    Assert.Equal("Minimal Track", metadata.Title);
+    Assert.Equal("Unknown Artist", metadata.Artist);
+    Assert.Null(metadata.Album);
+    Assert.Null(metadata.ReleaseYear);
+    Assert.Null(metadata.Genre);
+    Assert.Null(metadata.CoverArtUrl);
+  }
+
+  [Fact]
+  public void ParseResult_WithNullTitle_UsesDefault()
+  {
+    var result = new SongRecRecognitionService.SongRecResult
+    {
+      Track = new SongRecRecognitionService.SongRecTrack
+      {
+        Title = null,
+        Subtitle = null
+      }
+    };
+
+    var metadata = SongRecRecognitionService.ParseResult(result);
+
+    Assert.NotNull(metadata);
+    Assert.Equal("Unknown Title", metadata.Title);
+    Assert.Equal("Unknown Artist", metadata.Artist);
+  }
+
+  private static AudioSampleBuffer CreateTestSamples(double durationSeconds)
+  {
+    const int sampleRate = 44100;
+    const int channels = 2;
+    var totalSamples = (int)(sampleRate * channels * durationSeconds);
+    var samples = new float[totalSamples];
+
+    // Generate a simple sine wave for test purposes
+    for (int i = 0; i < totalSamples; i++)
+    {
+      var t = (double)i / (sampleRate * channels);
+      samples[i] = (float)(Math.Sin(2 * Math.PI * 440 * t) * 0.5);
+    }
+
+    return new AudioSampleBuffer
+    {
+      Samples = samples,
+      SampleRate = sampleRate,
+      Channels = channels,
+      Duration = TimeSpan.FromSeconds(durationSeconds)
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- **SongRec integration (Phase 2)**: Add SongRec (open-source Shazam client) as a fallback recognizer when AcoustID fails for live sources (vinyl, FM radio, USB). SongRec handles degraded/noisy audio much better than Chromaprint.
- **Now Playing fix**: Fix panel staying stuck on previous source (e.g., "Bluetooth") when switching inputs — NowPlayingPanel now subscribes to `SourceChanged` SignalR event.

## Details

### SongRec Fallback
- New `ISongRecRecognitionService` interface + `SongRecRecognitionService` implementation
- Writes captured audio to temp WAV, invokes `songrec audio-file-to-recognized-song`, parses Shazam JSON
- Extracts: title, artist, album, cover art (HQ preferred), genre, release year
- Pipeline: `Capture → Chromaprint/AcoustID → (if no match) → SongRec/Shazam`
- Configurable via `Fingerprinting:SongRec` section (Enabled, SongRecPath, TimeoutSeconds)
- Respects Enabled flag and IsAvailable (binary detection)
- Install on Ubuntu: `sudo add-apt-repository ppa:marin-m/songrec && sudo apt install songrec`

### Now Playing Fix
- `NowPlayingPanel.razor` now subscribes to `SourceChanged` event
- Triggers immediate refresh of playback state + source gain offsets on source switch

## Test plan
- [x] 9 new unit tests for SongRec service (parsing, availability, edge cases)
- [x] All 1,400 tests pass (0 warnings)
- [ ] Deploy to Ubuntu and install SongRec (`sudo apt install songrec`)
- [ ] Enable SongRec: set `Fingerprinting:SongRec:Enabled=true` in appsettings
- [ ] Play vinyl (known track) and verify SongRec identifies after AcoustID fails
- [ ] Switch sources (BT → Vinyl → Radio) and verify Now Playing updates immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)