### PR TITLE
fix: Immediate NowPlaying refresh on source switch

### DIFF
--- a/src/Radio.Web/Components/Layout/MainLayout.razor
+++ b/src/Radio.Web/Components/Layout/MainLayout.razor
@@ -440,6 +440,10 @@
       {
         _selectedSourceId = newSourceId;
         Logger.LogInformation("Switched to source: {SourceType}", source.Type);
+
+        // Immediately notify NowPlayingPanel of the source change so it refreshes
+        // without waiting for the 500ms AudioStateUpdateService polling cycle.
+        await HubService.NotifySourceChangedAsync();
       }
     }
     catch (Exception ex)

--- a/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
@@ -295,6 +295,9 @@
   private Dictionary<string, float> _sourceGainOffsets = new();
   private System.Threading.Timer? _gainDebounceTimer;
 
+  // Periodic fallback poll for now playing updates (safety net for missed SignalR events)
+  private System.Threading.Timer? _nowPlayingPollTimer;
+
   private bool _hasValidAlbumArt =>
     !_albumArtFailed
     && !string.IsNullOrEmpty(_albumArtUrl)
@@ -315,6 +318,14 @@
       await RefreshPlaybackStateAsync();
       await RefreshFingerprintStatusAsync();
       await LoadSourceGainOffsetsAsync();
+
+      // Periodic fallback poll for now playing updates. Catches track identifications
+      // or metadata changes if a SignalR NowPlayingChanged event is missed.
+      _nowPlayingPollTimer = new System.Threading.Timer(
+        async _ => await OnNowPlayingPollAsync(),
+        null,
+        TimeSpan.FromSeconds(10),
+        TimeSpan.FromSeconds(10));
     }
     catch (Exception ex)
     {
@@ -352,6 +363,23 @@
   {
     await RefreshFingerprintStatusAsync();
     await InvokeAsync(StateHasChanged);
+  }
+
+  private async Task OnNowPlayingPollAsync()
+  {
+    try
+    {
+      var nowPlaying = await AudioApi.GetNowPlayingAsync();
+      if (nowPlaying != null && nowPlaying.Title != _title)
+      {
+        await RefreshPlaybackStateAsync();
+        await InvokeAsync(StateHasChanged);
+      }
+    }
+    catch
+    {
+      // Ignore — this is a background safety net, not critical
+    }
   }
 
   private async Task RefreshFingerprintStatusAsync()
@@ -737,6 +765,7 @@
     HubService.VolumeChanged -= OnVolumeChangedEvent;
     HubService.FingerprintStatusChanged -= OnFingerprintStatusChanged;
     _gainDebounceTimer?.Dispose();
+    _nowPlayingPollTimer?.Dispose();
     await Task.CompletedTask;
   }
 }

--- a/src/Radio.Web/Services/Hub/AudioStateHubService.cs
+++ b/src/Radio.Web/Services/Hub/AudioStateHubService.cs
@@ -70,14 +70,18 @@ public class AudioStateHubService : IAsyncDisposable
         .Build();
 
       // Register event handlers
-      _hubConnection.On("PlaybackStateChanged", async () =>
+      // Server sends PlaybackStateChanged with a PlaybackStateDto payload —
+      // accept and discard it so SignalR dispatches the message.
+      _hubConnection.On<object>("PlaybackStateChanged", async (_) =>
       {
         _logger.LogDebug("Received PlaybackStateChanged event");
         if (PlaybackStateChanged != null)
           await PlaybackStateChanged.Invoke();
       });
 
-      _hubConnection.On("NowPlayingChanged", async () =>
+      // Server sends NowPlayingChanged with a NowPlayingDto payload —
+      // accept and discard it so SignalR dispatches the message.
+      _hubConnection.On<object>("NowPlayingChanged", async (_) =>
       {
         _logger.LogDebug("Received NowPlayingChanged event");
         if (NowPlayingChanged != null)
@@ -227,6 +231,17 @@ public class AudioStateHubService : IAsyncDisposable
     {
       _connectionLock.Release();
     }
+  }
+
+  /// <summary>
+  /// Locally triggers the SourceChanged event without going through SignalR.
+  /// Call after a source switch API call succeeds to immediately notify
+  /// NowPlayingPanel and other subscribers (bypasses the 500ms polling delay).
+  /// </summary>
+  public async Task NotifySourceChangedAsync()
+  {
+    if (SourceChanged != null)
+      await SourceChanged.Invoke();
   }
 
   public async Task StopAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- **Fix SignalR event handlers**: `NowPlayingChanged` and `PlaybackStateChanged` handlers now use `On<object>()` to accept the server payload, matching `QueueChanged`/`RadioStateChanged` patterns. Previously used parameterless `On()` which could miss events.
- **Immediate source switch notification**: `MainLayout.HandleSourceChangeAsync` now calls `HubService.NotifySourceChangedAsync()` directly after a successful source switch. NowPlayingPanel refreshes instantly instead of waiting up to 500ms for the polling cycle.
- **10s fallback poll**: NowPlayingPanel now polls the API every 10 seconds as a safety net. Only triggers a full refresh when the title has actually changed (e.g., SongRec identifies a new track).

## Test plan
- [x] All 1,402 tests pass
- [ ] Deploy and verify: switch from BT to Phono — NowPlaying should update immediately
- [ ] Verify SongRec identifications appear in NowPlaying panel within 10 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)