### PR TITLE
fix: Decouple kiosk screen blanking from audio pause

### DIFF
--- a/deploy/debian-x64/kiosk/radio-console.desktop
+++ b/deploy/debian-x64/kiosk/radio-console.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Radio Console
 Comment=Grandpa Anderson's Console Radio Web UI
-Exec=google-chrome --kiosk --noerrdialogs --disable-infobars --disable-session-crashed-bubble --remote-debugging-port=9223 http://localhost:5002
+Exec=google-chrome --kiosk --noerrdialogs --disable-infobars --disable-session-crashed-bubble --disable-background-timer-throttling --disable-renderer-backgrounding --disable-backgrounding-occluded-windows --remote-debugging-port=9223 http://localhost:5002
 Icon=audio-radio
 Terminal=false
 Type=Application

--- a/deploy/debian-x64/kiosk/radio-kiosk-autostart.desktop
+++ b/deploy/debian-x64/kiosk/radio-kiosk-autostart.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Radio Console Kiosk
 Comment=Auto-launch Radio Console in kiosk mode
-Exec=google-chrome --kiosk --noerrdialogs --disable-infobars --disable-session-crashed-bubble --remote-debugging-port=9223 http://localhost:5002
+Exec=google-chrome --kiosk --noerrdialogs --disable-infobars --disable-session-crashed-bubble --disable-background-timer-throttling --disable-renderer-backgrounding --disable-backgrounding-occluded-windows --remote-debugging-port=9223 http://localhost:5002
 Icon=audio-radio
 Terminal=false
 Type=Application

--- a/deploy/debian-x64/kiosk/setup-kiosk.sh
+++ b/deploy/debian-x64/kiosk/setup-kiosk.sh
@@ -99,8 +99,16 @@ echo "[5/7] Disabling screen blanking and lock..."
 gsettings set org.gnome.desktop.session idle-delay 0
 gsettings set org.gnome.desktop.screensaver lock-enabled false
 gsettings set org.gnome.desktop.screensaver idle-activation-enabled false
+
+# Disable X11 DPMS (Display Power Management Signaling).
+# GNOME screensaver settings above don't cover DPMS, which is a separate X11/kernel
+# feature that can blank/suspend the display independently.
+xset s off 2>/dev/null || true
+xset -dpms 2>/dev/null || true
+xset s noblank 2>/dev/null || true
 echo "  Screen blanking disabled."
 echo "  Screen lock disabled."
+echo "  X11 DPMS disabled."
 
 # ---- 6. Install unclutter (hide idle mouse cursor) ----
 echo ""
@@ -111,6 +119,23 @@ if ! command -v unclutter &>/dev/null; then
   echo "  unclutter installed."
 else
   echo "  unclutter already installed."
+fi
+
+# Add DPMS disable to autostart (xset commands only apply to the current session,
+# so they must run on every login)
+DPMS_AUTOSTART="$AUTOSTART_DIR/disable-dpms.desktop"
+if [ ! -f "$DPMS_AUTOSTART" ]; then
+  cat > "$DPMS_AUTOSTART" << 'EOF'
+[Desktop Entry]
+Name=Disable DPMS
+Comment=Disable display power management for kiosk mode
+Exec=bash -c "xset s off; xset -dpms; xset s noblank"
+Terminal=false
+Type=Application
+X-GNOME-Autostart-enabled=true
+NoDisplay=true
+EOF
+  echo "  DPMS disable autostart entry created."
 fi
 
 # Add unclutter to autostart if not already there

--- a/src/Radio.API/Program.cs
+++ b/src/Radio.API/Program.cs
@@ -93,8 +93,14 @@ builder.Services.AddCors(options =>
   });
 });
 
-// Add SignalR
-builder.Services.AddSignalR();
+// Add SignalR — tuned for kiosk reliability.
+// Chrome may throttle JS timers when the page is visually occluded (screen-blanked overlay),
+// so we allow generous timeouts to avoid killing the circuit during idle screen-blank.
+builder.Services.AddSignalR(options =>
+{
+  options.ClientTimeoutInterval = TimeSpan.FromMinutes(2);
+  options.KeepAliveInterval = TimeSpan.FromSeconds(30);
+});
 
 // Add health checks
 builder.Services.AddHealthChecks()

--- a/src/Radio.Web/Components/App.razor
+++ b/src/Radio.Web/Components/App.razor
@@ -49,15 +49,18 @@
   <script>
     // Start Blazor AFTER all JS dependencies are loaded.
     // Configure reconnection for kiosk reliability.
+    // Kiosk-grade circuit reliability: 300 retries x 2s = 10 minutes of reconnection,
+    // matching the server-side DisconnectedCircuitRetentionPeriod of 10 minutes.
+    // Server keepalive is 30s, so client timeout must be > 2x that.
     Blazor.start({
       circuit: {
         reconnectionOptions: {
-          maxRetries: 30,
+          maxRetries: 300,
           retryIntervalMilliseconds: 2000
         },
         configureSignalR: function (builder) {
-          builder.withServerTimeout(60000);
-          builder.withKeepAliveInterval(15000);
+          builder.withServerTimeout(120000);
+          builder.withKeepAliveInterval(30000);
         }
       }
     }).then(function() {

--- a/src/Radio.Web/wwwroot/js/idle-dimmer.js
+++ b/src/Radio.Web/wwwroot/js/idle-dimmer.js
@@ -1,7 +1,13 @@
 // Screen idle dimmer + sleep manager for kiosk mode
-// - Dim: reduces brightness after 5 minutes of no interaction
-// - Sleep: black overlay, notifies Blazor to pause audio
-// - Wake: touch/pointer/key restores screen, notifies Blazor to resume audio
+//
+// Three states:
+//   1. Dimmed:        brightness reduced after idle timeout (music continues)
+//   2. Screen-blanked: black overlay after longer idle (music continues)
+//   3. Deep sleep:     black overlay + audio paused (explicit user/server action only)
+//
+// Key design: idle timeouts NEVER pause audio. Only explicit sleep (button/server)
+// pauses playback. This lets the radio play indefinitely while preserving the screen.
+//
 // Exposes window.radioSleepManager for JS interop from Blazor
 
 // Safe setter for API base URL (called from Blazor JS interop instead of eval)
@@ -11,13 +17,14 @@ window.radioSetApiBaseUrl = function (url) {
 
 (function () {
   const IDLE_TIMEOUT = 5 * 60 * 1000; // 5 minutes → dim
-  const SLEEP_TIMEOUT = 30 * 60 * 1000; // 30 minutes → sleep
+  const BLANK_TIMEOUT = 30 * 60 * 1000; // 30 minutes → screen blank (visual only)
   const DIM_BRIGHTNESS = 0.3;
 
   let dimTimer = null;
-  let sleepTimer = null;
+  let blankTimer = null;
   let dimmed = false;
-  let sleeping = false;
+  let screenBlanked = false; // Visual-only blank (idle timeout) — music keeps playing
+  let deepSleep = false;     // Full sleep (audio paused) — explicit action only
   let overlay = null;
   let blazorRef = null;
 
@@ -34,9 +41,9 @@ window.radioSetApiBaseUrl = function (url) {
 
   function resetTimers() {
     clearTimeout(dimTimer);
-    clearTimeout(sleepTimer);
+    clearTimeout(blankTimer);
     dimTimer = setTimeout(dim, IDLE_TIMEOUT);
-    sleepTimer = setTimeout(function () { enterSleep('idle'); }, SLEEP_TIMEOUT);
+    blankTimer = setTimeout(function () { blankScreen(); }, BLANK_TIMEOUT);
   }
 
   function undim() {
@@ -48,47 +55,75 @@ window.radioSetApiBaseUrl = function (url) {
   }
 
   function dim() {
-    if (sleeping) return;
+    if (screenBlanked || deepSleep) return;
     document.body.style.transition = 'filter 2s ease';
     document.body.style.filter = 'brightness(' + DIM_BRIGHTNESS + ')';
     dimmed = true;
   }
 
-  function enterSleep(source) {
-    if (sleeping) return;
-    sleeping = true;
+  // Screen blank: visual-only, music keeps playing.
+  // Triggered by idle timeout — does NOT call the API.
+  function blankScreen() {
+    if (screenBlanked || deepSleep) return;
+    screenBlanked = true;
 
     // Show black overlay
     var el = createOverlay();
     el.style.pointerEvents = 'auto';
-    // Force reflow before setting opacity for transition
     void el.offsetWidth;
     el.style.opacity = '1';
 
-    // Dim body as well
+    // Dim body fully
     document.body.style.transition = 'filter 2s ease';
     document.body.style.filter = 'brightness(0)';
     dimmed = true;
 
-    // Notify Blazor to call API server-side (unless triggered by server)
+    clearTimeout(dimTimer);
+    clearTimeout(blankTimer);
+  }
+
+  // Deep sleep: black overlay + audio paused.
+  // Only triggered by explicit action (button press or server command).
+  function enterSleep(source) {
+    if (deepSleep) return;
+
+    // If we're already screen-blanked, upgrade to deep sleep
+    if (!screenBlanked) {
+      // Show black overlay
+      var el = createOverlay();
+      el.style.pointerEvents = 'auto';
+      void el.offsetWidth;
+      el.style.opacity = '1';
+
+      document.body.style.transition = 'filter 2s ease';
+      document.body.style.filter = 'brightness(0)';
+      dimmed = true;
+    }
+
+    deepSleep = true;
+    screenBlanked = false; // Upgrade from blank to deep sleep
+
+    // Notify Blazor to pause audio (unless triggered by server — server already knows)
     if (source !== 'server' && blazorRef) {
       blazorRef.invokeMethodAsync('OnJsSleepRequested', true)
         .catch(function () { /* ignore */ });
     }
 
     clearTimeout(dimTimer);
-    clearTimeout(sleepTimer);
+    clearTimeout(blankTimer);
   }
 
   function wake(source) {
-    if (!sleeping) {
-      // Not sleeping, just undim and reset timers
+    if (!screenBlanked && !deepSleep) {
+      // Not blanked or sleeping, just undim and reset timers
       undim();
       resetTimers();
       return;
     }
 
-    sleeping = false;
+    var wasDeepSleep = deepSleep;
+    deepSleep = false;
+    screenBlanked = false;
     undim();
 
     // Hide overlay
@@ -97,8 +132,9 @@ window.radioSetApiBaseUrl = function (url) {
       overlay.style.pointerEvents = 'none';
     }
 
-    // Notify Blazor to call API server-side (unless triggered by server)
-    if (source !== 'server' && blazorRef) {
+    // Only notify Blazor to resume audio if we were in deep sleep
+    // (screen-blank is visual only — nothing to resume)
+    if (wasDeepSleep && source !== 'server' && blazorRef) {
       blazorRef.invokeMethodAsync('OnJsSleepRequested', false)
         .catch(function () { /* ignore */ });
     }
@@ -127,9 +163,11 @@ window.radioSetApiBaseUrl = function (url) {
 
   // Expose global API for Blazor JS interop
   window.radioSleepManager = {
-    enterSleep: enterSleep,
+    enterSleep: enterSleep,      // Deep sleep (pauses audio) — for button/server
+    blankScreen: blankScreen,    // Screen blank only (no audio impact)
     wake: wake,
-    isSleeping: function () { return sleeping; },
+    isSleeping: function () { return deepSleep; },
+    isScreenBlanked: function () { return screenBlanked; },
     setBlazorRef: function (ref) { blazorRef = ref; }
   };
 


### PR DESCRIPTION
## Summary

- **Root cause**: `idle-dimmer.js` called `SleepService.EnterSleepAsync()` after 30 min idle, which paused the active audio source and muted — stopping music by design. A radio should play indefinitely.
- **Fix**: Split idle-dimmer into three states:
  - **Dimmed** (5 min idle): brightness reduced, music continues
  - **Screen-blanked** (30 min idle): black overlay for screen preservation, music continues
  - **Deep sleep** (explicit button/server only): black overlay + audio paused
- **Chrome kiosk flags**: Added `--disable-background-timer-throttling`, `--disable-renderer-backgrounding`, `--disable-backgrounding-occluded-windows` to prevent JS timer throttling when CSS overlay is shown
- **DPMS**: Disabled X11 display power management in kiosk setup + autostart entry
- **SignalR/Blazor circuit**: Increased timeouts for kiosk reliability (server: 2min client timeout, 30s keepalive; client: 300 retries over 10 min matching server retention)

## Files Changed

| File | Change |
|------|--------|
| `src/Radio.Web/wwwroot/js/idle-dimmer.js` | Split sleep into screen-blank (visual) vs deep-sleep (audio) |
| `deploy/debian-x64/kiosk/radio-console.desktop` | Chrome anti-throttling flags |
| `deploy/debian-x64/kiosk/radio-kiosk-autostart.desktop` | Chrome anti-throttling flags |
| `deploy/debian-x64/kiosk/setup-kiosk.sh` | DPMS disable + autostart entry |
| `src/Radio.API/Program.cs` | SignalR kiosk timeouts |
| `src/Radio.Web/Components/App.razor` | Blazor circuit kiosk reconnection |

## Test plan

- [x] `dotnet build --configuration Release` — 0 warnings
- [x] All ~1,437 tests pass
- [ ] Deploy to Ubuntu kiosk, verify music plays through 30+ min idle without stopping
- [ ] Verify screen dims at 5 min, blanks at 30 min
- [ ] Verify touch wakes from screen-blank without audio interruption
- [ ] Verify explicit sleep button still pauses audio
- [ ] Verify Blazor circuit survives 30+ min screen-blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)