### PR TITLE
fix: Fingerprinting metadata overwrites generic play history on cold start

### DIFF
--- a/src/Radio.Infrastructure/Audio/Services/PlayHistoryTracker.cs
+++ b/src/Radio.Infrastructure/Audio/Services/PlayHistoryTracker.cs
@@ -242,7 +242,8 @@ public class PlayHistoryTracker : IDisposable
         SourceDetails = sourceDetails,
         DurationSeconds = durationSeconds,
         IdentificationConfidence = null,
-        WasIdentified = trackMetadataId != null,
+        WasIdentified = trackMetadataId != null
+          && !IsPlaceholderMetadata(newTitle, newArtist, playSource, btDeviceName),
         Track = metadata
       };
 
@@ -448,12 +449,18 @@ public class PlayHistoryTracker : IDisposable
 
       if (existingEntry != null)
       {
+        // Persist the identified track metadata so the DB row exists for JOIN queries
+        var metadataRepository = scope.ServiceProvider.GetService<ITrackMetadataRepository>();
+        if (metadataRepository != null)
+          await metadataRepository.StoreAsync(e.Track);
+
         // Update the existing entry with fingerprinting data
         var updatedEntry = existingEntry with
         {
           TrackMetadataId = e.Track.Id,
           FingerprintId = e.Track.FingerprintId,
           MetadataSource = MetadataSource.Fingerprinting,
+          SourceDetails = $"{e.Track.Title} - {e.Track.Artist}",
           IdentificationConfidence = e.Confidence,
           WasIdentified = true,
           Track = e.Track


### PR DESCRIPTION
## Summary
- **Bug 1**: Placeholder history entries (e.g., "Vinyl - Vinyl") were marked `WasIdentified = true` because they had a `TrackMetadata` record, even with generic content. `GetRecentUnidentifiedAsync()` queries `WHERE WasIdentified = 0` and never found them. Fixed by adding an `IsPlaceholderMetadata()` check before setting `WasIdentified`.
- **Bug 2**: `OnTrackIdentified` set `TrackMetadataId` to the SongRec track ID but never called `metadataRepository.StoreAsync()` to persist the row. Future LEFT JOINs returned NULL. Added the store call and `SourceDetails` update for consistency with `OnSongChanged`.

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings
- [x] `dotnet test --configuration Release` — all tests pass
- [ ] Deploy to Ubuntu, restart service (cold start)
- [ ] Play vinyl → generic "Vinyl - Vinyl" entry created
- [ ] ~16s later SongRec identifies → history entry updated with real metadata
- [ ] `/api/playhistory` returns entry with real title/artist, `WasIdentified = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)