### PR TITLE
test: Add AudioManager tests + missing controller tests + Result<T>

### DIFF
--- a/src/Radio.Web/Models/Result.cs
+++ b/src/Radio.Web/Models/Result.cs
@@ -1,0 +1,70 @@
+namespace Radio.Web.Models;
+
+/// <summary>
+/// Represents the outcome of an API call with typed data or an error.
+/// Use instead of throwing exceptions from API service methods.
+/// </summary>
+/// <typeparam name="T">The type of the successful result value.</typeparam>
+public class Result<T>
+{
+  public T? Value { get; }
+  public string? Error { get; }
+  public bool IsSuccess { get; }
+  public bool IsDisconnected { get; }
+
+  private Result(T? value, string? error, bool isSuccess, bool isDisconnected)
+  {
+    Value = value;
+    Error = error;
+    IsSuccess = isSuccess;
+    IsDisconnected = isDisconnected;
+  }
+
+  /// <summary>Creates a successful result with a value.</summary>
+  public static Result<T> Success(T value) => new(value, null, true, false);
+
+  /// <summary>Creates an error result with a message.</summary>
+  public static Result<T> Fail(string error) => new(default, error, false, false);
+
+  /// <summary>Creates a disconnected result (API unreachable).</summary>
+  public static Result<T> Disconnected() => new(default, "API is not available", false, true);
+
+  /// <summary>Maps the value to a new type if successful.</summary>
+  public Result<TOut> Map<TOut>(Func<T, TOut> mapper)
+  {
+    if (!IsSuccess || Value == null)
+    {
+      return IsDisconnected
+        ? Result<TOut>.Disconnected()
+        : Result<TOut>.Fail(Error ?? "Unknown error");
+    }
+
+    return Result<TOut>.Success(mapper(Value));
+  }
+}
+
+/// <summary>
+/// Represents the outcome of an API call with no return value.
+/// </summary>
+public class Result
+{
+  public string? Error { get; }
+  public bool IsSuccess { get; }
+  public bool IsDisconnected { get; }
+
+  private Result(string? error, bool isSuccess, bool isDisconnected)
+  {
+    Error = error;
+    IsSuccess = isSuccess;
+    IsDisconnected = isDisconnected;
+  }
+
+  /// <summary>Creates a successful result.</summary>
+  public static Result Success() => new(null, true, false);
+
+  /// <summary>Creates an error result with a message.</summary>
+  public static Result Fail(string error) => new(error, false, false);
+
+  /// <summary>Creates a disconnected result (API unreachable).</summary>
+  public static Result Disconnected() => new("API is not available", false, true);
+}

--- a/tests/Radio.API.Tests/Controllers/AudioDiagnosticsControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/AudioDiagnosticsControllerTests.cs
@@ -1,0 +1,41 @@
+using System.Net;
+using Radio.API.Tests.TestSupport;
+
+namespace Radio.API.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for AudioDiagnosticsController.
+/// Tests diagnostic pipeline info and capture endpoints.
+/// </summary>
+public class AudioDiagnosticsControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
+{
+  private readonly HttpClient _client;
+
+  public AudioDiagnosticsControllerTests(CustomWebApplicationFactory<Program> factory)
+  {
+    _client = factory.CreateClient();
+  }
+
+  [Fact]
+  public async Task GetAudioPipelineDiagnostics_ReturnsOk()
+  {
+    var response = await _client.GetAsync("/api/diagnostics/audio-pipeline");
+
+    Assert.True(response.IsSuccessStatusCode, $"Expected success, got {response.StatusCode}");
+
+    var content = await response.Content.ReadAsStringAsync();
+    Assert.Contains("engineState", content);
+    Assert.Contains("engineReady", content);
+  }
+
+  [Fact]
+  public async Task GetAudioPipelineDiagnostics_ContainsPipelineInfo()
+  {
+    var response = await _client.GetAsync("/api/diagnostics/audio-pipeline");
+
+    Assert.True(response.IsSuccessStatusCode);
+
+    var content = await response.Content.ReadAsStringAsync();
+    Assert.Contains("timestamp", content);
+  }
+}

--- a/tests/Radio.API.Tests/Controllers/IntegrationsControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/IntegrationsControllerTests.cs
@@ -1,0 +1,39 @@
+using Radio.API.Tests.TestSupport;
+
+namespace Radio.API.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for IntegrationsController.
+/// Tests rotary encoder and phone integration status endpoints.
+/// </summary>
+public class IntegrationsControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
+{
+  private readonly HttpClient _client;
+
+  public IntegrationsControllerTests(CustomWebApplicationFactory<Program> factory)
+  {
+    _client = factory.CreateClient();
+  }
+
+  [Fact]
+  public async Task GetEncoderStatus_ReturnsOk()
+  {
+    var response = await _client.GetAsync("/api/integrations/encoder/status");
+
+    Assert.True(response.IsSuccessStatusCode, $"Expected success, got {response.StatusCode}");
+
+    var content = await response.Content.ReadAsStringAsync();
+    Assert.Contains("enabled", content, StringComparison.OrdinalIgnoreCase);
+  }
+
+  [Fact]
+  public async Task GetPhoneStatus_ReturnsOk()
+  {
+    var response = await _client.GetAsync("/api/integrations/phone/status");
+
+    Assert.True(response.IsSuccessStatusCode, $"Expected success, got {response.StatusCode}");
+
+    var content = await response.Content.ReadAsStringAsync();
+    Assert.Contains("enabled", content, StringComparison.OrdinalIgnoreCase);
+  }
+}

--- a/tests/Radio.API.Tests/Controllers/NotificationsControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/NotificationsControllerTests.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using System.Net.Http.Json;
+using Radio.API.Tests.TestSupport;
+
+namespace Radio.API.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for NotificationsController.
+/// Tests TTS announcement endpoint.
+/// </summary>
+public class NotificationsControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
+{
+  private readonly HttpClient _client;
+
+  public NotificationsControllerTests(CustomWebApplicationFactory<Program> factory)
+  {
+    _client = factory.CreateClient();
+  }
+
+  [Fact]
+  public async Task Announce_WithValidMessage_ReturnsOk()
+  {
+    var request = new { Message = "Test announcement", Priority = 5 };
+
+    var response = await _client.PostAsJsonAsync("/api/notifications/announce", request);
+
+    // Should succeed (announcement is fire-and-forget)
+    Assert.True(response.IsSuccessStatusCode, $"Expected success, got {response.StatusCode}");
+  }
+
+  [Fact]
+  public async Task Announce_WithEmptyMessage_ReturnsBadRequest()
+  {
+    var request = new { Message = "", Priority = 5 };
+
+    var response = await _client.PostAsJsonAsync("/api/notifications/announce", request);
+
+    Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+  }
+}

--- a/tests/Radio.API.Tests/Controllers/PlaylistsControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/PlaylistsControllerTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Net.Http.Json;
+using Radio.API.Tests.TestSupport;
+
+namespace Radio.API.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for PlaylistsController.
+/// Tests playlist CRUD operations via HTTP endpoints.
+/// </summary>
+public class PlaylistsControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>
+{
+  private readonly HttpClient _client;
+
+  public PlaylistsControllerTests(CustomWebApplicationFactory<Program> factory)
+  {
+    _client = factory.CreateClient();
+  }
+
+  [Fact]
+  public async Task GetAll_ReturnsOk()
+  {
+    var response = await _client.GetAsync("/api/playlists");
+
+    Assert.True(response.IsSuccessStatusCode, $"Expected success, got {response.StatusCode}");
+  }
+
+  [Fact]
+  public async Task GetById_WithNonExistentId_ReturnsNotFound()
+  {
+    var response = await _client.GetAsync("/api/playlists/nonexistent-id");
+
+    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+  }
+
+  [Fact]
+  public async Task Create_WithEmptyName_ReturnsBadRequest()
+  {
+    var request = new { Name = "", Description = "test" };
+
+    var response = await _client.PostAsJsonAsync("/api/playlists", request);
+
+    Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+  }
+
+  [Fact]
+  public async Task Create_WithWhitespaceName_ReturnsBadRequest()
+  {
+    var request = new { Name = "   ", Description = "test" };
+
+    var response = await _client.PostAsJsonAsync("/api/playlists", request);
+
+    Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+  }
+
+  [Fact]
+  public async Task Delete_WithNonExistentId_ReturnsNotFound()
+  {
+    var response = await _client.DeleteAsync("/api/playlists/nonexistent-id");
+
+    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+  }
+
+  [Fact]
+  public async Task Load_WithNonExistentId_ReturnsNotFound()
+  {
+    var response = await _client.PostAsync("/api/playlists/nonexistent-id/load", null);
+
+    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+  }
+}

--- a/tests/Radio.Infrastructure.Tests/Audio/Services/AudioManagerTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Services/AudioManagerTests.cs
@@ -1,0 +1,395 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Radio.Core.Events;
+using Radio.Core.Interfaces.Audio;
+using Radio.Core.Models.Audio;
+using Radio.Infrastructure.Audio.Services;
+
+namespace Radio.Infrastructure.Tests.Audio.Services;
+
+public class AudioManagerTests : IAsyncDisposable
+{
+  private readonly Mock<ILogger<AudioManager>> _loggerMock;
+  private readonly Mock<IAudioEngine> _engineMock;
+  private readonly Mock<IAudioSourceFactory> _sourceFactoryMock;
+  private readonly Mock<IMasterMixer> _mixerMock;
+  private readonly AudioManager _sut;
+
+  public AudioManagerTests()
+  {
+    _loggerMock = new Mock<ILogger<AudioManager>>();
+    _engineMock = new Mock<IAudioEngine>();
+    _sourceFactoryMock = new Mock<IAudioSourceFactory>();
+    _mixerMock = new Mock<IMasterMixer>();
+
+    _engineMock.Setup(e => e.GetMasterMixer()).Returns(_mixerMock.Object);
+    _engineMock.Setup(e => e.IsReady).Returns(true);
+    _mixerMock.Setup(m => m.GetActiveSources()).Returns(Array.Empty<IAudioSource>());
+
+    _sut = new AudioManager(
+      _loggerMock.Object,
+      _engineMock.Object,
+      _sourceFactoryMock.Object);
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    await _sut.DisposeAsync();
+    GC.SuppressFinalize(this);
+  }
+
+  // --- Source Management Tests ---
+
+  [Fact]
+  public void ActiveSource_Initially_IsNull()
+  {
+    Assert.Null(_sut.ActiveSource);
+  }
+
+  [Fact]
+  public async Task SwitchSourceAsync_SetsActiveSource()
+  {
+    // Arrange
+    var source = CreateMockPrimarySource(AudioSourceType.Radio, "FM Radio");
+
+    // Act
+    await _sut.SwitchSourceAsync(source.Object);
+
+    // Assert
+    Assert.Equal(source.Object, _sut.ActiveSource);
+  }
+
+  [Fact]
+  public async Task SwitchSourceAsync_StopsOldSource()
+  {
+    // Arrange
+    var oldSource = CreateMockPrimarySource(AudioSourceType.Radio, "FM Radio");
+    var newSource = CreateMockPrimarySource(AudioSourceType.Bluetooth, "BT");
+
+    _mixerMock.Setup(m => m.GetActiveSources())
+      .Returns(new[] { oldSource.Object });
+
+    await _sut.SwitchSourceAsync(oldSource.Object);
+
+    // Act
+    await _sut.SwitchSourceAsync(newSource.Object);
+
+    // Assert
+    oldSource.Verify(s => s.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+    Assert.Equal(newSource.Object, _sut.ActiveSource);
+  }
+
+  [Fact]
+  public async Task SwitchSourceAsync_AddsNewSourceToMixer()
+  {
+    // Arrange
+    var source = CreateMockPrimarySource(AudioSourceType.Radio, "FM Radio");
+
+    // Act
+    await _sut.SwitchSourceAsync(source.Object);
+
+    // Assert
+    _mixerMock.Verify(m => m.AddSource(source.Object), Times.Once);
+  }
+
+  [Fact]
+  public async Task SwitchSourceAsync_AutoPlaysRadioSource()
+  {
+    // Arrange
+    var source = CreateMockPrimarySource(AudioSourceType.Radio, "FM Radio");
+    source.Setup(s => s.State).Returns(AudioSourceState.Ready);
+
+    // Act
+    await _sut.SwitchSourceAsync(source.Object);
+
+    // Assert
+    source.Verify(s => s.PlayAsync(It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task SwitchSourceAsync_DoesNotAutoPlayFilePlayer()
+  {
+    // Arrange
+    var source = CreateMockPrimarySource(AudioSourceType.FilePlayer, "File Player");
+    source.Setup(s => s.State).Returns(AudioSourceState.Ready);
+
+    // Act
+    await _sut.SwitchSourceAsync(source.Object);
+
+    // Assert
+    source.Verify(s => s.PlayAsync(It.IsAny<CancellationToken>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task SwitchSourceAsync_ThrowsForNonPrimarySource()
+  {
+    // Arrange
+    var source = new Mock<IAudioSource>();
+    source.Setup(s => s.Category).Returns(AudioSourceCategory.Event);
+
+    // Act & Assert
+    await Assert.ThrowsAsync<ArgumentException>(
+      () => _sut.SwitchSourceAsync(source.Object));
+  }
+
+  [Fact]
+  public async Task GetOrCreateSourceAsync_CachesSource()
+  {
+    // Arrange
+    var source = CreateMockPrimarySource(AudioSourceType.Radio, "FM Radio");
+    _sourceFactoryMock.Setup(f => f.CreateSource(AudioSourceType.Radio))
+      .Returns(source.Object);
+
+    // Act
+    var result1 = await _sut.GetOrCreateSourceAsync(AudioSourceType.Radio);
+    var result2 = await _sut.GetOrCreateSourceAsync(AudioSourceType.Radio);
+
+    // Assert
+    Assert.Same(result1, result2);
+    _sourceFactoryMock.Verify(f => f.CreateSource(AudioSourceType.Radio), Times.Once);
+  }
+
+  [Fact]
+  public async Task GetOrCreateSourceAsync_ReturnsNullForUnsupportedType()
+  {
+    // Arrange
+    _sourceFactoryMock.Setup(f => f.CreateSource(It.IsAny<AudioSourceType>()))
+      .Throws<ArgumentOutOfRangeException>();
+
+    // Act
+    var result = await _sut.GetOrCreateSourceAsync(AudioSourceType.TestTone, switchToSource: false);
+
+    // Assert
+    Assert.Null(result);
+  }
+
+  [Fact]
+  public async Task GetOrCreateSourceAsync_SwitchesToSourceByDefault()
+  {
+    // Arrange
+    var source = CreateMockPrimarySource(AudioSourceType.Radio, "FM Radio");
+    _sourceFactoryMock.Setup(f => f.CreateSource(AudioSourceType.Radio))
+      .Returns(source.Object);
+
+    // Act
+    await _sut.GetOrCreateSourceAsync(AudioSourceType.Radio);
+
+    // Assert
+    Assert.Equal(source.Object, _sut.ActiveSource);
+  }
+
+  [Fact]
+  public async Task GetOrCreateSourceAsync_WithSwitchFalse_DoesNotSwitch()
+  {
+    // Arrange
+    var source = CreateMockPrimarySource(AudioSourceType.Radio, "FM Radio");
+    _sourceFactoryMock.Setup(f => f.CreateSource(AudioSourceType.Radio))
+      .Returns(source.Object);
+
+    // Act
+    await _sut.GetOrCreateSourceAsync(AudioSourceType.Radio, switchToSource: false);
+
+    // Assert — active source should still be null since we didn't switch
+    Assert.Null(_sut.ActiveSource);
+  }
+
+  [Fact]
+  public void GetCachedSource_ReturnsNullIfNotCreated()
+  {
+    Assert.Null(_sut.GetCachedSource(AudioSourceType.Radio));
+  }
+
+  [Fact]
+  public async Task GetCachedSource_ReturnsCachedSourceAfterCreation()
+  {
+    // Arrange
+    var source = CreateMockPrimarySource(AudioSourceType.Radio, "FM Radio");
+    _sourceFactoryMock.Setup(f => f.CreateSource(AudioSourceType.Radio))
+      .Returns(source.Object);
+
+    await _sut.GetOrCreateSourceAsync(AudioSourceType.Radio, switchToSource: false);
+
+    // Act
+    var cached = _sut.GetCachedSource(AudioSourceType.Radio);
+
+    // Assert
+    Assert.Same(source.Object, cached);
+  }
+
+  // --- Volume & Mixer Tests ---
+
+  [Fact]
+  public void MasterVolume_DelegatesToMixer()
+  {
+    // Arrange
+    _mixerMock.SetupProperty(m => m.MasterVolume, 0.5f);
+
+    // Act
+    _sut.MasterVolume = 0.75f;
+
+    // Assert
+    _mixerMock.VerifySet(m => m.MasterVolume = 0.75f, Times.Once);
+  }
+
+  [Fact]
+  public void MasterVolume_ReadsFromMixer()
+  {
+    _mixerMock.Setup(m => m.MasterVolume).Returns(0.42f);
+
+    Assert.Equal(0.42f, _sut.MasterVolume);
+  }
+
+  [Fact]
+  public void IsMuted_DelegatesToMixer()
+  {
+    _mixerMock.SetupProperty(m => m.IsMuted, false);
+
+    _sut.IsMuted = true;
+
+    _mixerMock.VerifySet(m => m.IsMuted = true, Times.Once);
+  }
+
+  [Fact]
+  public void Balance_DelegatesToMixer()
+  {
+    _mixerMock.SetupProperty(m => m.Balance, 0.0f);
+
+    _sut.Balance = -0.5f;
+
+    _mixerMock.VerifySet(m => m.Balance = -0.5f, Times.Once);
+  }
+
+  // --- Gain Tests ---
+
+  [Fact]
+  public void GetSourceGain_ReturnsDefaultWhenNoPersistence()
+  {
+    // Without persistence service, should return 1.0 default
+    Assert.Equal(1.0f, _sut.GetSourceGain(AudioSourceType.Radio));
+  }
+
+  [Fact]
+  public void GetAllSourceGains_ReturnsEmptyWhenNoPersistence()
+  {
+    Assert.Empty(_sut.GetAllSourceGains());
+  }
+
+  // --- Lifecycle Tests ---
+
+  [Fact]
+  public async Task InitializeAsync_InitializesEngine()
+  {
+    // Arrange
+    _engineMock.Setup(e => e.IsReady).Returns(false);
+
+    // Act
+    await _sut.InitializeAsync();
+
+    // Assert
+    _engineMock.Verify(e => e.InitializeAsync(It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task InitializeAsync_SkipsIfAlreadyReady()
+  {
+    // Arrange
+    _engineMock.Setup(e => e.IsReady).Returns(true);
+
+    // Act
+    await _sut.InitializeAsync();
+
+    // Assert
+    _engineMock.Verify(e => e.InitializeAsync(It.IsAny<CancellationToken>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task InitializeAsync_OnlyRunsOnce()
+  {
+    // Act
+    await _sut.InitializeAsync();
+    await _sut.InitializeAsync();
+
+    // Assert — should only try to initialize once
+    _engineMock.Verify(e => e.InitializeAsync(It.IsAny<CancellationToken>()), Times.AtMostOnce);
+  }
+
+  [Fact]
+  public async Task StopAsync_StopsActiveSource()
+  {
+    // Arrange
+    var source = CreateMockPrimarySource(AudioSourceType.Radio, "FM Radio");
+    await _sut.SwitchSourceAsync(source.Object);
+
+    // Act
+    await _sut.StopAsync();
+
+    // Assert
+    source.Verify(s => s.StopAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+  }
+
+  [Fact]
+  public async Task StopAsync_NoopWhenNoActiveSource()
+  {
+    // Should not throw
+    await _sut.StopAsync();
+  }
+
+  [Fact]
+  public async Task DisposeAsync_DisposesSourceCache()
+  {
+    // Arrange
+    var source = CreateMockPrimarySource(AudioSourceType.Radio, "FM Radio");
+    _sourceFactoryMock.Setup(f => f.CreateSource(AudioSourceType.Radio))
+      .Returns(source.Object);
+
+    await _sut.GetOrCreateSourceAsync(AudioSourceType.Radio, switchToSource: false);
+
+    // Act
+    await _sut.DisposeAsync();
+
+    // Assert
+    source.Verify(s => s.DisposeAsync(), Times.Once);
+  }
+
+  // --- Concurrent Source Switching ---
+
+  [Fact]
+  public async Task SwitchSourceAsync_ConcurrentCalls_SerializedCorrectly()
+  {
+    // Arrange
+    var source1 = CreateMockPrimarySource(AudioSourceType.Radio, "FM Radio");
+    var source2 = CreateMockPrimarySource(AudioSourceType.Bluetooth, "BT");
+
+    // Act — switch concurrently
+    var t1 = _sut.SwitchSourceAsync(source1.Object);
+    var t2 = _sut.SwitchSourceAsync(source2.Object);
+
+    await Task.WhenAll(t1, t2);
+
+    // Assert — one of them should be the final active source
+    Assert.NotNull(_sut.ActiveSource);
+  }
+
+  // --- Helper Methods ---
+
+  private static Mock<IPrimaryAudioSource> CreateMockPrimarySource(
+    AudioSourceType type, string name)
+  {
+    var source = new Mock<IPrimaryAudioSource>();
+    source.Setup(s => s.Type).Returns(type);
+    source.Setup(s => s.Name).Returns(name);
+    source.Setup(s => s.Id).Returns(Guid.NewGuid().ToString());
+    source.Setup(s => s.Category).Returns(AudioSourceCategory.Primary);
+    source.Setup(s => s.State).Returns(AudioSourceState.Ready);
+    source.As<IAsyncDisposable>()
+      .Setup(d => d.DisposeAsync()).Returns(ValueTask.CompletedTask);
+    source.As<IAudioSource>()
+      .Setup(s => s.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+    // Set up StateChanged event
+    source.SetupAdd(s => s.StateChanged += It.IsAny<EventHandler<AudioSourceStateChangedEventArgs>>());
+    source.SetupRemove(s => s.StateChanged -= It.IsAny<EventHandler<AudioSourceStateChangedEventArgs>>());
+
+    return source;
+  }
+}


### PR DESCRIPTION
## Summary
- **6A**: 26 AudioManager unit tests covering source management, volume/mixer delegation, lifecycle, gain defaults, and concurrent switching
- **6B**: 12 new controller integration tests for PlaylistsController, AudioDiagnosticsController, IntegrationsController, and NotificationsController (all previously untested)
- **6C**: `Result<T>` / `Result` wrapper types for Web API client error handling (Success/Fail/Disconnected states)

## Test plan
- [x] `dotnet build --configuration Release` — 0 errors
- [x] All 38 new tests pass
- [x] Full test suite: 1,289 pass, 1 pre-existing skip (batch capture test needing Ubuntu data)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)