### PR TITLE
fix: SongRec use 'recognize --json' command

### DIFF
--- a/src/Radio.Infrastructure/Audio/Fingerprinting/SongRecRecognitionService.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/SongRecRecognitionService.cs
@@ -104,7 +104,7 @@ public sealed class SongRecRecognitionService : ISongRecRecognitionService
       var psi = new ProcessStartInfo
       {
         FileName = _songRecPath,
-        Arguments = $"audio-file-to-recognized-song \"{wavFilePath}\"",
+        Arguments = $"recognize --json \"{wavFilePath}\"",
         RedirectStandardOutput = true,
         RedirectStandardError = true,
         UseShellExecute = false,
@@ -202,6 +202,10 @@ public sealed class SongRecRecognitionService : ISongRecRecognitionService
         }
       }
     }
+
+    // Genre: prefer sections metadata, fall back to track.genres.primary
+    if (string.IsNullOrEmpty(genre))
+      genre = track.Genres?.Primary;
 
     // Cover art: prefer high-res, fall back to standard
     string? coverArtUrl = track.Images?.CoverArtHq
@@ -343,6 +347,9 @@ public sealed class SongRecRecognitionService : ISongRecRecognitionService
     [JsonPropertyName("sections")]
     public List<SongRecSection>? Sections { get; set; }
 
+    [JsonPropertyName("genres")]
+    public SongRecGenres? Genres { get; set; }
+
     [JsonPropertyName("key")]
     public string? Key { get; set; }
   }
@@ -372,6 +379,12 @@ public sealed class SongRecRecognitionService : ISongRecRecognitionService
 
     [JsonPropertyName("text")]
     public string? Text { get; set; }
+  }
+
+  internal sealed class SongRecGenres
+  {
+    [JsonPropertyName("primary")]
+    public string? Primary { get; set; }
   }
 
   internal sealed class SongRecMatch

--- a/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/SongRecRecognitionServiceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/SongRecRecognitionServiceTests.cs
@@ -195,6 +195,74 @@ public class SongRecRecognitionServiceTests
   }
 
   [Fact]
+  public void ParseResult_FallsBackToGenresPrimary_WhenNoSectionGenre()
+  {
+    var result = new SongRecRecognitionService.SongRecResult
+    {
+      Track = new SongRecRecognitionService.SongRecTrack
+      {
+        Title = "Test Song",
+        Subtitle = "Test Artist",
+        Genres = new SongRecRecognitionService.SongRecGenres
+        {
+          Primary = "Pop"
+        },
+        Sections =
+        [
+          new SongRecRecognitionService.SongRecSection
+          {
+            Type = "SONG",
+            Metadata =
+            [
+              new SongRecRecognitionService.SongRecMetadataItem
+                { Title = "Album", Text = "Test Album" }
+            ]
+          }
+        ]
+      }
+    };
+
+    var metadata = SongRecRecognitionService.ParseResult(result);
+
+    Assert.NotNull(metadata);
+    Assert.Equal("Pop", metadata.Genre);
+  }
+
+  [Fact]
+  public void ParseResult_PrefersSectionGenre_OverGenresPrimary()
+  {
+    var result = new SongRecRecognitionService.SongRecResult
+    {
+      Track = new SongRecRecognitionService.SongRecTrack
+      {
+        Title = "Test Song",
+        Subtitle = "Test Artist",
+        Genres = new SongRecRecognitionService.SongRecGenres
+        {
+          Primary = "Pop"
+        },
+        Sections =
+        [
+          new SongRecRecognitionService.SongRecSection
+          {
+            Type = "SONG",
+            Metadata =
+            [
+              new SongRecRecognitionService.SongRecMetadataItem
+                { Title = "Genre", Text = "Rock" }
+            ]
+          }
+        ]
+      }
+    };
+
+    var metadata = SongRecRecognitionService.ParseResult(result);
+
+    Assert.NotNull(metadata);
+    Assert.Equal("Rock", metadata.Genre);
+  }
+
+  [Fact]
   public void ParseResult_WithNullTitle_UsesDefault()
   {
     var result = new SongRecRecognitionService.SongRecResult


### PR DESCRIPTION
## Summary
- **Fix SongRec hanging on headless Linux**: The `audio-file-to-recognized-song` subcommand tries to initialize GTK4 display subsystems and hangs indefinitely. Switched to `recognize --json` which works correctly without a display.
- **Add genre fallback**: Real Shazam responses put genre in `track.genres.primary` rather than in sections metadata. Added fallback parsing with section genre taking priority.
- **Verified**: SongRec correctly identifies "I'm Not In Love" by 10cc from a 15s stereo WAV file on Ubuntu.

## Test plan
- [x] All 1,402 tests pass (11 SongRec-specific tests including 2 new genre fallback tests)
- [ ] Deploy to Ubuntu and verify SongRec recognizes vinyl audio
- [ ] Check logs for successful Shazam recognition results

🤖 Generated with [Claude Code](https://claude.com/claude-code)