### PR TITLE
fix: Cast dropdown UX — first-touch auto-select, click-outside dismiss

### DIFF
--- a/src/Radio.Web/Components/Layout/MainLayout.razor
+++ b/src/Radio.Web/Components/Layout/MainLayout.razor
@@ -456,21 +456,33 @@
   {
     if (string.IsNullOrEmpty(newOutputId)) return;
 
-    // Second click on already-selected Cast → toggle dropdown
-    if (newOutputId == _selectedOutputId && newOutputId == "google-cast")
+    if (newOutputId == "google-cast")
     {
-      _showCastDropdown = !_showCastDropdown;
+      // Cast already active → toggle dropdown for device switching
+      if (newOutputId == _selectedOutputId)
+      {
+        _showCastDropdown = !_showCastDropdown;
+        return;
+      }
+
+      // First click on Cast with a saved default → auto-connect (no dropdown)
+      if (_defaultCastDevice != null)
+      {
+        await AutoConnectCastDeviceAsync(newOutputId);
+        return;
+      }
+
+      // First click on Cast with no default → open dropdown for device selection
+      _selectedOutputId = newOutputId;
+      _showCastDropdown = true;
       return;
     }
 
     if (newOutputId == _selectedOutputId) return;
 
-    // When selecting Google Cast with a default device, auto-connect
-    if (newOutputId == "google-cast" && _defaultCastDevice != null)
-    {
-      await AutoConnectCastDeviceAsync(newOutputId);
-      return;
-    }
+    // Switching away from Cast → close dropdown if open
+    if (_showCastDropdown)
+      _showCastDropdown = false;
 
     try
     {

--- a/src/Radio.Web/Components/Shared/CastDeviceDropdown.razor
+++ b/src/Radio.Web/Components/Shared/CastDeviceDropdown.razor
@@ -1,12 +1,13 @@
 @using Radio.Web.Models
 @using Radio.Web.Services.ApiClients
 
-<!-- Click-away overlay -->
+<!-- Click-away overlay (onclick + ontouchend for reliable touch dismissal) -->
 @if (IsOpen)
 {
   <div @onclick="Close" @onclick:stopPropagation="true"
-       style="position: fixed; inset: 0; z-index: 99;"></div>
-  <div @onclick:stopPropagation="true"
+       @ontouchend="Close" @ontouchend:stopPropagation="true"
+       style="position: fixed; inset: 0; z-index: 99; -webkit-tap-highlight-color: transparent;"></div>
+  <div @onclick:stopPropagation="true" @ontouchend:stopPropagation="true"
        style="position: absolute; top: 100%; right: 0; z-index: 100; min-width: 280px; max-width: 340px;
               background: rgba(30,30,30,0.95); backdrop-filter: blur(12px);
               border: 1px solid rgba(255,255,255,0.15); border-radius: 8px;


### PR DESCRIPTION
## Summary

- **First touch** with saved default Cast device: auto-connects without showing dropdown (unchanged)
- **First touch** with no saved default: now opens the dropdown for device selection (previously silently switched output type without connecting to any device)
- **Second touch** (Cast already active): toggles dropdown for switching devices (unchanged)
- **Click/touch outside dropdown**: closes it — added `@ontouchend` handler alongside `@onclick` for reliable touch-screen dismissal on the kiosk
- **Switching away from Cast**: auto-closes dropdown if it was open

## Files changed

- `MainLayout.razor` — Restructured `HandleOutputChangeAsync` to handle Cast-specific logic upfront with clear first-click/second-click flow
- `CastDeviceDropdown.razor` — Added `@ontouchend` event handlers on click-away overlay and dropdown content for touch-screen reliability

## Test plan

- [x] Build: 0 warnings
- [x] All tests pass (1 pre-existing diagnostic test skip — requires Ubuntu capture data)
- [ ] Verify on kiosk: first touch selects default device, second touch opens dropdown
- [ ] Verify on kiosk: tapping outside dropdown closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)