### PR TITLE
feat: Radio preset naming format + numeric keypad mode (Phase 11 & 12)

### DIFF
--- a/findings.md
+++ b/findings.md
@@ -62,12 +62,81 @@ Sources (Radio/SDR/File/BT/USB)
 - Linux binary available, can be invoked like fpcalc
 - Good for vinyl and radio where AcoustID struggles
 
-## Strategy Per Source Type
+## Strategy Per Source Type (Updated)
 
 | Source | Primary | Fallback | Notes |
 |--------|---------|----------|-------|
-| File | Chromaprint/AcoustID (file) | — | Already works well |
-| Bluetooth | AVRCP metadata | Chromaprint/AcoustID | Already implemented |
-| FM Radio | RDS via redsea | ACRCloud or SongRec | RDS is free, instant |
-| Vinyl | Chromaprint + high-pass filter | SongRec or ACRCloud | Clean audio first |
-| Generic USB | Chromaprint/AcoustID | SongRec or ACRCloud | Same as vinyl approach |
+| File | ID3 tags (embedded) | SongRec (if tags incomplete) | AcoustID being removed |
+| Bluetooth | AVRCP metadata | SongRec (if AVRCP incomplete) | Event-driven on AVRCP arrival |
+| FM Radio | SongRec (polling) | — | RDS provides station name only |
+| Vinyl | SongRec (polling) | — | High-pass filter before capture |
+| Generic USB | SongRec (polling) | — | Same as vinyl approach |
+
+## Metrics Dashboard Architecture
+
+### Current State
+- `MetricsDashboardPage.razor`: flat grid of cards, custom SVG sparklines (~200×24px)
+- Left panel: time range toggles (1h/24h/7d), category filter chips
+- Right panel: metric cards (MudGrid xs=6 sm=4 md=3), click → aggregate stats
+- No real charting library — hand-rolled SVG `<path>` for sparklines
+- Data: SQLite with 3-tier rollup (minute/hour/day), retention 2h/48h/365d
+
+### Charting Options
+1. **MudBlazor `MudTimeSeriesChart`** — built-in, no new dependencies, Material Design styled
+2. **BlazorChartjs (Chart.js wrapper)** — more features (zoom, tooltips, annotations), but adds JS dependency
+3. **Custom SVG** — current approach, maximally lightweight but limited
+
+### API Endpoints
+- `GET /api/metrics/history` → time-series data (key, start, end, resolution)
+- `GET /api/metrics/snapshots` → current values for batch of keys
+- `GET /api/metrics/aggregate` → stats (count, avg, min, max, stddev)
+- `GET /api/metrics/keys` → available metric names
+
+### Data Resolution
+- Minute data: 120 minutes retention → for 5m/1h views
+- Hour data: 48 hours retention → for 24h view
+- Day data: 365 days retention → for 7d/30d views
+
+### Design References
+- [Grafana dashboard best practices](https://grafana.com/docs/grafana/latest/visualizations/dashboards/build-dashboards/best-practices/) — F-pattern, <12 panels, progressive disclosure
+- [Grafana stat panels](https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/stat/) — large value + sparkline + threshold colors
+- [MudBlazor TimeSeriesChart](https://mudblazor.com/components/timeserieschart) — built-in Blazor chart component
+
+## Audio Distortion / CPU Analysis
+
+### Threading Model
+- Audio callback thread: MiniAudio, runs every 5.3ms (512 samples @ 48kHz)
+- Per-sample processing: 96k ops/sec on audio thread (Balance → Limiter → FingerprintTap → VizTap → OutputTap)
+- Each modifier holds a per-sample lock briefly (~1μs)
+- ThreadPool handles tap buffer flushes and FFT computation
+- Risk: ThreadPool starvation delays flushes → lock contention on audio thread
+
+### Known Buffer Settings
+| Component | Size | Impact |
+|-----------|------|--------|
+| MiniAudio period | 512 samples (5.3ms) | Callback frequency |
+| PipeWire quantum | 512 (10.67ms, tuned) | Min graph unit |
+| BufferedSoundGenerator | 2.0s max | Source clock drift absorption |
+| Fingerprint/Viz tap | 2048 samples (~42ms) | Lock batch size |
+| OutputTap ring buffer | 2-5s | HTTP/Cast readers |
+
+### Distortion Correlation with UI Load
+- Blazor Server uses SignalR (WebSocket) — rendering happens server-side, serialized DOM diffs sent to client
+- Loading metrics page: multiple HTTP calls to API (keys, snapshots, history for each metric)
+- API serves metrics from SQLite — may hold write lock during flush, blocking reads
+- Hypothesis: CPU spike from rendering + DB I/O starves ThreadPool → audio tap flushes delayed → callback stalls
+
+## USB Audio (AB13X) Architecture
+
+### Device Selection Flow
+1. Config: `Devices:Radio:USBPort` or `Devices:GenericUSB:USBPort` = "AB13X"
+2. `USBAudioSourceBase.InitializeUSBCaptureAsync("AB13X")`
+3. Searches MiniAudio `CaptureDevices` for name containing "AB13X" (case-insensitive substring)
+4. If not found → falls back to first available capture device (with warning log)
+5. Capture format matched to playback engine (48kHz)
+
+### Potential Failure Points
+- Device not in `appsettings.Production.json` (overwritten on deploy)
+- PipeWire reports different device name than expected
+- USB hub power issue / device disconnected
+- Another source already reserved the USB port

--- a/progress.md
+++ b/progress.md
@@ -30,3 +30,23 @@
 - Added 9 unit tests for SongRec service (parsing, availability, edge cases)
 - Fixed Now Playing panel stuck on previous source (subscribed to SourceChanged event)
 - All 1,400 tests pass (9 new SongRec tests)
+
+## Session: 2026-03-05
+
+- Phases 7 & 8 implemented and merged (PR #288)
+- Phase 7: Virtual keyboard auto-show for dialogs, RDS preset auto-naming
+- Phase 8: Source auto-activation on startup, file player position restore
+- Fixed virtual-keyboard.js not loading (missing script tag in App.razor)
+- Fixed CSS dialog shift selector (descendant vs direct child)
+- All 1,414 tests pass
+
+## Session: 2026-03-05 (planning)
+
+- Planned 6 new phases (9-14) based on user requirements
+- Researched metrics dashboard: current flat card layout, SQLite 3-tier rollup, custom SVG sparklines
+- Researched Blazor charting: MudBlazor has built-in `MudTimeSeriesChart`, also Chart.js wrappers available
+- Researched SRE dashboard patterns: Grafana F-pattern, stat panels, progressive disclosure, <12 panels/page
+- Researched AcoustID removal: only used for file sources, SongRec can replace for all
+- Researched USB audio (AB13X): config via `Devices:Radio:USBPort`, substring match on MiniAudio device names
+- Researched audio distortion: per-sample locks on audio thread, ThreadPool starvation risk from UI/DB load
+- Ready to begin Phase 9 (Metrics Dashboard Redesign)

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -1091,8 +1091,8 @@
     if (_radioState != null)
     {
       _presetName = !string.IsNullOrEmpty(_radioState.RdsStationName)
-        ? _radioState.RdsStationName
-        : $"{_radioState.Band} - {FormatFrequency(_radioState.Frequency, _radioState.Band)}";
+        ? $"{_radioState.Band} {_radioState.RdsStationName} {FormatFrequency(_radioState.Frequency, _radioState.Band)}"
+        : $"{_radioState.Band} {FormatFrequency(_radioState.Frequency, _radioState.Band)}";
     }
     _isSavePresetDialogOpen = true;
   }

--- a/src/Radio.Web/wwwroot/css/virtual-keyboard.css
+++ b/src/Radio.Web/wwwroot/css/virtual-keyboard.css
@@ -210,3 +210,33 @@ body.keyboard-active .mud-overlay .mud-paper {
   transform: translateY(-150px);
   transition: transform 0.3s ease;
 }
+
+/* Numeric keypad — compact centered layout */
+.virtual-keyboard.numpad {
+  max-width: 360px;
+}
+
+.numpad-keys {
+  gap: 10px;
+}
+
+.numpad-keys .keyboard-row {
+  gap: 10px;
+}
+
+.numpad-key {
+  min-width: 70px;
+  min-height: 60px;
+  height: 60px;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.numpad-key.key-backspace {
+  font-size: 24px;
+}
+
+.numpad-key.key-enter {
+  min-width: 70px;
+  font-size: 14px;
+}

--- a/src/Radio.Web/wwwroot/js/virtual-keyboard.js
+++ b/src/Radio.Web/wwwroot/js/virtual-keyboard.js
@@ -7,6 +7,7 @@ class VirtualKeyboard {
     this.currentInput = null;
     this.keyboardElement = null;
     this.capsLock = false;
+    this.currentMode = 'qwerty'; // 'qwerty' or 'numeric'
   }
 
   initialize() {
@@ -16,10 +17,10 @@ class VirtualKeyboard {
     this.keyboardElement.className = 'virtual-keyboard-container';
     this.keyboardElement.style.display = 'none';
 
-    this.keyboardElement.innerHTML = this.getKeyboardHTML();
+    this.keyboardElement.innerHTML = this.getKeyboardHTML('qwerty');
     document.body.appendChild(this.keyboardElement);
 
-    // Add event listeners
+    // Attach event listeners on the outer container (delegates to inner content)
     this.attachEventListeners();
 
     // Auto-show keyboard when inputs inside dialog overlays receive focus
@@ -46,7 +47,12 @@ class VirtualKeyboard {
     });
   }
 
-  getKeyboardHTML() {
+  getKeyboardHTML(mode) {
+    if (mode === 'numeric') return this.getNumericHTML();
+    return this.getQwertyHTML();
+  }
+
+  getQwertyHTML() {
     return `
       <div class="virtual-keyboard">
         <div class="keyboard-header">
@@ -68,7 +74,7 @@ class VirtualKeyboard {
             <button class="key" data-key="0">0</button>
             <button class="key key-backspace" data-action="backspace">⌫</button>
           </div>
-          
+
           <!-- Top Row -->
           <div class="keyboard-row">
             <button class="key" data-key="q">q</button>
@@ -82,7 +88,7 @@ class VirtualKeyboard {
             <button class="key" data-key="o">o</button>
             <button class="key" data-key="p">p</button>
           </div>
-          
+
           <!-- Middle Row -->
           <div class="keyboard-row">
             <button class="key" data-key="a">a</button>
@@ -95,7 +101,7 @@ class VirtualKeyboard {
             <button class="key" data-key="k">k</button>
             <button class="key" data-key="l">l</button>
           </div>
-          
+
           <!-- Bottom Row -->
           <div class="keyboard-row">
             <button class="key key-shift" data-action="shift">⇧ Shift</button>
@@ -109,7 +115,7 @@ class VirtualKeyboard {
             <button class="key" data-key="-">-</button>
             <button class="key" data-key="_">_</button>
           </div>
-          
+
           <!-- Special Characters Row -->
           <div class="keyboard-row">
             <button class="key" data-key="/">/ </button>
@@ -121,6 +127,42 @@ class VirtualKeyboard {
             <button class="key" data-key="$">$</button>
             <button class="key" data-key="#">#</button>
             <button class="key key-enter" data-action="enter">Enter</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  getNumericHTML() {
+    return `
+      <div class="virtual-keyboard numpad">
+        <div class="keyboard-header">
+          <span class="keyboard-title">Numpad</span>
+          <button class="keyboard-close" data-action="close">✕</button>
+        </div>
+        <div class="keyboard-keys numpad-keys">
+          <div class="keyboard-row">
+            <button class="key numpad-key" data-key="7">7</button>
+            <button class="key numpad-key" data-key="8">8</button>
+            <button class="key numpad-key" data-key="9">9</button>
+            <button class="key numpad-key key-backspace" data-action="backspace">⌫</button>
+          </div>
+          <div class="keyboard-row">
+            <button class="key numpad-key" data-key="4">4</button>
+            <button class="key numpad-key" data-key="5">5</button>
+            <button class="key numpad-key" data-key="6">6</button>
+            <button class="key numpad-key" data-key=".">.</button>
+          </div>
+          <div class="keyboard-row">
+            <button class="key numpad-key" data-key="1">1</button>
+            <button class="key numpad-key" data-key="2">2</button>
+            <button class="key numpad-key" data-key="3">3</button>
+            <button class="key numpad-key" data-key="-">-</button>
+          </div>
+          <div class="keyboard-row">
+            <button class="key numpad-key numpad-zero" data-key="0">0</button>
+            <button class="key numpad-key" data-key="00">00</button>
+            <button class="key numpad-key key-enter" data-action="enter">Enter</button>
           </div>
         </div>
       </div>
@@ -270,8 +312,42 @@ class VirtualKeyboard {
     setTimeout(() => this.hide(), 100);
   }
 
+  detectInputMode(inputElement) {
+    // Explicit opt-in via data attribute
+    const dataKeyboard = inputElement.getAttribute('data-keyboard');
+    if (dataKeyboard === 'numeric') return 'numeric';
+    if (dataKeyboard === 'qwerty') return 'qwerty';
+
+    // Detect from input type and inputmode attributes
+    const type = inputElement.getAttribute('type');
+    const inputMode = inputElement.getAttribute('inputmode');
+
+    if (type === 'number' || inputMode === 'numeric' || inputMode === 'decimal') {
+      return 'numeric';
+    }
+
+    // MudNumericField renders an inner <input> with type="number" inside a wrapper
+    // that may have inputmode on the outer element
+    const wrapper = inputElement.closest('.mud-input-control');
+    if (wrapper && wrapper.querySelector('input[type="number"]')) {
+      return 'numeric';
+    }
+
+    return 'qwerty';
+  }
+
   show(inputElement) {
     this.currentInput = inputElement;
+
+    // Detect desired keyboard mode
+    const mode = this.detectInputMode(inputElement);
+
+    // Swap layout if mode changed (event listeners delegate from outer container, no re-attach needed)
+    if (mode !== this.currentMode) {
+      this.currentMode = mode;
+      this.keyboardElement.innerHTML = this.getKeyboardHTML(mode);
+    }
+
     this.keyboardElement.style.display = 'block';
     this.isVisible = true;
     document.body.classList.add('keyboard-active');
@@ -292,11 +368,15 @@ class VirtualKeyboard {
       this.currentInput = null;
       this.capsLock = false;
 
-      // Reset shift button
+      // Reset shift button (only present in qwerty mode)
       const shiftButton = this.keyboardElement.querySelector('[data-action="shift"]');
       if (shiftButton) {
         shiftButton.classList.remove('active');
       }
+
+      // Reset mode so next show() re-evaluates
+      this.currentMode = 'qwerty';
+      this.keyboardElement.innerHTML = this.getKeyboardHTML('qwerty');
     }, 300);
   }
 

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,144 +1,368 @@
 # Task Plan
 
 ## Goal
-Test and validate alternative metadata identification approaches for non-file audio sources (vinyl, FM radio). Improve fingerprinting accuracy with audio preprocessing, add RDS metadata for FM, and integrate alternative recognition services (ACRCloud, SongRec) as fallbacks.
+Build a polished audio console with reliable song identification, rich metadata display, and smooth UX. SongRec (Shazam) is the primary recognition engine for live sources; AcoustID for local files only. RDS provides station identity for FM radio. Modern observability dashboard for system health. Responsive touch UX.
 
 ## Current Phase
-Phase 2 — SongRec Integration (complete, needs deployment + vinyl testing)
+Phase 9 — Metrics Dashboard Redesign (pending)
 
 ## Phases
 
 | # | Phase | Status | Notes |
 |---|-------|--------|-------|
 | 1 | Audio preprocessing for vinyl fingerprinting | complete | High-pass filter deployed, tested — AcoustID still can't match vinyl |
-| 2 | SongRec integration (Shazam) | complete | Fallback recognizer wired into BackgroundIdentificationService |
-| 3 | ACRCloud integration | pending | Cloud fallback, 5K/month limit |
-| 4 | RDS metadata for FM radio | pending | redsea + RTL-SDR investigation |
-| 5 | Strategy-per-source architecture | pending | Pluggable identification per source type |
-| 6 | Fingerprint UI enhancements | pending | Source type display, color-coded results |
+| 2 | SongRec integration (Shazam) | complete | Deployed + vinyl tested. Uses `recognize --json`. Identified Cars tracks from vinyl in ~1s. |
+| 3 | ACRCloud integration | cancelled | SongRec covers all use cases; ACRCloud 5K/month limit unnecessary |
+| 4 | RDS station name for FM radio | complete | Station name, PTY/genre on RadioControlPanel. Biphase decoding, Costas loop, CRC sync. PR #284 merged. |
+| 5 | SongRec as primary recognition engine | complete | SongRec primary for live sources, album art caching, exponential backoff. PR #285 merged. |
+| 6 | Play history enhancements | complete | Radio context, album art, source icons. PR #287 merged. |
+| 7 | UX polish | complete | Virtual keyboard auto-show for dialogs, RDS preset auto-naming. PR #288 merged. |
+| 8 | Session persistence | complete | Source auto-activation, file player queue/position restore. PR #288 merged. |
+| 9 | Metrics dashboard redesign | pending | Grafana-inspired layout: stat cards, time-series charts, time range selector, drill-down |
+| 10 | Smart fingerprinting (remove AcoustID) | pending | Event-driven recognition for BT/File; remove AcoustID; SongRec-only for all sources |
+| 11 | Radio preset naming format | pending | Change format to `{Band} {CallSign} {Frequency}` |
+| 12 | Numeric keypad mode | pending | Smaller numeric keypad layout for number-only inputs (frequency, etc.) |
+| 13 | AB13X USB input debug | pending | Investigate why USB audio input stopped working |
+| 14 | Audio distortion / CPU investigation | pending | Diagnose periodic distortion correlated with UI/metrics loading |
 
 ---
 
 ## Phase 1: Audio Preprocessing for Vinyl Fingerprinting
 
+**Status**: complete
+
 **Goal**: Add a high-pass filter to audio samples before fingerprinting to remove turntable rumble, then test if Chromaprint/AcoustID match rate improves for vinyl.
 
-**Steps**:
-1. Add high-pass filter (Butterworth 2nd-order, ~80Hz cutoff) in `ChromaprintFingerprintService` applied to samples before WAV generation — only for non-file sources
-2. Deploy and test with vinyl playing known tracks
-3. Compare match rates: before (current) vs after (filtered)
-4. If significantly improved, ship it. If still poor, Phase 2 becomes higher priority.
-
-**Key insight**: Spectrum analyzer confirms strong sub-100Hz energy from vinyl even with silence. This rumble pollutes Chromaprint hashes.
-
-**Files to modify**:
-- `Radio.Infrastructure/Audio/Fingerprinting/ChromaprintFingerprintService.cs` — add filtering step
-- Possibly `SoundFlowAudioTap.cs` — if filtering should happen at capture time
-
-**Validation**:
-- Play 5 known vinyl tracks, check if AcoustID matches
-- Compare fingerprint hash lengths (short = bad, 800+ chars = good)
-- Check logs for match confidence scores
+**Result**: High-pass filter deployed and tested. AcoustID still can't match vinyl — the algorithm fundamentally struggles with live/degraded audio. Validated that an alternative recognizer (SongRec) is needed.
 
 ---
 
 ## Phase 2: SongRec Integration (Shazam)
 
+**Status**: complete
+
 **Goal**: Add SongRec as an alternative fingerprinting service for sources where AcoustID struggles.
 
-**Steps**:
-1. Research SongRec CLI interface — how to invoke, what audio format it needs, what it returns
-2. Install SongRec on Ubuntu deployment target
-3. Create `SongRecFingerprintService` implementing a new `IAlternativeLookupService` interface
-4. Wire into `BackgroundIdentificationService` as fallback when AcoustID returns no match
-5. Test with vinyl and radio sources
-
-**Key facts**:
-- SongRec is a CLI tool (like fpcalc) — can be invoked as a subprocess
-- Handles noisy/degraded audio natively (Shazam's algorithm is designed for it)
-- No API call limits (unofficial Shazam client, personal use)
-- Available on Linux (apt install or build from source)
-
-**Validation**:
-- Play 5 known vinyl tracks that AcoustID fails to match
-- Play FM radio and check recognition rate
-- Measure latency (SongRec vs AcoustID)
+**Result**: SongRec deployed, working across vinyl and radio sources. Uses `recognize --json` command. Identifies tracks from vinyl in ~1 second. Currently wired as fallback after AcoustID.
 
 ---
 
 ## Phase 3: ACRCloud Integration
 
-**Goal**: Add ACRCloud as a cloud-based recognition fallback with rate limiting.
+**Status**: cancelled
 
-**Steps**:
-1. Research ACRCloud API — REST endpoint, auth, audio format requirements
-2. Create `ACRCloudLookupService` with rate limiting (budget: ~160 calls/day from 5K/month)
-3. Store API key in secrets store (existing `${secret:...}` infrastructure)
-4. Wire as final fallback after AcoustID + SongRec fail
-5. Add rate tracking to fingerprint status UI
-
-**Key constraints**:
-- 5,000 calls/month — must be used sparingly
-- Only call when other methods fail AND source is actively playing
-- Longer duplicate suppression window for ACRCloud matches (save quota)
-
-**Validation**:
-- Test with tracks that AcoustID and SongRec both miss
-- Verify rate limiting works (never exceeds budget)
-- Check that secrets store handles ACRCloud credentials
+SongRec covers all recognition use cases effectively. ACRCloud's 5K/month limit adds complexity without benefit.
 
 ---
 
 ## Phase 4: RDS Metadata for FM Radio
 
-**Goal**: Extract Radio Data System (RDS) metadata from FM broadcasts as primary metadata source for radio.
+**Status**: complete (PR #284)
+
+Built full RDS decoder in RTLSDRCore: 57 kHz BPF → Costas loop BPSK demod → biphase (Manchester) decoding → CRC block sync → Group 0A/2A parsing. Displays station name and PTY/genre on RadioControlPanel. Verified on WFJA 105.5 FM.
+
+---
+
+## Phase 5: SongRec as Primary Recognition Engine
+
+**Status**: complete (PR #285)
+
+**Goal**: Make SongRec the primary song identification path for all live audio sources. Add album art fetching. Add exponential backoff for rate limit resilience.
+
+**Result**: SongRec is now the sole recognizer for live sources (radio, vinyl, BT, USB), bypassing Chromaprint/AcoustID entirely. AcoustID preserved for file sources. Album art cached locally from Shazam CDN. Exponential backoff (15/30/60/120s) on consecutive failures. Identification interval lowered to 15s, sample duration 15s — total cycle ~31s. Verified on vinyl: "Candy-O", "Heartbeat City", "Touch and Go" by The Cars all identified correctly.
+
+---
+
+## Phase 6: Play History Enhancements
+
+**Status**: complete (PR #287)
+
+**Goal**: Enrich play history entries with contextual information and album art.
+
+**Result**: Album art thumbnails displayed in history panel. Source icons (Radio/Vinyl/BT/File/USB) shown as fallback when no art available. Radio context string includes band/frequency/station name.
+
+---
+
+## Phase 7: UX Polish
+
+**Status**: complete (PR #288)
+
+**Goal**: Fix touch keyboard issues and improve radio preset naming.
+
+**Result**:
+- Virtual keyboard auto-shows when any input inside a MudBlazor dialog receives focus (`focusin` listener). Auto-hides on `focusout`. Z-index 10001 (above dialog overlay). Dialog paper shifts up 150px when keyboard opens via `body.keyboard-active` CSS class.
+- Fixed missing `<script type="module">` tag for `virtual-keyboard.js` in `App.razor`.
+- Fixed CSS descendant selector (`.mud-overlay .mud-paper` not direct child `>`).
+- Radio preset save dialog pre-fills with RDS station name when available (e.g., "WFJA"), falls back to "FM - 105.5 MHz" format.
+
+---
+
+## Phase 8: Session Persistence
+
+**Status**: complete (PR #288)
+
+**Goal**: Remember audio state across restarts so the system resumes where it left off.
+
+**Key finding**: Most state was already persisted — radio frequency/band, volume, output device, Cast, file player queue. The only gap was source auto-activation on startup.
+
+**Result**:
+- `AudioEngineInitializationService` now activates persisted source after volume restore: output device → volume/gain → source activation → BT pre-warm.
+- New `ActivatePersistedSourceAsync()` reads `AudioPreferences.CurrentSource`, calls `AudioManager.GetOrCreateSourceAsync()`. Falls back to Radio on invalid/missing value.
+- File player: added `_pendingSeekMs` field to restore playback position on first play after queue restoration.
+- Verified: FilePlayer activated from preferences on restart (was defaulting to Radio). Volume restored before source starts.
+
+---
+
+## Phase 9: Metrics Dashboard Redesign
+
+**Status**: pending
+
+**Goal**: Transform the metrics page from a flat list of cards into a modern, Grafana-inspired observability dashboard with time-series charts, stat cards with sparklines, gauge visualizations, and intuitive drill-down.
+
+**Design Inspiration**: Grafana stat panels + time-series charts, AWS CloudWatch dashboards, Google Cloud Monitoring. Key principles: F-reading pattern (critical KPIs top-left), one page = one decision, progressive disclosure, <12 panels per view.
+
+**Current State**:
+- Flat grid of metric cards with tiny SVG sparklines (~200×24px)
+- Categories via filter chips (left panel)
+- Time ranges: 1h, 24h, 7d
+- Click card → shows aggregate stats (count, avg, min, max, stddev)
+- No real time-series charts, no gauges, no drill-down detail view
+- Custom SVG sparklines (no charting library)
+- Data: SQLite with minute/hour/day rollup tables, retention 2h/48h/365d
+
+**Charting Approach**: MudBlazor has a built-in `MudTimeSeriesChart` component. Evaluate whether it's sufficient, or if a lightweight Chart.js wrapper (BlazorChartjs) provides better interactivity (zoom, hover tooltips, annotations). Prefer MudBlazor-native if it meets needs.
+
+**Layout Plan** (Grafana-inspired):
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Time Range: [5m] [1h] [24h] [7d] [30d]    [⟳ Auto-refresh]│
+├─────────────────────────────────────────────────────────────┤
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐          │
+│  │ CPU Temp│ │ Memory  │ │ Buffer  │ │ Underruns│ ← Stat   │
+│  │  42°C   │ │ 312 MB  │ │  47%    │ │   0     │   Cards   │
+│  │ ▁▂▃▅▃▂ │ │ ▃▃▄▅▆▅▄│ │ ▅▅▄▃▄▅▅│ │ ▁▁▁▁▁▁▁│   w/spark │
+│  └─────────┘ └─────────┘ └─────────┘ └─────────┘          │
+├─────────────────────────────────────────────────────────────┤
+│  Category: [All] [Audio] [System] [DB] [UI]                │
+├─────────────────────────────────────────────────────────────┤
+│  ┌───────────────────────────────────────────────────┐      │
+│  │  Time Series Chart (selected metric or group)     │      │
+│  │  ▁▂▃▅▇█▇▅▃▂▁▂▃▅▇█▇▅▃▂▁▂▃▅▇█▇▅▃▂▁              │      │
+│  │  ──────────────────────────────────                │      │
+│  │  10:00    10:15    10:30    10:45    11:00         │      │
+│  └───────────────────────────────────────────────────┘      │
+├─────────────────────────────────────────────────────────────┤
+│  Metric Detail Table (when drilled down)                    │
+│  Count: 1,234 │ Avg: 42.3 │ Min: 12 │ Max: 87 │ P95: 78  │
+└─────────────────────────────────────────────────────────────┘
+```
 
 **Steps**:
-1. Investigate if RTLSDRCore exposes raw IQ data or RDS decoding
-2. Research redsea CLI — can it read from RTL-SDR while our app is using it?
-3. If RTLSDRCore has RDS: add RDS text parsing to SDRRadioAudioSource
-4. If not: evaluate running redsea as a sidecar process with shared SDR access
-5. Parse RDS Radio Text (RT) for "Artist - Title" patterns
-6. Use RDS as primary metadata, fingerprinting as fallback for stations without RDS
-
-**Key challenge**: RTL-SDR is a single-user device. If our app is using it for audio demodulation, redsea can't access it simultaneously unless RTLSDRCore exposes RDS data.
+1. Evaluate MudBlazor `MudTimeSeriesChart` vs Chart.js wrapper — build a spike with real metric data
+2. Redesign stat cards: larger sparklines, color-coded thresholds (green/amber/red), gauge for percentages
+3. Add full-width time-series chart panel that shows the selected metric(s) over time
+4. Improve time range selector: add 5m and 30d options, auto-refresh toggle
+5. Add metric grouping/sections with collapsible rows (Audio, System, Database)
+6. Add drill-down: click stat card → expands time-series chart below with detail stats
+7. Responsive: works on 1920×720 touchscreen
 
 **Validation**:
-- Tune to FM station known to broadcast RDS
-- Verify station name (PS) and radio text (RT) are captured
-- Check if song title/artist appears in RT field
+- Dashboard loads in <2s with all metrics
+- Time-series chart shows smooth lines with hover tooltips
+- Switching time ranges updates all panels
+- Stat cards show current value + trend sparkline + threshold color
+- Touch-friendly: tap card to drill down, swipe time range
 
 ---
 
-## Phase 5: Strategy-Per-Source Architecture
+## Phase 10: Smart Fingerprinting (Remove AcoustID)
 
-**Goal**: Refactor identification pipeline to support pluggable strategies per source type.
+**Status**: pending
+
+**Goal**: Remove AcoustID/Chromaprint dependency entirely. Use SongRec for all recognition. Make fingerprinting event-driven for sources that have song boundaries (BT AVRCP, FilePlayer) — capture immediately on song start, stop once identified.
+
+**Current State**:
+- AcoustID used only for file sources (via `GenerateFingerprintFromFileAsync`)
+- SongRec used for all live sources (radio, vinyl, BT, USB)
+- Polling every 15s regardless of song state
+- BT already has `RequestImmediateIdentification()` on AVRCP metadata
+- FilePlayer already has `RequestImmediateIdentification()` on track load
+- `fpcalc` binary still required for Chromaprint fingerprint generation
+
+**Event-Driven Design**:
+```
+BT song starts → AVRCP metadata arrives
+  → If title+artist present: skip fingerprinting, just fetch cover art
+  → If incomplete: start SongRec capture immediately → identify → stop
+
+FilePlayer song starts → ID3/metadata read
+  → If complete metadata: skip fingerprinting, just fetch cover art
+  → If missing: SongRec capture → identify → stop
+
+Radio/Vinyl/USB → no song boundaries → keep polling (SongRec, 15s cycle)
+```
 
 **Steps**:
-1. Define `IIdentificationStrategy` interface with `IdentifyAsync(AudioSampleBuffer, AudioSourceType)` method
-2. Create strategy implementations: `ChromaprintStrategy`, `SongRecStrategy`, `ACRCloudStrategy`, `RDSStrategy`
-3. Create `IdentificationStrategyResolver` that selects strategy chain per source type
-4. Refactor `BackgroundIdentificationService` to use strategy resolver instead of hardcoded Chromaprint path
-5. Make strategy chains configurable via `appsettings.json`
+1. Remove AcoustID client, Chromaprint service, fpcalc dependency
+2. Route file source recognition through SongRec (capture from mixer, not file-based fingerprint)
+3. Add `IdentificationComplete` flag per song — once identified, stop capturing until next song change
+4. For BT: if AVRCP provides full metadata, skip SongRec entirely — just do cover art lookup
+5. For FilePlayer: if ID3 tags have title+artist, skip SongRec — just do cover art lookup
+6. For radio/vinyl/USB: keep current polling but add "identified" suppression (don't re-identify same song)
+7. Remove `fpcalc` from deployment, update tests
+8. Clean up unused interfaces, DTOs, config options
 
-**Default chains**:
-- File: Chromaprint/AcoustID only
-- Bluetooth: AVRCP → Chromaprint/AcoustID
-- FM Radio: RDS → SongRec → ACRCloud
-- Vinyl: Chromaprint+filter → SongRec → ACRCloud
-- Generic USB: Chromaprint → SongRec → ACRCloud
+**Files to modify**:
+- `BackgroundIdentificationService.cs` — event-driven logic, remove AcoustID path
+- `ChromaprintFingerprintService.cs` — delete or gut (remove fpcalc invocation)
+- `MetadataLookupService.cs` — remove AcoustID lookup, simplify to cache + MusicBrainz cover art
+- `AcoustIdClient.cs` — delete
+- `FingerprintingOptions.cs` — remove AcoustID-related options
+- `FingerprintingServiceExtensions.cs` — remove AcoustID DI registrations
+- Tests: update/remove AcoustID-specific tests
+
+**Validation**:
+- BT with AVRCP: metadata appears instantly, no SongRec call, cover art fetched
+- BT without AVRCP: SongRec identifies within ~20s of song start
+- FilePlayer with ID3 tags: metadata from tags, cover art fetched, no SongRec
+- FilePlayer without tags: SongRec identifies after playback starts
+- Radio/Vinyl: SongRec identifies, stops re-identifying same song
+- No `fpcalc` binary needed on deployment target
+- All tests pass
 
 ---
 
-## Phase 6: Fingerprint UI Enhancements
+## Phase 11: Radio Preset Naming Format
 
-**Goal**: Update fingerprint status UI to show identification method and color-code results.
+**Status**: pending
+
+**Goal**: Change preset auto-naming from `{RdsStationName}` or `{Band} - {Frequency}` to `{Band} {CallSign} {Frequency}`.
+
+**Current Code** (`RadioControlPanel.razor:1089-1098`):
+```csharp
+_presetName = !string.IsNullOrEmpty(_radioState.RdsStationName)
+  ? _radioState.RdsStationName
+  : $"{_radioState.Band} - {FormatFrequency(_radioState.Frequency, _radioState.Band)}";
+```
+
+**New Format**:
+```csharp
+// With RDS:  "FM WFJA 105.5 MHz"
+// Without:   "FM 105.5 MHz"
+_presetName = !string.IsNullOrEmpty(_radioState.RdsStationName)
+  ? $"{_radioState.Band} {_radioState.RdsStationName} {FormatFrequency(_radioState.Frequency, _radioState.Band)}"
+  : $"{_radioState.Band} {FormatFrequency(_radioState.Frequency, _radioState.Band)}";
+```
 
 **Steps**:
-1. Add `IdentificationMethod` field to status events (Chromaprint, SongRec, ACRCloud, RDS, AVRCP)
-2. Color-code results: green = matched, orange = no match, red = error
-3. Show which strategy was used for each identification attempt
-4. Show rate limits for ACRCloud (calls used / remaining this month)
+1. Update `OpenSavePresetDialog()` in `RadioControlPanel.razor`
+2. Test with RDS station (e.g., "FM WFJA 105.5 MHz")
+3. Test without RDS (e.g., "FM 105.5 MHz")
+
+---
+
+## Phase 12: Numeric Keypad Mode
+
+**Status**: pending
+
+**Goal**: Add a compact numeric keypad layout for number-only inputs (frequency entry, etc.) instead of showing the full QWERTY keyboard.
+
+**Current State**: Single QWERTY layout for all inputs. No `inputmode` detection. Keyboard is 5 rows × 10+ keys.
+
+**Design**:
+```
+┌─────────────────────┐
+│  7    8    9   ⌫    │
+│  4    5    6   .    │
+│  1    2    3   -    │
+│  0    00   ←→  Enter│
+└─────────────────────┘
+```
+
+**Detection Logic**: Show numeric keypad when:
+- Input has `type="number"` or `inputmode="numeric"` or `inputmode="decimal"`
+- Input has `data-keyboard="numeric"` attribute (explicit opt-in)
+- Otherwise show full QWERTY
+
+**Steps**:
+1. Add numeric keypad layout definition in `virtual-keyboard.js`
+2. Add input type detection in `show()` method
+3. Add CSS for compact keypad layout (fewer, larger keys)
+4. Add `data-keyboard="numeric"` to frequency input in RadioControlPanel
+5. Test: frequency dialog shows numpad, preset name shows QWERTY
+
+**Validation**:
+- Tap frequency input → compact numpad appears
+- Tap preset name input → full QWERTY appears
+- Numpad keys are larger (easier touch targets)
+- Decimal point available on numpad for frequency entry
+
+---
+
+## Phase 13: AB13X USB Input Debug
+
+**Status**: pending
+
+**Goal**: Diagnose and fix why the AB13X USB audio input is no longer playing audio.
+
+**Investigation Plan**:
+1. SSH to Ubuntu, check if AB13X device is physically connected and recognized:
+   - `lsusb | grep -i audio` or `AB13X`
+   - `arecord -l` to list ALSA capture devices
+   - `pw-cli list-objects | grep AB13X` to check PipeWire nodes
+2. Check configuration:
+   - `appsettings.Production.json` → `Devices:Radio:USBPort` or `Devices:GenericUSB`
+   - Config store (SQLite) for persisted device config
+3. Check logs for USB source initialization:
+   - `journalctl -u radio-api | grep -i "USB\|AB13X\|capture"`
+   - Look for "Could not find USB capture device" warning
+4. Check if device name changed (PipeWire may report different name than MiniAudio)
+5. Verify sample rate matching (48kHz capture ↔ 48kHz playback)
+6. Test manual capture: `pw-record --target=<node-id> test.wav` to verify device works
+
+**Potential Causes**:
+- Device not configured in `appsettings.Production.json`
+- Device name changed after PipeWire update
+- USB device physically disconnected or hub issue
+- Another process claimed exclusive access
+- Sample rate mismatch after engine change
+
+---
+
+## Phase 14: Audio Distortion / CPU Investigation
+
+**Status**: pending
+
+**Goal**: Diagnose periodic audio distortion that correlates with CPU-intensive UI operations (loading Web UI, loading metrics page).
+
+**Hypothesis**: CPU spikes from Blazor Server rendering or metrics DB queries starve the audio callback thread or ThreadPool, causing buffer underruns or lock contention.
+
+**Evidence**:
+- Distortion heard when starting Web UI (Blazor circuit init, component rendering)
+- Distortion heard when loading metrics page (DB queries, card rendering)
+- Shorter bursts than general distortion → suggests transient CPU spikes
+
+**Investigation Plan**:
+1. **Correlate distortion with metrics**: Monitor `audio.buffer.fill_percent` and `audio.buffer.underruns` while triggering UI load
+2. **CPU profiling**: `top -p <pid>` or `htop` during UI load to see CPU spike
+3. **ThreadPool starvation**: Check `ThreadPool.PendingWorkItemCount` during load — if high, async flushes from audio taps may be delayed
+4. **PipeWire xruns**: `journalctl -u pipewire | grep xrun` during distortion events
+5. **Buffer underrun logs**: Watch for "Buffer underrun" warnings in radio-api logs during UI load
+6. **Isolate**: Does distortion happen with radio source only, or all sources?
+
+**Potential Mitigations** (to test after diagnosis):
+- Increase `BufferedSoundGenerator` ring buffer from 2.0s to 4.0s
+- Increase PipeWire quantum from 512 to 1024 (adds latency but more headroom)
+- Move metrics DB queries to a background thread with lower priority
+- Add `ThreadPool.SetMinThreads()` to ensure minimum available threads
+- Offload Blazor SSR to separate process (unlikely to be worth it)
+- Add audio thread priority boosting (`nice -20` or SCHED_FIFO)
+
+**Validation**:
+- Load metrics page → no audible distortion
+- Start Web UI → no audible distortion
+- Sustained audio playback during heavy UI interaction → clean audio
 
 ---
 
@@ -148,9 +372,14 @@ Phase 2 — SongRec Integration (complete, needs deployment + vinyl testing)
 |----------|-----------|------|
 | Start with audio preprocessing (Phase 1) | Cheapest test — if high-pass filter fixes vinyl AcoustID, we may not need SongRec/ACRCloud for vinyl at all | 2026-03-04 |
 | SongRec before ACRCloud (Phase 2 before 3) | SongRec has no call limits; ACRCloud is limited to 5K/month. Test free option first. | 2026-03-04 |
-| RDS after SongRec (Phase 4) | RDS requires RTL-SDR investigation and may have device sharing constraints. SongRec is a simpler integration. | 2026-03-04 |
+| ACRCloud cancelled | SongRec working well for vinyl/radio song ID (~1s recognition). ACRCloud 5K/month not needed. | 2026-03-04 |
+| RDS scope narrowed to station name only | SongRec handles song identification. RDS only needed for station name (PS) display on RadioControlPanel. | 2026-03-04 |
 | No pitch correction for vinyl | User's direct-drive turntable doesn't have wow/flutter issues | 2026-03-04 |
 | High-pass at ~80Hz for vinyl preprocessing | Spectrum shows strong sub-100Hz rumble energy even during silence | 2026-03-04 |
+| SongRec as primary for live sources | AcoustID/Chromaprint designed for clean file matching; SongRec/Shazam designed for real-world recognition. SongRec proven across all live source types. | 2026-03-04 |
+| Poll-based song boundary detection | Detect song changes when SongRec returns a different result. No complex audio analysis (silence detection, spectral flux) — unreliable across source types and not worth complexity. | 2026-03-04 |
+| Strategy-per-source architecture cancelled | Simple if/else on source type sufficient. SongRec for live, AcoustID for files. No need for pluggable strategy framework. | 2026-03-04 |
+| Album art: SongRec first, MusicBrainz fallback | SongRec/Shazam often returns cover art URLs. MusicBrainz/Cover Art Archive as fallback. Cache locally. | 2026-03-04 |
 
 ## Errors Encountered
 


### PR DESCRIPTION
## Summary
- **Phase 11**: Radio preset auto-naming now uses `{Band} {CallSign} {Frequency}` format (e.g., "FM WFJA 105.5 MHz") instead of just call letters. Falls back to `{Band} {Frequency}` without RDS.
- **Phase 12**: Virtual keyboard auto-detects numeric inputs (`type="number"`, `inputmode="numeric/decimal"`, or `data-keyboard="numeric"`) and shows a compact 4x4 numpad with larger touch targets instead of the full QWERTY layout.

## Test plan
- [ ] Open Radio, tune to WFJA, save preset → name pre-fills as "FM WFJA 105.5 MHz"
- [ ] Save preset with no RDS → name shows "FM 105.5 MHz"
- [ ] Open frequency dialog → compact numpad appears (not QWERTY)
- [ ] Open preset name dialog → full QWERTY appears
- [ ] Numpad: tap digits, decimal point, backspace, enter all work
- [ ] Numpad keys are visibly larger than QWERTY keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)