### PR TITLE
fix: Clear BT audio buffer on song transitions, fix CI flaky test

### DIFF
--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -240,11 +240,13 @@ public class BluetoothAudioSource : USBAudioSourceBase
 
   public override async Task NextAsync(CancellationToken cancellationToken = default)
   {
+    ClearAudioBuffer();
     await _bluetoothService.NextTrackAsync(cancellationToken);
   }
 
   public override async Task PreviousAsync(CancellationToken cancellationToken = default)
   {
+    ClearAudioBuffer();
     await _bluetoothService.PreviousTrackAsync(cancellationToken);
   }
 
@@ -285,6 +287,20 @@ public class BluetoothAudioSource : USBAudioSourceBase
 
     _routeLock.Dispose();
     await base.DisposeAsyncCore();
+  }
+
+  private void ClearAudioBuffer()
+  {
+    if (_captureGenerator != null)
+    {
+      _captureGenerator.ClearBuffer();
+      Logger.LogDebug("BluetoothAudioSource: cleared audio buffer on song change");
+    }
+    else if (SoundComponent is BufferedSoundGenerator<float> generator)
+    {
+      generator.ClearBuffer();
+      Logger.LogDebug("BluetoothAudioSource: cleared PipeWire audio buffer on song change");
+    }
   }
 
   private void SetConnectedDeviceMetadata()
@@ -589,6 +605,10 @@ public class BluetoothAudioSource : USBAudioSourceBase
   private void OnMetadataChanged(object? sender, BluetoothPlaybackMetadata e)
   {
     if (e == null) return;
+
+    // Clear stale audio from the previous song so the new track is heard immediately
+    // rather than draining 0.8-2.0s of buffered audio from the old song.
+    ClearAudioBuffer();
 
     // AVRCP metadata arriving means a media player is attached — enable next/prev
     _hasMediaPlayer = true;

--- a/src/Radio.Web/Components/Pages/RadioPage.razor
+++ b/src/Radio.Web/Components/Pages/RadioPage.razor
@@ -243,10 +243,17 @@
     await LoadRadioStateAsync();
     await LoadPresetsAsync();
     await LoadBandsAsync();
-    
+
     // Subscribe to SignalR radio state changes
     HubService.RadioStateChanged += HandleRadioStateChanged;
-    await HubService.StartAsync();
+    try
+    {
+      await HubService.StartAsync();
+    }
+    catch (Exception ex)
+    {
+      Logger.LogWarning(ex, "Failed to connect to SignalR hub — radio page will not receive live updates");
+    }
   }
   
   private async Task LoadBandsAsync()


### PR DESCRIPTION
## Summary
- **Clear audio buffer on BT song transitions** to eliminate 0.8-2.0s of stale audio delay when skipping songs via AVRCP. `ClearAudioBuffer()` is called in `OnMetadataChanged` (universal trigger for all transitions) and proactively in `NextAsync`/`PreviousAsync` (fastest response for user-initiated skips).
- **Fix CI flaky test** `RadioPage_StructureIsValid` by wrapping `HubService.StartAsync()` in try/catch, preventing `Connection refused` crashes when no API server is running (matches existing `SystemConfigPage` pattern).

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings
- [x] `dotnet test --configuration Release` — all tests pass
- [ ] Deploy to Ubuntu, connect phone via BT, play music
- [ ] Skip songs via AVRCP Next — verify new song audio starts within ~100-200ms, not 1-2s
- [ ] Verify no underruns or glitches during transition (check logs for `Missed callback deadline`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)