### PR TITLE
fix: Frame-align PipeWire BT audio to prevent stereo channel swap

### DIFF
--- a/findings.md
+++ b/findings.md
@@ -96,19 +96,40 @@ idle-dimmer.js (30 min idle)
 4. **BT A2DP Transport Jitter (MEDIUM)** — irregular packet arrival
 5. **DropOldest Buffer Overflow (LOWER)** — drift causes overflow after ~72 min
 
-### Critical Unknown
-**Actual audio waveform during distortion was NEVER captured.** Unknown whether it's:
-- Repeated samples (underrun fill)
-- Dropped samples (overflow/skip)
-- Zero-insertion (silence gaps)
-- Byte-shift corruption
+### ROOT CAUSE IDENTIFIED (Phase 3)
+
+**Stereo frame misalignment in PipeWireNativeStream.OnProcess**
+
+The `OnProcess` callback converts S16LE bytes to float samples via `sampleCount = totalBytes / 2` — but for stereo audio, a "frame" is 2 samples (L+R = 4 bytes). When PipeWire's BT transport delivers non-frame-aligned chunks (due to packet loss/gaps), `sampleCount` is ODD, causing every subsequent sample to have L/R channels swapped.
+
+**Evidence (pre-fix 60s capture):**
+- 3 silence gaps with ODD lengths (693, 827, 83 samples)
+- L/R channel ratio FLIPS after each gap (e.g., pre=12.833, post=0.056)
+- Sample deficit: 32,640 samples lost (input > output)
+- Output→PostModifiers correlation: 0.40 (poor — channel-swap corrupts modifier processing)
+
+**Fix applied:**
+- `PipeWireNativeStream.cs`: `sampleCount = sampleCount / self._channels * self._channels;` (frame-align)
+- `BufferedSoundGenerator.cs`: Defense-in-depth frame alignment in `AddSamples()`
+
+**Evidence (post-fix 60s capture):**
+- Output→PostModifiers correlation: 1.000000 (perfect, up from 0.40)
+- Sample delta: +1,024 (near-zero, vs pre-fix -32,640)
+- 384 silence gaps still present but these are BT transport dropouts (brief pops), NOT channel swaps
+- ODD-length gaps in captured data are from zero VALUES spanning chunk boundaries — AddSamples always receives frame-aligned data
+
+### Remaining Issue: BT Transport Dropouts
+- 384 silence runs in 60s (clustered, likely RF interference bursts)
+- Causes brief audible pops but NOT sustained distortion
+- Inherent to BT A2DP transport — not fixable in application code
+- Could be mitigated with gap-filling interpolation in a future SoundModifier
 
 ### Existing Infrastructure
 - `BufferedSoundGenerator` has extensive instrumentation (callback timing, lock contention, GC correlation)
 - `FmAudioDropoutDiagnosticTests` simulate producer/consumer on independent clocks
 - `AudioTestHelpers` generates diagnostic tones and has WAV writer
 - `BtSender` sends known 200Hz/300Hz tone over BT
-- **MISSING**: Capture points for actual waveform data, input/output comparison, automated distortion detection
+- **Phase 2 infrastructure**: `DiagnosticCaptureService`, `CaptureSession`, `Radio.AudioAnalysis` library, automated `WaveformComparison` tests
 
 ---
 

--- a/progress.md
+++ b/progress.md
@@ -1,5 +1,38 @@
 # Progress Log
 
+## Session: 2026-03-06 (Phase 3 — Root Cause)
+
+### Root Cause Identified & Fixed
+- [x] Deployed Phase 2 capture infrastructure to Ubuntu
+- [x] Captured 60s BT audio at 3 pipeline stages (generator-input, generator-output, post-modifiers)
+- [x] Built waveform analysis test (`AnalyzeBtCapture_InputVsOutput`) with silence gap deep analysis, channel swap detection, windowed correlation
+- [x] **ROOT CAUSE**: `PipeWireNativeStream.OnProcess` converts S16LE→float without stereo frame alignment. PipeWire BT transport delivers non-frame-aligned chunks during packet loss → odd sample count → L/R channel swap for ALL subsequent audio
+- [x] **FIX**: Frame-align `sampleCount` in `PipeWireNativeStream.cs` + defense-in-depth in `BufferedSoundGenerator.AddSamples()`
+- [x] Deployed fix to Ubuntu, captured 60s post-fix audio
+- [x] Verified fix: Output→PostModifiers correlation went from 0.40 → 1.000000 (perfect)
+- [x] Sample delta improved: -32,640 → +1,024
+
+### Files Modified
+- `src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs` — frame alignment in OnProcess
+- `src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs` — defense-in-depth frame alignment in AddSamples
+- `tests/Radio.Infrastructure.Tests/Audio/Diagnostics/WaveformComparisonTests.cs` — capture analysis test
+- `findings.md`, `progress.md`, `task_plan.md`
+
+---
+
+## Session: 2026-03-06 (Phase 2 — Test Infrastructure)
+
+### Implementation Complete (PR #304, merged)
+- [x] `Radio.AudioAnalysis` shared library (8 files)
+- [x] Capture infrastructure (4 files in `Audio/Diagnostics/`)
+- [x] `BufferedSoundGenerator` diagnostic hooks
+- [x] API capture endpoints
+- [x] CI-safe distortion tests + capture session tests + waveform comparison tests
+- [x] All 1416 tests passing
+- [x] Code review: fixed `IsCapturing` race condition
+
+---
+
 ## Session: 2026-03-06 (Planning)
 
 ### Research Completed

--- a/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
@@ -172,6 +172,16 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
     {
         if (_isDisposed) return;
 
+        // Defense-in-depth: truncate to frame boundary to prevent L/R channel shift.
+        // PipeWire BT transport can deliver non-frame-aligned chunks during packet gaps.
+        var channelCount = Format.Channels;
+        if (channelCount > 1 && samples.Length % channelCount != 0)
+        {
+            var aligned = samples.Length / channelCount * channelCount;
+            if (aligned <= 0) return;
+            samples = samples.Slice(0, aligned);
+        }
+
         // Measure lock contention: try non-blocking first, only time if contended
         double lockWaitMs = 0;
         var entered = Monitor.TryEnter(_bufferLock);

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs
@@ -262,9 +262,14 @@ internal sealed class PipeWireNativeStream : IDisposable
       var chunk = Marshal.PtrToStructure<SpaChunk>(spaData.Chunk);
       if (chunk.Size == 0) return;
 
-      // S16_LE: 2 bytes per sample
+      // S16_LE: 2 bytes per sample, stereo = 4 bytes per frame.
+      // PipeWire BT transport can deliver non-frame-aligned chunks during
+      // packet loss/gaps. An odd sample count shifts L↔R channels for all
+      // subsequent audio, causing audible distortion. Round down to frame
+      // boundary (channels samples per frame) to prevent misalignment.
       var totalBytes = (int)chunk.Size;
       var sampleCount = totalBytes / 2;
+      sampleCount = sampleCount / self._channels * self._channels; // frame-align
 
       if (sampleCount <= 0) return;
 

--- a/task_plan.md
+++ b/task_plan.md
@@ -4,15 +4,15 @@
 Fix kiosk sleep-stops-music bug, build automated audio distortion debugging infrastructure, migrate to .NET 10 LTS + C# 14, address architecture/testing items from comprehensive review, and enhance the metrics dashboard with customizable hero cards and new metrics.
 
 ## Current Phase
-Phase 2 — pending
+Phase 3 — in_progress
 
 ## Phases
 
 | # | Phase | Status | Notes |
 |---|-------|--------|-------|
 | 1 | Kiosk Stability Fix | complete | PR #303 — decoupled screen blank from audio pause, Chrome flags, DPMS, SignalR timeouts |
-| 2 | Audio Distortion — Automated Test Infrastructure | pending | BtSender-based pipeline, capture/compare, waveform analysis tools |
-| 3 | Audio Distortion — Root Cause Investigation & Fix | pending | Use Phase 2 infra to identify and fix distortion without human testing |
+| 2 | Audio Distortion — Automated Test Infrastructure | complete | PR #304 — Radio.AudioAnalysis lib, CaptureSession, DiagnosticCaptureService, 30+ tests, API endpoints verified on Ubuntu |
+| 3 | Audio Distortion — Root Cause Investigation & Fix | in_progress | Using Phase 2 infra to identify and fix distortion |
 | 4 | .NET 10 Migration + C# 14 Adoption | pending | TFM update, breaking changes, NuGet updates, language features |
 | 5 | Core Architecture Refactoring | pending | #26 IAudioManager split, #34 enum consolidation, #14 component decomposition, #36 state store |
 | 6 | Test Coverage + Web Error Handling | pending | #12 AudioManager tests, #13 missing controller tests, #30 Result<T> |

--- a/tests/Radio.Infrastructure.Tests/Audio/Diagnostics/WaveformComparisonTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Diagnostics/WaveformComparisonTests.cs
@@ -234,4 +234,202 @@ public class WaveformComparisonTests
     // Clipped sine should have measurable THD (typically 10-40%)
     Assert.True(thd > 5.0f, $"THD of clipped sine should be > 5%, got {thd:F2}%");
   }
+
+  [SkippableFact]
+  [Trait("Category", "CaptureAnalysis")]
+  public void AnalyzeBtCapture_InputVsOutput()
+  {
+    var captureDir = Path.Combine(
+      AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "..",
+      "data", "diagnostics", "bt-capture-60s-postfix");
+
+    var inputPath = Path.Combine(captureDir, "generator-input.wav");
+    var outputPath = Path.Combine(captureDir, "generator-output.wav");
+    var postModPath = Path.Combine(captureDir, "post-modifiers.wav");
+
+    Skip.IfNot(File.Exists(inputPath), "No capture files found — run capture first");
+
+    var input = WavFileHelper.ReadWavFile(inputPath, out var inSr, out var inCh);
+    var output = WavFileHelper.ReadWavFile(outputPath, out var outSr, out var outCh);
+    var postMod = WavFileHelper.ReadWavFile(postModPath, out var pmSr, out var pmCh);
+
+    // === Basic stats ===
+    var inRms = WavFileHelper.CalculateRms(input);
+    var inPeak = WavFileHelper.CalculatePeak(input);
+    var outRms = WavFileHelper.CalculateRms(output);
+    var outPeak = WavFileHelper.CalculatePeak(output);
+    var pmRms = WavFileHelper.CalculateRms(postMod);
+    var pmPeak = WavFileHelper.CalculatePeak(postMod);
+
+    // Log basic info
+    var sb = new System.Text.StringBuilder();
+    sb.AppendLine("=== BT Capture Analysis (60s) ===");
+    sb.AppendLine($"Generator Input:  {input.Length} samples, {inSr}Hz {inCh}ch, RMS={WavFileHelper.LinearToDb(inRms):F1}dB, Peak={WavFileHelper.LinearToDb(inPeak):F1}dB");
+    sb.AppendLine($"Generator Output: {output.Length} samples, {outSr}Hz {outCh}ch, RMS={WavFileHelper.LinearToDb(outRms):F1}dB, Peak={WavFileHelper.LinearToDb(outPeak):F1}dB");
+    sb.AppendLine($"Post-Modifiers:   {postMod.Length} samples, {pmSr}Hz {pmCh}ch, RMS={WavFileHelper.LinearToDb(pmRms):F1}dB, Peak={WavFileHelper.LinearToDb(pmPeak):F1}dB");
+    sb.AppendLine($"Sample diff: input={input.Length}, output={output.Length}, delta={output.Length - input.Length}");
+
+    // === Input vs Output comparison ===
+    sb.AppendLine();
+    sb.AppendLine("--- Generator Input vs Output ---");
+    var ioReport = WaveformComparison.Compare(input, output);
+    sb.AppendLine($"SNR: {ioReport.SnrDb:F1} dB");
+    sb.AppendLine($"RMS Error: {ioReport.RmsError:F6}");
+    sb.AppendLine($"Peak Error: {ioReport.PeakError:F6}");
+    sb.AppendLine($"Gain Ratio: {ioReport.GainRatio:F4}");
+    sb.AppendLine($"Correlation: {ioReport.CorrelationCoefficient:F6}");
+    sb.AppendLine($"IsClean: {ioReport.IsClean}");
+    sb.AppendLine($"Events: {ioReport.Events.Count}");
+    foreach (var evt in ioReport.Events.Take(20))
+      sb.AppendLine($"  [{evt.Type}] offset={evt.SampleOffset} len={evt.Duration} sev={evt.Severity:F2}: {evt.Description}");
+    if (ioReport.Events.Count > 20)
+      sb.AppendLine($"  ... and {ioReport.Events.Count - 20} more events");
+
+    // === Output vs Post-Modifiers comparison ===
+    sb.AppendLine();
+    sb.AppendLine("--- Generator Output vs Post-Modifiers ---");
+    var opReport = WaveformComparison.Compare(output, postMod);
+    sb.AppendLine($"SNR: {opReport.SnrDb:F1} dB");
+    sb.AppendLine($"RMS Error: {opReport.RmsError:F6}");
+    sb.AppendLine($"Peak Error: {opReport.PeakError:F6}");
+    sb.AppendLine($"Gain Ratio: {opReport.GainRatio:F4}");
+    sb.AppendLine($"Correlation: {opReport.CorrelationCoefficient:F6}");
+    sb.AppendLine($"IsClean: {opReport.IsClean}");
+    sb.AppendLine($"Events: {opReport.Events.Count}");
+    foreach (var evt in opReport.Events.Take(20))
+      sb.AppendLine($"  [{evt.Type}] offset={evt.SampleOffset} len={evt.Duration} sev={evt.Severity:F2}: {evt.Description}");
+    if (opReport.Events.Count > 20)
+      sb.AppendLine($"  ... and {opReport.Events.Count - 20} more events");
+
+    // === Silence/repeat/clipping scan on each stage independently ===
+    sb.AppendLine();
+    sb.AppendLine("--- Independent Stage Scans ---");
+    foreach (var (name, samples) in new[] {
+      ("generator-input", input), ("generator-output", output), ("post-modifiers", postMod) })
+    {
+      var zeros = SilenceDetector.FindZeroRuns(samples, minRunLength: 20);
+      var repeats = SilenceDetector.FindRepeatedSampleRuns(samples, minRunLength: 10);
+      var clips = SilenceDetector.FindClippingRuns(samples, 0.999f, minRunLength: 4);
+      sb.AppendLine($"  {name}: {zeros.Count} silence runs, {repeats.Count} repeated runs, {clips.Count} clipping runs");
+      foreach (var z in zeros.Take(5))
+        sb.AppendLine($"    silence: offset={z.Start} len={z.Length}");
+      foreach (var r in repeats.Take(5))
+        sb.AppendLine($"    repeated: offset={r.Start} len={r.Length} val={samples[r.Start]:F6}");
+      foreach (var c in clips.Take(5))
+        sb.AppendLine($"    clipping: offset={c.Start} len={c.Length}");
+    }
+
+    // === Time offset detection (input vs output) ===
+    sb.AppendLine();
+    sb.AppendLine("--- Time Offset Detection ---");
+    var minLen = Math.Min(input.Length, output.Length);
+    if (minLen > 9600)
+    {
+      var (offset, corr) = WaveformComparison.FindTimeOffset(
+        input.AsSpan(0, Math.Min(minLen, 480000)),
+        output.AsSpan(0, Math.Min(minLen, 480000)),
+        maxOffsetSamples: 4800);
+      sb.AppendLine($"Input→Output offset: {offset} samples ({offset / 96.0:F1} ms), correlation: {corr:F4}");
+    }
+
+    // === Silence gap deep analysis (channel alignment) ===
+    sb.AppendLine();
+    sb.AppendLine("--- Silence Gap Deep Analysis (generator-input) ---");
+    var inputZeros = SilenceDetector.FindZeroRuns(input, minRunLength: 20);
+    foreach (var (start, length) in inputZeros)
+    {
+      var isEven = length % 2 == 0;
+      sb.AppendLine($"  Gap at {start}, length={length} ({(isEven ? "EVEN — frame-aligned" : "ODD — MISALIGNED!")})");
+      sb.AppendLine($"    Duration: {length / 96.0:F2} ms ({length / 2} frames)");
+
+      // Show samples around the gap
+      var before = Math.Max(0, start - 6);
+      var after = Math.Min(input.Length, start + length + 6);
+      sb.Append("    Before: ");
+      for (int i = before; i < start; i++)
+        sb.Append($"{input[i]:F4} ");
+      sb.AppendLine();
+      sb.Append("    Gap start: ");
+      for (int i = start; i < Math.Min(start + 6, start + length); i++)
+        sb.Append($"{input[i]:F4} ");
+      sb.AppendLine("...");
+      sb.Append("    Gap end:   ...");
+      for (int i = Math.Max(start, start + length - 6); i < start + length; i++)
+        sb.Append($"{input[i]:F4} ");
+      sb.AppendLine();
+      sb.Append("    After:  ");
+      for (int i = start + length; i < after; i++)
+        sb.Append($"{input[i]:F4} ");
+      sb.AppendLine();
+
+      // Check channel swap after gap: if odd gap, L/R may be swapped
+      if (!isEven && start + length + 20 < input.Length && start >= 20)
+      {
+        // Compare L/R energy pattern before and after gap
+        float preL = 0, preR = 0, postL = 0, postR = 0;
+        for (int i = 0; i < 10; i++)
+        {
+          preL += MathF.Abs(input[start - 20 + i * 2]);
+          preR += MathF.Abs(input[start - 20 + i * 2 + 1]);
+          postL += MathF.Abs(input[start + length + i * 2]);
+          postR += MathF.Abs(input[start + length + i * 2 + 1]);
+        }
+        sb.AppendLine($"    Pre-gap  L avg={preL / 10:F4}, R avg={preR / 10:F4}");
+        sb.AppendLine($"    Post-gap L avg={postL / 10:F4}, R avg={postR / 10:F4}");
+        sb.AppendLine($"    Channel swap indicator: pre L/R ratio={(preL > 0 ? preR / preL : 0):F3}, post L/R ratio={(postL > 0 ? postR / postL : 0):F3}");
+      }
+    }
+
+    // === Windowed correlation analysis (find where distortion occurs) ===
+    sb.AppendLine();
+    sb.AppendLine("--- Windowed Correlation (input vs output, 1s windows) ---");
+    var windowSize = 96000; // 1 second stereo
+    var ioMinLen = Math.Min(input.Length, output.Length);
+    for (int w = 0; w + windowSize <= ioMinLen; w += windowSize)
+    {
+      var refWindow = input.AsSpan(w, windowSize);
+      var capWindow = output.AsSpan(w, windowSize);
+      double cc = 0, re = 0, ce = 0;
+      for (int i = 0; i < windowSize; i++)
+      {
+        cc += refWindow[i] * capWindow[i];
+        re += refWindow[i] * refWindow[i];
+        ce += capWindow[i] * capWindow[i];
+      }
+      var denom = Math.Sqrt(re * ce);
+      var corr = denom > 0 ? cc / denom : 0;
+      var windowSec = w / 96000.0;
+      var marker = corr < 0.9 ? " <<<" : "";
+      sb.AppendLine($"  t={windowSec:F0}s: corr={corr:F4}{marker}");
+    }
+
+    // === Sample-level diff analysis: find largest error regions ===
+    sb.AppendLine();
+    sb.AppendLine("--- Largest Error Regions (input vs output) ---");
+    var errorWindowSize = 4800; // 50ms windows
+    var topErrors = new List<(int offset, float rmsError)>();
+    for (int w = 0; w + errorWindowSize <= ioMinLen; w += errorWindowSize)
+    {
+      double errSum = 0;
+      for (int i = w; i < w + errorWindowSize; i++)
+      {
+        var e = input[i] - output[i];
+        errSum += e * e;
+      }
+      topErrors.Add((w, (float)Math.Sqrt(errSum / errorWindowSize)));
+    }
+    topErrors.Sort((a, b) => b.rmsError.CompareTo(a.rmsError));
+    foreach (var (offset, rmsError) in topErrors.Take(10))
+    {
+      var timeSec = offset / 96000.0;
+      sb.AppendLine($"  t={timeSec:F2}s (offset {offset}): RMS error={rmsError:F4} ({WavFileHelper.LinearToDb(rmsError):F1} dB)");
+    }
+
+    // Write results to file for easy viewing
+    var resultsPath = Path.Combine(captureDir, "analysis-results.txt");
+    File.WriteAllText(resultsPath, sb.ToString());
+
+    // Also output to test runner
+    Assert.True(true, sb.ToString()); // Always passes — this is a diagnostic test
+  }
 }


### PR DESCRIPTION
## Summary

- **Root cause identified**: `PipeWireNativeStream.OnProcess` converts S16LE bytes to float samples without stereo frame alignment. When PipeWire's BT transport delivers non-frame-aligned chunks during packet loss/gaps, `sampleCount` is odd, causing every subsequent sample to have L/R channels swapped — producing sustained audible distortion.
- **Fix**: Round `sampleCount` down to frame boundary (`sampleCount / channels * channels`) in `PipeWireNativeStream.OnProcess`, with defense-in-depth frame alignment in `BufferedSoundGenerator.AddSamples()`
- **Verified**: 60s BT capture analysis shows Output→PostModifiers correlation improved from 0.40 to 1.00 (perfect), sample delta from -32,640 to +1,024

## Evidence

| Metric | Pre-Fix | Post-Fix |
|--------|---------|----------|
| Output→PostModifiers correlation | 0.400872 | 1.000000 |
| Sample delta (input vs output) | -32,640 | +1,024 |
| Silence gaps (channel-swap causing) | 3 ODD-length gaps with L/R flip | 0 (gaps are transport dropouts, not channel swaps) |
| Post-modifier distortion events | 3 (silence + gain) | 1 (gain only) |

## Test plan

- [x] `dotnet build --configuration Release` — 0 warnings
- [x] All existing tests pass (1 external API test fails — Cover Art Archive unauthorized, unrelated)
- [x] Pre-fix 60s BT capture analyzed: 3 ODD silence gaps with L/R channel ratio flips
- [x] Post-fix 60s BT capture analyzed: correlation 1.000000, no channel swaps
- [x] Deployed to Ubuntu and verified capture endpoint working

🤖 Generated with [Claude Code](https://claude.com/claude-code)