### PR TITLE
feat: SQLite config bridge provider for IOptionsMonitor unification (R1)

### DIFF
--- a/src/Radio.API/Program.cs
+++ b/src/Radio.API/Program.cs
@@ -7,6 +7,7 @@ using Radio.API.Streaming;
 using Radio.Core.Constants;
 using Radio.Core.Interfaces;
 using Radio.API.Logging;
+using Radio.Infrastructure.Configuration.Bridge;
 using Radio.Infrastructure.DependencyInjection;
 using Serilog;
 
@@ -16,6 +17,19 @@ var builder = WebApplication.CreateBuilder(args);
 // Add custom configuration source (config.json) which is managed by ConfigurationManager
 // This ensures that persistent settings saved by the app are loaded and reloaded on change
 builder.Configuration.AddJsonFile("config.json", optional: true, reloadOnChange: true);
+
+// Bridge the SQLite config store into .NET's IConfiguration pipeline.
+// Values written by the UI (via ConfigurationManager → SQLite) now override appsettings.json
+// defaults, and ConfigStoreChangeNotifier triggers IOptionsMonitor re-evaluation on writes.
+var dbSection = builder.Configuration.GetSection("Database");
+var rootPath = dbSection["RootPath"] ?? "./data";
+var configSubdir = dbSection["ConfigurationSubdirectory"] ?? "config";
+var configFile = dbSection["ConfigurationFileName"] ?? "configuration.db";
+var configDbPath = Path.GetFullPath(Path.Combine(rootPath, configSubdir, configFile));
+
+var configStoreNotifier = new ConfigStoreChangeNotifier();
+builder.Configuration.AddSqliteConfigStore(configDbPath, "sqlite", configStoreNotifier);
+builder.Services.AddSingleton(configStoreNotifier);
 
 // Configure Serilog with systemd-compatible console formatter.
 // The SystemdConsoleFormatter prefixes each log line with <N> syslog priority

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/BackgroundIdentificationService.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/BackgroundIdentificationService.cs
@@ -20,8 +20,11 @@ public sealed class BackgroundIdentificationService : BackgroundService
 {
   private readonly ILogger<BackgroundIdentificationService> _logger;
   private readonly IServiceProvider _serviceProvider;
-  private readonly FingerprintingOptions _options;
+  private readonly IOptionsMonitor<FingerprintingOptions> _optionsMonitor;
   private readonly IMetricsCollector? _metricsCollector;
+
+  /// <summary>Current fingerprinting options (live from IOptionsMonitor).</summary>
+  private FingerprintingOptions _options => _optionsMonitor.CurrentValue;
 
   // Track recent identifications for duplicate suppression (key → (timestamp, confidence))
   private readonly ConcurrentDictionary<string, (DateTime Timestamp, double Confidence)> _recentIdentifications = new();
@@ -85,12 +88,12 @@ public sealed class BackgroundIdentificationService : BackgroundService
   public BackgroundIdentificationService(
     ILogger<BackgroundIdentificationService> logger,
     IServiceProvider serviceProvider,
-    IOptions<FingerprintingOptions> options,
+    IOptionsMonitor<FingerprintingOptions> options,
     IMetricsCollector? metricsCollector = null)
   {
     _logger = logger;
     _serviceProvider = serviceProvider;
-    _options = options.Value;
+    _optionsMonitor = options;
     _metricsCollector = metricsCollector;
   }
 

--- a/src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs
@@ -37,7 +37,7 @@ public class AudioSourceFactory : IAudioSourceFactory
   private readonly IServiceScopeFactory? _serviceScopeFactory;
   private readonly AlbumArtCacheService? _albumArtCache;
   private readonly DeviceOptionsResolver? _deviceOptionsResolver;
-  private readonly IOptions<FingerprintingOptions>? _fingerprintingOptions;
+  private readonly IOptionsMonitor<FingerprintingOptions>? _fingerprintingOptions;
 
   public AudioSourceFactory(
     ILogger<AudioSourceFactory> logger,
@@ -58,7 +58,7 @@ public class AudioSourceFactory : IAudioSourceFactory
     IServiceScopeFactory? serviceScopeFactory = null,
     AlbumArtCacheService? albumArtCache = null,
     DeviceOptionsResolver? deviceOptionsResolver = null,
-    IOptions<FingerprintingOptions>? fingerprintingOptions = null)
+    IOptionsMonitor<FingerprintingOptions>? fingerprintingOptions = null)
   {
     _logger = logger;
     _loggerFactory = loggerFactory;
@@ -105,7 +105,6 @@ public class AudioSourceFactory : IAudioSourceFactory
 
   private IAudioSource CreateBluetoothSource()
   {
-    SyncFingerprintingOptionsFromStore();
     var logger = _loggerFactory.CreateLogger<BluetoothAudioSource>();
     return new BluetoothAudioSource(
       logger,
@@ -122,7 +121,6 @@ public class AudioSourceFactory : IAudioSourceFactory
 
   private IAudioSource CreateFilePlayerSource()
   {
-    SyncFingerprintingOptionsFromStore();
     var rootDir = _configuration["RootDir"] ?? Directory.GetCurrentDirectory();
     var logger = _loggerFactory.CreateLogger<FilePlayerAudioSource>();
     return new FilePlayerAudioSource(
@@ -208,38 +206,6 @@ public class AudioSourceFactory : IAudioSourceFactory
 
     var logger = _loggerFactory.CreateLogger<TestToneAudioSource>();
     return new TestToneAudioSource(logger, _playbackService);
-  }
-
-  /// <summary>
-  /// Syncs FingerprintingOptions from the runtime config store (SQLite/JSON).
-  /// UI config changes write to the config store, which is separate from the
-  /// IConfiguration/appsettings.json pipeline that IOptions binds from at startup.
-  /// Without this sync, runtime config changes (e.g. UseShazamForAllSources toggle)
-  /// are invisible to IOptions consumers.
-  /// </summary>
-  private void SyncFingerprintingOptionsFromStore()
-  {
-    if (_fingerprintingOptions == null || _configurationManager == null) return;
-    try
-    {
-      var storeId = _configurationManager.CurrentStoreType ==
-        Configuration.Models.ConfigurationStoreType.Sqlite ? "sqlite" : "config";
-      var useShazamStr = _configurationManager
-        .GetValueAsync<string>(storeId, "fingerprinting:useShazamForAllSources")
-        .GetAwaiter().GetResult();
-      if (bool.TryParse(useShazamStr, out var useShazam) &&
-          useShazam != _fingerprintingOptions.Value.UseShazamForAllSources)
-      {
-        _logger.LogDebug(
-          "Syncing FingerprintingOptions.UseShazamForAllSources from config store: {Value}",
-          useShazam);
-        _fingerprintingOptions.Value.UseShazamForAllSources = useShazam;
-      }
-    }
-    catch (Exception ex)
-    {
-      _logger.LogDebug(ex, "Failed to sync fingerprinting options from config store");
-    }
   }
 
   /// <summary>

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -27,7 +27,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
   private readonly IServiceScopeFactory? _serviceScopeFactory;
   private readonly AlbumArtCacheService? _albumArtCache;
   private readonly IOptionsMonitor<BluetoothOptions> _options;
-  private readonly FingerprintingOptions _fingerprintingOptions;
+  private readonly IOptionsMonitor<FingerprintingOptions>? _fingerprintingOptionsMonitor;
   private readonly SoundFlowPlaybackService? _playbackService;
   private readonly SemaphoreSlim _routeLock = new(1, 1);
   private readonly HashSet<string> _failedArtLookups = new();
@@ -39,6 +39,10 @@ public class BluetoothAudioSource : USBAudioSourceBase
   private TimeSpan? _btDuration;
   private bool _hasMediaPlayer;
   private CancellationTokenSource? _captureRetryCts;
+
+  /// <summary>Current fingerprinting options (live from IOptionsMonitor).</summary>
+  private FingerprintingOptions FpOptions =>
+    _fingerprintingOptionsMonitor?.CurrentValue ?? new FingerprintingOptions();
 
   /// <summary>
   /// When true, the fingerprinting pipeline will attempt to identify the current track.
@@ -56,7 +60,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
     SoundFlowPlaybackService? playbackService = null,
     IServiceScopeFactory? serviceScopeFactory = null,
     AlbumArtCacheService? albumArtCache = null,
-    IOptions<FingerprintingOptions>? fingerprintingOptions = null)
+    IOptionsMonitor<FingerprintingOptions>? fingerprintingOptions = null)
     : base(logger, deviceManager, identificationService, metricsCollector)
   {
     _bluetoothService = bluetoothService;
@@ -64,7 +68,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
     _serviceScopeFactory = serviceScopeFactory;
     _albumArtCache = albumArtCache;
     _options = options;
-    _fingerprintingOptions = fingerprintingOptions?.Value ?? new FingerprintingOptions();
+    _fingerprintingOptionsMonitor = fingerprintingOptions;
     _playbackService = playbackService;
     SetDefaultMetadata("Bluetooth", "Bluetooth", "Bluetooth Device");
 
@@ -647,7 +651,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
     // When UseShazamForAllSources is enabled, always fingerprint — SongRec provides
     // higher-quality cover art (Apple Music CDN) and more accurate metadata.
     var hasIncompleteMetadata = string.IsNullOrEmpty(e.Title) || string.IsNullOrEmpty(e.Artist);
-    NeedsFingerprintingLookup = hasIncompleteMetadata || _fingerprintingOptions.UseShazamForAllSources;
+    NeedsFingerprintingLookup = hasIncompleteMetadata || FpOptions.UseShazamForAllSources;
 
     if (NeedsFingerprintingLookup)
     {
@@ -679,7 +683,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
 
     // When UseShazamForAllSources is enabled, SongRec metadata replaces AVRCP metadata
     // (SongRec is more authoritative and has better cover art from Apple Music CDN)
-    if (_fingerprintingOptions.UseShazamForAllSources)
+    if (FpOptions.UseShazamForAllSources)
     {
       if (!string.IsNullOrEmpty(e.Track.Title))
         MetadataInternal[StandardMetadataKeys.Title] = e.Track.Title;

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
@@ -30,7 +30,7 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
   private readonly SoundFlowPlaybackService? _playbackService;
   private readonly IConfigurationManager? _configurationManager;
   private readonly AlbumArtCacheService? _albumArtCache;
-  private readonly FingerprintingOptions _fingerprintingOptions;
+  private readonly IOptionsMonitor<FingerprintingOptions>? _fingerprintingOptionsMonitor;
   private readonly string _rootDir;
   private readonly Dictionary<string, object> _metadata = new();
   private readonly HashSet<string> _errorFiles = new();
@@ -51,6 +51,10 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
   private Task? _playbackMonitorTask;
   private bool _trackEndedNaturally;
   private long _pendingSeekMs;
+
+  /// <summary>Current fingerprinting options (live from IOptionsMonitor).</summary>
+  private FingerprintingOptions FpOptions =>
+    _fingerprintingOptionsMonitor?.CurrentValue ?? new FingerprintingOptions();
 
   /// <summary>
   /// Initializes a new instance of the <see cref="FilePlayerAudioSource"/> class.
@@ -75,7 +79,7 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
     SoundFlowPlaybackService? playbackService = null,
     IConfigurationManager? configurationManager = null,
     AlbumArtCacheService? albumArtCache = null,
-    IOptions<FingerprintingOptions>? fingerprintingOptions = null)
+    IOptionsMonitor<FingerprintingOptions>? fingerprintingOptions = null)
     : base(logger, metricsCollector)
   {
     _options = options;
@@ -85,7 +89,7 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
     _playbackService = playbackService;
     _configurationManager = configurationManager;
     _albumArtCache = albumArtCache;
-    _fingerprintingOptions = fingerprintingOptions?.Value ?? new FingerprintingOptions();
+    _fingerprintingOptionsMonitor = fingerprintingOptions;
 
     // Subscribe to track identification events if service is available
     if (_identificationService != null)
@@ -1937,12 +1941,12 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
         bool hasIncompleteMetadata =
           _metadata[StandardMetadataKeys.Artist].Equals(StandardMetadataKeys.DefaultArtist) ||
           _metadata[StandardMetadataKeys.Album].Equals(StandardMetadataKeys.DefaultAlbum);
-        bool needsFingerprinting = hasIncompleteMetadata || _fingerprintingOptions.UseShazamForAllSources;
+        bool needsFingerprinting = hasIncompleteMetadata || FpOptions.UseShazamForAllSources;
 
         if (needsFingerprinting)
         {
           Logger.LogDebug("File {File} needs fingerprinting (incomplete={Incomplete}, shazamAll={ShazamAll})",
-            filePath, hasIncompleteMetadata, _fingerprintingOptions.UseShazamForAllSources);
+            filePath, hasIncompleteMetadata, FpOptions.UseShazamForAllSources);
           _metadata["NeedsFingerprintingLookup"] = true;
         }
       }
@@ -2028,7 +2032,7 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
 
     // When UseShazamForAllSources is enabled, SongRec metadata replaces ID3 metadata
     // (SongRec is more authoritative and has better cover art from Apple Music CDN)
-    if (_fingerprintingOptions.UseShazamForAllSources && needsLookup)
+    if (FpOptions.UseShazamForAllSources && needsLookup)
     {
       if (!string.IsNullOrEmpty(track.Title))
         _metadata[StandardMetadataKeys.Title] = track.Title;

--- a/src/Radio.Infrastructure/Configuration/Bridge/ConfigStoreChangeNotifier.cs
+++ b/src/Radio.Infrastructure/Configuration/Bridge/ConfigStoreChangeNotifier.cs
@@ -1,0 +1,30 @@
+namespace Radio.Infrastructure.Configuration.Bridge;
+
+/// <summary>
+/// Notification bridge between ConfigurationManager writes and the
+/// SqliteConfigurationProvider. When a config value is written via the UI,
+/// ConfigurationManager calls <see cref="NotifyReload"/> which triggers the
+/// provider to re-read from SQLite and fire IOptionsMonitor change tokens.
+/// </summary>
+public sealed class ConfigStoreChangeNotifier
+{
+  private SqliteConfigurationProvider? _provider;
+
+  /// <summary>
+  /// Registers the provider that should be reloaded on config changes.
+  /// Called by <see cref="SqliteConfigurationSource.Build"/>.
+  /// </summary>
+  internal void SetProvider(SqliteConfigurationProvider provider)
+  {
+    _provider = provider;
+  }
+
+  /// <summary>
+  /// Triggers the provider to reload from SQLite and fire change tokens.
+  /// Safe to call when no provider is registered (no-op).
+  /// </summary>
+  public void NotifyReload()
+  {
+    _provider?.Reload();
+  }
+}

--- a/src/Radio.Infrastructure/Configuration/Bridge/ConfigurationBuilderExtensions.cs
+++ b/src/Radio.Infrastructure/Configuration/Bridge/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,44 @@
+namespace Radio.Infrastructure.Configuration.Bridge;
+
+using Microsoft.Extensions.Configuration;
+
+/// <summary>
+/// Extension methods for adding the SQLite configuration bridge to the
+/// .NET configuration pipeline.
+/// </summary>
+public static class ConfigurationBuilderExtensions
+{
+  /// <summary>
+  /// Adds the SQLite configuration store as a configuration source.
+  /// Values from the SQLite store override earlier sources (e.g., appsettings.json)
+  /// because they are added later in the configuration chain.
+  /// </summary>
+  /// <param name="builder">The configuration builder.</param>
+  /// <param name="dbPath">Full path to the SQLite database file.</param>
+  /// <param name="storeId">The store identifier (used to derive the table name).</param>
+  /// <param name="notifier">
+  /// Optional notifier that will be wired to the provider so that
+  /// <see cref="ConfigStoreChangeNotifier.NotifyReload"/> triggers
+  /// IOptionsMonitor change tokens.
+  /// </param>
+  /// <returns>The configuration builder for chaining.</returns>
+  public static IConfigurationBuilder AddSqliteConfigStore(
+    this IConfigurationBuilder builder,
+    string dbPath,
+    string storeId,
+    ConfigStoreChangeNotifier? notifier = null)
+  {
+    var connectionString = $"Data Source={dbPath}";
+
+    // Sanitize table name the same way SqliteConfigurationStore does
+    var sanitized = new string(storeId
+      .Replace("-", "_")
+      .Replace(".", "_")
+      .Where(c => char.IsLetterOrDigit(c) || c == '_')
+      .ToArray());
+    var tableName = $"Config_{sanitized}";
+
+    builder.Add(new SqliteConfigurationSource(connectionString, tableName, notifier));
+    return builder;
+  }
+}

--- a/src/Radio.Infrastructure/Configuration/Bridge/SqliteConfigurationProvider.cs
+++ b/src/Radio.Infrastructure/Configuration/Bridge/SqliteConfigurationProvider.cs
@@ -1,0 +1,166 @@
+namespace Radio.Infrastructure.Configuration.Bridge;
+
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Configuration;
+
+/// <summary>
+/// Custom <see cref="ConfigurationProvider"/> backed by the SQLite configuration
+/// store. Reads all key/value entries from the Config_{storeId} table and
+/// populates them into .NET's configuration pipeline so that
+/// <c>IOptions&lt;T&gt;</c> / <c>IOptionsMonitor&lt;T&gt;</c> bindings
+/// automatically reflect runtime config changes.
+///
+/// JSON object/array values are flattened into hierarchical keys using ':'
+/// as the separator (matching .NET configuration conventions).
+/// </summary>
+public sealed class SqliteConfigurationProvider : ConfigurationProvider
+{
+  private readonly string _connectionString;
+  private readonly string _tableName;
+
+  public SqliteConfigurationProvider(string connectionString, string tableName)
+  {
+    _connectionString = connectionString;
+    _tableName = tableName;
+  }
+
+  /// <summary>
+  /// Reads all entries from the SQLite table and populates the Data dictionary.
+  /// JSON values are flattened into hierarchical keys.
+  /// Handles missing database or table gracefully (leaves Data empty).
+  /// </summary>
+  public override void Load()
+  {
+    var data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+    try
+    {
+      // Extract DB path from connection string to check existence
+      var builder = new SqliteConnectionStringBuilder(_connectionString);
+      if (!File.Exists(builder.DataSource))
+        return;
+
+      using var connection = new SqliteConnection(_connectionString);
+      connection.Open();
+
+      // Check if the table exists before querying
+      if (!TableExists(connection))
+        return;
+
+      using var cmd = connection.CreateCommand();
+      cmd.CommandText = $"SELECT Key, Value FROM {_tableName}";
+
+      using var reader = cmd.ExecuteReader();
+      while (reader.Read())
+      {
+        var key = reader.GetString(0);
+        var value = reader.GetString(1);
+
+        // Convert config store key separators (colon-delimited) to
+        // .NET configuration key format (also colon-delimited — same convention)
+        var configKey = key;
+
+        // If the value looks like a JSON object or array, flatten it
+        if (IsJsonObjectOrArray(value))
+        {
+          FlattenJson(configKey, value, data);
+        }
+        else
+        {
+          data[configKey] = value;
+        }
+      }
+    }
+    catch (SqliteException)
+    {
+      // Database might be locked, corrupt, or inaccessible.
+      // Fall through with empty data — appsettings defaults will apply.
+    }
+    finally
+    {
+      Data = data;
+    }
+  }
+
+  /// <summary>
+  /// Re-reads from SQLite and triggers IOptionsMonitor change tokens.
+  /// </summary>
+  public void Reload()
+  {
+    Load();
+    OnReload();
+  }
+
+  private bool TableExists(SqliteConnection connection)
+  {
+    using var cmd = connection.CreateCommand();
+    cmd.CommandText = "SELECT 1 FROM sqlite_master WHERE type='table' AND name=@Name LIMIT 1";
+    cmd.Parameters.AddWithValue("@Name", _tableName);
+    return cmd.ExecuteScalar() != null;
+  }
+
+  private static bool IsJsonObjectOrArray(string value)
+  {
+    if (string.IsNullOrWhiteSpace(value))
+      return false;
+
+    var trimmed = value.TrimStart();
+    return trimmed.StartsWith('{') || trimmed.StartsWith('[');
+  }
+
+  /// <summary>
+  /// Flattens a JSON object/array value into hierarchical configuration keys.
+  /// E.g., key="devices:Radio", value={"USBPort":"AB13X"}
+  ///   → data["devices:Radio:USBPort"] = "AB13X"
+  /// </summary>
+  private static void FlattenJson(string prefix, string json, Dictionary<string, string?> data)
+  {
+    try
+    {
+      using var doc = JsonDocument.Parse(json);
+      FlattenElement(prefix, doc.RootElement, data);
+    }
+    catch (JsonException)
+    {
+      // Not valid JSON despite starting with { or [. Store as-is.
+      data[prefix] = json;
+    }
+  }
+
+  private static void FlattenElement(string prefix, JsonElement element, Dictionary<string, string?> data)
+  {
+    switch (element.ValueKind)
+    {
+      case JsonValueKind.Object:
+        foreach (var property in element.EnumerateObject())
+        {
+          var childKey = string.IsNullOrEmpty(prefix)
+            ? property.Name
+            : $"{prefix}:{property.Name}";
+          FlattenElement(childKey, property.Value, data);
+        }
+        break;
+
+      case JsonValueKind.Array:
+        var index = 0;
+        foreach (var item in element.EnumerateArray())
+        {
+          var childKey = $"{prefix}:{index}";
+          FlattenElement(childKey, item, data);
+          index++;
+        }
+        break;
+
+      case JsonValueKind.Null:
+      case JsonValueKind.Undefined:
+        data[prefix] = null;
+        break;
+
+      default:
+        // String, Number, True, False — store raw text
+        data[prefix] = element.ToString();
+        break;
+    }
+  }
+}

--- a/src/Radio.Infrastructure/Configuration/Bridge/SqliteConfigurationSource.cs
+++ b/src/Radio.Infrastructure/Configuration/Bridge/SqliteConfigurationSource.cs
@@ -1,0 +1,30 @@
+namespace Radio.Infrastructure.Configuration.Bridge;
+
+using Microsoft.Extensions.Configuration;
+
+/// <summary>
+/// Configuration source that creates a <see cref="SqliteConfigurationProvider"/>
+/// and registers it with the <see cref="ConfigStoreChangeNotifier"/> so that
+/// runtime config writes trigger IOptionsMonitor re-evaluation.
+/// </summary>
+public sealed class SqliteConfigurationSource : IConfigurationSource
+{
+  private readonly string _connectionString;
+  private readonly string _tableName;
+  private readonly ConfigStoreChangeNotifier? _notifier;
+
+  public SqliteConfigurationSource(string connectionString, string tableName, ConfigStoreChangeNotifier? notifier)
+  {
+    _connectionString = connectionString;
+    _tableName = tableName;
+    _notifier = notifier;
+  }
+
+  /// <inheritdoc/>
+  public IConfigurationProvider Build(IConfigurationBuilder builder)
+  {
+    var provider = new SqliteConfigurationProvider(_connectionString, _tableName);
+    _notifier?.SetProvider(provider);
+    return provider;
+  }
+}

--- a/src/Radio.Infrastructure/Configuration/Services/ConfigurationManager.cs
+++ b/src/Radio.Infrastructure/Configuration/Services/ConfigurationManager.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Radio.Infrastructure.Configuration.Abstractions;
+using Radio.Infrastructure.Configuration.Bridge;
 using Radio.Infrastructure.Configuration.Exceptions;
 using Radio.Infrastructure.Configuration.Models;
 
@@ -17,6 +18,7 @@ public sealed class ConfigurationManager : IConfigurationManager
   private readonly ISecretsProvider _secretsProvider;
   private readonly IConfigurationBackupService _backupService;
   private readonly ILogger<ConfigurationManager> _logger;
+  private readonly ConfigStoreChangeNotifier? _changeNotifier;
   private readonly JsonSerializerOptions _jsonOptions;
 
   /// <inheritdoc/>
@@ -33,7 +35,8 @@ public sealed class ConfigurationManager : IConfigurationManager
     IConfigurationStoreFactory storeFactory,
     ISecretsProvider secretsProvider,
     IConfigurationBackupService backupService,
-    ILogger<ConfigurationManager> logger)
+    ILogger<ConfigurationManager> logger,
+    ConfigStoreChangeNotifier? changeNotifier = null)
   {
     ArgumentNullException.ThrowIfNull(options);
     ArgumentNullException.ThrowIfNull(storeFactory);
@@ -46,6 +49,7 @@ public sealed class ConfigurationManager : IConfigurationManager
     _secretsProvider = secretsProvider;
     _backupService = backupService;
     _logger = logger;
+    _changeNotifier = changeNotifier;
     _jsonOptions = new JsonSerializerOptions
     {
       PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -199,6 +203,9 @@ public sealed class ConfigurationManager : IConfigurationManager
 
     await store.SetEntryAsync(key, stringValue, ct);
     _logger.LogDebug("Set value for key {Key} in store {StoreId}", key, storeId);
+
+    // Trigger IOptionsMonitor re-evaluation so consumers see the new value
+    _changeNotifier?.NotifyReload();
   }
 
   /// <inheritdoc/>

--- a/src/Radio.Infrastructure/DependencyInjection/FingerprintingServiceExtensions.cs
+++ b/src/Radio.Infrastructure/DependencyInjection/FingerprintingServiceExtensions.cs
@@ -86,7 +86,7 @@ public static class FingerprintingServiceExtensions
       new BackgroundIdentificationService(
         sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<BackgroundIdentificationService>>(),
         sp,
-        sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<FingerprintingOptions>>(),
+        sp.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<FingerprintingOptions>>(),
         sp.GetService<IMetricsCollector>()));
     services.AddHostedService(sp => sp.GetRequiredService<BackgroundIdentificationService>());
 

--- a/tests/Radio.Infrastructure.Tests/Audio/BluetoothAudioSourceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/BluetoothAudioSourceTests.cs
@@ -228,7 +228,8 @@ public class BluetoothAudioSourceTests : IAsyncDisposable
   public async Task MetadataChanged_WithShazamToggleOn_SetsNeedsFingerprintingEvenWithCompleteMetadata()
   {
     // Arrange — create source with UseShazamForAllSources enabled
-    var fingerprintingOptions = Options.Create(new FingerprintingOptions
+    var fpMonitor = new Mock<IOptionsMonitor<FingerprintingOptions>>();
+    fpMonitor.Setup(o => o.CurrentValue).Returns(new FingerprintingOptions
     {
       UseShazamForAllSources = true
     });
@@ -241,7 +242,7 @@ public class BluetoothAudioSourceTests : IAsyncDisposable
       _options,
       identificationService: null,
       metricsCollector: _metricsMock.Object,
-      fingerprintingOptions: fingerprintingOptions);
+      fingerprintingOptions: fpMonitor.Object);
 
     // Act — send complete AVRCP metadata (title + artist present)
     _mockBluetooth.SimulateMetadataChange("Known Song", "Known Artist");
@@ -254,7 +255,8 @@ public class BluetoothAudioSourceTests : IAsyncDisposable
   public async Task MetadataChanged_WithShazamToggleOff_DoesNotFingerprintCompleteMetadata()
   {
     // Arrange — create source with UseShazamForAllSources disabled (default)
-    var fingerprintingOptions = Options.Create(new FingerprintingOptions
+    var fpMonitor = new Mock<IOptionsMonitor<FingerprintingOptions>>();
+    fpMonitor.Setup(o => o.CurrentValue).Returns(new FingerprintingOptions
     {
       UseShazamForAllSources = false
     });
@@ -267,7 +269,7 @@ public class BluetoothAudioSourceTests : IAsyncDisposable
       _options,
       identificationService: null,
       metricsCollector: _metricsMock.Object,
-      fingerprintingOptions: fingerprintingOptions);
+      fingerprintingOptions: fpMonitor.Object);
 
     // Act — send complete AVRCP metadata
     _mockBluetooth.SimulateMetadataChange("Known Song", "Known Artist");

--- a/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/BackgroundIdentificationServiceSongChangeTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/BackgroundIdentificationServiceSongChangeTests.cs
@@ -30,10 +30,13 @@ public class BackgroundIdentificationServiceSongChangeTests
     var serviceProvider = new ServiceCollection().BuildServiceProvider();
     var logger = new Mock<ILogger<BackgroundIdentificationService>>();
 
+    var optionsMonitor = new Mock<IOptionsMonitor<FingerprintingOptions>>();
+    optionsMonitor.Setup(o => o.CurrentValue).Returns(_options);
+
     _service = new BackgroundIdentificationService(
       logger.Object,
       serviceProvider,
-      Options.Create(_options));
+      optionsMonitor.Object);
 
     _service.SongChanged += (_, e) => _songChangedEvents.Add(e);
     _service.TrackIdentified += (_, e) => _trackIdentifiedEvents.Add(e);

--- a/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/BackgroundIdentificationServiceStatusTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/BackgroundIdentificationServiceStatusTests.cs
@@ -31,10 +31,13 @@ public class BackgroundIdentificationServiceStatusTests
     var serviceProvider = new ServiceCollection().BuildServiceProvider();
     var logger = new Mock<ILogger<BackgroundIdentificationService>>();
 
+    var optionsMonitor = new Mock<IOptionsMonitor<FingerprintingOptions>>();
+    optionsMonitor.Setup(o => o.CurrentValue).Returns(options);
+
     _service = new BackgroundIdentificationService(
       logger.Object,
       serviceProvider,
-      Options.Create(options));
+      optionsMonitor.Object);
   }
 
   [Fact]

--- a/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/FilePlayerAudioSourceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/FilePlayerAudioSourceTests.cs
@@ -1380,7 +1380,8 @@ public class FilePlayerAudioSourceTests : IDisposable
   public void Constructor_WithShazamToggleOn_DefaultDoesNotThrow()
   {
     // Arrange — create with UseShazamForAllSources enabled
-    var fingerprintingOptions = Options.Create(new FingerprintingOptions
+    var fpMonitor = new Mock<IOptionsMonitor<FingerprintingOptions>>();
+    fpMonitor.Setup(o => o.CurrentValue).Returns(new FingerprintingOptions
     {
       UseShazamForAllSources = true
     });
@@ -1391,7 +1392,7 @@ public class FilePlayerAudioSourceTests : IDisposable
       _optionsMock.Object,
       _preferencesMock.Object,
       _testDir,
-      fingerprintingOptions: fingerprintingOptions);
+      fingerprintingOptions: fpMonitor.Object);
 
     // Assert
     Assert.Equal("File Player", source.Name);

--- a/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/SDRRadioAudioSourceFingerprintingTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/SDRRadioAudioSourceFingerprintingTests.cs
@@ -455,12 +455,13 @@ public class SDRRadioAudioSourceFingerprintingTests
   {
     var mockLogger = new Mock<ILogger<BackgroundIdentificationService>>();
     var mockServiceProvider = new Mock<IServiceProvider>();
-    var options = Options.Create(new FingerprintingOptions { Enabled = false });
-    
+    var optionsMonitor = new Mock<IOptionsMonitor<FingerprintingOptions>>();
+    optionsMonitor.Setup(o => o.CurrentValue).Returns(new FingerprintingOptions { Enabled = false });
+
     return new BackgroundIdentificationService(
       mockLogger.Object,
       mockServiceProvider.Object,
-      options);
+      optionsMonitor.Object);
   }
 
   private TrackMetadata CreateTrackMetadata(

--- a/tests/Radio.Infrastructure.Tests/Configuration/SqliteConfigurationProviderTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Configuration/SqliteConfigurationProviderTests.cs
@@ -1,0 +1,295 @@
+namespace Radio.Infrastructure.Tests.Configuration;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Radio.Core.Configuration;
+using Radio.Infrastructure.Configuration.Bridge;
+
+/// <summary>
+/// Tests for the SQLite configuration bridge provider that connects
+/// the SQLite config store to .NET's IConfiguration/IOptionsMonitor pipeline.
+/// </summary>
+public class SqliteConfigurationProviderTests : IDisposable
+{
+  private readonly string _testDirectory;
+  private readonly string _dbPath;
+  private readonly string _connectionString;
+  private const string TableName = "Config_sqlite";
+
+  public SqliteConfigurationProviderTests()
+  {
+    _testDirectory = Path.Combine(Path.GetTempPath(), $"SqliteBridgeTests_{Guid.NewGuid():N}");
+    Directory.CreateDirectory(_testDirectory);
+    _dbPath = Path.Combine(_testDirectory, "test.db");
+    _connectionString = $"Data Source={_dbPath}";
+  }
+
+  public void Dispose()
+  {
+    try
+    {
+      if (Directory.Exists(_testDirectory))
+        Directory.Delete(_testDirectory, recursive: true);
+    }
+    catch { /* cleanup best-effort */ }
+  }
+
+  [Fact]
+  public void Load_ReadsValuesFromSqliteTable()
+  {
+    // Arrange
+    CreateTableAndInsert(("audio:volume", "75"), ("audio:muted", "false"));
+
+    var provider = new SqliteConfigurationProvider(_connectionString, TableName);
+
+    // Act
+    provider.Load();
+
+    // Assert
+    Assert.True(provider.TryGet("audio:volume", out var volume));
+    Assert.Equal("75", volume);
+    Assert.True(provider.TryGet("audio:muted", out var muted));
+    Assert.Equal("false", muted);
+  }
+
+  [Fact]
+  public void Load_FlattensJsonObject_IntoHierarchicalKeys()
+  {
+    // Arrange — store a JSON object value
+    CreateTableAndInsert(("devices:Radio", """{"USBPort":"AB13X","Enabled":true}"""));
+
+    var provider = new SqliteConfigurationProvider(_connectionString, TableName);
+
+    // Act
+    provider.Load();
+
+    // Assert
+    Assert.True(provider.TryGet("devices:Radio:USBPort", out var usbPort));
+    Assert.Equal("AB13X", usbPort);
+    Assert.True(provider.TryGet("devices:Radio:Enabled", out var enabled));
+    Assert.Equal("True", enabled);
+  }
+
+  [Fact]
+  public void Load_FlattensJsonArray_IntoIndexedKeys()
+  {
+    // Arrange — store a JSON array value
+    CreateTableAndInsert(("presets", """["FM 101.1","AM 780","FM 93.5"]"""));
+
+    var provider = new SqliteConfigurationProvider(_connectionString, TableName);
+
+    // Act
+    provider.Load();
+
+    // Assert
+    Assert.True(provider.TryGet("presets:0", out var v0));
+    Assert.Equal("FM 101.1", v0);
+    Assert.True(provider.TryGet("presets:1", out var v1));
+    Assert.Equal("AM 780", v1);
+    Assert.True(provider.TryGet("presets:2", out var v2));
+    Assert.Equal("FM 93.5", v2);
+  }
+
+  [Fact]
+  public void Load_CaseInsensitiveKeyLookup()
+  {
+    // Arrange
+    CreateTableAndInsert(("Fingerprinting:UseShazamForAllSources", "true"));
+
+    var provider = new SqliteConfigurationProvider(_connectionString, TableName);
+
+    // Act
+    provider.Load();
+
+    // Assert — lookup with different casing should succeed
+    Assert.True(provider.TryGet("fingerprinting:useshazamforallsources", out var value));
+    Assert.Equal("true", value);
+    Assert.True(provider.TryGet("FINGERPRINTING:USESHAZAMFORALLSOURCES", out var value2));
+    Assert.Equal("true", value2);
+  }
+
+  [Fact]
+  public void Load_MissingDatabase_EmptyData_NoException()
+  {
+    // Arrange — point at a non-existent database
+    var missingDbPath = Path.Combine(_testDirectory, "nonexistent.db");
+    var connectionString = $"Data Source={missingDbPath}";
+    var provider = new SqliteConfigurationProvider(connectionString, TableName);
+
+    // Act — should not throw
+    provider.Load();
+
+    // Assert — no values loaded
+    Assert.False(provider.TryGet("any:key", out _));
+  }
+
+  [Fact]
+  public void Load_MissingTable_EmptyData_NoException()
+  {
+    // Arrange — create DB but don't create the Config_sqlite table
+    using (var conn = new SqliteConnection(_connectionString))
+    {
+      conn.Open();
+      using var cmd = conn.CreateCommand();
+      cmd.CommandText = "CREATE TABLE SomeOtherTable (Id INTEGER PRIMARY KEY)";
+      cmd.ExecuteNonQuery();
+    }
+
+    var provider = new SqliteConfigurationProvider(_connectionString, TableName);
+
+    // Act — should not throw
+    provider.Load();
+
+    // Assert — no values loaded
+    Assert.False(provider.TryGet("any:key", out _));
+  }
+
+  [Fact]
+  public void Reload_PicksUpNewValues()
+  {
+    // Arrange — initial load with one value
+    CreateTableAndInsert(("audio:volume", "50"));
+    var provider = new SqliteConfigurationProvider(_connectionString, TableName);
+    provider.Load();
+
+    Assert.True(provider.TryGet("audio:volume", out var initial));
+    Assert.Equal("50", initial);
+
+    // Act — update value in DB and reload
+    UpdateValue("audio:volume", "80");
+    provider.Reload();
+
+    // Assert — new value visible
+    Assert.True(provider.TryGet("audio:volume", out var updated));
+    Assert.Equal("80", updated);
+  }
+
+  [Fact]
+  public void Integration_WriteToSqlite_NotifyReload_IOptionsMonitorReflectsChange()
+  {
+    // Arrange — set up config with appsettings default + SQLite bridge
+    CreateTableAndInsert(("Fingerprinting:UseShazamForAllSources", "false"));
+
+    var notifier = new ConfigStoreChangeNotifier();
+
+    var configBuilder = new ConfigurationBuilder();
+
+    // Add a base JSON config with a default value
+    var baseConfig = new Dictionary<string, string?>
+    {
+      ["Fingerprinting:Enabled"] = "true",
+      ["Fingerprinting:UseShazamForAllSources"] = "false"
+    };
+    configBuilder.AddInMemoryCollection(baseConfig);
+
+    // Add SQLite bridge (overrides base)
+    configBuilder.AddSqliteConfigStore(_dbPath, "sqlite", notifier);
+
+    var configuration = configBuilder.Build();
+
+    // Wire up IOptionsMonitor via DI
+    var services = new ServiceCollection();
+    services.AddSingleton<IConfiguration>(configuration);
+    services.Configure<FingerprintingOptions>(configuration.GetSection("Fingerprinting"));
+    services.AddSingleton(notifier);
+    var sp = services.BuildServiceProvider();
+
+    var optionsMonitor = sp.GetRequiredService<IOptionsMonitor<FingerprintingOptions>>();
+
+    // Initial state: UseShazamForAllSources = false
+    Assert.False(optionsMonitor.CurrentValue.UseShazamForAllSources);
+
+    // Act — simulate UI writing to SQLite and triggering reload
+    UpdateValue("Fingerprinting:UseShazamForAllSources", "true");
+    notifier.NotifyReload();
+
+    // Assert — IOptionsMonitor now reflects the change
+    Assert.True(optionsMonitor.CurrentValue.UseShazamForAllSources);
+  }
+
+  [Fact]
+  public void Load_NonJsonStringValue_StoredAsIs()
+  {
+    // Arrange — plain string value that starts with neither { nor [
+    CreateTableAndInsert(("source:name", "Bluetooth A2DP"));
+
+    var provider = new SqliteConfigurationProvider(_connectionString, TableName);
+
+    // Act
+    provider.Load();
+
+    // Assert
+    Assert.True(provider.TryGet("source:name", out var value));
+    Assert.Equal("Bluetooth A2DP", value);
+  }
+
+  [Fact]
+  public void Load_NestedJsonObject_FlattensRecursively()
+  {
+    // Arrange — nested JSON
+    var json = """{"SongRec":{"Enabled":true,"TimeoutSeconds":15},"Enabled":false}""";
+    CreateTableAndInsert(("Fingerprinting", json));
+
+    var provider = new SqliteConfigurationProvider(_connectionString, TableName);
+
+    // Act
+    provider.Load();
+
+    // Assert
+    Assert.True(provider.TryGet("Fingerprinting:SongRec:Enabled", out var songRecEnabled));
+    Assert.Equal("True", songRecEnabled);
+    Assert.True(provider.TryGet("Fingerprinting:SongRec:TimeoutSeconds", out var timeout));
+    Assert.Equal("15", timeout);
+    Assert.True(provider.TryGet("Fingerprinting:Enabled", out var fpEnabled));
+    Assert.Equal("False", fpEnabled);
+  }
+
+  #region Helpers
+
+  private void CreateTableAndInsert(params (string Key, string Value)[] entries)
+  {
+    using var conn = new SqliteConnection(_connectionString);
+    conn.Open();
+
+    using var createCmd = conn.CreateCommand();
+    createCmd.CommandText = $@"
+      CREATE TABLE IF NOT EXISTS {TableName} (
+        Key TEXT PRIMARY KEY,
+        Value TEXT NOT NULL,
+        Description TEXT,
+        LastModified TEXT NOT NULL
+      )";
+    createCmd.ExecuteNonQuery();
+
+    foreach (var (key, value) in entries)
+    {
+      using var insertCmd = conn.CreateCommand();
+      insertCmd.CommandText = $@"
+        INSERT OR REPLACE INTO {TableName} (Key, Value, LastModified)
+        VALUES (@Key, @Value, @LastModified)";
+      insertCmd.Parameters.AddWithValue("@Key", key);
+      insertCmd.Parameters.AddWithValue("@Value", value);
+      insertCmd.Parameters.AddWithValue("@LastModified", DateTimeOffset.UtcNow.ToString("O"));
+      insertCmd.ExecuteNonQuery();
+    }
+  }
+
+  private void UpdateValue(string key, string value)
+  {
+    using var conn = new SqliteConnection(_connectionString);
+    conn.Open();
+
+    using var cmd = conn.CreateCommand();
+    cmd.CommandText = $@"
+      UPDATE {TableName} SET Value = @Value, LastModified = @LastModified
+      WHERE Key = @Key";
+    cmd.Parameters.AddWithValue("@Key", key);
+    cmd.Parameters.AddWithValue("@Value", value);
+    cmd.Parameters.AddWithValue("@LastModified", DateTimeOffset.UtcNow.ToString("O"));
+    cmd.ExecuteNonQuery();
+  }
+
+  #endregion
+}


### PR DESCRIPTION
## Summary

- **Bridge SQLite config store into .NET's IConfiguration pipeline** so UI config changes are immediately visible to `IOptionsMonitor<T>` consumers without restart
- **Remove `SyncFingerprintingOptionsFromStore()` workaround** from AudioSourceFactory — the bridge makes it unnecessary
- **Switch FingerprintingOptions consumers from `IOptions` to `IOptionsMonitor`** so they read live values: AudioSourceFactory, BluetoothAudioSource, FilePlayerAudioSource, BackgroundIdentificationService

## Problem

The app had two independent config systems causing bugs:
1. `IConfiguration` / `IOptions<T>` — reads from `appsettings.json` at startup, frozen
2. `IConfigurationManager` (SQLite store) — UI config pages read/write here at runtime

When the UI saved a config change (e.g., `UseShazamForAllSources` toggle), it wrote to SQLite but `IOptions<T>` still held the stale `appsettings.json` value. This caused BT fingerprinting not running despite the user enabling the toggle.

## Solution

Custom `SqliteConfigurationProvider` that:
- Reads all entries from `Config_sqlite` table at startup
- Flattens JSON object/array values into hierarchical configuration keys (matching .NET conventions)
- Handles missing DB/table gracefully (appsettings defaults win)
- `ConfigStoreChangeNotifier` triggers reload after every `ConfigurationManager.SetValueAsync()`, firing `IOptionsMonitor` change tokens

### New files
| File | Purpose |
|------|---------|
| `Configuration/Bridge/SqliteConfigurationProvider.cs` | ConfigurationProvider backed by SQLite |
| `Configuration/Bridge/SqliteConfigurationSource.cs` | IConfigurationSource factory |
| `Configuration/Bridge/ConfigStoreChangeNotifier.cs` | Notification bridge |
| `Configuration/Bridge/ConfigurationBuilderExtensions.cs` | `AddSqliteConfigStore()` extension |
| `SqliteConfigurationProviderTests.cs` | 10 tests |

### Modified files
| File | Change |
|------|--------|
| `Program.cs` | Register SQLite config source after appsettings.json |
| `ConfigurationManager.cs` | Call `NotifyReload()` after `SetValueAsync()` |
| `AudioSourceFactory.cs` | Remove workaround, `IOptions` → `IOptionsMonitor` |
| `BluetoothAudioSource.cs` | `IOptions` → `IOptionsMonitor` with live `FpOptions` property |
| `FilePlayerAudioSource.cs` | Same pattern |
| `BackgroundIdentificationService.cs` | `IOptions` → `IOptionsMonitor` with live property |
| `FingerprintingServiceExtensions.cs` | Updated DI registration |

## Test plan

- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test --configuration Release` — 1,416 tests pass across 7 projects
- [x] 10 new tests cover: Load, JSON flattening (objects + arrays), case-insensitive lookup, missing DB/table resilience, reload, end-to-end IOptionsMonitor integration
- [x] Deploy to Ubuntu — verified:
  - Service starts cleanly, no bridge-related errors
  - SQLite values loaded at startup: `identificationIntervalSeconds: 30` (from SQLite) correctly overrides `15` (from appsettings.json)
  - `POST /api/configuration/fingerprinting` writes to SQLite and triggers `NotifyReload`
  - IOptionsMonitor change tokens fire on write (confirmed via "Audio output options changed" log)
  - Toggle `UseShazamForAllSources` false↔true — both directions work, no crashes
  - Audio playback, fingerprinting (SongRec), and radio all working normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)