### PR TITLE
fix: Wire ducking events to reduce primary source volume during TTS

### DIFF
--- a/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
@@ -5,6 +5,9 @@ using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.SoundFlow;
 
+// Ducking support: AudioManager subscribes to IDuckingService events and applies
+// volume reduction to the active primary source via SoundFlowPlaybackService.
+
 namespace Radio.Infrastructure.Audio.Services;
 
 /// <summary>
@@ -20,6 +23,7 @@ public class AudioManager : IAudioManager, IAsyncDisposable
   private readonly AudioPreferencePersistence? _preferencePersistence;
   private readonly PlayHistoryTracker? _playHistoryTracker;
   private readonly SoundFlowPlaybackService? _playbackService;
+  private readonly IDuckingService? _duckingService;
 
   // State
   private IAudioSource? _activeSource;
@@ -39,7 +43,8 @@ public class AudioManager : IAudioManager, IAsyncDisposable
     BackgroundIdentificationService? identificationService = null,
     AudioPreferencePersistence? preferencePersistence = null,
     PlayHistoryTracker? playHistoryTracker = null,
-    SoundFlowPlaybackService? playbackService = null)
+    SoundFlowPlaybackService? playbackService = null,
+    IDuckingService? duckingService = null)
   {
     _logger = logger;
     _audioEngine = audioEngine;
@@ -48,6 +53,14 @@ public class AudioManager : IAudioManager, IAsyncDisposable
     _preferencePersistence = preferencePersistence;
     _playHistoryTracker = playHistoryTracker;
     _playbackService = playbackService;
+    _duckingService = duckingService;
+
+    // Subscribe to ducking events to apply volume reduction to active primary source
+    if (_duckingService != null)
+    {
+      _duckingService.DuckingLevelChanged += OnDuckingLevelChanged;
+      _duckingService.DuckingStateChanged += OnDuckingStateChanged;
+    }
   }
 
   /// <inheritdoc/>
@@ -215,6 +228,19 @@ public class AudioManager : IAudioManager, IAsyncDisposable
 
       // Update the active source reference
       _activeSource = source;
+
+      // Clear ducking multiplier on old source (prevents stale multiplier if reactivated)
+      if (oldSource != null && _playbackService != null)
+      {
+        _playbackService.ClearDuckingMultiplier(oldSource.Id);
+      }
+
+      // If ducking is currently active, apply the current duck level to the new source
+      if (_duckingService is { IsDucking: true } && _playbackService != null)
+      {
+        var multiplier = _duckingService.CurrentDuckLevel / 100f;
+        _playbackService.SetDuckingMultiplier(source.Id, multiplier);
+      }
 
       // Reset song change detection state for the new source
       _identificationService?.ResetSongChangeState();
@@ -430,6 +456,53 @@ public class AudioManager : IAudioManager, IAsyncDisposable
       source.Name, source.Type, e.PreviousState, e.NewState, source == _activeSource);
   }
 
+  /// <summary>
+  /// Handles ducking level changes by applying a volume multiplier to the active primary source.
+  /// Called during fade transitions (attack/release) with interpolated duck levels.
+  /// </summary>
+  private void OnDuckingLevelChanged(object? sender, DuckingLevelChangedEventArgs e)
+  {
+    if (_playbackService == null || _activeSource == null)
+      return;
+
+    // Convert duck level percentage (0-100) to multiplier (0.0-1.0)
+    var multiplier = e.NewLevel / 100f;
+    _playbackService.SetDuckingMultiplier(_activeSource.Id, multiplier);
+
+    _logger.LogDebug(
+      "Ducking level: {PrevLevel:F0}% -> {NewLevel:F0}% (multiplier={Mult:F2}, source={Source})",
+      e.PreviousLevel, e.NewLevel, multiplier, _activeSource.Name);
+  }
+
+  /// <summary>
+  /// Handles ducking state changes (start/stop).
+  /// Clears the ducking multiplier when ducking ends to ensure clean restoration.
+  /// </summary>
+  private void OnDuckingStateChanged(object? sender, DuckingStateChangedEventArgs e)
+  {
+    if (_playbackService == null)
+      return;
+
+    if (e.IsDucking)
+    {
+      _logger.LogInformation(
+        "Ducking started: source={TriggerSource}, duckLevel={DuckLevel:F0}%, activeEvents={EventCount}",
+        e.TriggeringSource?.Name ?? "unknown", e.DuckLevel, e.ActiveEventCount);
+    }
+    else
+    {
+      // Ducking ended — clear all ducking multipliers to restore full volume
+      if (_activeSource != null)
+      {
+        _playbackService.ClearDuckingMultiplier(_activeSource.Id);
+      }
+
+      _logger.LogInformation(
+        "Ducking ended: volume restored, activeEvents={EventCount}",
+        e.ActiveEventCount);
+    }
+  }
+
   /// <inheritdoc/>
   public async ValueTask DisposeAsync()
   {
@@ -441,6 +514,13 @@ public class AudioManager : IAudioManager, IAsyncDisposable
     _disposed = true;
 
     _logger.LogInformation("Disposing AudioManager");
+
+    // Unsubscribe from ducking events
+    if (_duckingService != null)
+    {
+      _duckingService.DuckingLevelChanged -= OnDuckingLevelChanged;
+      _duckingService.DuckingStateChanged -= OnDuckingStateChanged;
+    }
 
     // Dispose play history tracker (unsubscribes from identification + BT metadata events)
     _playHistoryTracker?.Dispose();

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowPlaybackService.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowPlaybackService.cs
@@ -25,6 +25,7 @@ public class SoundFlowPlaybackService : IDisposable
   private readonly Dictionary<string, SoundComponent> _activeComponents = new();
   private readonly Dictionary<string, float> _baseVolumes = new();
   private readonly Dictionary<string, float> _gainOffsets = new();
+  private readonly Dictionary<string, float> _duckingMultipliers = new();
   private readonly object _playersLock = new();
   private bool _disposed;
 
@@ -132,7 +133,8 @@ public class SoundFlowPlaybackService : IDisposable
         _baseVolumes[sourceId] = volume;
         gainOffset = _gainOffsets.GetValueOrDefault(sourceId, 1.0f);
       }
-      soundPlayer.Volume = Math.Clamp(volume * gainOffset, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
+      var fileDuckMult = _duckingMultipliers.GetValueOrDefault(sourceId, 1.0f);
+      soundPlayer.Volume = Math.Clamp(volume * gainOffset * fileDuckMult, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
       _logger.LogDebug("PlayFileAsync: SoundPlayer created, Volume: {Volume}, GainOffset: {Gain}", volume, gainOffset);
 
       // Add to the playback device's mixer
@@ -258,7 +260,8 @@ public class SoundFlowPlaybackService : IDisposable
         _baseVolumes[sourceId] = volume;
         streamGainOffset = _gainOffsets.GetValueOrDefault(sourceId, 1.0f);
       }
-      soundPlayer.Volume = Math.Clamp(volume * streamGainOffset, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
+      var streamDuckMult = _duckingMultipliers.GetValueOrDefault(sourceId, 1.0f);
+      soundPlayer.Volume = Math.Clamp(volume * streamGainOffset * streamDuckMult, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
 
       // Add to the playback device's mixer
       playbackDevice.MasterMixer.AddComponent(soundPlayer);
@@ -323,7 +326,8 @@ public class SoundFlowPlaybackService : IDisposable
         _baseVolumes[sourceId] = volume;
         dpGainOffset = _gainOffsets.GetValueOrDefault(sourceId, 1.0f);
       }
-      soundPlayer.Volume = Math.Clamp(volume * dpGainOffset, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
+      var dpDuckMult = _duckingMultipliers.GetValueOrDefault(sourceId, 1.0f);
+      soundPlayer.Volume = Math.Clamp(volume * dpGainOffset * dpDuckMult, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
 
       // Add to the playback device's mixer
       playbackDevice.MasterMixer.AddComponent(soundPlayer);
@@ -386,7 +390,8 @@ public class SoundFlowPlaybackService : IDisposable
         _baseVolumes[sourceId] = volume;
         compGainOffset = _gainOffsets.GetValueOrDefault(sourceId, 1.0f);
       }
-      component.Volume = Math.Clamp(volume * compGainOffset, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
+      var compDuckMult = _duckingMultipliers.GetValueOrDefault(sourceId, 1.0f);
+      component.Volume = Math.Clamp(volume * compGainOffset * compDuckMult, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
 
       // Add to the playback device's mixer
       _logger.LogInformation(
@@ -486,6 +491,7 @@ public class SoundFlowPlaybackService : IDisposable
         _activeComponents.Remove(sourceId);
       }
       _baseVolumes.Remove(sourceId);
+      _duckingMultipliers.Remove(sourceId);
       // Keep _gainOffsets — they persist across stop/start for the same source
     }
 
@@ -584,17 +590,7 @@ public class SoundFlowPlaybackService : IDisposable
     lock (_playersLock)
     {
       _baseVolumes[sourceId] = Math.Clamp(volume, 0f, 1f);
-      var gainOffset = _gainOffsets.GetValueOrDefault(sourceId, 1.0f);
-      var effective = Math.Clamp(volume * gainOffset, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
-
-      if (_activePlayers.TryGetValue(sourceId, out var player))
-      {
-        player.Volume = effective;
-      }
-      if (_activeComponents.TryGetValue(sourceId, out var component))
-      {
-        component.Volume = effective;
-      }
+      ApplyEffectiveVolume(sourceId);
     }
   }
 
@@ -611,21 +607,67 @@ public class SoundFlowPlaybackService : IDisposable
     {
       gainOffset = Math.Clamp(gainOffset, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
       _gainOffsets[sourceId] = gainOffset;
-      var baseVol = _baseVolumes.GetValueOrDefault(sourceId, 1.0f);
-      var effective = Math.Clamp(baseVol * gainOffset, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
+      ApplyEffectiveVolume(sourceId);
 
-      if (_activePlayers.TryGetValue(sourceId, out var player))
-      {
-        player.Volume = effective;
-        _logger.LogDebug("Applied gain offset {Gain:F2} to player (SourceId={SourceId}, EffectiveVolume={Volume:F2})",
-          gainOffset, sourceId, effective);
-      }
-      if (_activeComponents.TryGetValue(sourceId, out var component))
-      {
-        component.Volume = effective;
-        _logger.LogDebug("Applied gain offset {Gain:F2} to component (SourceId={SourceId}, EffectiveVolume={Volume:F2})",
-          gainOffset, sourceId, effective);
-      }
+      _logger.LogDebug("Applied gain offset {Gain:F2} to source (SourceId={SourceId})",
+        gainOffset, sourceId);
+    }
+  }
+
+  /// <summary>
+  /// Sets a ducking multiplier for a specific source.
+  /// Used by the ducking system to temporarily reduce volume of primary sources
+  /// while event audio (TTS, notifications) plays.
+  /// Effective volume = base volume * gain offset * ducking multiplier.
+  /// </summary>
+  /// <param name="sourceId">The source identifier.</param>
+  /// <param name="multiplier">Ducking multiplier (0.0 to 1.0, where 1.0 = no ducking).</param>
+  public void SetDuckingMultiplier(string sourceId, float multiplier)
+  {
+    ThrowIfDisposed();
+
+    lock (_playersLock)
+    {
+      multiplier = Math.Clamp(multiplier, 0f, 1f);
+      _duckingMultipliers[sourceId] = multiplier;
+      ApplyEffectiveVolume(sourceId);
+    }
+  }
+
+  /// <summary>
+  /// Clears the ducking multiplier for a specific source, restoring full volume.
+  /// </summary>
+  /// <param name="sourceId">The source identifier.</param>
+  public void ClearDuckingMultiplier(string sourceId)
+  {
+    ThrowIfDisposed();
+
+    lock (_playersLock)
+    {
+      _duckingMultipliers.Remove(sourceId);
+      ApplyEffectiveVolume(sourceId);
+    }
+  }
+
+  /// <summary>
+  /// Recalculates and applies the effective volume for a source.
+  /// Must be called under _playersLock.
+  /// </summary>
+  private void ApplyEffectiveVolume(string sourceId)
+  {
+    var baseVol = _baseVolumes.GetValueOrDefault(sourceId, 1.0f);
+    var gainOffset = _gainOffsets.GetValueOrDefault(sourceId, 1.0f);
+    var duckMult = _duckingMultipliers.GetValueOrDefault(sourceId, 1.0f);
+    var effective = Math.Clamp(baseVol * gainOffset * duckMult,
+      AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
+
+    if (_activePlayers.TryGetValue(sourceId, out var player))
+    {
+      player.Volume = effective;
+    }
+    if (_activeComponents.TryGetValue(sourceId, out var component))
+    {
+      component.Volume = effective;
     }
   }
 

--- a/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
+++ b/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
@@ -147,7 +147,8 @@ public static class AudioServiceExtensions
       sp.GetService<BackgroundIdentificationService>(),
       sp.GetRequiredService<AudioPreferencePersistence>(),
       sp.GetRequiredService<PlayHistoryTracker>(),
-      sp.GetRequiredService<SoundFlowPlaybackService>()));
+      sp.GetRequiredService<SoundFlowPlaybackService>(),
+      sp.GetRequiredService<IDuckingService>()));
     services.AddSingleton<IAudioManager>(sp => sp.GetRequiredService<AudioManager>());
     services.AddSingleton<IAudioSourceManager>(sp => sp.GetRequiredService<AudioManager>());
     services.AddSingleton<IAudioMixerControl>(sp => sp.GetRequiredService<AudioManager>());


### PR DESCRIPTION
## Summary
- `DuckingService` raised events but nothing subscribed — primary source volume was never actually reduced during TTS/notification playback
- Added ducking multiplier system to `SoundFlowPlaybackService` (effective volume = base × gain × duck)
- `AudioManager` now subscribes to ducking events and applies multiplier to active primary source
- Handles edge cases: source switch during ducking, stale multiplier cleanup, initial volume on Play*

## Test plan
- [x] 33 existing DuckingService unit tests pass
- [x] Full test suite passes (75 passed, 3 skipped, 0 failed)
- [x] Deployed to Ubuntu — TTS message ducks BT audio and restores after

🤖 Generated with [Claude Code](https://claude.com/claude-code)