### PR TITLE
fix: Add 15s timeout to BT ConnectAsync for reconnection loop

### DIFF
--- a/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothReconnectionLoop.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothReconnectionLoop.cs
@@ -91,7 +91,7 @@ internal sealed class BluetoothReconnectionLoop : IDisposable
       }
 
       var delay = CalculateBackoffDelay(attempt, _options.ReconnectBaseDelayMs, _options.ReconnectMaxDelayMs);
-      _logger.LogDebug("Reconnect attempt {Attempt}/{Max} for {Address} in {Delay}ms",
+      _logger.LogInformation("Reconnect attempt {Attempt}/{Max} for {Address} in {Delay}ms",
         attempt, _options.MaxReconnectAttempts, deviceAddress, (int)delay.TotalMilliseconds);
 
       try
@@ -129,7 +129,7 @@ internal sealed class BluetoothReconnectionLoop : IDisposable
       }
       catch (Exception ex)
       {
-        _logger.LogDebug(ex, "Reconnect attempt {Attempt} failed for {Address}", attempt, deviceAddress);
+        _logger.LogWarning(ex, "Reconnect attempt {Attempt} failed for {Address}", attempt, deviceAddress);
       }
     }
 

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -610,9 +610,20 @@ namespace Radio.Infrastructure.Platform.Bluetooth
 
                 var device = _connection.CreateProxy<Linux.IDevice1>(
                     Linux.BluezConstants.ServiceName, devicePath.Value);
-                await device.ConnectAsync();
+
+                // BlueZ Connect() blocks for 30-60s when device is unreachable.
+                // Use a 15s timeout so the reconnection backoff loop can progress.
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(TimeSpan.FromSeconds(15));
+
+                await device.ConnectAsync().WaitAsync(timeoutCts.Token);
                 _logger.LogInformation("Initiated connection to device {Address}", deviceAddress);
                 return true;
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug("Connect to {Address} timed out after 15s", deviceAddress);
+                return false;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- BlueZ D-Bus `Connect()` blocks 30-60s when device is unreachable, which stalled the reconnection backoff loop on a single hanging attempt
- Added 15s timeout via `WaitAsync()` with linked cancellation token so attempts complete promptly and exponential backoff progresses (3s → 6s → 12s → 24s → 48s → 60s)
- Promoted reconnect attempt logs from Debug → Info and failure logs from Debug → Warning for production observability

## Test plan
- [x] Verified on Ubuntu: phone BT off → backoff progresses correctly through all delay intervals
- [x] Phone BT back on → auto-reconnects on next attempt
- [x] API disconnect (user-initiated) → no reconnection loop triggered
- [x] Build: 0 warnings, all 1,437 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)