### PR TITLE
perf: Async logging, reduce log noise 69%, fix 39s test timeout

### DIFF
--- a/src/Radio.API/Program.cs
+++ b/src/Radio.API/Program.cs
@@ -39,7 +39,7 @@ builder.Services.AddSingleton(configStoreNotifier);
 // gets the default priority, allowing filtering with `journalctl -p info`.
 Log.Logger = new LoggerConfiguration()
   .ReadFrom.Configuration(builder.Configuration)
-  .WriteTo.Console(new SystemdConsoleFormatter())
+  .WriteTo.Async(a => a.Console(new SystemdConsoleFormatter()))
   .CreateLogger();
 
 builder.Host.UseSerilog();

--- a/src/Radio.API/Radio.API.csproj
+++ b/src/Radio.API/Radio.API.csproj
@@ -9,6 +9,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.*" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.*" />

--- a/src/Radio.API/appsettings.json
+++ b/src/Radio.API/appsettings.json
@@ -9,7 +9,8 @@
   },
   "Serilog": {
     "Using": [
-      "Serilog.Sinks.File"
+      "Serilog.Sinks.File",
+      "Serilog.Sinks.Async"
     ],
     "MinimumLevel": {
       "Default": "Warning",
@@ -22,12 +23,19 @@
     },
     "WriteTo": [
       {
-        "Name": "File",
+        "Name": "Async",
         "Args": {
-          "path": "./logs/radio-.txt",
-          "rollingInterval": "Day",
-          "retainedFileCountLimit": 7,
-          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}"
+          "configure": [
+            {
+              "Name": "File",
+              "Args": {
+                "path": "./logs/radio-.txt",
+                "rollingInterval": "Day",
+                "retainedFileCountLimit": 7,
+                "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}"
+              }
+            }
+          ]
         }
       }
     ],

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/BackgroundIdentificationService.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/BackgroundIdentificationService.cs
@@ -311,10 +311,6 @@ public sealed class BackgroundIdentificationService : BackgroundService
 
       if (songRecMetadata != null)
       {
-        _logger.LogInformation(
-          "SongRec identified: '{Title}' by '{Artist}' (album: {Album})",
-          songRecMetadata.Title, songRecMetadata.Artist, songRecMetadata.Album ?? "(none)");
-
         // Cache album art from Shazam CDN to serve locally
         if (!string.IsNullOrEmpty(songRecMetadata.CoverArtUrl))
         {

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/SoundFlowAudioTap.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/SoundFlowAudioTap.cs
@@ -120,7 +120,7 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
       return null;
     }
 
-    _logger.LogInformation("Capturing {Duration}s of audio from SoundFlow output", duration.TotalSeconds);
+    _logger.LogDebug("Capturing {Duration}s of audio from SoundFlow output", duration.TotalSeconds);
     var captureStartTime = DateTime.UtcNow;
 
     try
@@ -239,7 +239,7 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
       }
 
       var actualDuration = (double)sampleCount / sampleRate / channels;
-      _logger.LogInformation("Successfully captured {Samples} samples ({Duration:F2}s, {Percentage:F0}% of requested, RMS: {RmsDb:F1}dB) in {Elapsed}ms",
+      _logger.LogDebug("Successfully captured {Samples} samples ({Duration:F2}s, {Percentage:F0}% of requested, RMS: {RmsDb:F1}dB) in {Elapsed}ms",
         sampleCount, actualDuration, (actualDuration / duration.TotalSeconds) * 100, rmsDb, captureElapsed);
 
       return new AudioSampleBuffer

--- a/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
@@ -433,7 +433,7 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
                     }
                 }
 
-                _logger.LogInformation(
+                _logger.LogDebug(
                     "🔄 Clock drift compensation: duplicated {Samples} samples (buffer: {Level}→{NewLevel}/{Capacity}, total compensated: {Total})",
                     deficit, currentLevel, currentLevel + deficit, _maxBufferSamples, _totalSamplesCompensated);
             }
@@ -476,7 +476,7 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
                     _totalSamplesReceived, _totalSamplesOutput,
                     _totalSamplesDropped, _totalSamplesCompensated, _underrunCount);
 
-                _logger.LogInformation(
+                _logger.LogDebug(
                     "🔬 Timing ({Type}): callback interval min={MinInterval:F2}ms max={MaxInterval:F2}ms, " +
                     "missed deadlines={Missed} (GC-correlated={GcMisses}), execution max={MaxExec:F2}ms, " +
                     "lock contention: addSamples={AddContentions} (max {AddWait:F2}ms), " +

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
@@ -311,7 +311,7 @@ public class SoundFlowAudioEngine : IAudioEngine
         var s = stats.Value;
         if (s.LimitedSamples > 0)
         {
-          _logger.LogWarning(
+          _logger.LogInformation(
             "🔊 Limiter engaged: {Percent:F1}% of samples compressed ({Limited}/{Total}), " +
             "max input {MaxInput:F3} ({MaxInputDb:F1} dBFS), max reduction {MaxReduction:F1} dB",
             s.EngagementPercent, s.LimitedSamples, s.TotalSamples,

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/SDRRadioAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/SDRRadioAudioSource.cs
@@ -145,7 +145,7 @@ public class SDRRadioAudioSource : PrimaryAudioSourceBase, Radio.Core.Interfaces
       _silentCallbackCount++;
       if (_silentCallbackCount % 100 == 1)
       {
-        Logger.LogWarning(
+        Logger.LogDebug(
           "SDR RADIO: Silent audio data received ({SampleCount} zero samples, silent callbacks: {SilentCount})",
           sampleCount, _silentCallbackCount);
       }

--- a/src/Radio.Web/Program.cs
+++ b/src/Radio.Web/Program.cs
@@ -28,11 +28,11 @@ Log.Logger = new LoggerConfiguration()
     return false;
   })
   .Enrich.FromLogContext()
-  .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}")
-  .WriteTo.File(
+  .WriteTo.Async(a => a.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}"))
+  .WriteTo.Async(a => a.File(
     "logs/web-.txt",
     rollingInterval: RollingInterval.Day,
-    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}")
+    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}"))
   .CreateLogger();
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/Radio.Web/Radio.Web.csproj
+++ b/src/Radio.Web/Radio.Web.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.11" />
     <PackageReference Include="MudBlazor" Version="8.15.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.*" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/Radio.Web.Tests/Services/AudioApiServiceTests.cs
+++ b/tests/Radio.Web.Tests/Services/AudioApiServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
 using Radio.Web.Services.ApiClients;
 
@@ -14,7 +15,11 @@ public class AudioApiServiceTests
 
   public AudioApiServiceTests()
   {
-    _httpClient = new HttpClient
+    // Use a handler that immediately returns 503 instead of making real HTTP calls.
+    // The previous approach (real HttpClient to localhost:5000) waited ~4s per test
+    // for TCP connection timeout, wasting ~40s total across 10+ tests.
+    var handler = new ImmediateFailureHandler();
+    _httpClient = new HttpClient(handler)
     {
       BaseAddress = new Uri("http://localhost:5000")
     };
@@ -159,5 +164,18 @@ public class AudioApiServiceTests
     // Assert - Should complete (either with result or cancellation)
     await Task.WhenAll(tasks.Select(t => t.ContinueWith(_ => { })));
     Assert.NotNull(_service); // Verify service remains in valid state
+  }
+
+  /// <summary>
+  /// HttpMessageHandler that immediately throws HttpRequestException,
+  /// simulating a server that is not available without waiting for TCP timeout.
+  /// </summary>
+  private class ImmediateFailureHandler : HttpMessageHandler
+  {
+    protected override Task<HttpResponseMessage> SendAsync(
+      HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+      throw new HttpRequestException("Connection refused", null, HttpStatusCode.ServiceUnavailable);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- **Serilog.Sinks.Async**: Wrap all Console + File sinks in async wrappers to decouple log I/O from audio callback threads. Prevents journald backpressure from blocking the audio pipeline.
- **Log level downgrades**: 69% reduction in log volume (~1,024/hr → ~322/hr). Warning-level volume drops 96% (~324/hr → ~12/hr). Six changes across 5 files — SDR silent audio, generator timing stats, clock drift, audio tap capture, limiter engagement, duplicate identification log removal.
- **Test timeout fix**: Replace real `HttpClient` (4s TCP timeout per test × 10 tests = 40s wasted) with `ImmediateFailureHandler` mock. Radio.Web.Tests drops from **45.76s to 4.87s**.

## Changes
| Category | Files | Impact |
|---|---|---|
| Async sinks | `Radio.API/Program.cs`, `Radio.Web/Program.cs`, `appsettings.json`, 2 `.csproj` | Decouple log writes from audio threads |
| Log levels | `SDRRadioAudioSource.cs`, `BufferedSoundGenerator.cs` (×2), `BackgroundIdentificationService.cs`, `SoundFlowAudioTap.cs` (×2), `SoundFlowAudioEngine.cs` | -702 lines/hour |
| Test fix | `AudioApiServiceTests.cs` | -41s test runtime |

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] All 1,437 tests pass (72+3 skipped in Integration, as before)
- [x] Radio.Web.Tests: 45.76s → 4.87s confirmed
- [ ] Deploy to Ubuntu, verify logs are async (no audio thread blocking)
- [ ] Verify log volume reduction in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)