### PR TITLE
feat: BT single-device exclusivity with discoverability toggling

### DIFF
--- a/src/Radio.Infrastructure/Platform/Bluetooth/Linux/BluezAgent.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Linux/BluezAgent.cs
@@ -103,8 +103,15 @@ internal sealed class BluezAgent : IAgent1
       if (connectedAddress != null)
       {
         var requestingAddress = ExtractAddressFromDevicePath(device);
-        if (requestingAddress != null &&
-            !string.Equals(requestingAddress, connectedAddress, StringComparison.OrdinalIgnoreCase))
+        if (requestingAddress == null)
+        {
+          // Can't determine requesting device — reject to be safe when another device is connected
+          _logger.LogWarning(
+            "Rejecting Bluetooth service {UUID} from {Device} — cannot parse address and {ConnectedName} ({ConnectedAddress}) is already connected",
+            uuid, device, connectedName ?? "Unknown", connectedAddress);
+          throw new DBusException("org.bluez.Error.Rejected", "Another device is already connected");
+        }
+        if (!string.Equals(requestingAddress, connectedAddress, StringComparison.OrdinalIgnoreCase))
         {
           _logger.LogInformation(
             "Rejecting Bluetooth service {UUID} from {Device} — {ConnectedName} ({ConnectedAddress}) is already connected",

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -423,6 +423,10 @@ namespace Radio.Infrastructure.Platform.Bluetooth
                     _metricsCollector?.Gauge("bluetooth.active_connections", 1);
                     _logger.LogInformation("Bluetooth device connected: {DeviceName} ({Address})",
                         device.Name, device.Address);
+
+                    // Hide adapter from other devices while one is connected
+                    _ = SetDiscoverableAsync(false);
+
                     DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = device });
                 }
 

--- a/tests/Radio.Infrastructure.Tests/Platform/Bluetooth/BluezAgentTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Platform/Bluetooth/BluezAgentTests.cs
@@ -106,6 +106,23 @@ public class BluezAgentTests
   }
 
   [Fact]
+  public async Task AuthorizeServiceAsync_Rejects_WhenDevicePathUnparseable_AndDeviceConnected()
+  {
+    var agent = CreateAgent(
+      autoAccept: true,
+      connectedAddress: "AA:BB:CC:DD:EE:FF",
+      connectedName: "Phone A");
+
+    // Malformed path with no dev_ prefix — should reject (fail-closed)
+    var ex = await Assert.ThrowsAsync<DBusException>(() =>
+      agent.AuthorizeServiceAsync(
+        new ObjectPath("/org/bluez/hci0/something"),
+        "0000110b-0000-1000-8000-00805f9b34fb"));
+
+    Assert.Contains("Another device is already connected", ex.ErrorMessage);
+  }
+
+  [Fact]
   public async Task RequestConfirmationAsync_AutoAccepts()
   {
     var agent = CreateAgent(autoAccept: true);


### PR DESCRIPTION
## Summary
- Enforce single-device exclusivity at the BlueZ agent level — `AuthorizeServiceAsync` rejects service connections from a second device when one is already connected
- Toggle adapter discoverability off while a device is connected, back on after disconnect — prevents other phones from seeing the radio during active streaming
- Inspired by [bt-speaker](https://github.com/lukasjapan/bt-speaker)'s `AutoAcceptSingleAudioAgent` pattern

## Changes
- **`BluezAgent.cs`** — Added `_getConnectedDevice` callback, single-device gating in `AuthorizeServiceAsync`, `ExtractAddressFromDevicePath` helper
- **`LinuxBluetoothService.cs`** — Added `SetDiscoverableAsync` helper, discoverability toggling on connect/disconnect, startup check for already-connected device
- **`BluezAgentTests.cs`** — 13 new tests covering address parsing, exclusivity logic, case-insensitive matching, auto-accept enable/disable

## Test plan
- [x] All 13 new BluezAgentTests pass
- [x] All 53 existing Bluetooth tests pass
- [x] Full test suite passes (only pre-existing WaveformComparison hardware test fails)
- [ ] Deploy to Ubuntu and verify: connect Phone A, confirm adapter hides from Phone B
- [ ] Disconnect Phone A, confirm adapter becomes discoverable again
- [ ] While Phone A is connected, attempt Phone B connection — verify agent rejects with log message

🤖 Generated with [Claude Code](https://claude.com/claude-code)