### PR TITLE
fix: Skip PipeWire monitor devices in USB capture device matching

### DIFF
--- a/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
@@ -178,7 +178,10 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
       {
         // Match by device name containing the USB port identifier
         // USB devices on Linux typically include card/device info in the name
-        if (device.Name.Contains(usbPort, StringComparison.OrdinalIgnoreCase))
+        // Skip "Monitor of ..." devices — these are PipeWire loopbacks of output sinks,
+        // not physical audio inputs
+        if (device.Name.Contains(usbPort, StringComparison.OrdinalIgnoreCase) &&
+            !device.Name.StartsWith("Monitor of", StringComparison.OrdinalIgnoreCase))
         {
           targetDevice = device;
           break;


### PR DESCRIPTION
## Summary
- USB capture device matching searched for devices containing the port name (e.g., "AB13X")
- PipeWire exposes "Monitor of AB13X USB Audio Analog Stereo" loopback sources alongside the real input
- The monitor matched first, capturing silence from the idle output sink instead of physical audio input
- Fix: skip devices whose name starts with "Monitor of" during matching

## Test plan
- [x] Deploy to Ubuntu, switch to GenericUSB source
- [x] Verify logs show actual input device ("AB13X USB Audio Analog Stereo") not monitor
- [x] Confirm audio is audible through speakers
- [x] Confirm visualizer shows activity
- [x] Confirm SongRec captures audio (15s, ~-26dB RMS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)