### PR TITLE
docs: Research findings for R1 and R4

### DIFF
--- a/progress.md
+++ b/progress.md
@@ -1,5 +1,34 @@
 # Progress Log
 
+## Session: 2026-03-05 (late — R1 + R4 research)
+
+### R4: BT Active Reconnection — Research Complete
+
+- [x] Analyzed LinuxBluetoothService.cs (1,660 lines) — full D-Bus integration via Tmds.DBus
+- [x] Found key gap: IBluetoothService has DisconnectAsync() but NOT ConnectAsync()
+- [x] D-Bus IDevice1.ConnectAsync() exists in BluezInterfaces.cs but is unreachable from service contract
+- [x] Identified BluetoothPreferences.TrustedDevices list — exists but unused (perfect reconnect target)
+- [x] Analyzed BluetoothAutoSwitchService — already handles source activation on DeviceConnected event
+- [x] Reviewed PhoneCallClient retry pattern — exponential backoff already in codebase, reusable
+- [x] Documented recommended approach: D-Bus Device1.Connect() + exponential backoff (5s→60s cap)
+- [x] Documented edge cases: user-initiated disconnect, phone at car, multiple devices, adapter off
+- [x] Updated task_plan.md R4 section with full findings
+
+### R1: Unify Config Systems — Research Complete
+
+- [x] Analyzed all 20+ IOptions<T> classes and their binding in AudioServiceExtensions.cs
+- [x] Traced full data flow: UI toggle → ConfigurationApiService → ConfigurationController → SQLite store (IOptions stays stale)
+- [x] Analyzed SqliteConfigurationStore.cs — flat key-value with section:key format (matches IConfiguration convention)
+- [x] Analyzed JsonConfigurationStore.cs — file-per-store with in-memory dictionary
+- [x] Analyzed both existing workarounds: SyncFingerprintingOptionsFromStore (mutates IOptions) and DeviceOptionsResolver (reads store)
+- [x] Analyzed PreferencesPersistenceService — saves preferences every 30s, special handling for AudioPreferences
+- [x] Analyzed ConfigurationController — 14 endpoints, UpdateConfigurationSection writes to store only
+- [x] Analyzed SecretResolvingPostConfigureOptions — post-configure hook for secret tag resolution
+- [x] Evaluated 4 options: Drop SQLite, Bridge SQLite→IConfiguration, Drop IOptions, Hybrid
+- [x] Recommended Option 2: Custom SqliteConfigurationProvider bridging SQLite into IConfiguration pipeline
+- [x] Key insight: SQLite key format ("section:key") already matches IConfiguration's colon-delimited paths — migration is natural
+- [x] Updated task_plan.md R1 section with full findings and implementation plan
+
 ## Session: 2026-03-05 (R2 perf optimization)
 
 ### R2: Performance & Memory Deep Dive — Implementation

--- a/task_plan.md
+++ b/task_plan.md
@@ -37,33 +37,89 @@ Phase 5 — Complete. Ready for new task.
 ### R4: BT Active Reconnection (Auto-Connect on Proximity)
 
 **Priority:** Medium — UX improvement, phone should auto-connect like a car stereo
-**Status:** Research needed
+**Status:** Research complete
 
 **Problem:** When the phone leaves and re-enters Bluetooth range, it doesn't automatically reconnect to the radio. The user must manually connect from the phone's BT settings. Cars handle this seamlessly by actively polling for known devices.
 
-**Current state:**
-- Phone (Pixel 8 Pro) is paired, bonded, and trusted in BlueZ
-- BlueZ accepts incoming connections automatically (pairing agent auto-accept is enabled)
-- Phone does NOT auto-connect to `Grandpas Radio` when in range (unlike car stereos)
-- The radio doesn't actively try to connect to known devices either
-- Need the radio to actively initiate reconnection so the phone connects seamlessly
+#### Current Infrastructure (from code analysis)
 
-**Approach options:**
-1. **BlueZ-side active reconnect** — Periodically run `bluetoothctl connect <address>` for trusted/paired devices that aren't connected. Simple, proven approach used by many Linux car-head-unit projects.
-2. **D-Bus `Device1.Connect()`** — Same as option 1 but via D-Bus API instead of shelling out. Cleaner integration with existing `LinuxBluetoothService`.
-3. **BlueZ `AutoConnect` property** — Some BlueZ versions support `AutoConnect=true` on `Device1`. May already work but needs testing.
-4. **Systemd timer + script** — Lightweight external approach, decoupled from the app. Less integrated but simpler.
+**What exists:**
+- `IBluetoothService` has `DeviceConnected`/`DeviceDisconnected` events, `AcceptConnectionAsync()`, discovery, pair/unpair
+- `LinuxBluetoothService` (1,660 lines) talks to BlueZ via Tmds.DBus — manages IAdapter1, IDevice1, IMediaPlayer1, IMediaTransport1
+- `BluetoothAutoSwitchService` already auto-switches audio source on `DeviceConnected` event
+- `BluetoothPreferences.TrustedDevices` list exists but is **unused** — perfect hook for auto-reconnect target list
+- `BluetoothOptions` has `AutoAcceptConnections`, `AutoSwitchOnConnect`, `EnableOnStartup` — but no reconnection options
 
-**Investigation:**
-1. Check if BlueZ `AutoConnect` property is available and what it does on our version
-2. Test `bluetoothctl connect D4:3A:2C:64:87:9E` when phone is in range but disconnected — does it work?
-3. Decide polling interval (every 15-30s seems standard for car systems)
-4. Handle edge cases: phone intentionally disconnected by user, multiple paired devices, phone connected to another audio sink
-5. Consider adding a config toggle (`AutoReconnect: true/false`) so user can disable
+**Key gap:** `IBluetoothService` exposes `DisconnectAsync()` but **NOT `ConnectAsync()`**. The D-Bus `IDevice1.ConnectAsync()` method is available in `BluezInterfaces.cs` but unreachable from the service contract.
 
-**Key files:**
-- `src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs` — D-Bus BT management
-- `src/Radio.Core/Configuration/BluetoothOptions.cs` — BT config options
+**What happens on disconnect today:**
+1. `WatchDevicePropertiesAsync` detects `Connected=false`
+2. Fires `DeviceDisconnected` event
+3. Audio capture stops, source goes to Ready state
+4. System waits passively — no reconnection attempt
+
+#### Recommended Approach: D-Bus Device1.Connect() with Exponential Backoff
+
+**Option 2 (D-Bus direct) is the clear winner** — cleanest integration, no subprocess overhead, consistent with existing code patterns.
+
+**Implementation plan:**
+
+1. **Add `ConnectAsync(string address)` to `IBluetoothService`**
+   - Linux: call `IDevice1.ConnectAsync()` via D-Bus (already available in BluezInterfaces.cs)
+   - Windows: `BluetoothClient` connect or stub (Windows BT is secondary platform)
+
+2. **Add reconnection config to `BluetoothOptions`:**
+   ```csharp
+   public bool AutoReconnect { get; set; } = true;
+   public int ReconnectBaseDelayMs { get; set; } = 5000;    // 5s initial
+   public int ReconnectMaxDelayMs { get; set; } = 60000;    // 60s cap
+   public int MaxReconnectAttempts { get; set; } = 0;       // 0 = infinite
+   ```
+
+3. **Add reconnection logic to `LinuxBluetoothService`:**
+   - On `DeviceDisconnected`: if device is in `TrustedDevices` (or `PairedDevices` if `AutoReconnect=true`), start background reconnection loop
+   - Exponential backoff: 5s → 10s → 20s → 40s → 60s (capped)
+   - Follow existing `PhoneCallClient` retry pattern (already in codebase)
+   - Cancel reconnection if: user explicitly disconnects, device is unpaired, or new device connects
+
+4. **Distinguish user-initiated vs unexpected disconnect:**
+   - Add `_userInitiatedDisconnect` flag set by `DisconnectAsync()`
+   - Only auto-reconnect on unexpected disconnects (range loss, interference)
+   - Reset flag on next manual connect
+
+5. **Wire into existing `BluetoothAutoSwitchService`:**
+   - Reconnection succeeds → `DeviceConnected` fires → auto-switch already handles source activation
+   - No new service needed; reconnection loop lives in `LinuxBluetoothService` itself
+
+#### Edge Cases
+
+| Scenario | Handling |
+|----------|----------|
+| User intentionally disconnects | `_userInitiatedDisconnect` flag — skip reconnection |
+| Phone connected to car instead | `ConnectAsync()` will fail (device busy) — backoff continues, eventually succeeds when phone leaves car |
+| Multiple paired devices | Reconnect only the last-connected device (`BluetoothPreferences.LastConnectedDevice`) |
+| BT adapter powered off | Cancel all reconnection tasks on adapter state change |
+| App restart while phone in range | `StartAsync()` checks `LastConnectedDevice`, attempts connect once after adapter warmup |
+
+#### Metrics to Add
+
+- `bluetooth.reconnect_attempts` (counter, tags: device, result=success/fail)
+- `bluetooth.reconnect_backoff_seconds` (gauge, current backoff delay)
+
+#### Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/Radio.Core/Interfaces/Audio/IBluetoothService.cs` | Add `ConnectAsync(string address)` |
+| `src/Radio.Core/Configuration/BluetoothOptions.cs` | Add reconnection options |
+| `src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs` | Implement ConnectAsync + reconnection loop |
+| `src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs` | Stub ConnectAsync |
+| `appsettings.json` | Add default reconnection config |
+| Tests: `BluetoothAutoSwitchServiceTests.cs`, new `BluetoothReconnectionTests.cs` | Unit tests |
+
+#### Estimated Effort
+
+Small-medium. Core change is ~100-150 lines in LinuxBluetoothService (connect method + reconnection loop + cancellation). Interface change is 1 line. Config is 4 properties. Most complexity is in edge-case handling.
 
 ### R2: Performance & Memory Deep Dive (API + Web)
 
@@ -99,7 +155,7 @@ Phase 5 — Complete. Ready for new task.
 ### R1: Unify Config Systems (SQLite vs appsettings.json)
 
 **Priority:** High — has caused multiple bugs
-**Status:** Research needed
+**Status:** Research complete
 
 **Problem:** The app has two independent config systems:
 1. `.NET IConfiguration` pipeline — reads from `appsettings.json` at startup, feeds `IOptions<T>`
@@ -109,13 +165,109 @@ When the UI saves a config change (e.g. `UseShazamForAllSources` toggle), it wri
 - BT fingerprinting not running despite user enabling the toggle
 - Likely other settings silently ignoring UI changes until restart
 
-**Options to research:**
-1. **Drop SQLite, use JSON config only** — simpler, `IOptionsMonitor<T>` auto-reloads on file change. Downside: harder to manage via API/UI (must write JSON files).
-2. **Bridge SQLite → IConfiguration** — implement `IConfigurationProvider` backed by SQLite. Config changes flow to `IOptionsMonitor<T>` via change tokens. Architectural but most correct.
-3. **Drop IOptions<T>, use IConfigurationManager everywhere** — all config reads go through the store. Downside: lose type-safe options binding, need to convert from key-value strings.
-4. **Hybrid: Save to both stores simultaneously** — API controller saves to SQLite AND updates `IConfiguration`/JSON. `IOptionsMonitor<T>` picks up changes. Fragile synchronization.
+#### Current Architecture (from code analysis)
 
-**Current workaround:** `AudioSourceFactory.SyncFingerprintingOptionsFromStore()` manually reads from SQLite and patches the `IOptions<T>` value on source creation. This is a band-aid.
+**IOptions<T> side (20+ options classes):**
+- Bound in `AudioServiceExtensions.AddSoundFlowAudio()` via `services.Configure<T>(configuration.GetSection(...))`
+- All 20+ options classes in `src/Radio.Core/Configuration/` (AudioEngineOptions, BluetoothOptions, FingerprintingOptions, etc.)
+- Secret resolution via `SecretResolvingPostConfigureOptions<T>` post-configure hook (startup only)
+- Consumed by singletons: AudioSourceFactory, BackgroundIdentificationService, SoundFlowAudioEngine, etc.
+- **Frozen at startup** — `IOptions<T>.Value` never changes; `IOptionsMonitor<T>.CurrentValue` only changes if underlying `IConfiguration` source changes
+
+**Config Store side (SQLite/JSON):**
+- `RadioConfigurationManager` → `IConfigurationStoreFactory` → `SqliteConfigurationStore` or `JsonConfigurationStore`
+- SQLite table per store: `Config_<storeId>` with `Key TEXT, Value TEXT, Description TEXT, LastModified TEXT`
+- All values stored as strings (JSON-serialized for complex types)
+- Keys use section prefix: `"fingerprinting:useShazamForAllSources"`, `"audio:defaultSource"`, etc.
+- `PreferencesPersistenceService` (hosted service) saves preferences to store every 30s
+- `ConfigurationController` has 14 endpoints — UI saves via `POST /api/configuration/{section}`
+
+**Existing workarounds (2 known):**
+1. `AudioSourceFactory.SyncFingerprintingOptionsFromStore()` — mutates `IOptions<FingerprintingOptions>.Value` directly (fragile, sync-over-async)
+2. `DeviceOptionsResolver` — reads store, returns merged DeviceOptions instance (better pattern but manual per-class)
+
+**Data flow of a UI config change:**
+```
+UI toggle → ConfigurationApiService.UpdateConfigurationAsync()
+         → POST /api/configuration/fingerprinting { "useShazamForAllSources": true }
+         → ConfigurationController.UpdateConfigurationSection()
+         → IConfigurationManager.SetValueAsync("sqlite", "fingerprinting:useShazamForAllSources", "true")
+         → SQLite write ✓
+         → IOptions<FingerprintingOptions>.Value.UseShazamForAllSources = false ← STALE
+```
+
+#### Option Analysis
+
+**Option 1: Drop SQLite, use JSON config only**
+- `IOptionsMonitor<T>` auto-reloads when JSON file changes (`reloadOnChange: true`)
+- UI saves would write JSON files directly → change tokens fire → IOptionsMonitor updates
+- **Pros:** Simplest, leverages built-in .NET infra, eliminates dual-store entirely
+- **Cons:** Loses SQLite benefits (atomic writes, concurrent access, backup/restore infra, secrets table). JSON file writes aren't atomic (power loss = corrupt config). Existing backup/export/import system built around SQLite.
+- **Verdict:** Too disruptive — would need to rewrite backup, secrets, and config management infra
+
+**Option 2: Bridge SQLite → IConfiguration (custom IConfigurationProvider)** ⭐ RECOMMENDED
+- Implement `SqliteConfigurationProvider : ConfigurationProvider` + `SqliteConfigurationSource : IConfigurationSource`
+- Register in `ConfigurationBuilder` before options binding
+- On `SetValueAsync()`: write to SQLite AND call `provider.Set()` + `OnReload()` → triggers `IOptionsMonitor<T>` change tokens
+- **Pros:** Most correct .NET pattern. All existing `IOptions<T>` consumers automatically get updates. No workarounds needed. Secret resolution can hook into change tokens too.
+- **Cons:** Moderate implementation effort. Need to map SQLite flat keys to IConfiguration hierarchy (already using `section:key` format, which is IConfiguration's native format).
+- **Verdict:** Best long-term solution. The key format in SQLite (`fingerprinting:useShazamForAllSources`) already matches IConfiguration's colon-delimited path convention.
+
+**Option 3: Drop IOptions<T>, use IConfigurationManager everywhere**
+- Replace all `IOptions<T>` / `IOptionsMonitor<T>` injections with store reads
+- **Pros:** Single source of truth
+- **Cons:** Loses type-safe binding, compile-time checking, and the entire ASP.NET Core options pattern. Every consumer needs async store access. Massive refactor across 50+ files.
+- **Verdict:** Too invasive, loses too many .NET conventions
+
+**Option 4: Hybrid — save to both stores**
+- `ConfigurationController.UpdateConfigurationSection()` writes to SQLite AND updates a JSON file → `IOptionsMonitor` picks up changes
+- **Pros:** Minimal code change (just add JSON write in controller)
+- **Cons:** Two sources of truth that can diverge. JSON file is a shadow copy. Restart loads from appsettings.json (not the shadow JSON). Fragile.
+- **Verdict:** Band-aid, not a real fix
+
+#### Recommended Implementation: Option 2
+
+**Phase 1: Core bridge (eliminates the problem)**
+1. Create `SqliteConfigurationProvider` extending `ConfigurationProvider`
+   - `Load()`: read all entries from SQLite, populate `Data` dictionary
+   - `Set(string key, string? value)`: write to SQLite + update `Data` + call `OnReload()`
+2. Create `SqliteConfigurationSource` implementing `IConfigurationSource`
+3. Register in `Program.cs`: `builder.Configuration.AddSqliteConfigStore(connectionString)`
+4. Ensure it's added AFTER `appsettings.json` so SQLite values override JSON defaults
+
+**Phase 2: Cleanup workarounds**
+1. Remove `AudioSourceFactory.SyncFingerprintingOptionsFromStore()` — no longer needed
+2. Remove `DeviceOptionsResolver` — `IOptionsMonitor<DeviceOptions>` works directly
+3. Switch any `IOptions<T>` to `IOptionsMonitor<T>` where runtime updates are needed
+
+**Phase 3: Bidirectional sync (optional)**
+1. When `ConfigurationController.UpdateConfigurationSection()` writes to store, the bridge provider automatically notifies `IOptionsMonitor`
+2. When `appsettings.json` changes on disk (deploy), the standard JSON provider fires, but SQLite overrides take precedence (later in chain)
+
+#### Key Files to Modify
+
+| File | Change |
+|------|--------|
+| New: `SqliteConfigurationProvider.cs` | Custom IConfigurationProvider backed by SQLite |
+| New: `SqliteConfigurationSource.cs` | IConfigurationSource factory |
+| New: `ConfigurationBuilderExtensions.cs` | `AddSqliteConfigStore()` extension method |
+| `src/Radio.API/Program.cs` | Register SQLite config source |
+| `src/Radio.Infrastructure/Configuration/Stores/SqliteConfigurationStore.cs` | Add change notification support |
+| `src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs` | Remove SyncFingerprintingOptionsFromStore workaround |
+| `src/Radio.Infrastructure/Configuration/DeviceOptionsResolver.cs` | Remove (replaced by IOptionsMonitor) |
+| `src/Radio.API/Controllers/ConfigurationController.cs` | SetValueAsync now triggers IOptionsMonitor via bridge |
+| Tests: new `SqliteConfigurationProviderTests.cs` | Verify bridge behavior |
+
+#### Estimated Effort
+
+Medium. Core bridge is ~150-200 lines (provider + source + extension). Cleanup removes more code than it adds. Main risk is ensuring key format compatibility between SQLite store keys and IConfiguration paths (should be 1:1 since both use colon-delimited format).
+
+#### Migration Notes
+
+- Existing SQLite data is preserved — the bridge reads from the same `Config_sqlite` table
+- `appsettings.json` remains the source of defaults for new installs
+- SQLite values override JSON values (later in configuration chain wins)
+- No data migration needed — key format already matches
 
 ## Key Decisions
 | Decision | Rationale | Date |


### PR DESCRIPTION
## Summary
- **R1 (Config Unification):** Full analysis of the dual config system (IOptions vs SQLite store). Evaluated 4 approaches, recommending a custom `SqliteConfigurationProvider` that bridges SQLite into the IConfiguration pipeline. SQLite key format already matches IConfiguration's colon-delimited paths, making this a natural fit.
- **R4 (BT Auto-Reconnect):** Analyzed BT infrastructure, found `ConnectAsync()` missing from `IBluetoothService` (D-Bus method exists but is unreachable). Documented implementation plan using D-Bus `Device1.Connect()` with exponential backoff, user-disconnect detection, and edge case handling.

## Test plan
- [x] Research only — no code changes, no tests needed
- [ ] Review findings in `task_plan.md` for accuracy and preferred approach
- [ ] Decide which to implement first (R1 is higher priority due to existing bugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)