### PR TITLE
perf: Reduce GC pressure and memory allocations (R2)

### DIFF
--- a/progress.md
+++ b/progress.md
@@ -1,6 +1,77 @@
 # Progress Log
 
-## Session: 2026-03-05
+## Session: 2026-03-05 (R2 perf optimization)
+
+### R2: Performance & Memory Deep Dive — Implementation
+
+All 4 phases implemented, build passes (0 warnings), all 1,406 tests pass.
+
+**Phase 1: Audio Thread GC Pressure**
+- [x] 1A: SoundFlowAudioTap — ArrayPool for large buffers, reusable chunk buffer, deferred float[] until after silence check
+- [x] 1B: BufferedSoundGenerator — GC.CollectionCount moved to LogStats timer, audio callback uses Volatile.Read
+- [x] 1C: TappedOutputStream — Two-chunk linear write replaces per-sample modulo (192K→94 ops/sec)
+
+**Phase 2: Redundant Network & Serialization**
+- [x] 2A: AudioStateUpdateService — Lightweight snapshot comparison before DTO construction
+- [x] 2B: NowPlayingPanel — Poll interval 10s→60s, skip if SignalR event within 30s
+- [x] 2C: AudioStateHubService + NowPlayingPanel — Typed SignalR payloads (NowPlayingDto, VolumeDto) used directly
+
+**Phase 3: UI Render Efficiency**
+- [x] 3A: NowPlayingPanel — Gain debounce timer reused via .Change() instead of dispose+recreate
+- [x] 3B: RadioControlPanel — Presets sorted on load, not per render
+- [x] 3C: NowPlayingPanel — Reversed fingerprint events cached in field
+- [x] 3D: PlayHistoryTracker — Static readonly fallback string arrays
+
+**Phase 4: Background Service Efficiency**
+- [x] 4A: BackgroundIdentificationService — Version-tracked cached status snapshot
+
+**Files modified (9 + 1 test fix):**
+- `SoundFlowAudioTap.cs`, `BufferedSoundGenerator.cs`, `TappedOutputStream.cs`
+- `AudioStateUpdateService.cs`, `NowPlayingPanel.razor`, `AudioStateHubService.cs`, `MainLayout.razor`
+- `RadioControlPanel.razor`, `PlayHistoryTracker.cs`, `BackgroundIdentificationService.cs`
+- `AudioStateHubServiceTests.cs` (updated for typed event signatures)
+
+### Key Files Modified
+- 10 production files, 1 test file
+
+### Test Results
+- `dotnet build --configuration Release` — 0 warnings, 0 errors
+- `dotnet test --configuration Release` — 1,406 tests passed across 7 projects
+
+---
+
+## Session: 2026-03-05 (continued)
+
+### Completed This Session
+
+- [x] Investigated why BT fingerprinting wasn't running despite UseShazamForAllSources=true
+- [x] Root cause: IOptions<T> reads from appsettings.json (false), UI toggle writes to SQLite (true)
+- [x] Fix: Added `SyncFingerprintingOptionsFromStore()` in AudioSourceFactory
+- [x] Committed `4235978`, pushed, deployed — BT fingerprinting confirmed working
+- [x] Found second bug: BT source stays in Ready state (not Playing) after service restart
+- [x] Root cause: PlaybackStatusChanged fires during StartAsync() before State=Ready
+- [x] Fix: Check PlaybackStatus metadata after InitializeAsync sets State=Ready
+- [x] Committed `5562fcd`, pushed to main, deployed — BT state transition confirmed working
+- [x] Merged PR #294 (Shazam for all sources, GC pressure fixes, instrumentation)
+- [x] Added config unification research item (R1) to task_plan.md
+- [x] Added distortion/SSH correlation and config store duplication notes to MEMORY.md
+
+### Commits This Session
+- `4235978` fix: Sync UseShazamForAllSources from config store to fix BT fingerprinting
+- `831c005` docs: Update investigation findings, progress, and config unification research item
+- `5562fcd` fix: Race condition where BT source stays Ready when phone is already playing
+
+### Key Files Modified
+- `src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs` — SyncFingerprintingOptionsFromStore()
+- `src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs` — InitializeAsync race fix
+
+### Test Results
+- `dotnet build --configuration Release` — 0 warnings
+- `dotnet test --configuration Release` — 75 tests passed, 3 skipped
+- BT fingerprinting confirmed working on Ubuntu deploy
+- BT state transition to Playing confirmed working after restart
+
+## Session: 2026-03-05 (earlier)
 
 ### Phase 1: Analysis & Research
 
@@ -15,14 +86,14 @@
 - [x] Noted source state anomaly: 49% "Ready" during active audio playback
 - [x] Wrote findings.md with ranked possible root causes
 
-### Files Read (Research Only)
-- `src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs` (lines 90-327)
-- `src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs` (lines 200-270)
-- `src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs` (lines 365-425)
-- `src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs` (lines 935-966)
+### Phase 2-3: GC Pressure + Instrumentation (previous context window)
 
-### Files Modified
-(none — research only)
-
-### Test Results
-(none — research only)
+- [x] Lock-free BufferedTapModifier (eliminated 192K lock ops/sec)
+- [x] Pre-allocated mono buffer in VisualizerService
+- [x] Cached metrics tags in BufferedSoundGenerator
+- [x] GC SustainedLowLatency mode in SoundFlowAudioEngine
+- [x] Removed DateTime.UtcNow from TappedOutputStream hot path
+- [x] Span-based S16→float conversion in PipeWireNativeStream
+- [x] Callback timing instrumentation in BufferedSoundGenerator
+- [x] Limiter engagement instrumentation in LimiterModifier
+- [x] Throttled per-miss logging (fixed journald feedback loop at 91.7% CPU)

--- a/src/Radio.API/Services/AudioStateUpdateService.cs
+++ b/src/Radio.API/Services/AudioStateUpdateService.cs
@@ -51,6 +51,8 @@ public class AudioStateUpdateService : BackgroundService
   private PlaybackStateDto? _lastPlaybackState;
   private NowPlayingDto? _lastNowPlaying;
   private List<QueueItemDto>? _lastQueue;
+  // Lightweight queue snapshot for cheap change detection (avoids building full DTOs every 500ms)
+  private List<(string Id, int Index, bool IsCurrent, string State)>? _lastQueueSnapshot;
   private RadioStateDto? _lastRadioState;
   private VolumeDto? _lastVolume;
   private string? _lastActiveSourceType;
@@ -374,17 +376,25 @@ public class AudioStateUpdateService : BackgroundService
 
     // Use full playlist so UI always gets played + current + upcoming with state
     var fullPlaylist = await playQueue.GetFullPlaylistAsync(cancellationToken);
+
+    // Build lightweight snapshot first for cheap change detection.
+    // Only construct full DTOs when something actually changed.
+    var snapshot = fullPlaylist
+      .Select(item => (item.Id, item.Index, item.IsCurrent, State: item.State.ToString()))
+      .ToList();
+
+    if (!HasQueueSnapshotChanged(_lastQueueSnapshot, snapshot))
+      return;
+
     var currentQueue = fullPlaylist
       .Select(MapToQueueItemDto)
       .ToList();
 
-    if (HasQueueChanged(_lastQueue, currentQueue))
-    {
-      _lastQueue = currentQueue;
-      await _hubContext.Clients.Group("Queue")
-        .SendAsync("QueueChanged", currentQueue, cancellationToken);
-      _logger.LogDebug("Broadcast QueueChanged with {Count} items", currentQueue.Count);
-    }
+    _lastQueueSnapshot = snapshot;
+    _lastQueue = currentQueue;
+    await _hubContext.Clients.Group("Queue")
+      .SendAsync("QueueChanged", currentQueue, cancellationToken);
+    _logger.LogDebug("Broadcast QueueChanged with {Count} items", currentQueue.Count);
   }
 
   private async Task CheckRadioStateAsync(IAudioSource? activeSource, CancellationToken cancellationToken)
@@ -475,27 +485,22 @@ public class AudioStateUpdateService : BackgroundService
            previous.Duration != current.Duration; // Duration can change on track change
   }
 
-  private static bool HasQueueChanged(List<QueueItemDto>? previous, List<QueueItemDto>? current)
+  private static bool HasQueueSnapshotChanged(
+    List<(string Id, int Index, bool IsCurrent, string State)>? previous,
+    List<(string Id, int Index, bool IsCurrent, string State)>? current)
   {
     if (previous == null || current == null)
-    {
       return true;
-    }
     if (previous.Count != current.Count)
-    {
       return true;
-    }
 
-    // Check if items are the same (by ID, order, and state)
     for (int i = 0; i < previous.Count; i++)
     {
       if (previous[i].Id != current[i].Id ||
           previous[i].Index != current[i].Index ||
           previous[i].IsCurrent != current[i].IsCurrent ||
           previous[i].State != current[i].State)
-      {
         return true;
-      }
     }
 
     return false;

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/BackgroundIdentificationService.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/BackgroundIdentificationService.cs
@@ -43,6 +43,13 @@ public sealed class BackgroundIdentificationService : BackgroundService
   private string? _lastError;
   private string? _currentSourceName;
 
+  // Cached status snapshot — only rebuilt when _eventsVersion changes.
+  // GetStatus() is called every ~3s by the API; caching avoids rebuilding
+  // 40 record copies + List + ReadOnlyCollection on every call.
+  private long _eventsVersion;
+  private FingerprintStatusSnapshot? _cachedSnapshot;
+  private long _cachedSnapshotVersion = -1;
+
   // Event log — circular buffer of recent events, capped at MaxRecentEvents
   private const int MaxRecentEvents = 40;
   private readonly List<FingerprintEventRecord> _recentEvents = new(MaxRecentEvents + 1);
@@ -89,13 +96,27 @@ public sealed class BackgroundIdentificationService : BackgroundService
 
   /// <summary>
   /// Returns the current fingerprint identification status snapshot.
+  /// Uses a cached snapshot that is only rebuilt when events change.
   /// </summary>
   public FingerprintStatusSnapshot GetStatus()
   {
     lock (_statusLock)
     {
+      if (_cachedSnapshot != null && _cachedSnapshotVersion == _eventsVersion)
+      {
+        // Snapshot is still valid — only refresh rate counters (cheap)
+        PruneRateTimestamps();
+        return _cachedSnapshot with
+        {
+          Phase = _currentPhase,
+          FingerprintsPerMinute = ComputeRate(_fingerprintTimestamps),
+          MetadataCallsPerMinute = ComputeRate(_metadataCallTimestamps),
+          LastError = _lastError
+        };
+      }
+
       PruneRateTimestamps();
-      return new FingerprintStatusSnapshot
+      _cachedSnapshot = new FingerprintStatusSnapshot
       {
         Phase = _currentPhase,
         IsEnabled = _options.Enabled,
@@ -104,6 +125,8 @@ public sealed class BackgroundIdentificationService : BackgroundService
         RecentEvents = _recentEvents.Select(e => e with { }).ToList().AsReadOnly(),
         LastError = _lastError
       };
+      _cachedSnapshotVersion = _eventsVersion;
+      return _cachedSnapshot;
     }
   }
 
@@ -426,6 +449,7 @@ public sealed class BackgroundIdentificationService : BackgroundService
         _currentEvent.Phase = phase;
         _currentEvent.Timestamp = DateTime.UtcNow;
       }
+      _eventsVersion++;
     }
     FireStatusChanged();
   }
@@ -448,6 +472,7 @@ public sealed class BackgroundIdentificationService : BackgroundService
         _recentEvents.Add(_currentEvent);
         if (_recentEvents.Count > MaxRecentEvents)
           _recentEvents.RemoveAt(0);
+        _eventsVersion++;
       }
     }
   }
@@ -461,6 +486,8 @@ public sealed class BackgroundIdentificationService : BackgroundService
     lock (_statusLock)
     {
       if (_currentEvent == null) return;
+
+      _eventsVersion++;
 
       // Aggregate if same source, same title, and already a match row
       if (_currentEvent.IsMatch && _currentEvent.Title == metadata.Title)
@@ -515,6 +542,8 @@ public sealed class BackgroundIdentificationService : BackgroundService
     lock (_statusLock)
     {
       if (_currentEvent == null) return;
+
+      _eventsVersion++;
 
       // Aggregate into existing no-match row (or fresh empty row from EnsureCurrentEvent)
       if (!_currentEvent.IsMatch)

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/SoundFlowAudioTap.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/SoundFlowAudioTap.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using Microsoft.Extensions.Logging;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
@@ -15,6 +16,9 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
   private readonly ILogger<SoundFlowAudioTap> _logger;
   private readonly IAudioEngine _audioEngine;
   private readonly IAudioManager _audioManager;
+
+  // Reusable chunk buffer — avoids allocating a new byte[4096] per loop iteration
+  private readonly byte[] _chunkBuffer = new byte[4096];
 
   /// <summary>
   /// Initializes a new instance of the <see cref="SoundFlowAudioTap"/> class.
@@ -136,7 +140,10 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
       _logger.LogDebug("Expecting to read {Bytes} bytes ({Samples} samples) for {Duration}s at {SampleRate}Hz {Channels}ch",
         bytesToRead, totalSamples, duration.TotalSeconds, sampleRate, channels);
 
-      var buffer = new byte[bytesToRead];
+      // Rent from ArrayPool to avoid LOH allocation (~2.7MB)
+      var buffer = ArrayPool<byte>.Shared.Rent(bytesToRead);
+      try
+      {
       var bytesRead = 0;
 
       // IMPORTANT: Use ReadAsync with real-time pacing, not sync Read.
@@ -153,10 +160,9 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
       while (stopwatch.Elapsed < duration && bytesRead < bytesToRead && !ct.IsCancellationRequested)
       {
         var remaining = bytesToRead - bytesRead;
-        var chunkSize = Math.Min(remaining, 4096);
-        var tempBuffer = new byte[chunkSize];
+        var chunkSize = Math.Min(remaining, _chunkBuffer.Length);
 
-        var read = await stream.ReadAsync(tempBuffer, 0, chunkSize, ct);
+        var read = await stream.ReadAsync(_chunkBuffer, 0, chunkSize, ct);
         readAttempts++;
 
         if (read > 0)
@@ -165,7 +171,7 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
           bool hasAudio = false;
           for (int i = 0; i < read; i += 2)
           {
-            if (i + 1 < read && (tempBuffer[i] != 0 || tempBuffer[i + 1] != 0))
+            if (i + 1 < read && (_chunkBuffer[i] != 0 || _chunkBuffer[i + 1] != 0))
             {
               hasAudio = true;
               break;
@@ -174,7 +180,7 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
 
           if (hasAudio)
           {
-            Buffer.BlockCopy(tempBuffer, 0, buffer, bytesRead, read);
+            Buffer.BlockCopy(_chunkBuffer, 0, buffer, bytesRead, read);
             bytesRead += read;
           }
           else
@@ -197,24 +203,19 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
       _logger.LogDebug("Read {BytesRead} bytes in {Attempts} attempts over {Elapsed}ms",
         bytesRead, readAttempts, captureElapsed);
 
-      // Convert bytes to float samples
+      // RMS silence check on raw PCM shorts — avoids allocating a float[] (~5.5MB LOH)
+      // when audio is silence (the common case during idle).
       var sampleCount = bytesRead / bytesPerSample;
-      var samples = new float[sampleCount];
-      for (int i = 0; i < sampleCount; i++)
-      {
-        var byteIndex = i * bytesPerSample;
-        if (byteIndex + 1 < buffer.Length)
-        {
-          var pcm = (short)(buffer[byteIndex] | (buffer[byteIndex + 1] << 8));
-          samples[i] = pcm / (float)short.MaxValue;
-        }
-      }
-
-      // RMS silence check: skip if captured audio is below -60dB
       var sumSquares = 0.0;
       for (int i = 0; i < sampleCount; i++)
       {
-        sumSquares += samples[i] * samples[i];
+        var byteIndex = i * bytesPerSample;
+        if (byteIndex + 1 < bytesRead)
+        {
+          var pcm = (short)(buffer[byteIndex] | (buffer[byteIndex + 1] << 8));
+          var normalized = pcm / (double)short.MaxValue;
+          sumSquares += normalized * normalized;
+        }
       }
       var rms = Math.Sqrt(sumSquares / sampleCount);
       var rmsDb = rms > 0 ? 20 * Math.Log10(rms) : -100;
@@ -223,6 +224,18 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
       {
         _logger.LogDebug("Captured audio is silence (RMS: {RmsDb:F1}dB), skipping identification", rmsDb);
         return null;
+      }
+
+      // Audio passed silence check — now convert bytes to float samples
+      var samples = new float[sampleCount];
+      for (int i = 0; i < sampleCount; i++)
+      {
+        var byteIndex = i * bytesPerSample;
+        if (byteIndex + 1 < bytesRead)
+        {
+          var pcm = (short)(buffer[byteIndex] | (buffer[byteIndex + 1] << 8));
+          samples[i] = pcm / (float)short.MaxValue;
+        }
       }
 
       var actualDuration = (double)sampleCount / sampleRate / channels;
@@ -237,6 +250,11 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
         Duration = TimeSpan.FromSeconds(actualDuration),
         SourceName = SourceName
       };
+      }
+      finally
+      {
+        ArrayPool<byte>.Shared.Return(buffer);
+      }
     }
     catch (Exception ex)
     {

--- a/src/Radio.Infrastructure/Audio/Services/PlayHistoryTracker.cs
+++ b/src/Radio.Infrastructure/Audio/Services/PlayHistoryTracker.cs
@@ -23,6 +23,13 @@ public class PlayHistoryTracker : IDisposable
   private readonly IBluetoothService _bluetoothService;
   private readonly IMetricsCollector? _metricsCollector;
 
+  // Pre-allocated fallback title arrays for placeholder detection —
+  // avoids allocating new string[] on every IsPlaceholderMetadata call.
+  private static readonly string[] BluetoothFallbackTitles = ["Bluetooth Audio", "Bluetooth"];
+  private static readonly string[] VinylFallbackTitles = ["Vinyl"];
+  private static readonly string[] UsbFallbackTitles = ["USB Audio", "Generic USB Audio"];
+  private static readonly string[] RadioFallbackTitles = ["SDR Radio", "Radio"];
+
   private string? _currentPlayHistoryEntryId;
   private bool _disposed;
 
@@ -295,13 +302,13 @@ public class PlayHistoryTracker : IDisposable
     if (fallbackArtist != null && string.Equals(artist, fallbackArtist, StringComparison.OrdinalIgnoreCase))
       return true;
 
-    // Source-type fallback titles
+    // Source-type fallback titles (static readonly arrays to avoid per-call allocations)
     var fallbackTitles = source switch
     {
-      PlaySource.Bluetooth => new[] { "Bluetooth Audio", "Bluetooth" },
-      PlaySource.Vinyl => new[] { "Vinyl" },
-      PlaySource.GenericUSB => new[] { "USB Audio", "Generic USB Audio" },
-      PlaySource.Radio => new[] { "SDR Radio", "Radio" },
+      PlaySource.Bluetooth => BluetoothFallbackTitles,
+      PlaySource.Vinyl => VinylFallbackTitles,
+      PlaySource.GenericUSB => UsbFallbackTitles,
+      PlaySource.Radio => RadioFallbackTitles,
       _ => Array.Empty<string>()
     };
     if (fallbackTitles.Any(f => string.Equals(title, f, StringComparison.OrdinalIgnoreCase)))

--- a/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
@@ -72,10 +72,14 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
     private long _generateAudioContentionCount;
     private double _maxGenerateAudioLockWaitMs;
 
-    // GC pause correlation
-    private int _lastGen0Count;
-    private int _lastGen1Count;
-    private int _lastGen2Count;
+    // GC pause correlation — counts are sampled in LogStats (every 10s) and cached
+    // via Volatile so the audio callback avoids GC.CollectionCount() syscalls.
+    private int _cachedGen0Count;
+    private int _cachedGen1Count;
+    private int _cachedGen2Count;
+    private int _prevGen0Count;
+    private int _prevGen1Count;
+    private int _prevGen2Count;
     private long _gcCorrelatedMissedDeadlines;
 
     // Throttle per-miss logging to avoid overwhelming journald
@@ -224,10 +228,12 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
             if (intervalMs > expectedMs * 2)
             {
                 _missedDeadlineCount++;
-                var gen0 = GC.CollectionCount(0);
-                var gen1 = GC.CollectionCount(1);
-                var gen2 = GC.CollectionCount(2);
-                if (gen0 != _lastGen0Count || gen1 != _lastGen1Count || gen2 != _lastGen2Count)
+                // Read cached GC counts (sampled every 10s in LogStats) to avoid
+                // GC.CollectionCount() syscalls on the audio callback thread.
+                var gen0 = Volatile.Read(ref _cachedGen0Count);
+                var gen1 = Volatile.Read(ref _cachedGen1Count);
+                var gen2 = Volatile.Read(ref _cachedGen2Count);
+                if (gen0 != _prevGen0Count || gen1 != _prevGen1Count || gen2 != _prevGen2Count)
                 {
                     _gcCorrelatedMissedDeadlines++;
                     // Throttle per-miss logging to once per 5s to avoid overwhelming journald
@@ -240,12 +246,12 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
                             "🔬 Missed callback deadline ({Interval:F1}ms) with GC activity: " +
                             "Gen0 +{G0}, Gen1 +{G1}, Gen2 +{G2}",
                             intervalMs,
-                            gen0 - _lastGen0Count, gen1 - _lastGen1Count, gen2 - _lastGen2Count);
+                            gen0 - _prevGen0Count, gen1 - _prevGen1Count, gen2 - _prevGen2Count);
                     }
                 }
-                _lastGen0Count = gen0;
-                _lastGen1Count = gen1;
-                _lastGen2Count = gen2;
+                _prevGen0Count = gen0;
+                _prevGen1Count = gen1;
+                _prevGen2Count = gen2;
             }
         }
         _lastGenerateAudioTimestamp = callbackStartTicks;
@@ -442,6 +448,12 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
         var now = DateTime.UtcNow;
         if ((now - _lastLogTime).TotalSeconds >= 10)
         {
+            // Sample GC collection counts here (every 10s) so the audio callback
+            // can read cached values via Volatile.Read instead of making syscalls.
+            Volatile.Write(ref _cachedGen0Count, GC.CollectionCount(0));
+            Volatile.Write(ref _cachedGen1Count, GC.CollectionCount(1));
+            Volatile.Write(ref _cachedGen2Count, GC.CollectionCount(2));
+
             int currentBuffer;
             lock (_bufferLock)
             {

--- a/src/Radio.Infrastructure/Audio/SoundFlow/TappedOutputStream.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/TappedOutputStream.cs
@@ -195,6 +195,7 @@ internal sealed class TappedOutputStream : Stream
   /// <summary>
   /// Writes audio samples from the engine to the ring buffer.
   /// Converts float samples (-1.0 to 1.0) to 16-bit PCM.
+  /// Uses two-chunk linear writes to avoid per-sample modulo ops.
   /// </summary>
   /// <param name="samples">The float samples to write.</param>
   public void WriteFromEngine(float[] samples)
@@ -204,21 +205,10 @@ internal sealed class TappedOutputStream : Stream
     lock (_lock)
     {
       _totalWriteCalls++;
-      _totalBytesWritten += samples.Length * _bytesPerSample;
+      var totalBytes = samples.Length * _bytesPerSample;
+      _totalBytesWritten += totalBytes;
 
-      foreach (var sample in samples)
-      {
-        // Clamp and convert float to 16-bit PCM
-        var clampedSample = Math.Clamp(sample, -1f, 1f);
-        var pcm = (short)(clampedSample * short.MaxValue);
-
-        // Write low byte then high byte (little-endian)
-        _buffer[_writePosition] = (byte)(pcm & 0xFF);
-        _writePosition = (_writePosition + 1) % _bufferSize;
-
-        _buffer[_writePosition] = (byte)((pcm >> 8) & 0xFF);
-        _writePosition = (_writePosition + 1) % _bufferSize;
-      }
+      WriteSamplesLinear(samples, 0, samples.Length);
     }
 
     ReportMetrics();
@@ -227,6 +217,7 @@ internal sealed class TappedOutputStream : Stream
   /// <summary>
   /// Writes audio samples from the engine to the ring buffer.
   /// Converts float samples (-1.0 to 1.0) to 16-bit PCM.
+  /// Uses two-chunk linear writes to avoid per-sample modulo ops.
   /// </summary>
   /// <param name="samples">The samples span to write.</param>
   /// <param name="count">The number of samples to write.</param>
@@ -239,22 +230,50 @@ internal sealed class TappedOutputStream : Stream
       _totalWriteCalls++;
       _totalBytesWritten += count * _bytesPerSample;
 
-      for (var i = 0; i < count; i++)
-      {
-        // Clamp and convert float to 16-bit PCM
-        var clampedSample = Math.Clamp(samples[i], -1f, 1f);
-        var pcm = (short)(clampedSample * short.MaxValue);
-
-        // Write low byte then high byte (little-endian)
-        _buffer[_writePosition] = (byte)(pcm & 0xFF);
-        _writePosition = (_writePosition + 1) % _bufferSize;
-
-        _buffer[_writePosition] = (byte)((pcm >> 8) & 0xFF);
-        _writePosition = (_writePosition + 1) % _bufferSize;
-      }
+      WriteSamplesLinear(samples, 0, count);
     }
 
     ReportMetrics();
+  }
+
+  /// <summary>
+  /// Converts float samples to 16-bit PCM and writes to the ring buffer using
+  /// linear chunks. Splits the write at the buffer boundary to avoid per-sample
+  /// modulo operations (reduces from ~192K mod/sec to ~94/sec at 48kHz stereo).
+  /// Must be called under _lock.
+  /// </summary>
+  private void WriteSamplesLinear(ReadOnlySpan<float> samples, int offset, int count)
+  {
+    // How many samples fit before the write position wraps?
+    var bytesBeforeWrap = _bufferSize - _writePosition;
+    var samplesBeforeWrap = bytesBeforeWrap / _bytesPerSample;
+    var firstChunkCount = Math.Min(count, samplesBeforeWrap);
+
+    // First chunk: write linearly from _writePosition
+    var wp = _writePosition;
+    for (var i = offset; i < offset + firstChunkCount; i++)
+    {
+      var pcm = (short)(Math.Clamp(samples[i], -1f, 1f) * short.MaxValue);
+      _buffer[wp] = (byte)(pcm & 0xFF);
+      _buffer[wp + 1] = (byte)((pcm >> 8) & 0xFF);
+      wp += _bytesPerSample;
+    }
+
+    // Second chunk: wrap to start of buffer
+    var secondChunkCount = count - firstChunkCount;
+    if (secondChunkCount > 0)
+    {
+      wp = 0;
+      for (var i = offset + firstChunkCount; i < offset + count; i++)
+      {
+        var pcm = (short)(Math.Clamp(samples[i], -1f, 1f) * short.MaxValue);
+        _buffer[wp] = (byte)(pcm & 0xFF);
+        _buffer[wp + 1] = (byte)((pcm >> 8) & 0xFF);
+        wp += _bytesPerSample;
+      }
+    }
+
+    _writePosition = (_writePosition + count * _bytesPerSample) % _bufferSize;
   }
 
   private void ReportMetrics()

--- a/src/Radio.Web/Components/Layout/MainLayout.razor
+++ b/src/Radio.Web/Components/Layout/MainLayout.razor
@@ -692,7 +692,7 @@
     await InvokeAsync(StateHasChanged);
   }
 
-  private async Task OnNowPlayingChanged()
+  private async Task OnNowPlayingChanged(NowPlayingDto? _)
   {
     await InvokeAsync(StateHasChanged);
   }

--- a/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
@@ -49,9 +49,9 @@
               </tr>
             </thead>
             <tbody>
-              @if (_fpStatus?.RecentEvents != null)
+              @if (_fpEventsReversed != null)
               {
-                @foreach (var evt in _fpStatus.RecentEvents.AsEnumerable().Reverse())
+                @foreach (var evt in _fpEventsReversed)
                 {
                   <tr style="border-bottom: 1px solid rgba(255,255,255,0.04); height: 22px; color: @(GetEventRowColor(evt));">
                     <td style="text-align: center; padding: 3px 4px;" title="@evt.SourceType">
@@ -286,6 +286,9 @@
   private double _totalDurationSeconds;
   // Fingerprint status state
   private FingerprintStatusDto? _fpStatus;
+  // Pre-reversed event list cached when fingerprint status refreshes,
+  // avoids calling .Reverse() on every render.
+  private List<FingerprintEventDto>? _fpEventsReversed;
   private bool _showFingerprintDetail;
 
   // Source gain state
@@ -297,6 +300,8 @@
 
   // Periodic fallback poll for now playing updates (safety net for missed SignalR events)
   private System.Threading.Timer? _nowPlayingPollTimer;
+  // Tracks when the last SignalR event was received to skip redundant polls
+  private DateTime _lastSignalREventUtc = DateTime.MinValue;
 
   private bool _hasValidAlbumArt =>
     !_albumArtFailed
@@ -321,11 +326,12 @@
 
       // Periodic fallback poll for now playing updates. Catches track identifications
       // or metadata changes if a SignalR NowPlayingChanged event is missed.
+      // 60s interval — SignalR provides real-time updates; this is a safety net only.
       _nowPlayingPollTimer = new System.Threading.Timer(
         async _ => await OnNowPlayingPollAsync(),
         null,
-        TimeSpan.FromSeconds(10),
-        TimeSpan.FromSeconds(10));
+        TimeSpan.FromSeconds(60),
+        TimeSpan.FromSeconds(60));
     }
     catch (Exception ex)
     {
@@ -335,32 +341,54 @@
 
   private async Task OnPlaybackStateChanged()
   {
+    _lastSignalREventUtc = DateTime.UtcNow;
     await RefreshPlaybackStateAsync();
     await InvokeAsync(StateHasChanged);
   }
 
-  private async Task OnNowPlayingChanged()
+  private async Task OnNowPlayingChanged(NowPlayingDto? dto)
   {
-    await RefreshPlaybackStateAsync();
+    _lastSignalREventUtc = DateTime.UtcNow;
+    if (dto != null)
+    {
+      // Use the SignalR payload directly instead of making a redundant HTTP call
+      ApplyNowPlayingDto(dto);
+    }
+    else
+    {
+      await RefreshPlaybackStateAsync();
+    }
     await InvokeAsync(StateHasChanged);
   }
 
   private async Task OnSourceChanged()
   {
+    _lastSignalREventUtc = DateTime.UtcNow;
     // Source switched — immediately refresh to show the new source's metadata
     await RefreshPlaybackStateAsync();
     await LoadSourceGainOffsetsAsync();
     await InvokeAsync(StateHasChanged);
   }
 
-  private async Task OnVolumeChangedEvent()
+  private async Task OnVolumeChangedEvent(VolumeDto? dto)
   {
-    await RefreshPlaybackStateAsync();
+    _lastSignalREventUtc = DateTime.UtcNow;
+    if (dto != null)
+    {
+      // Use the SignalR payload directly instead of making a redundant HTTP call
+      _volume = dto.Volume;
+      _isMuted = dto.IsMuted;
+    }
+    else
+    {
+      await RefreshPlaybackStateAsync();
+    }
     await InvokeAsync(StateHasChanged);
   }
 
   private async Task OnFingerprintStatusChanged()
   {
+    _lastSignalREventUtc = DateTime.UtcNow;
     await RefreshFingerprintStatusAsync();
     await InvokeAsync(StateHasChanged);
   }
@@ -369,6 +397,11 @@
   {
     try
     {
+      // Skip poll if a SignalR event was received within the last 30s —
+      // the real-time path already refreshed state.
+      if ((DateTime.UtcNow - _lastSignalREventUtc).TotalSeconds < 30)
+        return;
+
       var nowPlaying = await AudioApi.GetNowPlayingAsync();
       if (nowPlaying != null && nowPlaying.Title != _title)
       {
@@ -387,6 +420,10 @@
     try
     {
       _fpStatus = await AudioApi.GetFingerprintStatusAsync();
+      // Cache the reversed list so the template doesn't call .Reverse() on every render
+      _fpEventsReversed = _fpStatus?.RecentEvents != null
+        ? Enumerable.Reverse(_fpStatus.RecentEvents).ToList()
+        : null;
     }
     catch (Exception ex)
     {
@@ -460,6 +497,26 @@
     {
       Logger.LogError(ex, "Error refreshing playback state in NowPlayingPanel");
     }
+  }
+
+  /// <summary>
+  /// Applies a NowPlayingDto received via SignalR directly to local state,
+  /// avoiding a redundant HTTP round-trip to re-fetch the same data.
+  /// </summary>
+  private void ApplyNowPlayingDto(NowPlayingDto dto)
+  {
+    _title = dto.Title;
+    _artist = dto.Artist;
+    _album = dto.Album;
+    _isPlaying = dto.IsPlaying;
+    if (_albumArtUrl != dto.AlbumArtUrl)
+    {
+      _albumArtFailed = false;
+    }
+    _albumArtUrl = dto.AlbumArtUrl;
+    _source = dto.SourceName;
+    _nowPlayingSourceType = dto.SourceType;
+    _currentSourceGain = _sourceGainOffsets.TryGetValue(dto.SourceType, out var g) ? g : 1.0f;
   }
 
   // --- Fingerprint badge helpers ---
@@ -594,20 +651,38 @@
     _currentSourceGain = newGain;
     _sourceGainOffsets[_nowPlayingSourceType] = newGain;
 
-    // Debounce the API call
-    _gainDebounceTimer?.Dispose();
-    var sourceType = _nowPlayingSourceType;
-    _gainDebounceTimer = new System.Threading.Timer(async _ =>
+    // Debounce the API call — reuse existing timer via Change() instead of
+    // dispose+recreate on each slider event to reduce GC pressure.
+    _pendingGainSourceType = _nowPlayingSourceType;
+    _pendingGainValue = newGain;
+    if (_gainDebounceTimer != null)
     {
-      try
-      {
-        await AudioApi.SetSourceGainAsync(sourceType, newGain);
-      }
-      catch (Exception ex)
-      {
-        Logger.LogWarning(ex, "Failed to set source gain for {SourceType}", sourceType);
-      }
-    }, null, TimeSpan.FromMilliseconds(200), Timeout.InfiniteTimeSpan);
+      _gainDebounceTimer.Change(TimeSpan.FromMilliseconds(200), Timeout.InfiniteTimeSpan);
+    }
+    else
+    {
+      _gainDebounceTimer = new System.Threading.Timer(
+        OnGainDebounceElapsed, null,
+        TimeSpan.FromMilliseconds(200), Timeout.InfiniteTimeSpan);
+    }
+  }
+
+  private string? _pendingGainSourceType;
+  private float _pendingGainValue;
+
+  private async void OnGainDebounceElapsed(object? _)
+  {
+    try
+    {
+      var sourceType = _pendingGainSourceType;
+      var gain = _pendingGainValue;
+      if (!string.IsNullOrEmpty(sourceType))
+        await AudioApi.SetSourceGainAsync(sourceType, gain);
+    }
+    catch (Exception ex)
+    {
+      Logger.LogWarning(ex, "Failed to set source gain for {SourceType}", _pendingGainSourceType);
+    }
   }
 
   private static string FormatGainDb(float gain)

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -184,7 +184,7 @@
         }
         else
         {
-          @foreach (var preset in _presets.OrderBy(p => p.CreatedAt))
+          @foreach (var preset in _presets)
           {
             <div class="rcp-preset-item" @onclick="@(() => LoadPresetAsync(preset.Id))">
               <div class="rcp-preset-name">@preset.Name</div>
@@ -954,7 +954,12 @@
 
   private async Task LoadPresetsAsync()
   {
-    try { _presets = await RadioApi.GetPresetsAsync(); }
+    try
+    {
+      var presets = await RadioApi.GetPresetsAsync();
+      // Sort once on load instead of per render via .OrderBy() in the template
+      _presets = presets?.OrderBy(p => p.CreatedAt).ToList();
+    }
     catch { /* Silently fail */ }
   }
 

--- a/src/Radio.Web/Services/Hub/AudioStateHubService.cs
+++ b/src/Radio.Web/Services/Hub/AudioStateHubService.cs
@@ -1,6 +1,7 @@
 using System.Net.Sockets;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
+using Radio.Web.Models;
 
 namespace Radio.Web.Services.Hub;
 
@@ -18,12 +19,14 @@ public class AudioStateHubService : IAsyncDisposable
   private bool _isDisposed;
   private readonly SemaphoreSlim _connectionLock = new(1, 1);
 
-  // Events that components can subscribe to
+  // Events that components can subscribe to.
+  // NowPlayingChanged and VolumeChanged pass the typed payload from SignalR
+  // so subscribers can use it directly instead of making a redundant HTTP call.
   public event Func<Task>? PlaybackStateChanged;
-  public event Func<Task>? NowPlayingChanged;
+  public event Func<NowPlayingDto?, Task>? NowPlayingChanged;
   public event Func<Task>? QueueChanged;
   public event Func<Task>? RadioStateChanged;
-  public event Func<Task>? VolumeChanged;
+  public event Func<VolumeDto?, Task>? VolumeChanged;
   public event Func<Task>? SourceChanged;
   public event Func<Task>? FingerprintStatusChanged;
   public event Func<Task>? PhoneCallStateChanged;
@@ -80,12 +83,12 @@ public class AudioStateHubService : IAsyncDisposable
       });
 
       // Server sends NowPlayingChanged with a NowPlayingDto payload —
-      // accept and discard it so SignalR dispatches the message.
-      _hubConnection.On<object>("NowPlayingChanged", async (_) =>
+      // deserialize and pass through so subscribers can use it directly.
+      _hubConnection.On<NowPlayingDto?>("NowPlayingChanged", async (dto) =>
       {
         _logger.LogDebug("Received NowPlayingChanged event");
         if (NowPlayingChanged != null)
-          await NowPlayingChanged.Invoke();
+          await NowPlayingChanged.Invoke(dto);
       });
 
       // Server sends QueueChanged with a list payload —
@@ -106,11 +109,13 @@ public class AudioStateHubService : IAsyncDisposable
           await RadioStateChanged.Invoke();
       });
 
-      _hubConnection.On("VolumeChanged", async () =>
+      // Server sends VolumeChanged with a VolumeDto payload —
+      // deserialize and pass through so subscribers can update directly.
+      _hubConnection.On<VolumeDto?>("VolumeChanged", async (dto) =>
       {
         _logger.LogDebug("Received VolumeChanged event");
         if (VolumeChanged != null)
-          await VolumeChanged.Invoke();
+          await VolumeChanged.Invoke(dto);
       });
 
       _hubConnection.On("SourceChanged", async () =>

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,69 +1,100 @@
-# Task Plan: Audio Distortion Debugging & Instrumentation
+# Task Plan: Audio Pipeline Stability & Fingerprinting
 
 ## Goal
-Investigate BT audio distortion events (slow/underwater/clipped sound) tagged by user over 90 minutes. Determine root cause before attempting fixes. Design instrumentation to make these issues diagnosable in the future.
+Stabilize audio pipeline (reduce GC pressure, fix distortion), enable Shazam-based fingerprinting for all sources, and fix config/state bugs preventing correct operation.
 
 ## Current Phase
-Phase 1 — Analysis & Research (complete)
+Phase 5 — Complete. Ready for new task.
 
 ## Phases
 
 | # | Phase | Status | Notes |
 |---|-------|--------|-------|
-| 1 | Analysis & Research | complete | Extracted 151 markers, correlated with logs, read pipeline code |
-| 2 | Instrumentation Design | in_progress | What metrics/logging to add |
-| 3 | Implementation | pending | Add the instrumentation |
-| 4 | Deploy & Collect Data | pending | Run with instrumentation, reproduce distortion, analyze |
+| 1 | Distortion Analysis & Research | complete | Extracted 151 markers, correlated with logs, ranked root causes |
+| 2 | GC Pressure Reduction | complete | 6 changes: lock-free taps, pre-alloc buffers, SustainedLowLatency, Span conversions |
+| 3 | Instrumentation & Logging Fixes | complete | Callback timing, limiter stats, throttled per-miss logging (broke journald feedback loop) |
+| 4 | Shazam for All Sources | complete | UI toggle, FingerprintingOptions pass-through, config store sync, BT state race fix |
+| 5 | Play History Fixes | complete | Off-by-one dedup, stale album art leak across BT song changes |
 
 ## Key Findings
 
-1. **NOT clipping** — all markers show isClipping=False, peaks at -6 to -11 dBFS
-2. **No app-level errors** during distortion — no buffer drops, underruns, or compensations
-3. **PipeWire-pulse overruns** logged at 14:01 — MiniAudio output not consuming fast enough
-4. **Buffer grows monotonically** — BT clock ~2.1s/hour faster than ALSA. received > output. No DropOldest or drift compensation triggered during the distortion window.
-5. **Lock contention possible** — both PipeWire thread (AddSamples) and MiniAudio thread (GenerateAudio) compete for `_bufferLock`
-6. **Source state anomaly** — 49% of markers show state="Ready" while audio is clearly playing
-7. **BT format S24LE** → our stream requests S16LE (PipeWire converts). Sample rates match at 48kHz.
-
-## Proposed Instrumentation
-
-### A. GenerateAudio Callback Timing
-- Measure interval between successive GenerateAudio calls (should be ~10.67ms for 512 samples at 48kHz)
-- Log when interval exceeds 2x expected (missed deadline)
-- Track min/max/avg over 10s windows
-
-### B. Lock Contention Timing
-- Time how long GenerateAudio waits for `_bufferLock` (use Stopwatch around lock acquisition)
-- Time how long AddSamples waits for `_bufferLock`
-- Log when wait exceeds 1ms (concerning for real-time audio)
-
-### C. Buffer Level Sampling
-- Record buffer level (as % of capacity) at every GenerateAudio call
-- Log periodic stats: min/max/avg level over 10s windows
-- Emit metric for buffer fill percentage
-
-### D. Audio Discontinuity Detection
-- In GenerateAudio, track the last N samples read
-- Detect discontinuities (sudden jumps in sample values) that indicate glitches
-- Count and log discontinuities per interval
-
-### E. PipeWire OnProcess Timing
-- Measure interval between OnProcess calls in PipeWireNativeStream
-- Log burst delivery (multiple callbacks within 1ms)
-- Track delivery jitter
-
-### F. GC Pause Monitoring
-- Use `GC.RegisterForFullGCNotification()` or monitor `GC.GetGCMemoryInfo()`
-- Log Gen2 collections with duration
-- Correlate with audio callback timing
-
-### G. Metrics Integration
-- Buffer fill % → metrics collector (for dashboard visualization)
-- Callback interval stats → metrics
-- Lock wait times → metrics
-- Discontinuity count → metrics
+1. **62-70% of missed deadlines correlate with GC activity** — Gen0 collections during audio callback
+2. **journald feedback loop** — per-miss LogWarning overwhelmed journald (91.7% CPU) → memory pressure → forced Gen2 GC → more misses
+3. **SSH activity on Ubuntu correlates with distortion** — log tailing and DB queries compete with audio pipeline on N100
+4. **Config store desync** — UI writes to SQLite, IOptions reads from appsettings.json. Multiple bugs caused by this.
+5. **BT source state race** — PlaybackStatusChanged fires during StartAsync() before State=Ready, so Playing transition skipped
+6. **Source state "Ready" anomaly** (finding #6 from analysis) — explained by the race condition in finding #5
 
 ## Research Items
+
+### R3: Reduce BT Audio Pre-fill Buffer Delay
+
+**Priority:** High — UX regression, noticeable lag when skipping songs
+**Status:** Complete (PR #295)
+
+**Resolution:** The pre-fill buffer (0.5s) was fine — the real problem was stale audio sitting in the buffer during song transitions. Added `ClearAudioBuffer()` calls in `OnMetadataChanged`, `NextAsync`, and `PreviousAsync` to flush stale samples immediately on song change. New audio starts within ~100-200ms (PipeWire delivery latency) instead of draining 0.8-2.0s of old audio.
+
+### R4: BT Active Reconnection (Auto-Connect on Proximity)
+
+**Priority:** Medium — UX improvement, phone should auto-connect like a car stereo
+**Status:** Research needed
+
+**Problem:** When the phone leaves and re-enters Bluetooth range, it doesn't automatically reconnect to the radio. The user must manually connect from the phone's BT settings. Cars handle this seamlessly by actively polling for known devices.
+
+**Current state:**
+- Phone (Pixel 8 Pro) is paired, bonded, and trusted in BlueZ
+- BlueZ accepts incoming connections automatically (pairing agent auto-accept is enabled)
+- Phone does NOT auto-connect to `Grandpas Radio` when in range (unlike car stereos)
+- The radio doesn't actively try to connect to known devices either
+- Need the radio to actively initiate reconnection so the phone connects seamlessly
+
+**Approach options:**
+1. **BlueZ-side active reconnect** — Periodically run `bluetoothctl connect <address>` for trusted/paired devices that aren't connected. Simple, proven approach used by many Linux car-head-unit projects.
+2. **D-Bus `Device1.Connect()`** — Same as option 1 but via D-Bus API instead of shelling out. Cleaner integration with existing `LinuxBluetoothService`.
+3. **BlueZ `AutoConnect` property** — Some BlueZ versions support `AutoConnect=true` on `Device1`. May already work but needs testing.
+4. **Systemd timer + script** — Lightweight external approach, decoupled from the app. Less integrated but simpler.
+
+**Investigation:**
+1. Check if BlueZ `AutoConnect` property is available and what it does on our version
+2. Test `bluetoothctl connect D4:3A:2C:64:87:9E` when phone is in range but disconnected — does it work?
+3. Decide polling interval (every 15-30s seems standard for car systems)
+4. Handle edge cases: phone intentionally disconnected by user, multiple paired devices, phone connected to another audio sink
+5. Consider adding a config toggle (`AutoReconnect: true/false`) so user can disable
+
+**Key files:**
+- `src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs` — D-Bus BT management
+- `src/Radio.Core/Configuration/BluetoothOptions.cs` — BT config options
+
+### R2: Performance & Memory Deep Dive (API + Web)
+
+**Priority:** High — Ubuntu N100 has limited resources; memory pressure causes GC-induced audio distortion
+**Status:** Complete (PR pending)
+
+**Goal:** Expert-level performance analysis of both Radio.API and Radio.Web projects. Identify memory allocation hotspots, GC pressure sources, unnecessary object retention, and CPU inefficiencies. Produce actionable optimization recommendations.
+
+**Scope:**
+1. **Radio.API (port 5000)** — Audio engine, BT service, SignalR hubs, REST controllers, fingerprinting, config stores, hosted services
+2. **Radio.Web (port 5002)** — Blazor Server UI, SignalR client, MudBlazor components, API client services
+
+**Analysis areas:**
+- **Memory allocations** — Hot-path allocations (per-request, per-callback, per-frame), closure captures, LINQ in tight loops, string interpolation in log calls, unnecessary boxing
+- **Object lifetime & retention** — Singleton services holding references longer than needed, event handler leaks, disposable resources not disposed, large object heap (LOH) pressure
+- **GC pressure** — Gen0/Gen1 churn from short-lived allocations, Gen2/LOH from large buffers, finalizer queue pressure
+- **SignalR efficiency** — Message serialization overhead, broadcast frequency (visualization at 20fps), connection management, hub method granularity
+- **HTTP client usage** — HttpClient lifecycle, connection pooling, DNS refresh, response buffering
+- **Blazor Server specifics** — Circuit memory (per-connection state), component render frequency, JS interop overhead, unnecessary re-renders, timer-driven updates
+- **DI container** — Scoped vs singleton lifetime mismatches, transient services that should be pooled, heavy constructor injection chains
+- **Async patterns** — Unnecessary async state machines, fire-and-forget without error handling, sync-over-async (.GetAwaiter().GetResult())
+- **Caching** — Missing caches (repeated DB/API calls), oversized caches, cache invalidation gaps
+- **Startup cost** — Service initialization order, lazy vs eager loading, cold-start allocations
+
+**Approach:**
+1. Static analysis — Read key files, identify anti-patterns, review DI registrations
+2. Runtime profiling (if needed) — `dotnet-counters`, `dotnet-trace`, `dotnet-dump` on Ubuntu
+3. Categorize findings by impact (High/Medium/Low) and effort
+4. Produce prioritized optimization list
+
+**Deliverable:** Findings in `findings.md`, prioritized implementation plan with phases
 
 ### R1: Unify Config Systems (SQLite vs appsettings.json)
 
@@ -90,11 +121,13 @@ When the UI saves a config change (e.g. `UseShazamForAllSources` toggle), it wri
 | Decision | Rationale | Date |
 |----------|-----------|------|
 | Research first, instrument second | User wants to understand before fixing — previous attempts at blind fixes didn't resolve | 2026-03-05 |
-| Focus on callback timing + lock contention first | PipeWire-pulse overruns + lock architecture are the most likely root causes | 2026-03-05 |
-| Don't fix the buffer growing issue yet | Buffer hasn't actually overflowed in these sessions; fixing it won't address current distortion | 2026-03-05 |
+| Throttle per-miss logging to 5s | High-freq logging caused journald feedback loop (91.7% CPU) | 2026-03-05 |
 | Config unification research needed | SQLite vs appsettings.json duplication has caused multiple bugs — needs architectural decision | 2026-03-05 |
+| Fix BT state race in InitializeAsync | PlaybackStatusChanged fires before State=Ready; check metadata after init completes | 2026-03-05 |
 
 ## Errors Encountered
 | Error | Attempt | Resolution |
 |-------|---------|------------|
-| (none yet) | | |
+| CS0169 unused field `_lastReportTicks` | 1 | Removed unused field from LimiterModifier |
+| CS0252 reference comparison on object | 1 | Cast `pbStatus` to `(string)` for value comparison |
+| API 404 on source switch | 1 | Correct API is `POST /api/sources` with JSON body, not `POST /api/sources/switch/Radio` |

--- a/tests/Radio.Web.Tests/Services/AudioStateHubServiceTests.cs
+++ b/tests/Radio.Web.Tests/Services/AudioStateHubServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Radio.Web.Models;
 using Radio.Web.Services.Hub;
 
 namespace Radio.Web.Tests.Services;
@@ -82,21 +83,23 @@ public class AudioStateHubServiceTests
   {
     // Arrange
     Func<Task> handler = () => Task.CompletedTask;
+    Func<NowPlayingDto?, Task> nowPlayingHandler = _ => Task.CompletedTask;
+    Func<VolumeDto?, Task> volumeHandler = _ => Task.CompletedTask;
 
     // Act - Subscribe to all event types (should not throw)
     _service.PlaybackStateChanged += handler;
-    _service.NowPlayingChanged += handler;
+    _service.NowPlayingChanged += nowPlayingHandler;
     _service.QueueChanged += handler;
     _service.RadioStateChanged += handler;
-    _service.VolumeChanged += handler;
+    _service.VolumeChanged += volumeHandler;
     _service.SourceChanged += handler;
 
     // Cleanup - Unsubscribe from all (should not throw)
     _service.PlaybackStateChanged -= handler;
-    _service.NowPlayingChanged -= handler;
+    _service.NowPlayingChanged -= nowPlayingHandler;
     _service.QueueChanged -= handler;
     _service.RadioStateChanged -= handler;
-    _service.VolumeChanged -= handler;
+    _service.VolumeChanged -= volumeHandler;
     _service.SourceChanged -= handler;
 
     // Assert - Verify all subscriptions completed successfully


### PR DESCRIPTION
## Summary

- **Phase 1 (Audio Thread GC Pressure):** Eliminates ~5.5MB LOH allocation every 15-30s via ArrayPool, deferred float[] creation, and silence-check-first in fingerprint capture. Moves GC.CollectionCount syscalls off the audio callback thread. Replaces per-sample modulo ops (192K/sec → 94/sec) with two-chunk linear writes in TappedOutputStream.
- **Phase 2 (Redundant Network):** Defers DTO construction in the 500ms update loop until a lightweight snapshot detects changes. Reduces NowPlayingPanel polling from 10s to 60s with a 30s SignalR skip guard. Uses typed SignalR payloads (NowPlayingDto, VolumeDto) directly instead of discarding them and re-fetching via HTTP.
- **Phase 3 (UI Render Efficiency):** Reuses gain debounce timer, sorts presets on load instead of per-render, caches reversed fingerprint events, uses static readonly fallback arrays.
- **Phase 4 (Background Service):** Version-tracked cached status snapshot in BackgroundIdentificationService reduces record copies from every 3s poll to only when events change.

## Test plan

- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test --configuration Release` — 1,406 tests pass across 7 projects
- [ ] Deploy to Ubuntu, play BT audio for 10+ minutes — monitor for reduced "Missed callback deadline" warnings
- [ ] Skip songs via AVRCP — verify no glitches during transitions
- [ ] Check Web UI responsiveness — NowPlaying updates should still be prompt via SignalR
- [ ] Compare GC stats before/after (BufferedSoundGenerator LogStats output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)