### PR TITLE
refactor: Split IAudioManager + add AudioStateStore + fix deploy scripts

### DIFF
--- a/deploy/Deploy-ToLinux.ps1
+++ b/deploy/Deploy-ToLinux.ps1
@@ -75,7 +75,7 @@ Write-Host "[1/4] Building for $Runtime..." -ForegroundColor Yellow
 $commonArgs = @(
   "--configuration", "Release",
   "--runtime", $Runtime,
-  "-f", "net8.0",
+  "-f", "net10.0",
   "-v", "quiet"
 )
 
@@ -91,10 +91,10 @@ if ($Quick) {
   )
 }
 
-# Restore for net8.0 (Windows conditional TFM means assets are built for windows TFM by default)
-Write-Host "  Restoring for net8.0 / $Runtime..." -ForegroundColor DarkGray
-dotnet restore "$RepoRoot\src\Radio.API\Radio.API.csproj" --runtime $Runtime -p:TargetFramework=net8.0 -v quiet
-dotnet restore "$RepoRoot\src\Radio.Web\Radio.Web.csproj" --runtime $Runtime -p:TargetFramework=net8.0 -v quiet
+# Restore for net10.0 (Windows conditional TFM means assets are built for windows TFM by default)
+Write-Host "  Restoring for net10.0 / $Runtime..." -ForegroundColor DarkGray
+dotnet restore "$RepoRoot\src\Radio.API\Radio.API.csproj" --runtime $Runtime -p:TargetFramework=net10.0 -v quiet
+dotnet restore "$RepoRoot\src\Radio.Web\Radio.Web.csproj" --runtime $Runtime -p:TargetFramework=net10.0 -v quiet
 
 # Publish Radio.API
 Write-Host "  Publishing Radio.API..." -ForegroundColor DarkGray

--- a/deploy/common/publish.sh
+++ b/deploy/common/publish.sh
@@ -29,7 +29,7 @@ publish_for_rid() {
   dotnet publish "$REPO_ROOT/src/Radio.API/Radio.API.csproj" \
     --configuration Release \
     --runtime "$RID" \
-    -f net8.0 \
+    -f net10.0 \
     --self-contained true \
     --output "$OUTPUT/api" \
     -p:PublishSingleFile=true \
@@ -42,7 +42,7 @@ publish_for_rid() {
   dotnet publish "$REPO_ROOT/src/Radio.Web/Radio.Web.csproj" \
     --configuration Release \
     --runtime "$RID" \
-    -f net8.0 \
+    -f net10.0 \
     --self-contained true \
     --output "$OUTPUT/web" \
     -p:PublishSingleFile=true \

--- a/deploy/deploy-to-pi.sh
+++ b/deploy/deploy-to-pi.sh
@@ -59,7 +59,7 @@ echo ""
 # Step 1: Build both projects
 echo "[1/4] Building for linux-arm64..."
 
-COMMON_ARGS="--configuration Release --runtime linux-arm64 -f net8.0"
+COMMON_ARGS="--configuration Release --runtime linux-arm64 -f net10.0"
 
 if [ "$QUICK" = true ]; then
   COMMON_ARGS="$COMMON_ARGS --no-self-contained"

--- a/src/Radio.Core/Interfaces/Audio/IAudioManager.cs
+++ b/src/Radio.Core/Interfaces/Audio/IAudioManager.cs
@@ -1,10 +1,12 @@
 namespace Radio.Core.Interfaces.Audio;
 
 /// <summary>
-/// Core interface for managing audio sources and playback.
-/// Coordinates the audio engine, mixer, and audio sources.
+/// Facade interface for managing audio sources, playback, and mixer settings.
+/// Extends <see cref="IAudioSourceManager"/> and <see cref="IAudioMixerControl"/>
+/// for consumers that need the full API. Prefer the sub-interfaces when only
+/// source management or mixer control is needed.
 /// </summary>
-public interface IAudioManager : IAsyncDisposable
+public interface IAudioManager : IAudioSourceManager, IAudioMixerControl, IAsyncDisposable
 {
   /// <summary>
   /// Gets the audio engine instance.
@@ -12,78 +14,8 @@ public interface IAudioManager : IAsyncDisposable
   IAudioEngine Engine { get; }
 
   /// <summary>
-  /// Gets the currently active primary audio source.
-  /// </summary>
-  IAudioSource? ActiveSource { get; }
-
-  /// <summary>
   /// Initializes the audio manager and underlying engine.
   /// </summary>
   /// <param name="cancellationToken">Cancellation token.</param>
-  /// <returns>A task representing the async operation.</returns>
   Task InitializeAsync(CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Switches to a new primary audio source.
-  /// </summary>
-  /// <param name="source">The audio source to switch to.</param>
-  /// <param name="cancellationToken">Cancellation token.</param>
-  /// <returns>A task representing the async operation.</returns>
-  Task SwitchSourceAsync(IAudioSource source, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Gets or creates an audio source of the specified type and optionally switches to it.
-  /// </summary>
-  /// <param name="sourceType">The type of audio source to get or create.</param>
-  /// <param name="switchToSource">If true, switches to the source after getting/creating it.</param>
-  /// <param name="cancellationToken">Cancellation token.</param>
-  /// <returns>The audio source, or null if the type is not supported.</returns>
-  Task<IAudioSource?> GetOrCreateSourceAsync(
-    AudioSourceType sourceType,
-    bool switchToSource = true,
-    CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Stops all audio playback.
-  /// </summary>
-  /// <param name="cancellationToken">Cancellation token.</param>
-  /// <returns>A task representing the async operation.</returns>
-  Task StopAsync(CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Gets or sets the master volume level (0.0 to 1.0).
-  /// </summary>
-  float MasterVolume { get; set; }
-
-  /// <summary>
-  /// Gets or sets whether master audio is muted.
-  /// </summary>
-  bool IsMuted { get; set; }
-
-  /// <summary>
-  /// Gets or sets the stereo balance (-1.0 = full left, 0.0 = center, 1.0 = full right).
-  /// </summary>
-  float Balance { get; set; }
-
-  /// <summary>
-  /// Gets the gain offset for a specific source type (linear multiplier, default 1.0).
-  /// </summary>
-  float GetSourceGain(AudioSourceType sourceType);
-
-  /// <summary>
-  /// Sets the gain offset for a specific source type (linear multiplier 0.0-2.0).
-  /// If the source type matches the active source, updates live playback immediately.
-  /// </summary>
-  void SetSourceGain(AudioSourceType sourceType, float gain);
-
-  /// <summary>
-  /// Gets all per-source gain offsets as a dictionary.
-  /// </summary>
-  Dictionary<string, float> GetAllSourceGains();
-
-  /// <summary>
-  /// Gets a previously created and cached source by type, without switching to it.
-  /// Returns null if the source type has never been created.
-  /// </summary>
-  IAudioSource? GetCachedSource(AudioSourceType sourceType);
 }

--- a/src/Radio.Core/Interfaces/Audio/IAudioMixerControl.cs
+++ b/src/Radio.Core/Interfaces/Audio/IAudioMixerControl.cs
@@ -1,0 +1,40 @@
+using Radio.Core.Models.Audio;
+
+namespace Radio.Core.Interfaces.Audio;
+
+/// <summary>
+/// Controls audio mixer settings: master volume, mute, balance, and per-source gain offsets.
+/// </summary>
+public interface IAudioMixerControl
+{
+  /// <summary>
+  /// Gets or sets the master volume level (0.0 to 1.0).
+  /// </summary>
+  float MasterVolume { get; set; }
+
+  /// <summary>
+  /// Gets or sets whether master audio is muted.
+  /// </summary>
+  bool IsMuted { get; set; }
+
+  /// <summary>
+  /// Gets or sets the stereo balance (-1.0 = full left, 0.0 = center, 1.0 = full right).
+  /// </summary>
+  float Balance { get; set; }
+
+  /// <summary>
+  /// Gets the gain offset for a specific source type (linear multiplier, default 1.0).
+  /// </summary>
+  float GetSourceGain(AudioSourceType sourceType);
+
+  /// <summary>
+  /// Sets the gain offset for a specific source type (linear multiplier 0.0-2.0).
+  /// If the source type matches the active source, updates live playback immediately.
+  /// </summary>
+  void SetSourceGain(AudioSourceType sourceType, float gain);
+
+  /// <summary>
+  /// Gets all per-source gain offsets as a dictionary.
+  /// </summary>
+  Dictionary<string, float> GetAllSourceGains();
+}

--- a/src/Radio.Core/Interfaces/Audio/IAudioSourceManager.cs
+++ b/src/Radio.Core/Interfaces/Audio/IAudioSourceManager.cs
@@ -1,0 +1,45 @@
+using Radio.Core.Models.Audio;
+
+namespace Radio.Core.Interfaces.Audio;
+
+/// <summary>
+/// Manages audio source lifecycle: creation, switching, caching, and stopping.
+/// </summary>
+public interface IAudioSourceManager
+{
+  /// <summary>
+  /// Gets the currently active primary audio source.
+  /// </summary>
+  IAudioSource? ActiveSource { get; }
+
+  /// <summary>
+  /// Switches to a new primary audio source.
+  /// </summary>
+  /// <param name="source">The audio source to switch to.</param>
+  /// <param name="cancellationToken">Cancellation token.</param>
+  Task SwitchSourceAsync(IAudioSource source, CancellationToken cancellationToken = default);
+
+  /// <summary>
+  /// Gets or creates an audio source of the specified type and optionally switches to it.
+  /// </summary>
+  /// <param name="sourceType">The type of audio source to get or create.</param>
+  /// <param name="switchToSource">If true, switches to the source after getting/creating it.</param>
+  /// <param name="cancellationToken">Cancellation token.</param>
+  /// <returns>The audio source, or null if the type is not supported.</returns>
+  Task<IAudioSource?> GetOrCreateSourceAsync(
+    AudioSourceType sourceType,
+    bool switchToSource = true,
+    CancellationToken cancellationToken = default);
+
+  /// <summary>
+  /// Stops all audio playback.
+  /// </summary>
+  /// <param name="cancellationToken">Cancellation token.</param>
+  Task StopAsync(CancellationToken cancellationToken = default);
+
+  /// <summary>
+  /// Gets a previously created and cached source by type, without switching to it.
+  /// Returns null if the source type has never been created.
+  /// </summary>
+  IAudioSource? GetCachedSource(AudioSourceType sourceType);
+}

--- a/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
+++ b/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
@@ -149,6 +149,8 @@ public static class AudioServiceExtensions
       sp.GetRequiredService<PlayHistoryTracker>(),
       sp.GetRequiredService<SoundFlowPlaybackService>()));
     services.AddSingleton<IAudioManager>(sp => sp.GetRequiredService<AudioManager>());
+    services.AddSingleton<IAudioSourceManager>(sp => sp.GetRequiredService<AudioManager>());
+    services.AddSingleton<IAudioMixerControl>(sp => sp.GetRequiredService<AudioManager>());
 
     // Register play history tracker (Func<> defers IAudioManager resolution, breaking circular dependency)
     services.AddSingleton<PlayHistoryTracker>(sp => new PlayHistoryTracker(

--- a/src/Radio.Web/Program.cs
+++ b/src/Radio.Web/Program.cs
@@ -292,6 +292,9 @@ builder.Services.AddHttpClient("AlbumArtProxy", client =>
 builder.Services.AddSingleton<AudioStateHubService>();
 builder.Services.AddSingleton<AudioVisualizationHubService>();
 
+// Register centralized audio state store (subscribes to hub, caches state for components)
+builder.Services.AddSingleton<AudioStateStore>();
+
 // Register application services
 builder.Services.AddScoped<Radio.Web.Services.QueuePersistenceService>();
 builder.Services.AddScoped<Radio.Web.Services.DeviceDisplayStateService>();

--- a/src/Radio.Web/Services/AudioStateStore.cs
+++ b/src/Radio.Web/Services/AudioStateStore.cs
@@ -1,0 +1,233 @@
+using Microsoft.Extensions.Logging;
+using Radio.Web.Models;
+using Radio.Web.Services.Hub;
+
+namespace Radio.Web.Services;
+
+/// <summary>
+/// Centralized observable store for audio state.
+/// Subscribes to SignalR events and caches playback, now-playing, volume,
+/// fingerprint, and queue state. Components subscribe to change events
+/// instead of managing their own SignalR subscriptions.
+/// </summary>
+public class AudioStateStore : IAsyncDisposable
+{
+  private readonly ILogger<AudioStateStore> _logger;
+  private readonly AudioStateHubService _hubService;
+
+  // --- Cached state ---
+  public PlaybackStateDto? PlaybackState { get; private set; }
+  public NowPlayingDto? NowPlaying { get; private set; }
+  public float Volume { get; private set; } = 0.75f;
+  public bool IsMuted { get; private set; }
+  public FingerprintStatusDto? FingerprintStatus { get; private set; }
+  public int QueueCount { get; private set; }
+  public Dictionary<string, float> SourceGainOffsets { get; private set; } = new();
+
+  // --- Change events ---
+  /// <summary>Raised when playback state (isPlaying, transport capabilities) changes.</summary>
+  public event Func<Task>? PlaybackStateChanged;
+
+  /// <summary>Raised when now-playing metadata (title, artist, album art) changes.</summary>
+  public event Func<Task>? NowPlayingChanged;
+
+  /// <summary>Raised when volume or mute state changes.</summary>
+  public event Func<Task>? VolumeChanged;
+
+  /// <summary>Raised when the active source changes.</summary>
+  public event Func<Task>? SourceChanged;
+
+  /// <summary>Raised when the queue changes.</summary>
+  public event Func<Task>? QueueChanged;
+
+  /// <summary>Raised when fingerprint status changes.</summary>
+  public event Func<Task>? FingerprintStatusChanged;
+
+  /// <summary>Raised when radio state changes.</summary>
+  public event Func<Task>? RadioStateChanged;
+
+  /// <summary>Raised when sleep state changes.</summary>
+  public event Func<bool, Task>? SleepStateChanged;
+
+  /// <summary>Raised when encoder connection state changes.</summary>
+  public event Func<Task>? EncoderConnectionChanged;
+
+  public AudioStateStore(
+    ILogger<AudioStateStore> logger,
+    AudioStateHubService hubService)
+  {
+    _logger = logger;
+    _hubService = hubService;
+
+    // Subscribe to hub events
+    _hubService.PlaybackStateChanged += OnHubPlaybackStateChanged;
+    _hubService.NowPlayingChanged += OnHubNowPlayingChanged;
+    _hubService.VolumeChanged += OnHubVolumeChanged;
+    _hubService.SourceChanged += OnHubSourceChanged;
+    _hubService.QueueChanged += OnHubQueueChanged;
+    _hubService.FingerprintStatusChanged += OnHubFingerprintStatusChanged;
+    _hubService.RadioStateChanged += OnHubRadioStateChanged;
+    _hubService.SleepStateChanged += OnHubSleepStateChanged;
+    _hubService.EncoderConnectionChanged += OnHubEncoderConnectionChanged;
+  }
+
+  /// <summary>
+  /// Updates cached playback state. Call from initial data load or API refresh.
+  /// </summary>
+  public async Task UpdatePlaybackStateAsync(PlaybackStateDto? state)
+  {
+    PlaybackState = state;
+    if (state != null)
+    {
+      Volume = state.Volume;
+      IsMuted = state.IsMuted;
+    }
+
+    await NotifyAsync(PlaybackStateChanged);
+  }
+
+  /// <summary>
+  /// Updates cached now-playing metadata. Call from initial data load or API refresh.
+  /// </summary>
+  public async Task UpdateNowPlayingAsync(NowPlayingDto? nowPlaying)
+  {
+    NowPlaying = nowPlaying;
+    await NotifyAsync(NowPlayingChanged);
+  }
+
+  /// <summary>
+  /// Updates cached volume/mute state.
+  /// </summary>
+  public async Task UpdateVolumeAsync(float volume, bool isMuted)
+  {
+    Volume = volume;
+    IsMuted = isMuted;
+    await NotifyAsync(VolumeChanged);
+  }
+
+  /// <summary>
+  /// Updates cached fingerprint status.
+  /// </summary>
+  public async Task UpdateFingerprintStatusAsync(FingerprintStatusDto? status)
+  {
+    FingerprintStatus = status;
+    await NotifyAsync(FingerprintStatusChanged);
+  }
+
+  /// <summary>
+  /// Updates cached queue count.
+  /// </summary>
+  public async Task UpdateQueueCountAsync(int count)
+  {
+    QueueCount = count;
+    await NotifyAsync(QueueChanged);
+  }
+
+  /// <summary>
+  /// Updates cached source gain offsets.
+  /// </summary>
+  public void UpdateSourceGainOffsets(Dictionary<string, float> offsets)
+  {
+    SourceGainOffsets = offsets;
+  }
+
+  /// <summary>
+  /// Triggers a source changed notification (e.g., after API call).
+  /// </summary>
+  public async Task NotifySourceChangedAsync()
+  {
+    await NotifyAsync(SourceChanged);
+  }
+
+  // --- Hub event handlers ---
+
+  private async Task OnHubPlaybackStateChanged()
+  {
+    await NotifyAsync(PlaybackStateChanged);
+  }
+
+  private async Task OnHubNowPlayingChanged(NowPlayingDto? dto)
+  {
+    if (dto != null)
+    {
+      NowPlaying = dto;
+    }
+
+    await NotifyAsync(NowPlayingChanged);
+  }
+
+  private async Task OnHubVolumeChanged(VolumeDto? dto)
+  {
+    if (dto != null)
+    {
+      Volume = dto.Volume;
+      IsMuted = dto.IsMuted;
+    }
+
+    await NotifyAsync(VolumeChanged);
+  }
+
+  private async Task OnHubSourceChanged()
+  {
+    await NotifyAsync(SourceChanged);
+  }
+
+  private async Task OnHubQueueChanged()
+  {
+    await NotifyAsync(QueueChanged);
+  }
+
+  private async Task OnHubFingerprintStatusChanged()
+  {
+    await NotifyAsync(FingerprintStatusChanged);
+  }
+
+  private async Task OnHubRadioStateChanged()
+  {
+    await NotifyAsync(RadioStateChanged);
+  }
+
+  private async Task OnHubSleepStateChanged(bool isSleeping)
+  {
+    if (SleepStateChanged != null)
+    {
+      await SleepStateChanged.Invoke(isSleeping);
+    }
+  }
+
+  private async Task OnHubEncoderConnectionChanged()
+  {
+    await NotifyAsync(EncoderConnectionChanged);
+  }
+
+  private async Task NotifyAsync(Func<Task>? handler)
+  {
+    if (handler != null)
+    {
+      try
+      {
+        await handler.Invoke();
+      }
+      catch (Exception ex)
+      {
+        _logger.LogWarning(ex, "Error notifying AudioStateStore subscriber");
+      }
+    }
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    _hubService.PlaybackStateChanged -= OnHubPlaybackStateChanged;
+    _hubService.NowPlayingChanged -= OnHubNowPlayingChanged;
+    _hubService.VolumeChanged -= OnHubVolumeChanged;
+    _hubService.SourceChanged -= OnHubSourceChanged;
+    _hubService.QueueChanged -= OnHubQueueChanged;
+    _hubService.FingerprintStatusChanged -= OnHubFingerprintStatusChanged;
+    _hubService.RadioStateChanged -= OnHubRadioStateChanged;
+    _hubService.SleepStateChanged -= OnHubSleepStateChanged;
+    _hubService.EncoderConnectionChanged -= OnHubEncoderConnectionChanged;
+
+    await Task.CompletedTask;
+    GC.SuppressFinalize(this);
+  }
+}


### PR DESCRIPTION
## Summary
- **5A**: Split `IAudioManager` into `IAudioSourceManager` (source lifecycle) and `IAudioMixerControl` (volume/gain). `IAudioManager` extends both as facade — existing consumers unchanged, new code can use narrower interfaces
- **5D**: Add `AudioStateStore` singleton — centralizes SignalR event subscriptions and caches playback/volume/fingerprint/queue state for Web components. Foundation for incremental component decomposition
- **Deploy fix**: Update deploy scripts from `net8.0` to `net10.0` (caught by code review of PR #308)

## Test plan
- [x] `dotnet build --configuration Release` — 0 errors
- [x] `dotnet test --configuration Release` — all tests pass (1 pre-existing skip)
- [ ] Verify deploy scripts work with `net10.0` TFM on Ubuntu
- [ ] Components can incrementally adopt AudioStateStore

🤖 Generated with [Claude Code](https://claude.com/claude-code)