### PR TITLE
fix: Prevent WirePlumber BT auto-link bypassing mixer

### DIFF
--- a/deploy/common/90-disable-bt-input-autolink.lua
+++ b/deploy/common/90-disable-bt-input-autolink.lua
@@ -1,0 +1,15 @@
+-- Prevent WirePlumber from auto-linking bluez_input nodes to the default sink.
+-- Radio Console captures BT audio via PipeWire native stream and routes it
+-- through its own mixer. Auto-linking causes duplicate audio that bypasses
+-- volume/mute controls.
+bluez_monitor.rules = bluez_monitor.rules or {}
+table.insert(bluez_monitor.rules, {
+  matches = {
+    {
+      { "node.name", "matches", "bluez_input.*" },
+    },
+  },
+  apply_properties = {
+    ["node.autoconnect"] = false,
+  },
+})

--- a/deploy/common/99-disable-intel-bt.rules
+++ b/deploy/common/99-disable-intel-bt.rules
@@ -1,5 +1,5 @@
 # Disable Intel AX201 Bluetooth (use dedicated USB BT adapter instead)
 # Intel combo WiFi+BT chip shares antenna, causing coexistence interference
 # that produces silence gaps in BT A2DP audio streams.
-# USB vendor:product 8087:0033 = Intel AX201 Bluetooth
-SUBSYSTEM=="usb", ATTR{idVendor}=="8087", ATTR{idProduct}=="0033", ATTR{authorized}="0"
+# USB vendor:product 8087:0026 = Intel AX201 Bluetooth
+SUBSYSTEM=="usb", ATTR{idVendor}=="8087", ATTR{idProduct}=="0026", ATTR{authorized}="0"

--- a/deploy/debian-x64/setup.sh
+++ b/deploy/debian-x64/setup.sh
@@ -258,6 +258,17 @@ else
   echo "  No USB BT adapter detected — skipping Intel BT disable"
 fi
 
+# WirePlumber: prevent auto-linking BT input to speakers
+# Radio Console captures BT audio via PipeWire native stream and routes through
+# its own mixer. Without this, WirePlumber auto-links bluez_input → default sink,
+# causing duplicate audio that bypasses volume/mute controls.
+WP_BT_RULE="$SCRIPT_DIR_COMMON/90-disable-bt-input-autolink.lua"
+if [ -f "$WP_BT_RULE" ]; then
+  mkdir -p /etc/wireplumber/bluetooth.lua.d
+  cp "$WP_BT_RULE" /etc/wireplumber/bluetooth.lua.d/
+  echo "  WirePlumber BT auto-link prevention rule installed"
+fi
+
 # ---- 8. Configure Audio & Bluetooth ----
 echo ""
 echo "[8/8] Configuring audio and Bluetooth..."


### PR DESCRIPTION
## Summary
- WirePlumber was auto-linking `bluez_input` nodes directly to the default audio sink, bypassing our SoundFlow mixer. This made mute, volume, and balance controls ineffective for Bluetooth audio.
- Added WirePlumber rule (`90-disable-bt-input-autolink.lua`) that sets `node.autoconnect=false` for `bluez_input.*` nodes
- Fixed Intel AX201 BT udev rule: USB product ID was `0033` (wrong) instead of `0026` — the adapter was never actually disabled
- Updated `setup.sh` to install the WirePlumber rule during deployment

## Test plan
- [x] Verified on Ubuntu: BT audio only routes through Radio.API mixer, no direct auto-link to speakers
- [x] Mute button now silences BT audio
- [x] Unmute restores audio
- [x] Visualization and fingerprinting continue working (taps are pre-volume in SoundFlow pipeline)
- [x] WirePlumber rule survives restart — auto-links no longer recreated
- [ ] Verify rule persists across deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)