### PR TITLE
fix: Enable in-app virtual keyboard for all kiosk text inputs

### DIFF
--- a/deploy/debian-x64/kiosk/radio-kiosk-autostart.desktop
+++ b/deploy/debian-x64/kiosk/radio-kiosk-autostart.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Radio Console Kiosk
 Comment=Auto-launch Radio Console in kiosk mode
-Exec=google-chrome --kiosk --noerrdialogs --disable-infobars --disable-session-crashed-bubble --disable-background-timer-throttling --disable-renderer-backgrounding --disable-backgrounding-occluded-windows --remote-debugging-port=9223 http://localhost:5002
+Exec=google-chrome --kiosk --noerrdialogs --disable-infobars --disable-session-crashed-bubble --disable-background-timer-throttling --disable-renderer-backgrounding --disable-backgrounding-occluded-windows --force-renderer-accessibility --ozone-platform=wayland --remote-debugging-port=9223 http://localhost:5002
 Icon=audio-radio
 Terminal=false
 Type=Application

--- a/deploy/debian-x64/kiosk/setup-kiosk.sh
+++ b/deploy/debian-x64/kiosk/setup-kiosk.sh
@@ -110,9 +110,11 @@ echo "  Screen blanking disabled."
 echo "  Screen lock disabled."
 echo "  X11 DPMS disabled."
 
-# ---- 6. Install unclutter (hide idle mouse cursor) ----
+# ---- 6. Install unclutter + display helpers ----
 echo ""
-echo "[6/7] Installing unclutter..."
+echo "[6/7] Installing unclutter and display helpers..."
+# Note: Virtual keyboard for text entry is built into the Radio Console Web UI.
+# No system-level on-screen keyboard needed (onboard doesn't work on Wayland).
 
 if ! command -v unclutter &>/dev/null; then
   sudo apt-get install -y unclutter

--- a/src/Radio.Web/Components/App.razor
+++ b/src/Radio.Web/Components/App.razor
@@ -44,7 +44,7 @@
   <script src="js/fileDownload.js"></script>
   <script src="js/pageTransitions.js"></script>
   <!-- visualizer.js uses ES module exports and is loaded via import() in VisualizerPanel -->
-  <script type="module" src="js/virtual-keyboard.js"></script>
+  <script type="module" src="js/virtual-keyboard.js?v=2"></script>
   <script src="js/idle-dimmer.js"></script>
   <script>
     // Start Blazor AFTER all JS dependencies are loaded.

--- a/src/Radio.Web/Components/Pages/SystemConfigPage.razor
+++ b/src/Radio.Web/Components/Pages/SystemConfigPage.razor
@@ -910,7 +910,8 @@
               </CardHeaderContent>
             </MudCardHeader>
             <MudCardContent>
-              <MudTextField @bind-Value="_ttsText" Label="Message" Variant="Variant.Outlined" InputMode="InputMode.text" Lines="3" />
+              <MudTextField T="string" @bind-Value="_ttsText" Label="Message" Variant="Variant.Outlined"
+                            Placeholder="Enter text to speak..." Lines="3" />
               
               <MudSelect T="string" Value="_selectedTTSEngine" Label="TTS Engine" Variant="Variant.Outlined" Class="mt-3" ValueChanged="@((string e) => OnTTSEngineChangedAsync(e))">
                 @if (_ttsEngines != null)

--- a/src/Radio.Web/wwwroot/js/virtual-keyboard.js
+++ b/src/Radio.Web/wwwroot/js/virtual-keyboard.js
@@ -23,12 +23,22 @@ class VirtualKeyboard {
     // Attach event listeners on the outer container (delegates to inner content)
     this.attachEventListeners();
 
-    // Auto-show keyboard when inputs inside dialog overlays receive focus
+    // Auto-show keyboard when any text-like input receives focus (kiosk has no physical keyboard)
     document.addEventListener('focusin', (e) => {
       const input = e.target;
-      if ((input.tagName === 'INPUT' || input.tagName === 'TEXTAREA') &&
-          input.closest('.mud-overlay, .mud-dialog')) {
+      if (input.tagName === 'TEXTAREA') {
         this.show(input);
+        return;
+      }
+      if (input.tagName === 'INPUT') {
+        // Skip inputs that are part of dropdown/select components (they open their own popover)
+        if (input.closest('.mud-select, .mud-autocomplete')) return;
+        // Skip hidden, checkbox, radio, file, color, range, button-like inputs
+        const type = (input.type || 'text').toLowerCase();
+        const textTypes = ['text', 'search', 'email', 'password', 'url', 'tel', 'number'];
+        if (textTypes.includes(type)) {
+          this.show(input);
+        }
       }
     });
 
@@ -185,17 +195,18 @@ class VirtualKeyboard {
       }
     });
     
-    // Prevent keyboard from closing when clicking inside, without blocking default focus/selection
+    // Prevent keyboard clicks from stealing focus from the active text input.
+    // preventDefault on ALL mousedown (including buttons) keeps focus on the input;
+    // the click handler still fires and dispatches key presses.
     this.keyboardElement.addEventListener('mousedown', (e) => {
-      const isButton = e.target.closest('button') !== null;
-      
-      // Always stop propagation so outer handlers (e.g. click-outside-to-close) don't see this
+      e.preventDefault();
       e.stopPropagation();
-      
-      // Only prevent default on non-interactive areas of the keyboard container
-      if (!isButton) {
-        e.preventDefault();
-      }
+    });
+
+    // Same for touchstart — prevent focus steal on touchscreen taps
+    this.keyboardElement.addEventListener('touchstart', (e) => {
+      // Don't preventDefault here (breaks touch click), but stop propagation
+      e.stopPropagation();
     });
   }
 


### PR DESCRIPTION
## Summary
- Virtual keyboard now auto-shows for ALL text inputs on the kiosk touchscreen, not just dialog inputs
- Numpad layout auto-detected for numeric fields, QWERTY for text/textarea
- Removed `onboard` from kiosk setup (doesn't work on Wayland)
- Added `--ozone-platform=wayland` and `--force-renderer-accessibility` to Chrome kiosk flags

## Test plan
- [x] Virtual keyboard shows on TTS Message textarea (Event Sources tab)
- [x] Numpad shows on numeric config fields (Configuration tab)
- [x] Typing works and Blazor picks up input events
- [x] Keyboard dismissed via close button or Enter
- [x] Select/dropdown inputs do NOT trigger keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)