### PR TITLE
feat: Extract Radio.Fingerprinting as standalone NuGet package (Phase 5)

### DIFF
--- a/RadioConsole.sln
+++ b/RadioConsole.sln
@@ -47,6 +47,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radio.Metrics", "src\Radio.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radio.Configuration", "src\Radio.Configuration\Radio.Configuration.csproj", "{928DC03B-E6A1-4E4D-8D2C-6B9494831D35}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radio.Fingerprinting", "src\Radio.Fingerprinting\Radio.Fingerprinting.csproj", "{82818C12-06D6-49A3-885D-C2DF885FC94B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -285,6 +287,18 @@ Global
 		{928DC03B-E6A1-4E4D-8D2C-6B9494831D35}.Release|x64.Build.0 = Release|Any CPU
 		{928DC03B-E6A1-4E4D-8D2C-6B9494831D35}.Release|x86.ActiveCfg = Release|Any CPU
 		{928DC03B-E6A1-4E4D-8D2C-6B9494831D35}.Release|x86.Build.0 = Release|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Debug|x64.Build.0 = Debug|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Debug|x86.Build.0 = Debug|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Release|x64.ActiveCfg = Release|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Release|x64.Build.0 = Release|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Release|x86.ActiveCfg = Release|Any CPU
+		{82818C12-06D6-49A3-885D-C2DF885FC94B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -309,5 +323,6 @@ Global
 		{614CB616-CD7F-4A39-9EE2-CD4E408FEB26} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{CEA62E3E-63CC-4882-99C1-105CF2588772} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{928DC03B-E6A1-4E4D-8D2C-6B9494831D35} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{82818C12-06D6-49A3-885D-C2DF885FC94B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/findings.md
+++ b/findings.md
@@ -1,243 +1,37 @@
-# Findings — NuGet Package Extraction
+# Findings: Radio.Fingerprinting Extraction
 
-## Candidate Analysis Summary
+## Architecture Analysis
 
-| Library | Standalone? | Dependencies | Tests | Pub-Ready |
-|---------|-------------|--------------|-------|-----------|
-| RTLSDRCore | YES | Serilog only | 75 | 8/10 |
-| Radio.AudioAnalysis | YES | None | Indirect only | 5/10 |
-| Radio.Core | YES | Extensions only | 37 | 6/10 |
-| Radio.Infrastructure | NO | 7+ packages | 200+ | Not ready |
+### FingerprintDbContext Problem
+- Manages 12 SQLite tables, only 3 are fingerprinting-specific (FingerprintCache, TrackMetadata, PlayHistory)
+- Non-FP tables: RadioPresets, AudioFiles, CastDeviceCache, Playlists, PlaylistItems, TTSVoiceCache, TTSVoiceFavorites
+- Cannot extract DbContext — too many non-FP consumers depend on it
+- Solution: IFingerprintDataConnection interface abstracts the connection
 
-## Current Build/Deploy Infrastructure
-- **No NuGet infrastructure exists** — no nuget.config, no custom feeds, no pack steps
-- CI (`.github/workflows/build.yml`): build + test only, no packaging
-- Deploy (`Deploy-ToLinux.ps1`): `dotnet restore` → `dotnet publish --self-contained` → rsync to target
-- `Directory.Build.props`: TreatWarningsAsErrors, GenerateDocumentationFile=true, no packaging defaults
-- No `Directory.Packages.props` (no central package versioning)
-- SDK: .NET 10.0.102 (`global.json` with `rollForward: latestMinor`)
-- **Local folder feed is simplest option** — `nuget.config` with `./packages` source, zero infra needed
-- Promotion path: local folder → GitHub Packages → NuGet.org
+### Consumer Impact Analysis
+- `Radio.Core.Models.Audio` imported by 75 files — too many to migrate
+- `Radio.Core.Interfaces.Audio` imported by 133 files — domain-wide
+- `Radio.Core.Events` imported by 12 files — all fingerprinting events
+- `FingerprintingOptions` referenced by 28 files (18 code, 10 docs)
+- `Radio.Infrastructure.Audio.Fingerprinting` namespace — ~15 implementation consumers
 
-## RTLSDRCore
-- Already has full NuGet metadata (PR #302): PackageId, Version 1.0.0, MIT, README, symbols
-- 24 source files across Bands/, DSP/, Enums/, Hardware/, Models/
-- `dotnet pack src/RTLSDRCore` already produces .nupkg + .snupkg
-- Only external dependency: Serilog 4.0.0
-- Clean public API: RadioReceiver, IRadioControl, ISdrDevice, demodulators, band presets
+### PlaySource/MetadataSource Enums
+- Used by IAudioSampleProvider, IPlayHistoryRepository, PlayHistoryEntry, BackgroundIdentificationService
+- Also used by non-FP code: API controllers, AudioManager, source implementations
+- Decision: Keep in Radio.Core, Radio.Fingerprinting depends on Radio.Core
 
-## Radio.AudioAnalysis
-- Currently in `tests/` directory with `IsPackable=false`
-- 7 files, ~1,400 LOC: WaveformComparison, FrequencyAnalysis, SilenceDetector, WavFileHelper
-- Zero NuGet dependencies — pure math/DSP
-- **Gap: No dedicated unit tests** — only tested indirectly via integration tests
-- Needs: relocation to src/, unit tests, NuGet metadata, README
+### BackgroundIdentificationService Dependencies (700 LOC)
+- IMetricsCollector? (optional, from Radio.Metrics)
+- IAudioSampleProvider (Radio.Core interface)
+- ISongRecRecognitionService, IMetadataLookupService (Radio.Core interfaces)
+- IFingerprintCacheRepository, ITrackMetadataRepository, IPlayHistoryRepository (Radio.Core interfaces)
+- FingerprintingOptions via IOptionsMonitor
+- TrackIdentifiedEventArgs, SongChangedEventArgs (Radio.Core events)
+- ALL dependencies are on interfaces in Radio.Core — fully extractable
 
-## Radio.Core
-- 84 files, ~90+ public types (interfaces, models, enums, config options)
-- Only depends on Microsoft.Extensions.Logging.Abstractions + Options
-- **Concern:** High surface area means strict semantic versioning needed
-- Domain-specific to Radio Console — may not be useful to external consumers
-- Question: publish externally, or just add metadata for internal package management?
-
-## Fingerprinting / Audio Recognition
-- **~2,000 LOC extractable** (65-70% of fingerprinting codebase)
-- Core: SongRecRecognitionService (songrec binary wrapper), MetadataLookupService (MusicBrainz/Cover Art Archive), SQLite cache/metadata repositories
-- Models: TrackMetadata, AudioSampleBuffer, FingerprintData, CachedFingerprint, FingerprintStatus
-- Events: TrackIdentifiedEventArgs, SongChangedEventArgs
-- BackgroundIdentificationService: extractable with one abstraction (IAudioSampleProvider needs Radio-specific properties removed)
-- **NOT extractable**: SoundFlowAudioTap (~270 LOC) — tightly coupled to IAudioEngine/IAudioManager. This is the bridge layer and stays in Radio.Infrastructure.
-- **Two changes needed**: (1) IAudioSampleProvider: strip Radio-specific properties (PlaySource enum, SourceFilePath, NeedsFingerprintingLookup) into a Radio adapter, (2) DatabasePathResolver → Func<string> or options pattern
-- Has good test coverage: ~8 test files across unit + integration
-- External deps: Microsoft.Data.Sqlite, HttpClient (MusicBrainz API), songrec binary at runtime
-
-## Configuration System
-- **35 C# files**, ~90% generic and reusable
-- Core: IConfigurationStore (JSON + SQLite backends), ISecretsProvider (encrypted tag substitution `${secret:id}`), IConfigurationManager, backup/restore (ZIP-based)
-- Bridge: SqliteConfigurationProvider hooks into .NET's IConfiguration/IOptionsMonitor pipeline — elegant and fully reusable
-- ConfigStoreChangeNotifier: UI writes propagate to IOptionsMonitor consumers in real-time
-- **Only 2 Radio-specific files**: DeviceOptionsResolver + PreferencesPersistenceService — these are application-layer consumers, not core config infrastructure. Just exclude them.
-- **One coupling**: DatabasePathResolver usage in SqliteSecretsProvider + ConfigurationStoreFactory → replace with IDatabasePathProvider interface or Func<string>
-- Deps: Microsoft.Data.Sqlite, Microsoft.AspNetCore.DataProtection (encryption), standard Extensions packages
-- Strong test coverage: store operations, backup, bridge integration, secrets
-
-## Metrics System
-- **~1,500 LOC**, 99% generic with zero Radio-specific logic
-- Core: IMetricsCollector (Increment/Gauge), IMetricsReader (history/snapshots/aggregate/keys), MetricPoint, MetricType, MetricResolution
-- Storage: SQLite with 3 resolution tables (Minute/Hour/Day), buffered writes (ConcurrentDictionary → periodic flush)
-- Rollup service: automatic aggregation Minute→Hour→Day with configurable retention policies
-- **One coupling**: MetricsDbContext uses GetConfigurationDatabasePath() → add explicit DatabasePath to MetricsOptions
-- SystemMonitorService (memory/disk/CPU/temp) is OS-specific — keep as optional or exclude
-- Dashboard UI is Radio-specific (hero cards, thresholds) — stays in Radio.Web
-- Deps: Microsoft.Data.Sqlite only
-- Good test coverage: schema, repository CRUD, rollup, API endpoints
-
-## Non-Candidates
-- **Radio.Infrastructure (bulk)**: Too many internal dependencies (SoundFlow, BlueZ, SharpCaster, etc.)
-- **Radio.API / Radio.Web**: Application-specific, not libraries
-- **SoundFlowAudioTap**: Bridge between SoundFlow and fingerprinting — stays in Radio.Infrastructure
-
----
-
-# Previous Findings (archived)
-
-## .NET 10 Migration Research
-
-### Release Status
-- **.NET 10 GA**: November 11, 2025 (LTS through November 14, 2028)
-- **.NET 8 EOL**: November 10, 2026 (~8 months remaining)
-- **Tooling**: Visual Studio 2026 or Rider 2025.3+ required
-
-### C# 14 Language Features (applicable to this codebase)
-
-| Feature | Use Case in Project | Impact |
-|---------|-------------------|--------|
-| `field` keyword | Volume, balance, gain properties with validation | Eliminates explicit backing fields |
-| Null-conditional assignment | Event handlers, nullable reference handling | Cleaner null guards |
-| `params ReadOnlySpan<T>` | Audio pipeline hot-path methods | Zero-allocation params |
-| Implicit Span conversions | Buffer method signatures (`float[]` ↔ `Span<float>`) | Simpler signatures |
-| Extension members | Utility/extension classes → extension properties | Cleaner API surface |
-| Partial constructors | Blazor code-behind patterns | Source gen support |
-
-### Breaking Changes (NET 8 → NET 10)
-
-| Change | Impact | Action |
-|--------|--------|--------|
-| Swashbuckle/OpenAPI v2.3 changes | Swagger at `/swagger` | Migrate to built-in OpenAPI |
-| `System.Linq.Async` removed | If used anywhere | Replace with `System.Linq.AsyncEnumerable` |
-| `WebHostBuilder` obsolete | Likely not used (modern hosting) | Verify |
-| `WithOpenApi()` deprecated | If used in minimal APIs | Update |
-| Cookie auth no longer redirects for API | Positive change for REST API | Verify |
-| Container images → Ubuntu base | If Docker used | Update base images |
-
-### Runtime Benefits (automatic, no code change)
-- **GC DATAS**: Auto-tunes heap size based on app behavior (memory reduction)
-- **Stack-allocated small arrays**: Zero GC for arrays that don't escape method
-- **JIT cascading inlining**: Better devirtualization, 15-30% perf on AVX-512 hardware
-- **ARM64 write barrier optimization**: Benefits Pi deployment
-
-### NuGet Packages to Audit
-- SoundFlow (audio engine, MiniAudio native interop)
-- SharpCaster 3.0.0 (Google Cast)
-- MudBlazor (Blazor UI framework)
-- Tmds.DBus (BlueZ D-Bus)
-- Serilog + sinks
-- NAudio (Windows BT sender)
-
----
-
-## Kiosk UI Blanking — Root Cause Analysis
-
-### The Sleep Chain
-```
-idle-dimmer.js (30 min idle)
-  → enterSleep('idle')
-    → blazorRef.invokeMethodAsync('OnJsSleepRequested', true)
-      → SystemApi.SetSleepAsync(true)
-        → POST /api/system/sleep
-          → SleepService.EnterSleepAsync()
-            → primary.PauseAsync()   ← STOPS MUSIC
-            → _audioManager.IsMuted = true  ← MUTES
-```
-
-### Contributing Factors
-1. **Sleep system pauses audio BY DESIGN** — the sleep feature was built to stop everything, not just dim the screen
-2. **Chrome timer throttling** — missing `--disable-background-timer-throttling` flag; CSS overlay may make Chrome think page is "hidden", throttling JS timers to 1/min, breaking SignalR keepalive
-3. **DPMS not disabled** — `setup-kiosk.sh` disables GNOME screensaver but NOT X11 DPMS
-4. **Blazor circuit timeout** — client retries only 30x (60s), but Chrome throttling means retries are slow; server kills connection after 30s without keepalive
-5. **No systemd watchdog** — hung processes not detected
-
-### Key Files
-| File | Role |
-|------|------|
-| `src/Radio.Web/wwwroot/js/idle-dimmer.js` | Idle detection, dim/sleep timers |
-| `src/Radio.Web/Components/Layout/MainLayout.razor` | `OnJsSleepRequested` JSInvokable |
-| `src/Radio.API/Services/SleepService.cs` | `EnterSleepAsync` pauses + mutes |
-| `deploy/debian-x64/kiosk/radio-console.desktop` | Chrome launch flags |
-| `deploy/debian-x64/kiosk/setup-kiosk.sh` | GNOME settings, missing DPMS |
-| `src/Radio.Web/Components/App.razor` | Blazor circuit reconnection config |
-| `src/Radio.API/Program.cs` | SignalR server configuration |
-
----
-
-## Audio Distortion — Previous Research Summary
-
-### What We Know
-- **151 distortion markers** across ~90 min BT playback — roughly one every 36s
-- **Not clipping** — peaks at -6.5 to -11 dBFS, all `isClipping=False`
-- **No app-level errors correlate** — no exceptions, no buffer drops/underruns/compensations
-- **BT clock drift**: ~0.035s/min faster than ALSA clock (~2.1s/hour)
-- **PipeWire-pulse overrun events** logged — MiniAudio not serviced fast enough
-- **BT format**: S24LE 48kHz 2ch from PipeWire, converted to S16LE for the app's stream
-
-### Ranked Root Causes
-1. **MiniAudio/ALSA Output Xruns (HIGH)** — modifier chain must complete within quantum (~10.67ms)
-2. **Lock Contention (HIGH)** — `AddSamples()` (PipeWire thread) and `GenerateAudio()` (MiniAudio thread) contend for `_bufferLock`
-3. **.NET GC Pauses (MEDIUM)** — Gen2 can pause 10-50ms, exceeding quantum
-4. **BT A2DP Transport Jitter (MEDIUM)** — irregular packet arrival
-5. **DropOldest Buffer Overflow (LOWER)** — drift causes overflow after ~72 min
-
-### ROOT CAUSE IDENTIFIED (Phase 3)
-
-**Stereo frame misalignment in PipeWireNativeStream.OnProcess**
-
-The `OnProcess` callback converts S16LE bytes to float samples via `sampleCount = totalBytes / 2` — but for stereo audio, a "frame" is 2 samples (L+R = 4 bytes). When PipeWire's BT transport delivers non-frame-aligned chunks (due to packet loss/gaps), `sampleCount` is ODD, causing every subsequent sample to have L/R channels swapped.
-
-**Evidence (pre-fix 60s capture):**
-- 3 silence gaps with ODD lengths (693, 827, 83 samples)
-- L/R channel ratio FLIPS after each gap (e.g., pre=12.833, post=0.056)
-- Sample deficit: 32,640 samples lost (input > output)
-- Output→PostModifiers correlation: 0.40 (poor — channel-swap corrupts modifier processing)
-
-**Fix applied:**
-- `PipeWireNativeStream.cs`: `sampleCount = sampleCount / self._channels * self._channels;` (frame-align)
-- `BufferedSoundGenerator.cs`: Defense-in-depth frame alignment in `AddSamples()`
-
-**Evidence (post-fix 60s capture):**
-- Output→PostModifiers correlation: 1.000000 (perfect, up from 0.40)
-- Sample delta: +1,024 (near-zero, vs pre-fix -32,640)
-- 384 silence gaps still present but these are BT transport dropouts (brief pops), NOT channel swaps
-- ODD-length gaps in captured data are from zero VALUES spanning chunk boundaries — AddSamples always receives frame-aligned data
-
-### Remaining Issue: BT Transport Dropouts — RESOLVED
-
-**Root cause**: Intel AX201 combo WiFi+BT chip shares antenna, causing WiFi/BT coexistence interference. WiFi `Invalid misc` counter: 961,752 (extremely high). BT packets dropped at RF level → silence gaps in A2DP stream.
-
-**Evidence**: Phone → standalone BT speaker works fine. Phone → Ubuntu with Intel AX201 has frequent gaps.
-
-**Fix**: TP-Link UB500 USB Bluetooth adapter (Realtek BT 5.1) physically separates BT from WiFi.
-
-**10-run capture comparison (60s each):**
-
-| Configuration | Perfect runs (0 gaps) | Worst correlation | Notes |
-|---|---|---|---|
-| Intel AX201 (baseline) | 0/10 | 0.685 (Run 6) | Constant interference |
-| Intel AX201 + CPU perf + WiFi PM off | 0/9 | 0.106 (Run 5) | Software tuning insufficient |
-| TP-Link UB500 USB adapter | 6/10 | 0.977 (Run 9) | Dramatic improvement |
-
-**System tuning applied (persistent):**
-- CPU governor: `performance` via `radio-performance.service`
-- WiFi PM: off via NetworkManager dispatcher script
-- Intel AX201 BT: disabled via udev rule (`99-disable-intel-bt.rules`)
-- PipeWire: upgraded 1.0.5 → 1.0.7 via upstream PPA
-
-### Existing Infrastructure
-- `BufferedSoundGenerator` has extensive instrumentation (callback timing, lock contention, GC correlation)
-- `FmAudioDropoutDiagnosticTests` simulate producer/consumer on independent clocks
-- `AudioTestHelpers` generates diagnostic tones and has WAV writer
-- `BtSender` sends known 200Hz/300Hz tone over BT
-- **Phase 2 infrastructure**: `DiagnosticCaptureService`, `CaptureSession`, `Radio.AudioAnalysis` library, automated `WaveformComparison` tests
-
----
-
-## Comprehensive Review Items
-
-| # | Category | Priority | Difficulty | Summary |
-|---|----------|----------|------------|---------|
-| 12 | Testing | High | Medium | `AudioManager` has zero unit tests |
-| 13 | Testing | High | Medium | 5 API controllers have no tests |
-| 14 | Architecture | High | Hard | 3 Blazor components >750 lines each |
-| 26 | Architecture | Medium | Medium | `IAudioManager` is 40+ member god interface |
-| 30 | Error Handling | Medium | Medium | All 14 Web API clients silently return null on errors |
-| 34 | Architecture | Medium | Medium | `AudioSourceState`/`AudioOutputState` duplicate 7 values |
-| 36 | State Mgmt | Medium | Hard | Audio state scattered across components, no centralized store |
+### What Radio.Fingerprinting Provides (as NuGet)
+1. SongRec (Shazam) audio recognition wrapper
+2. MusicBrainz metadata + Cover Art Archive lookup
+3. Background identification service with duplicate suppression + song change detection
+4. SQLite repositories for fingerprint cache, track metadata, play history
+5. FingerprintingOptions configuration

--- a/pack-local.ps1
+++ b/pack-local.ps1
@@ -31,8 +31,8 @@ $PackableProjects = @(
   "src/Radio.AudioAnalysis/Radio.AudioAnalysis.csproj"
   "src/Radio.Metrics/Radio.Metrics.csproj"
   "src/Radio.Configuration/Radio.Configuration.csproj"
+  "src/Radio.Fingerprinting/Radio.Fingerprinting.csproj"
   # Future:
-  # "src/Radio.Fingerprinting/Radio.Fingerprinting.csproj"
   # "src/Radio.Core/Radio.Core.csproj"
 )
 

--- a/progress.md
+++ b/progress.md
@@ -1,111 +1,16 @@
-# Progress Log
+# Progress: Radio.Fingerprinting Extraction
 
-## Session: 2026-03-09 (NuGet Extraction Planning)
+## Session: 2026-03-09
 
-### Research Completed
-- [x] Analyzed all src/ and tests/ projects for extraction candidates
-- [x] Reviewed dependency graphs, public API surfaces, test coverage
-- [x] Identified 3 candidates: RTLSDRCore (ready), Radio.AudioAnalysis (needs work), Radio.Core (needs metadata)
-- [x] Created 3-phase task plan
-- [x] Also completed BT single-device exclusivity (PR #322) and task plan status update
+### Completed
+- [x] Explored fingerprinting subsystem (45+ files examined)
+- [x] Analyzed consumer impact (75/133/12 file counts)
+- [x] Decided Option B: Implementation extraction with Radio.Core dependency
+- [x] Created task_plan.md with 6 phases
+- [x] Branch: extract/fingerprinting-nuget (created from main)
 
-### Planning Files
-- [x] `task_plan.md` — 3 phases for NuGet extraction
-- [x] `findings.md` — Candidate analysis summary
-- [x] `progress.md` — This file
-
----
-
-## Session: 2026-03-06 (Phase 3 — Root Cause + BT Transport Fix)
-
-### BT Transport Dropout Investigation & Fix
-- [x] Merged PR #305 (frame alignment fix)
-- [x] Deployed and ran 10x60s baseline captures (Intel AX201): 9/10 perfect correlation
-- [x] Investigated PipeWire/BT transport layer distortion — user hearing pops despite correct software processing
-- [x] Identified root cause: Intel AX201 combo WiFi+BT chip coexistence interference (WiFi `Invalid misc` counter: 961,752)
-- [x] Applied quick fixes (CPU governor=performance, WiFi PM=off) — didn't help (coexistence is RF-level)
-- [x] Switched to TP-Link UB500 USB BT adapter — dramatic improvement: 6/10 runs with ZERO silence gaps
-- [x] Upgraded PipeWire 1.0.5 → 1.0.7 via upstream PPA
-- [x] Made all settings permanent: systemd service, NetworkManager dispatcher, udev rule
-- [x] Disabled Intel AX201 BT permanently via udev rule
-- [x] Updated deployment docs (DEPLOYMENT.md, setup.sh) with audio quality tuning section
-- [x] Added deploy config files: `radio-performance.service`, `99-wifi-power-save-off`, `99-disable-intel-bt.rules`
-- [x] Restarted radio-web service (was dead after deployment)
-
-### Files Modified/Created
-- `deploy/DEPLOYMENT.md` — added Audio Quality Tuning section, updated hardware table
-- `deploy/debian-x64/setup.sh` — added audio quality tuning step (CPU governor, WiFi PM, Intel BT disable)
-- `deploy/common/radio-performance.service` — new systemd service
-- `deploy/common/99-wifi-power-save-off` — new NetworkManager dispatcher script
-- `deploy/common/99-disable-intel-bt.rules` — new udev rule
-- `findings.md`, `progress.md`
-
----
-
-### Root Cause Identified & Fixed
-- [x] Deployed Phase 2 capture infrastructure to Ubuntu
-- [x] Captured 60s BT audio at 3 pipeline stages (generator-input, generator-output, post-modifiers)
-- [x] Built waveform analysis test (`AnalyzeBtCapture_InputVsOutput`) with silence gap deep analysis, channel swap detection, windowed correlation
-- [x] **ROOT CAUSE**: `PipeWireNativeStream.OnProcess` converts S16LE→float without stereo frame alignment. PipeWire BT transport delivers non-frame-aligned chunks during packet loss → odd sample count → L/R channel swap for ALL subsequent audio
-- [x] **FIX**: Frame-align `sampleCount` in `PipeWireNativeStream.cs` + defense-in-depth in `BufferedSoundGenerator.AddSamples()`
-- [x] Deployed fix to Ubuntu, captured 60s post-fix audio
-- [x] Verified fix: Output→PostModifiers correlation went from 0.40 → 1.000000 (perfect)
-- [x] Sample delta improved: -32,640 → +1,024
+### In Progress
+- [ ] Phase 1: Create project + move files
 
 ### Files Modified
-- `src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs` — frame alignment in OnProcess
-- `src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs` — defense-in-depth frame alignment in AddSamples
-- `tests/Radio.Infrastructure.Tests/Audio/Diagnostics/WaveformComparisonTests.cs` — capture analysis test
-- `findings.md`, `progress.md`, `task_plan.md`
-
----
-
-## Session: 2026-03-06 (Phase 2 — Test Infrastructure)
-
-### Implementation Complete (PR #304, merged)
-- [x] `Radio.AudioAnalysis` shared library (8 files)
-- [x] Capture infrastructure (4 files in `Audio/Diagnostics/`)
-- [x] `BufferedSoundGenerator` diagnostic hooks
-- [x] API capture endpoints
-- [x] CI-safe distortion tests + capture session tests + waveform comparison tests
-- [x] All 1416 tests passing
-- [x] Code review: fixed `IsCapturing` race condition
-
----
-
-## Session: 2026-03-06 (Planning)
-
-### Research Completed
-- [x] .NET 10 GA status confirmed (Nov 11, 2025), LTS through Nov 14, 2028
-- [x] C# 14 features catalogued: `field` keyword, null-conditional assignment, `params ReadOnlySpan<T>`, implicit Span conversions, extension members
-- [x] Breaking changes audited: Swashbuckle → built-in OpenAPI, `System.Linq.Async` removal, `WebHostBuilder` obsolete
-- [x] Kiosk UI blanking root cause identified: `SleepService.EnterSleepAsync()` pauses audio + mutes by design after 30 min idle
-- [x] Chrome timer throttling risk identified: missing `--disable-background-timer-throttling` flag
-- [x] DPMS not disabled in kiosk setup (only GNOME screensaver)
-- [x] Blazor circuit timeout insufficient for kiosk (30 retries = 60s, vs 10 min retention)
-- [x] BtSender tool analyzed: Windows-only, 200Hz/300Hz diagnostic tone, WASAPI output, auto-reconnect
-- [x] Audio distortion findings reviewed: 151 markers, no waveform capture, ranked root causes
-- [x] Comprehensive review items #12, #13, #14, #26, #30, #34, #36 extracted and summarized
-- [x] Created 6-phase task plan covering all priorities
-
-### Planning Files
-- [x] `task_plan.md` — 6 phases with detailed sub-tasks
-- [x] `findings.md` — .NET 10, kiosk root cause, audio distortion, review items
-- [x] `progress.md` — this file
-
----
-
-## Previous Sessions (archived from earlier task plan)
-
-### Session: 2026-03-05 (R1 + R4 research)
-- R4 BT Auto-Reconnection — research complete, implemented in PR #299
-- R1 Config Unification — research complete, implemented in PR #298
-
-### Session: 2026-03-05 (R2 perf optimization)
-- R2 Performance Deep Dive — 10 production files optimized (PR #296)
-- GC pressure reduction, lock-free taps, render efficiency, background service optimization
-
-### Session: 2026-03-05 (earlier)
-- 151 distortion markers analyzed
-- GC/instrumentation improvements
-- BT state race fix, fingerprinting sync fix
+(none yet — planning phase)

--- a/src/Radio.API/Controllers/AudioController.cs
+++ b/src/Radio.API/Controllers/AudioController.cs
@@ -5,6 +5,7 @@ using Radio.API.Models;
 using Radio.Core.Interfaces.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.SoundFlow;
+using Radio.Fingerprinting.Services;
 
 namespace Radio.API.Controllers;
 

--- a/src/Radio.API/Services/AudioStateUpdateService.cs
+++ b/src/Radio.API/Services/AudioStateUpdateService.cs
@@ -11,6 +11,7 @@ using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.Outputs;
 using Radio.Infrastructure.Audio.Services;
+using Radio.Fingerprinting.Services;
 
 namespace Radio.API.Services;
 

--- a/src/Radio.Fingerprinting/Abstractions/IFingerprintDataConnection.cs
+++ b/src/Radio.Fingerprinting/Abstractions/IFingerprintDataConnection.cs
@@ -1,0 +1,17 @@
+using Microsoft.Data.Sqlite;
+
+namespace Radio.Fingerprinting.Abstractions;
+
+/// <summary>
+/// Provides a SQLite connection for fingerprinting data access.
+/// Implemented by the host application's database context.
+/// </summary>
+public interface IFingerprintDataConnection
+{
+  /// <summary>
+  /// Gets an initialized SQLite connection for fingerprinting data operations.
+  /// </summary>
+  /// <param name="ct">Cancellation token.</param>
+  /// <returns>An open SQLite connection.</returns>
+  Task<SqliteConnection> GetConnectionAsync(CancellationToken ct = default);
+}

--- a/src/Radio.Fingerprinting/Data/SqliteFingerprintCacheRepository.cs
+++ b/src/Radio.Fingerprinting/Data/SqliteFingerprintCacheRepository.cs
@@ -2,8 +2,9 @@ using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
+using Radio.Fingerprinting.Abstractions;
 
-namespace Radio.Infrastructure.Audio.Fingerprinting.Data;
+namespace Radio.Fingerprinting.Data;
 
 /// <summary>
 /// SQLite implementation of the fingerprint cache repository.
@@ -11,19 +12,19 @@ namespace Radio.Infrastructure.Audio.Fingerprinting.Data;
 public sealed class SqliteFingerprintCacheRepository : IFingerprintCacheRepository
 {
   private readonly ILogger<SqliteFingerprintCacheRepository> _logger;
-  private readonly FingerprintDbContext _dbContext;
+  private readonly IFingerprintDataConnection _dataConnection;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="SqliteFingerprintCacheRepository"/> class.
   /// </summary>
   /// <param name="logger">The logger instance.</param>
-  /// <param name="dbContext">The database context.</param>
+  /// <param name="dataConnection">The fingerprint data connection.</param>
   public SqliteFingerprintCacheRepository(
     ILogger<SqliteFingerprintCacheRepository> logger,
-    FingerprintDbContext dbContext)
+    IFingerprintDataConnection dataConnection)
   {
     _logger = logger;
-    _dbContext = dbContext;
+    _dataConnection = dataConnection;
   }
 
   /// <inheritdoc/>
@@ -31,7 +32,7 @@ public sealed class SqliteFingerprintCacheRepository : IFingerprintCacheReposito
     string chromaprintHash,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       SELECT f.Id, f.ChromaprintHash, f.Duration, f.AcoustId, f.MusicBrainzRecordingId,
@@ -64,7 +65,7 @@ public sealed class SqliteFingerprintCacheRepository : IFingerprintCacheReposito
     TrackMetadata? metadata,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var now = DateTime.UtcNow.ToString("O");
 
@@ -143,7 +144,7 @@ public sealed class SqliteFingerprintCacheRepository : IFingerprintCacheReposito
   /// <inheritdoc/>
   public async Task UpdateLastMatchedAsync(string id, CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       UPDATE FingerprintCache
@@ -163,7 +164,7 @@ public sealed class SqliteFingerprintCacheRepository : IFingerprintCacheReposito
   /// <inheritdoc/>
   public async Task<int> GetCacheCountAsync(CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     await using var cmd = conn.CreateCommand();
     cmd.CommandText = "SELECT COUNT(*) FROM FingerprintCache";
@@ -178,7 +179,7 @@ public sealed class SqliteFingerprintCacheRepository : IFingerprintCacheReposito
     int pageSize = 50,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var offset = (page - 1) * pageSize;
     var sql = """
@@ -212,7 +213,7 @@ public sealed class SqliteFingerprintCacheRepository : IFingerprintCacheReposito
   /// <inheritdoc/>
   public async Task<bool> DeleteAsync(string id, CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     // Delete metadata first (foreign key)
     await using var deleteMetadataCmd = conn.CreateCommand();

--- a/src/Radio.Fingerprinting/Data/SqlitePlayHistoryRepository.cs
+++ b/src/Radio.Fingerprinting/Data/SqlitePlayHistoryRepository.cs
@@ -1,8 +1,9 @@
 using Microsoft.Extensions.Logging;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
+using Radio.Fingerprinting.Abstractions;
 
-namespace Radio.Infrastructure.Audio.Fingerprinting.Data;
+namespace Radio.Fingerprinting.Data;
 
 /// <summary>
 /// SQLite implementation of the play history repository.
@@ -10,25 +11,25 @@ namespace Radio.Infrastructure.Audio.Fingerprinting.Data;
 public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
 {
   private readonly ILogger<SqlitePlayHistoryRepository> _logger;
-  private readonly FingerprintDbContext _dbContext;
+  private readonly IFingerprintDataConnection _dataConnection;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="SqlitePlayHistoryRepository"/> class.
   /// </summary>
   /// <param name="logger">The logger instance.</param>
-  /// <param name="dbContext">The database context.</param>
+  /// <param name="dataConnection">The fingerprint data connection.</param>
   public SqlitePlayHistoryRepository(
     ILogger<SqlitePlayHistoryRepository> logger,
-    FingerprintDbContext dbContext)
+    IFingerprintDataConnection dataConnection)
   {
     _logger = logger;
-    _dbContext = dbContext;
+    _dataConnection = dataConnection;
   }
 
   /// <inheritdoc/>
   public async Task RecordPlayAsync(PlayHistoryEntry entry, CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       INSERT INTO PlayHistory (Id, TrackMetadataId, FingerprintId, PlayedAt, EndedAt, Source, MetadataSource, SourceDetails, Duration, IdentificationConfidence, WasIdentified)
@@ -58,7 +59,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
     int count = 20,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       SELECT h.Id, h.TrackMetadataId, h.FingerprintId, h.PlayedAt, h.EndedAt, h.Source, h.MetadataSource, h.SourceDetails,
@@ -83,7 +84,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
     DateTime end,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       SELECT h.Id, h.TrackMetadataId, h.FingerprintId, h.PlayedAt, h.EndedAt, h.Source, h.MetadataSource, h.SourceDetails,
@@ -109,7 +110,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
     int count = 20,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       SELECT h.Id, h.TrackMetadataId, h.FingerprintId, h.PlayedAt, h.EndedAt, h.Source, h.MetadataSource, h.SourceDetails,
@@ -137,7 +138,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
     int withinMinutes = 5,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var cutoffTime = DateTime.UtcNow.AddMinutes(-withinMinutes);
 
@@ -160,7 +161,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
   /// <inheritdoc/>
   public async Task<PlayStatistics> GetStatisticsAsync(CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     // Get total counts
     await using var countCmd = conn.CreateCommand();
@@ -269,7 +270,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
   /// <inheritdoc/>
   public async Task<PlayHistoryEntry?> GetByIdAsync(string id, CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       SELECT h.Id, h.TrackMetadataId, h.FingerprintId, h.PlayedAt, h.EndedAt, h.Source, h.MetadataSource, h.SourceDetails,
@@ -296,7 +297,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
   /// <inheritdoc/>
   public async Task<bool> DeleteAsync(string id, CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     await using var cmd = conn.CreateCommand();
     cmd.CommandText = "DELETE FROM PlayHistory WHERE Id = @Id";
@@ -314,7 +315,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
   /// <inheritdoc/>
   public async Task<bool> UpdateAsync(PlayHistoryEntry entry, CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       UPDATE PlayHistory
@@ -356,7 +357,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
     int withinMinutes = 5,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var cutoffTime = DateTime.UtcNow.AddMinutes(-withinMinutes);
 
@@ -390,7 +391,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
   /// <inheritdoc/>
   public async Task<bool> FinalizeEntryAsync(string id, DateTime endedAt, CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     // Set EndedAt and calculate DurationSeconds from PlayedAt to endedAt
     var sql = """
@@ -417,7 +418,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
   /// <inheritdoc/>
   public async Task<int> CloseOrphanedEntriesAsync(TimeSpan olderThan, CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
     var cutoff = DateTime.UtcNow - olderThan;
 
     // Close orphaned entries: EndedAt IS NULL and PlayedAt is older than the cutoff.
@@ -462,7 +463,7 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
   {
     ArgumentException.ThrowIfNullOrWhiteSpace(searchTerm);
 
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
     var searchPattern = $"%{searchTerm}%";
 
     // Get total count

--- a/src/Radio.Fingerprinting/Data/SqliteTrackMetadataRepository.cs
+++ b/src/Radio.Fingerprinting/Data/SqliteTrackMetadataRepository.cs
@@ -1,8 +1,9 @@
 using Microsoft.Extensions.Logging;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
+using Radio.Fingerprinting.Abstractions;
 
-namespace Radio.Infrastructure.Audio.Fingerprinting.Data;
+namespace Radio.Fingerprinting.Data;
 
 /// <summary>
 /// SQLite implementation of the track metadata repository.
@@ -10,25 +11,25 @@ namespace Radio.Infrastructure.Audio.Fingerprinting.Data;
 public sealed class SqliteTrackMetadataRepository : ITrackMetadataRepository
 {
   private readonly ILogger<SqliteTrackMetadataRepository> _logger;
-  private readonly FingerprintDbContext _dbContext;
+  private readonly IFingerprintDataConnection _dataConnection;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="SqliteTrackMetadataRepository"/> class.
   /// </summary>
   /// <param name="logger">The logger instance.</param>
-  /// <param name="dbContext">The database context.</param>
+  /// <param name="dataConnection">The fingerprint data connection.</param>
   public SqliteTrackMetadataRepository(
     ILogger<SqliteTrackMetadataRepository> logger,
-    FingerprintDbContext dbContext)
+    IFingerprintDataConnection dataConnection)
   {
     _logger = logger;
-    _dbContext = dbContext;
+    _dataConnection = dataConnection;
   }
 
   /// <inheritdoc/>
   public async Task<TrackMetadata?> GetByIdAsync(string id, CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       SELECT Id, FingerprintId, Title, Artist, Album, AlbumArtist, TrackNumber,
@@ -56,7 +57,7 @@ public sealed class SqliteTrackMetadataRepository : ITrackMetadataRepository
     string fingerprintId,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       SELECT Id, FingerprintId, Title, Artist, Album, AlbumArtist, TrackNumber,
@@ -84,7 +85,7 @@ public sealed class SqliteTrackMetadataRepository : ITrackMetadataRepository
     string recordingId,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       SELECT Id, FingerprintId, Title, Artist, Album, AlbumArtist, TrackNumber,
@@ -112,7 +113,7 @@ public sealed class SqliteTrackMetadataRepository : ITrackMetadataRepository
     TrackMetadata metadata,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var now = DateTime.UtcNow.ToString("O");
     var sql = """
@@ -170,7 +171,7 @@ public sealed class SqliteTrackMetadataRepository : ITrackMetadataRepository
     int limit = 20,
     CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var searchPattern = $"%{query}%";
     var sql = """
@@ -201,7 +202,7 @@ public sealed class SqliteTrackMetadataRepository : ITrackMetadataRepository
   /// <inheritdoc/>
   public async Task UpdateCoverArtUrlAsync(string id, string coverArtUrl, CancellationToken ct = default)
   {
-    var conn = await _dbContext.GetConnectionAsync(ct);
+    var conn = await _dataConnection.GetConnectionAsync(ct);
 
     var sql = """
       UPDATE TrackMetadata

--- a/src/Radio.Fingerprinting/FingerprintingOptions.cs
+++ b/src/Radio.Fingerprinting/FingerprintingOptions.cs
@@ -1,4 +1,4 @@
-namespace Radio.Core.Configuration;
+namespace Radio.Fingerprinting;
 
 /// <summary>
 /// Configuration options for the audio fingerprinting system.

--- a/src/Radio.Fingerprinting/GlobalUsings.cs
+++ b/src/Radio.Fingerprinting/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Radio.Fingerprinting;

--- a/src/Radio.Fingerprinting/README.md
+++ b/src/Radio.Fingerprinting/README.md
@@ -1,0 +1,19 @@
+# Radio.Fingerprinting
+
+Audio fingerprinting and recognition library providing:
+
+- **SongRec (Shazam) integration** — wraps the SongRec binary for audio recognition
+- **MusicBrainz metadata lookup** — artist, album, cover art via MusicBrainz + Cover Art Archive APIs
+- **Background identification service** — hosted service with duplicate suppression and song change detection
+- **SQLite persistence** — fingerprint cache, track metadata, and play history repositories
+
+## Dependencies
+
+- `Radio.Core` — domain interfaces and models
+- `Radio.Metrics` — optional metrics collection
+- `Microsoft.Data.Sqlite` — database access
+- `Microsoft.Extensions.Hosting.Abstractions` — hosted service support
+
+## Usage
+
+Register services via DI in the consuming application. Implement `IFingerprintDataConnection` to provide a SQLite connection, or use the built-in `FingerprintDbContext` from `Radio.Infrastructure`.

--- a/src/Radio.Fingerprinting/Radio.Fingerprinting.csproj
+++ b/src/Radio.Fingerprinting/Radio.Fingerprinting.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <!-- NuGet Package Metadata -->
+    <PackageId>Radio.Fingerprinting</PackageId>
+    <Version>1.0.0</Version>
+    <Description>Audio fingerprinting and recognition library providing SongRec (Shazam) integration, MusicBrainz metadata lookup, background identification with duplicate suppression and song change detection, and SQLite persistence for fingerprint cache, track metadata, and play history.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>audio;fingerprinting;shazam;songrec;musicbrainz;recognition;metadata</PackageTags>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Radio.Core\Radio.Core.csproj" />
+    <ProjectReference Include="..\Radio.Metrics\Radio.Metrics.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Radio.Infrastructure" />
+    <InternalsVisibleTo Include="Radio.Infrastructure.Tests" />
+    <InternalsVisibleTo Include="Radio.IntegrationTests" />
+  </ItemGroup>
+</Project>

--- a/src/Radio.Fingerprinting/Services/BackgroundIdentificationService.cs
+++ b/src/Radio.Fingerprinting/Services/BackgroundIdentificationService.cs
@@ -3,14 +3,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Radio.Core.Configuration;
 using Radio.Core.Events;
 using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Metrics;
 
-namespace Radio.Infrastructure.Audio.Fingerprinting;
+namespace Radio.Fingerprinting.Services;
 
 /// <summary>
 /// Background service that periodically identifies audio from active sources using SongRec.

--- a/src/Radio.Fingerprinting/Services/MetadataLookupService.cs
+++ b/src/Radio.Fingerprinting/Services/MetadataLookupService.cs
@@ -2,12 +2,11 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Radio.Core.Configuration;
 using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
 using Radio.Metrics;
 
-namespace Radio.Infrastructure.Audio.Fingerprinting;
+namespace Radio.Fingerprinting.Services;
 
 /// <summary>
 /// Service for looking up cover art via MusicBrainz and the Cover Art Archive.

--- a/src/Radio.Fingerprinting/Services/SongRecRecognitionService.cs
+++ b/src/Radio.Fingerprinting/Services/SongRecRecognitionService.cs
@@ -4,11 +4,10 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Radio.Core.Configuration;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 
-namespace Radio.Infrastructure.Audio.Fingerprinting;
+namespace Radio.Fingerprinting.Services;
 
 /// <summary>
 /// Audio recognition service using SongRec (open-source Shazam client).

--- a/src/Radio.Infrastructure/Audio/Factories/RadioFactory.cs
+++ b/src/Radio.Infrastructure/Audio/Factories/RadioFactory.cs
@@ -9,6 +9,7 @@ using Radio.Infrastructure.Audio.SoundFlow;
 using Radio.Infrastructure.Audio.Sources.Primary;
 using Radio.Infrastructure.Configuration;
 using Radio.Metrics;
+using Radio.Fingerprinting.Services;
 using RTLSDRCore;
 using RTLSDRCore.Hardware;
 using RTLSDRCore.Models;

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/Data/FingerprintDbContext.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/Data/FingerprintDbContext.cs
@@ -2,13 +2,14 @@ using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
+using Radio.Fingerprinting.Abstractions;
 
 namespace Radio.Infrastructure.Audio.Fingerprinting.Data;
 
 /// <summary>
 /// Manages the SQLite database connection for fingerprinting data.
 /// </summary>
-public sealed class FingerprintDbContext : IAsyncDisposable
+public sealed class FingerprintDbContext : IFingerprintDataConnection, IAsyncDisposable
 {
   private readonly ILogger<FingerprintDbContext> _logger;
   private readonly DatabasePathResolver _pathResolver;

--- a/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
@@ -4,6 +4,7 @@ using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.SoundFlow;
+using Radio.Fingerprinting.Services;
 
 // Ducking support: AudioManager subscribes to IDuckingService events and applies
 // volume reduction to the active primary source via SoundFlowPlaybackService.

--- a/src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs
@@ -11,6 +11,8 @@ using Radio.Infrastructure.Audio.Sources.Primary;
 using Radio.Infrastructure.Configuration;
 using Radio.Configuration.Abstractions;
 using Radio.Metrics;
+using Radio.Fingerprinting.Services;
+using Radio.Fingerprinting;
 
 namespace Radio.Infrastructure.Audio.Services;
 

--- a/src/Radio.Infrastructure/Audio/Services/PlayHistoryTracker.cs
+++ b/src/Radio.Infrastructure/Audio/Services/PlayHistoryTracker.cs
@@ -7,6 +7,7 @@ using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.Sources.Primary;
 using Radio.Metrics;
+using Radio.Fingerprinting.Services;
 
 namespace Radio.Infrastructure.Audio.Services;
 

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -10,6 +10,8 @@ using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.SoundFlow;
 using Radio.Infrastructure.Platform.Bluetooth;
 using Radio.Metrics;
+using Radio.Fingerprinting.Services;
+using Radio.Fingerprinting;
 using SoundFlow.Abstracts;
 using SoundFlow.Abstracts.Devices;
 using SoundFlow.Components;

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
@@ -11,6 +11,8 @@ using Radio.Infrastructure.Audio.SoundFlow;
 using Radio.Configuration.Abstractions;
 using Radio.Configuration.Models;
 using Radio.Metrics;
+using Radio.Fingerprinting.Services;
+using Radio.Fingerprinting;
 using SoundFlow.Backends.MiniAudio;
 using SoundFlow.Interfaces;
 using SoundFlow.Metadata;

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/GenericUSBAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/GenericUSBAudioSource.cs
@@ -5,6 +5,7 @@ using Radio.Core.Exceptions;
 using Radio.Core.Interfaces.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.SoundFlow;
+using Radio.Fingerprinting.Services;
 
 namespace Radio.Infrastructure.Audio.Sources.Primary;
 

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/RadioAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/RadioAudioSource.cs
@@ -5,6 +5,7 @@ using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.SoundFlow;
+using Radio.Fingerprinting.Services;
 
 namespace Radio.Infrastructure.Audio.Sources.Primary;
 

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/SDRRadioAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/SDRRadioAudioSource.cs
@@ -9,6 +9,7 @@ using Radio.Infrastructure.Audio.SoundFlow;
 using Radio.Configuration.Abstractions;
 using Radio.Configuration.Models;
 using Radio.Metrics;
+using Radio.Fingerprinting.Services;
 using RTLSDRCore;
 using RTLSDRCore.Enums;
 

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
@@ -6,6 +6,7 @@ using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.SoundFlow;
 using Radio.Metrics;
+using Radio.Fingerprinting.Services;
 using SoundFlow.Abstracts.Devices;
 using SoundFlow.Backends.MiniAudio;
 using SoundFlow.Enums;

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/VinylAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/VinylAudioSource.cs
@@ -5,6 +5,7 @@ using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.SoundFlow;
+using Radio.Fingerprinting.Services;
 
 namespace Radio.Infrastructure.Audio.Sources.Primary;
 

--- a/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
+++ b/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
@@ -9,6 +9,7 @@ using Radio.Core.Interfaces.External;
 using Radio.Core.Interfaces.Input;
 using Radio.Infrastructure.Audio;
 using Radio.Infrastructure.Audio.Factories;
+using Radio.Fingerprinting.Services;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.Outputs;
 using Radio.Infrastructure.Audio.Services;

--- a/src/Radio.Infrastructure/DependencyInjection/FingerprintingServiceExtensions.cs
+++ b/src/Radio.Infrastructure/DependencyInjection/FingerprintingServiceExtensions.cs
@@ -1,8 +1,11 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Radio.Core.Configuration;
 using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
+using Radio.Fingerprinting;
+using Radio.Fingerprinting.Abstractions;
+using Radio.Fingerprinting.Data;
+using Radio.Fingerprinting.Services;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Infrastructure.Audio.Fingerprinting.Data;
 using Radio.Infrastructure.Audio.Playlists;
@@ -32,7 +35,9 @@ public static class FingerprintingServiceExtensions
     services.AddSecretResolution<FingerprintingOptions>();
 
     // Register database context as singleton (manages connection)
+    // Also register as IFingerprintDataConnection for the extracted repository implementations
     services.AddSingleton<FingerprintDbContext>();
+    services.AddSingleton<IFingerprintDataConnection>(sp => sp.GetRequiredService<FingerprintDbContext>());
 
     // Register repositories as scoped
     services.AddScoped<IFingerprintCacheRepository, SqliteFingerprintCacheRepository>();

--- a/src/Radio.Infrastructure/Radio.Infrastructure.csproj
+++ b/src/Radio.Infrastructure/Radio.Infrastructure.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Radio.Configuration\Radio.Configuration.csproj" />
     <ProjectReference Include="..\Radio.Core\Radio.Core.csproj" />
+    <ProjectReference Include="..\Radio.Fingerprinting\Radio.Fingerprinting.csproj" />
     <ProjectReference Include="..\Radio.Metrics\Radio.Metrics.csproj" />
     <ProjectReference Include="..\RTLSDRCore\RTLSDRCore.csproj" />
   </ItemGroup>

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,263 +1,85 @@
-# Task Plan: Extract Independent NuGet Packages from Radio Console
+# Task Plan: Extract Radio.Fingerprinting NuGet Package (Phase 5)
 
 ## Goal
-Extract standalone, reusable libraries from the Radio Console monorepo into publishable NuGet packages. Six candidates identified across SDR, audio analysis, fingerprinting, configuration, metrics, and domain core.
+Extract fingerprinting implementation code from Radio.Infrastructure into a standalone `Radio.Fingerprinting` NuGet package. The package depends on Radio.Core for shared models/interfaces and Radio.Metrics for optional metrics.
 
 ## Current Phase
-Planning complete — pending user decision on execution order
+Phase 6: complete
+
+## Architecture Decision
+**Option B: Implementation extraction with Radio.Core dependency.**
+- Models, interfaces, events STAY in Radio.Core (shared domain types used by 75+ files)
+- Only implementation files + FingerprintingOptions move to Radio.Fingerprinting
+- ~20 files need namespace updates (vs 75+ for full extraction)
+- Radio.Fingerprinting depends on Radio.Core + Radio.Metrics
 
 ## Phases
 
-| # | Phase | Status | Effort | Notes |
-|---|-------|--------|--------|-------|
-| 0 | Local NuGet feed infrastructure | pending | Low | nuget.config, CI pack step, deploy restore, Directory.Build.props packaging defaults |
-| 1 | RTLSDRCore | pending | Low | Already has full NuGet metadata, 75 tests, zero internal deps |
-| 2 | Radio.AudioAnalysis | pending | Medium | Move from tests/ to src/, add ~15 unit tests, NuGet metadata |
-| 3 | Metrics library | pending | Low-Med | 99% generic, ~1,500 LOC, only needs DatabasePath decoupling |
-| 4 | Configuration library | pending | Medium | 90% generic, ~35 files, remove 2 Radio-specific files + 1 interface extraction |
-| 5 | Fingerprinting library | pending | Med-High | 65-70% extractable, needs IAudioSampleProvider abstraction + DatabasePathResolver decoupling |
-| 6 | Radio.Core | pending | Medium | Add NuGet metadata, XML docs, README — but may be internal-only |
+| # | Phase | Status | Notes |
+|---|-------|--------|-------|
+| 1 | Create project + move files | complete | csproj, moved 7 files, created IFingerprintDataConnection |
+| 2 | Update namespaces + references | complete | ~25 consumer files updated with using additions |
+| 3 | DI split (library vs Infrastructure wrapper) | complete | FingerprintingServiceExtensions updated |
+| 4 | Build + fix errors | complete | 0 errors, 1 pre-existing warning |
+| 5 | Run tests + verify | complete | All tests pass (1 pre-existing flaky: WaveformComparisonTests) |
+| 6 | NuGet metadata + pack | complete | pack-local.ps1 updated, README.md created, .nupkg builds |
 
 ---
 
-## Phase 0: Local NuGet Feed Infrastructure
+## Phase 1: Create Project + Move Files
 
-**Goal:** Set up a local NuGet package feed so extracted packages can be consumed by Radio.Console projects during build, CI, and deploy — without publishing to NuGet.org.
+### 1A. Create `src/Radio.Fingerprinting/Radio.Fingerprinting.csproj`
+- Target: net10.0
+- Dependencies: Radio.Core, Radio.Metrics, Microsoft.Data.Sqlite, Microsoft.Extensions.Hosting.Abstractions, Microsoft.Extensions.Options
+- NuGet metadata, InternalsVisibleTo for test projects
 
-### 0A. Local feed directory
-- [ ] Create `packages/` directory at repo root for local .nupkg storage
-- [ ] Add `packages/` to `.gitignore` (binary artifacts, not source)
+### 1B. Create `IFingerprintDataConnection` abstraction
+- Single method: `Task<SqliteConnection> GetConnectionAsync(CancellationToken ct = default)`
+- FingerprintDbContext implements this interface (in Radio.Infrastructure)
 
-### 0B. `nuget.config` at repo root
-- [ ] Create `nuget.config` with two sources:
-  - `local` → `./packages` (local feed, highest priority)
-  - `nuget.org` → `https://api.nuget.org/v3/index.json` (public fallback)
-- [ ] Verify `dotnet restore` picks up local feed
+### 1C. Move files (7 files)
+| Source | Destination | New Namespace |
+|--------|------------|---------------|
+| Radio.Core/Configuration/FingerprintingOptions.cs | Radio.Fingerprinting/FingerprintingOptions.cs | Radio.Fingerprinting |
+| Radio.Infrastructure/.../BackgroundIdentificationService.cs | Radio.Fingerprinting/Services/ | Radio.Fingerprinting.Services |
+| Radio.Infrastructure/.../MetadataLookupService.cs | Radio.Fingerprinting/Services/ | Radio.Fingerprinting.Services |
+| Radio.Infrastructure/.../SongRecRecognitionService.cs | Radio.Fingerprinting/Services/ | Radio.Fingerprinting.Services |
+| Radio.Infrastructure/.../SqliteFingerprintCacheRepository.cs | Radio.Fingerprinting/Data/ | Radio.Fingerprinting.Data |
+| Radio.Infrastructure/.../SqliteTrackMetadataRepository.cs | Radio.Fingerprinting/Data/ | Radio.Fingerprinting.Data |
+| Radio.Infrastructure/.../SqlitePlayHistoryRepository.cs | Radio.Fingerprinting/Data/ | Radio.Fingerprinting.Data |
 
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="local" value="./packages" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>
-```
-
-### 0C. Pack + push workflow for extracted packages
-- [ ] Add a `pack-local.ps1` (or shell script) that:
-  1. Runs `dotnet pack` on each extractable project
-  2. Copies .nupkg files to `packages/` directory
-  3. Optionally bumps version (or uses `--version-suffix`)
-- [ ] Convention: packages use SemVer, pre-release suffix for local dev (`1.0.0-local.1`)
-
-### 0D. CI integration
-- [ ] Update `.github/workflows/build.yml` to:
-  1. Pack extractable projects after build
-  2. Run `dotnet restore` with local feed (already automatic via `nuget.config`)
-  3. Optionally upload .nupkg as build artifacts (for traceability)
-- [ ] Ensure CI `dotnet restore` respects `nuget.config` (it does by default)
-
-### 0E. Deploy script integration
-- [ ] Verify `Deploy-ToLinux.ps1` `dotnet restore` step picks up `nuget.config`
-  - Current: `dotnet restore ... --runtime $Runtime` — should auto-detect nuget.config
-- [ ] If packages/ directory is empty (first clone), restore still works (all deps on nuget.org)
-
-### 0F. Directory.Build.props packaging defaults
-- [ ] Add shared packaging properties for extractable projects:
-  - `Authors`, `Copyright`, `PackageLicenseExpression` (MIT)
-  - `RepositoryUrl`, `RepositoryType`
-  - `GenerateDocumentationFile` (already true)
-- [ ] Each extractable project overrides `PackageId`, `Description`, `Version`
-
-### Promotion path (future)
-When ready to publish publicly:
-1. Create GitHub Actions workflow with `dotnet nuget push` to NuGet.org
-2. Or push to GitHub Packages as intermediate step (private, version browsing)
-3. Remove `local` source from `nuget.config` once packages are on public feed
+### 1D. Update moved files
+- Change namespace declarations
+- Change repository constructors: FingerprintDbContext -> IFingerprintDataConnection
+- Update using statements
 
 ---
 
-## Phase 1: RTLSDRCore — Publish to NuGet
+## Phase 2: Update Namespaces + References
+~20 consumer files need using statement updates + project reference additions.
 
-**Readiness: 8/10 — Publish-ready today**
+## Phase 3: DI Split
+Library DI registers extracted services. Infrastructure wrapper calls library, adds Radio-specific services.
 
-### Current State
-- `src/RTLSDRCore/RTLSDRCore.csproj` — Full NuGet metadata (PackageId, Version 1.0.0, MIT license, README, symbols)
-- 75 unit tests in `tests/RTLSDRCore.Tests/`
-- Zero internal project references (depends only on Serilog 4.0.0)
-- `src/RTLSDRCore/README.md` already exists
+## Phase 4: Build + Fix Errors
+Iterative compile-fix cycle.
 
-### Tasks
-- [ ] Verify `dotnet pack src/RTLSDRCore --configuration Release` produces clean .nupkg
-- [ ] Review README for external consumers (not just internal docs)
-- [ ] Verify all public API has XML documentation
-- [ ] Test: create throwaway console project, add local .nupkg, verify standalone
-- [ ] Decide: NuGet.org or GitHub Packages first?
+## Phase 5: Run Tests + Verify
+All ~1416 tests must pass.
 
-### Public API
-- `RadioReceiver` — Main class (factory: `CreateWithMockDevice()`, `CreateWithFirstAvailableDevice()`)
-- `IRadioControl` — Tuning, scanning, band selection
-- `ISdrDevice` / `MockSdrDevice` / `RtlSdrDevice` — Hardware abstraction
-- Demodulators: AM, FM, SSB + StereoFmDecoder, RdsDecoder
-- Models: `BandType`, `ModulationType`, `RadioState`, `AudioFormat`, `BandPresets`
-
----
-
-## Phase 2: Radio.AudioAnalysis — Extract & Publish
-
-**Readiness: 5/10 — Needs relocation + unit tests**
-
-### Current State
-- Lives in `tests/Radio.AudioAnalysis/` with `IsPackable=false`
-- 7 source files, ~1,400 LOC, zero dependencies
-- No dedicated unit tests (only indirect via integration tests)
-
-### Tasks
-- [ ] Move from `tests/Radio.AudioAnalysis/` to `src/Radio.AudioAnalysis/`
-- [ ] Update all project references
-- [ ] Remove `IsPackable=false`, add NuGet metadata
-- [ ] Write ~15-20 unit tests (cross-correlation, THD, silence detection, WAV round-trip)
-- [ ] Add README with examples
-- [ ] Add XML documentation on public methods
-
-### Public API
-- `WaveformComparison` — Cross-correlation, time alignment, distortion detection
-- `FrequencyAnalysis` — THD measurement, Goertzel algorithm
-- `SilenceDetector` — Zero runs, repeated samples, clipping
-- `WavFileHelper` — WAV I/O (16/24/32-bit PCM)
-- `DistortionEvent`, `DistortionReport`, `ComparisonOptions`
-
----
-
-## Phase 3: Metrics Library
-
-**Readiness: 8/10 — 99% generic, minimal decoupling needed**
-
-### Current State
-- ~1,500 LOC across 5 implementation files + 3 core model/interface files
-- IMetricsCollector (Increment/Gauge) + IMetricsReader (history/snapshots/aggregate/keys)
-- SQLite storage with 3-resolution tables (Minute/Hour/Day) + buffered writes
-- MetricsRollupService: automatic aggregation + configurable retention policies
-- Zero Radio-specific logic in any metrics code
-
-### Decoupling Required
-- MetricsDbContext uses `GetConfigurationDatabasePath()` → add explicit `MetricsOptions.DatabasePath`
-- SystemMonitorService (OS-specific: CPU/memory/disk/temp) → exclude or make optional
-
-### Tasks
-- [ ] Add `DatabasePath` property to `MetricsOptions`, update `MetricsDbContext` to use it
-- [ ] Extract core files into standalone project structure
-- [ ] Decide: include SystemMonitorService as optional or exclude
-- [ ] Add NuGet metadata, README with usage examples
-- [ ] Verify tests pass in isolation
-
-### Public API
-- `IMetricsCollector` — `Increment(key, amount, tags?)`, `Gauge(key, value, tags?)`
-- `IMetricsReader` — `GetHistoryAsync()`, `GetCurrentSnapshotsAsync()`, `GetAggregateAsync()`, `ListMetricKeysAsync()`
-- `MetricPoint`, `MetricType`, `MetricResolution` — Domain models
-- `MetricsOptions` — Configuration
-- `AddMetrics(IServiceCollection, IConfiguration)` — DI extension
-
----
-
-## Phase 4: Configuration Library
-
-**Readiness: 7/10 — 90% generic, clean separation**
-
-### Current State
-- 35 C# files across 8 folders (Abstractions, Models, Stores, Secrets, Bridge, Backup, Services, Options)
-- Dual backend: JSON + SQLite stores, switchable via config
-- Encrypted secrets with `${secret:identifier}` tag substitution (Data Protection API)
-- Bridge to .NET IConfiguration/IOptionsMonitor pipeline (real-time config changes from UI)
-- Backup/restore via ZIP with manifests
-
-### Decoupling Required
-- Remove 2 Radio-specific files: `DeviceOptionsResolver`, `PreferencesPersistenceService` (keep in Radio.Infrastructure)
-- Replace `DatabasePathResolver` with `IDatabasePathProvider` interface or `Func<string>`
-
-### Tasks
-- [ ] Create `IDatabasePathProvider` interface
-- [ ] Remove/exclude Radio-specific files from package
-- [ ] Extract into standalone project structure
-- [ ] Add NuGet metadata, README with examples
-- [ ] Verify Bridge (SqliteConfigurationProvider → IOptionsMonitor) works in isolation
-
-### Public API
-- `IConfigurationStore` — CRUD on key-value config entries (JSON + SQLite impls)
-- `ISecretsProvider` — Encrypted secret resolution with `${secret:id}` substitution
-- `IConfigurationManager` — High-level orchestration
-- `IConfigurationBackupService` — ZIP-based backup/restore/import/export
-- Bridge: `SqliteConfigurationProvider` + `ConfigStoreChangeNotifier` → .NET IConfiguration pipeline
-- `AddManagedConfiguration(IServiceCollection, IConfiguration)` — DI extension
-
----
-
-## Phase 5: Fingerprinting / Audio Recognition Library
-
-**Readiness: 6/10 — 65-70% extractable, needs one interface abstraction**
-
-### Current State
-- ~3,000 LOC total, ~2,000 extractable
-- SongRecRecognitionService: wraps songrec binary (subprocess), zero Radio deps
-- MetadataLookupService: MusicBrainz + Cover Art Archive HTTP queries, zero Radio deps
-- SQLite repositories for fingerprint cache + track metadata
-- BackgroundIdentificationService: duplicate suppression, song change detection, status tracking
-
-### Decoupling Required
-- `IAudioSampleProvider`: strip Radio-specific properties (`PlaySource` enum, `SourceFilePath`, `NeedsFingerprintingLookup`) into a Radio adapter
-- `DatabasePathResolver` → `Func<string>` or options pattern
-- **NOT extractable**: `SoundFlowAudioTap` (~270 LOC) — bridge to SoundFlow engine, stays in Radio.Infrastructure
-
-### Tasks
-- [ ] Slim down `IAudioSampleProvider` to generic interface (CaptureAsync, IsActive, SourceName)
-- [ ] Create `RadioAudioSampleProviderAdapter` in Radio.Infrastructure wrapping SoundFlowAudioTap
-- [ ] Replace `DatabasePathResolver` with options pattern
-- [ ] Extract into standalone project structure
-- [ ] Verify ~8 existing test files work in isolation
-- [ ] Add NuGet metadata, README with examples
-- [ ] Document: requires `songrec` binary at runtime
-
-### Public API
-- `ISongRecRecognitionService` — Recognize audio → `TrackMetadata`
-- `IMetadataLookupService` — MusicBrainz/Cover Art Archive text search
-- `BackgroundIdentificationService` — Hosted service with duplicate suppression + song change events
-- `IAudioSampleProvider` — Generic audio capture abstraction (consumer-implemented)
-- `IFingerprintCacheRepository`, `ITrackMetadataRepository` — SQLite persistence
-- Models: `TrackMetadata`, `AudioSampleBuffer`, `FingerprintData`, `CachedFingerprint`
-- Events: `TrackIdentifiedEventArgs`, `SongChangedEventArgs`
-
----
-
-## Phase 6: Radio.Core — Package for Internal Structure
-
-**Readiness: 6/10 — Useful for internal package management, questionable external value**
-
-### Current State
-- 84 files, ~90+ public types, depends only on Microsoft.Extensions.*
-- 37 unit tests
-
-### Open Question
-Radio.Core is domain-specific to the Radio Console application. Unlike the other packages (SDR, audio analysis, metrics, config, fingerprinting), it doesn't solve a general problem. Options:
-- **A)** Publish externally — useful if someone wants to build a compatible Radio Console implementation
-- **B)** Internal package only — add NuGet metadata for internal dependency management but don't publish
-- **C)** Skip — not worth the versioning overhead for a monorepo
-
-### Tasks (if proceeding)
-- [ ] Add NuGet metadata
-- [ ] Audit XML documentation coverage
-- [ ] Write README explaining domain model
-- [ ] Decide A/B/C above
-
----
+## Phase 6: NuGet Metadata + Pack
+pack-local.ps1, README.
 
 ## Key Decisions
 | Decision | Rationale | Date |
 |----------|-----------|------|
-| Pending | | |
+| Option B: Depend on Radio.Core | Models used by 75+ files; moving them causes massive churn | 2026-03-09 |
+| Move FingerprintingOptions only | Library-specific config, not shared domain | 2026-03-09 |
+| IFingerprintDataConnection | Decouple repos from FingerprintDbContext (12-table monolith) | 2026-03-09 |
 
 ## Errors Encountered
 | Error | Attempt | Resolution |
 |-------|---------|------------|
-| (none yet) | | |
+| Python script placed usings inside method bodies | 1 | Manual fix: remove misplaced lines, add usings at file top |
+| Missing `using Radio.Fingerprinting;` in 6 test files | 1 | Added using to each file for FingerprintingOptions |
+| CoverArtPipelineIntegrationTests missing Services using | 1 | Added `using Radio.Fingerprinting.Services;` |

--- a/tests/Radio.Infrastructure.Tests/Audio/BluetoothAudioSourceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/BluetoothAudioSourceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Radio.Core.Configuration;
 using Radio.Core.Interfaces;
+using Radio.Fingerprinting;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Sources.Primary;

--- a/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/BackgroundIdentificationServiceSongChangeTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/BackgroundIdentificationServiceSongChangeTests.cs
@@ -6,6 +6,8 @@ using Radio.Core.Configuration;
 using Radio.Core.Events;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
+using Radio.Fingerprinting.Services;
+using Radio.Fingerprinting;
 
 namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
 

--- a/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/BackgroundIdentificationServiceStatusTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/BackgroundIdentificationServiceStatusTests.cs
@@ -5,6 +5,8 @@ using Moq;
 using Radio.Core.Configuration;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
+using Radio.Fingerprinting.Services;
+using Radio.Fingerprinting;
 
 namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
 

--- a/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/MetadataLookupServiceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/MetadataLookupServiceTests.cs
@@ -4,6 +4,8 @@ using Moq;
 using Radio.Core.Configuration;
 using Radio.Core.Interfaces;
 using Radio.Infrastructure.Audio.Fingerprinting;
+using Radio.Fingerprinting.Services;
+using Radio.Fingerprinting;
 
 namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
 

--- a/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/SongRecRecognitionServiceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/SongRecRecognitionServiceTests.cs
@@ -5,6 +5,8 @@ using Radio.Core.Configuration;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Xunit;
+using Radio.Fingerprinting.Services;
+using Radio.Fingerprinting;
 
 namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
 

--- a/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/SqliteFingerprintCacheRepositoryTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/SqliteFingerprintCacheRepositoryTests.cs
@@ -4,6 +4,9 @@ using Moq;
 using Radio.Core.Configuration;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting.Data;
+using Radio.Fingerprinting;
+using Radio.Fingerprinting.Abstractions;
+using Radio.Fingerprinting.Data;
 
 namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
 

--- a/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/SqlitePlayHistoryRepositoryTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Fingerprinting/SqlitePlayHistoryRepositoryTests.cs
@@ -4,6 +4,9 @@ using Moq;
 using Radio.Core.Configuration;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting.Data;
+using Radio.Fingerprinting;
+using Radio.Fingerprinting.Abstractions;
+using Radio.Fingerprinting.Data;
 
 namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
 

--- a/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/FilePlayerAudioSourceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/FilePlayerAudioSourceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Radio.Core.Configuration;
 using Radio.Core.Interfaces.Audio;
+using Radio.Fingerprinting;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Sources.Primary;
 

--- a/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/SDRRadioAudioSourceFingerprintingTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/SDRRadioAudioSourceFingerprintingTests.cs
@@ -12,6 +12,8 @@ using Radio.Infrastructure.Audio.Sources.Primary;
 using Radio.Metrics;
 using RTLSDRCore;
 using RTLSDRCore.Hardware;
+using Radio.Fingerprinting.Services;
+using Radio.Fingerprinting;
 
 namespace Radio.Infrastructure.Tests.Audio.Sources.Primary;
 

--- a/tests/Radio.Infrastructure.Tests/Configuration/SqliteConfigurationProviderTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Configuration/SqliteConfigurationProviderTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
 using Radio.Configuration.Bridge;
+using Radio.Fingerprinting;
 
 /// <summary>
 /// Tests for the SQLite configuration bridge provider that connects

--- a/tests/Radio.Infrastructure.Tests/Configuration/UnifiedDatabaseBackupTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Configuration/UnifiedDatabaseBackupTests.cs
@@ -10,6 +10,7 @@ using Radio.Infrastructure.Configuration.Backup;
 using Radio.Configuration.Models;
 using Radio.Configuration.Secrets;
 using Radio.Configuration.Stores;
+using Radio.Fingerprinting;
 using Radio.Metrics;
 
 /// <summary>

--- a/tests/Radio.Infrastructure.Tests/Radio.Infrastructure.Tests.csproj
+++ b/tests/Radio.Infrastructure.Tests/Radio.Infrastructure.Tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Radio.Configuration\Radio.Configuration.csproj" />
+    <ProjectReference Include="..\..\src\Radio.Fingerprinting\Radio.Fingerprinting.csproj" />
     <ProjectReference Include="..\..\src\Radio.Infrastructure\Radio.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Radio.AudioAnalysis\Radio.AudioAnalysis.csproj" />
   </ItemGroup>

--- a/tests/Radio.IntegrationTests/Fingerprinting/CoverArtPipelineIntegrationTests.cs
+++ b/tests/Radio.IntegrationTests/Fingerprinting/CoverArtPipelineIntegrationTests.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
+using Radio.Fingerprinting;
+using Radio.Fingerprinting.Services;
 using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.IntegrationTests.TestSupport;
 using Xunit.Abstractions;

--- a/tests/Radio.IntegrationTests/Fingerprinting/EndToEndFingerprintingIntegrationTests.cs
+++ b/tests/Radio.IntegrationTests/Fingerprinting/EndToEndFingerprintingIntegrationTests.cs
@@ -7,6 +7,10 @@ using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting.Data;
 using Radio.IntegrationTests.TestSupport;
+using Radio.Fingerprinting.Data;
+using Radio.Fingerprinting.Abstractions;
+using Radio.Fingerprinting.Services;
+using Radio.Fingerprinting;
 
 namespace Radio.IntegrationTests.Fingerprinting;
 

--- a/tests/Radio.IntegrationTests/Fingerprinting/FingerprintingConfigurationIntegrationTests.cs
+++ b/tests/Radio.IntegrationTests/Fingerprinting/FingerprintingConfigurationIntegrationTests.cs
@@ -5,6 +5,9 @@ using Moq;
 using Radio.Core.Configuration;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting.Data;
+using Radio.Fingerprinting;
+using Radio.Fingerprinting.Abstractions;
+using Radio.Fingerprinting.Data;
 using Radio.IntegrationTests.TestSupport;
 
 namespace Radio.IntegrationTests.Fingerprinting;

--- a/tests/Radio.IntegrationTests/PlayHistory/PlayHistoryRecordingIntegrationTests.cs
+++ b/tests/Radio.IntegrationTests/PlayHistory/PlayHistoryRecordingIntegrationTests.cs
@@ -6,6 +6,8 @@ using Radio.Core.Configuration;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting.Data;
+using Radio.Fingerprinting.Data;
+using Radio.Fingerprinting.Abstractions;
 
 namespace Radio.IntegrationTests.PlayHistory;
 

--- a/tests/Radio.IntegrationTests/Radio.IntegrationTests.csproj
+++ b/tests/Radio.IntegrationTests/Radio.IntegrationTests.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Radio.API\Radio.API.csproj" />
     <ProjectReference Include="..\..\src\Radio.Configuration\Radio.Configuration.csproj" />
+    <ProjectReference Include="..\..\src\Radio.Fingerprinting\Radio.Fingerprinting.csproj" />
     <ProjectReference Include="..\..\src\Radio.Infrastructure\Radio.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Radio.Core\Radio.Core.csproj" />
     <ProjectReference Include="..\..\src\RTLSDRCore\RTLSDRCore.csproj" />


### PR DESCRIPTION
## Summary

- Extract fingerprinting implementation from `Radio.Infrastructure` into standalone `Radio.Fingerprinting` NuGet library
- Move 7 files (3 services, 3 repositories, FingerprintingOptions) with `git mv` to preserve history
- Introduce `IFingerprintDataConnection` abstraction to decouple extracted repos from the 12-table `FingerprintDbContext`
- Update ~25 consumer files across Infrastructure, API, and test projects with new namespace imports
- Add to `pack-local.ps1`, package builds successfully as `Radio.Fingerprinting.1.0.0.nupkg`

## Architecture

```
Radio.Core (domain interfaces/models)
  ↑
Radio.Fingerprinting (NEW — services, repos, options)
  ↑
Radio.Infrastructure (audio engine, DI wiring, FingerprintDbContext implements IFingerprintDataConnection)
```

**What moved:**
- `FingerprintingOptions` (from Radio.Core/Configuration/)
- `BackgroundIdentificationService`, `MetadataLookupService`, `SongRecRecognitionService` (from Infrastructure/Audio/Fingerprinting/)
- `SqliteFingerprintCacheRepository`, `SqliteTrackMetadataRepository`, `SqlitePlayHistoryRepository` (from Infrastructure/Audio/Fingerprinting/Data/)

**What stayed in Infrastructure:**
- `FingerprintDbContext` (manages 12 tables, only 3 fingerprinting-specific)
- `SoundFlowAudioTap` (SoundFlow engine dependency)
- Non-fingerprinting repositories (RadioPreset, AudioFile, TTSVoice, Playlist, CastDeviceCache)

## Test plan

- [x] Solution builds with 0 errors
- [x] All tests pass (1 pre-existing flaky: `WaveformComparisonTests.AnalyzeBatchCaptures_10Runs`)
- [x] `dotnet pack` produces `Radio.Fingerprinting.1.0.0.nupkg` + `.snupkg`
- [x] Code review passed — no blocking issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)