### PR TITLE
test: Extract Radio.Configuration.Tests project (Phase 2/4)

### DIFF
--- a/RadioConsole.sln
+++ b/RadioConsole.sln
@@ -51,6 +51,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radio.Fingerprinting", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radio.Metrics.Tests", "tests\Radio.Metrics.Tests\Radio.Metrics.Tests.csproj", "{60DB543F-7498-4404-A9B5-E09988B60F9C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radio.Configuration.Tests", "tests\Radio.Configuration.Tests\Radio.Configuration.Tests.csproj", "{22F2CDB8-4450-4C72-8667-80BB20F60B3F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -313,6 +315,18 @@ Global
 		{60DB543F-7498-4404-A9B5-E09988B60F9C}.Release|x64.Build.0 = Release|Any CPU
 		{60DB543F-7498-4404-A9B5-E09988B60F9C}.Release|x86.ActiveCfg = Release|Any CPU
 		{60DB543F-7498-4404-A9B5-E09988B60F9C}.Release|x86.Build.0 = Release|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Debug|x64.Build.0 = Debug|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Debug|x86.Build.0 = Debug|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Release|x64.ActiveCfg = Release|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Release|x64.Build.0 = Release|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Release|x86.ActiveCfg = Release|Any CPU
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -339,5 +353,6 @@ Global
 		{928DC03B-E6A1-4E4D-8D2C-6B9494831D35} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{82818C12-06D6-49A3-885D-C2DF885FC94B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{60DB543F-7498-4404-A9B5-E09988B60F9C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{22F2CDB8-4450-4C72-8667-80BB20F60B3F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/tests/Radio.Configuration.Tests/Backup/ConfigurationBackupTests.cs
+++ b/tests/Radio.Configuration.Tests/Backup/ConfigurationBackupTests.cs
@@ -1,4 +1,4 @@
-namespace Radio.Infrastructure.Tests.Configuration;
+namespace Radio.Configuration.Tests.Backup;
 
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -36,7 +36,7 @@ public class ConfigurationBackupTests : IDisposable
 
     _options.DatabasePath = Path.Combine(_testDirectory, "config.db");
 
-    var optionsMock = Options.Create(_options);
+    var optionsMock = Microsoft.Extensions.Options.Options.Create(_options);
     var dataProtection = DataProtectionProvider.Create("TestApp");
 
     var secretsProvider = new JsonSecretsProvider(optionsMock, dataProtection, NullLogger<JsonSecretsProvider>.Instance);

--- a/tests/Radio.Configuration.Tests/Bridge/SqliteConfigurationProviderTests.cs
+++ b/tests/Radio.Configuration.Tests/Bridge/SqliteConfigurationProviderTests.cs
@@ -1,4 +1,4 @@
-namespace Radio.Infrastructure.Tests.Configuration;
+namespace Radio.Configuration.Tests.Bridge;
 
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;

--- a/tests/Radio.Configuration.Tests/DatabaseOptionsTests.cs
+++ b/tests/Radio.Configuration.Tests/DatabaseOptionsTests.cs
@@ -1,4 +1,4 @@
-namespace Radio.Core.Tests.Configuration;
+namespace Radio.Configuration.Tests;
 
 using Radio.Core.Configuration;
 

--- a/tests/Radio.Configuration.Tests/DatabasePathResolverTests.cs
+++ b/tests/Radio.Configuration.Tests/DatabasePathResolverTests.cs
@@ -1,4 +1,4 @@
-namespace Radio.Core.Tests.Configuration;
+namespace Radio.Configuration.Tests;
 
 using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
@@ -18,7 +18,7 @@ public class DatabasePathResolverTests
       ConfigurationSubdirectory = "cfg",
       ConfigurationFileName = "config.db"
     };
-    var resolver = new DatabasePathResolver(Options.Create(databaseOptions));
+    var resolver = new DatabasePathResolver(Microsoft.Extensions.Options.Options.Create(databaseOptions));
 
     // Act
     var path = resolver.GetConfigurationDatabasePath();
@@ -39,7 +39,7 @@ public class DatabasePathResolverTests
       FingerprintingSubdirectory = "fp",
       FingerprintingFileName = "fingerprints.db"
     };
-    var resolver = new DatabasePathResolver(Options.Create(databaseOptions));
+    var resolver = new DatabasePathResolver(Microsoft.Extensions.Options.Options.Create(databaseOptions));
 
     // Act
     var path = resolver.GetFingerprintingDatabasePath();
@@ -59,7 +59,7 @@ public class DatabasePathResolverTests
       RootPath = "./newdata",
       BackupSubdirectory = "bak"
     };
-    var resolver = new DatabasePathResolver(Options.Create(databaseOptions));
+    var resolver = new DatabasePathResolver(Microsoft.Extensions.Options.Options.Create(databaseOptions));
 
     // Act
     var path = resolver.GetBackupPath();
@@ -79,7 +79,7 @@ public class DatabasePathResolverTests
       SecretsSubdirectory = "sec",
       SecretsFileName = "secrets.db"
     };
-    var resolver = new DatabasePathResolver(Options.Create(databaseOptions));
+    var resolver = new DatabasePathResolver(Microsoft.Extensions.Options.Options.Create(databaseOptions));
 
     // Act
     var path = resolver.GetSecretsDatabasePath();
@@ -95,7 +95,7 @@ public class DatabasePathResolverTests
   {
     // Arrange
     var databaseOptions = new DatabaseOptions();
-    var resolver = new DatabasePathResolver(Options.Create(databaseOptions));
+    var resolver = new DatabasePathResolver(Microsoft.Extensions.Options.Options.Create(databaseOptions));
 
     // Act
     var paths = resolver.GetAllDatabasePaths();
@@ -113,7 +113,7 @@ public class DatabasePathResolverTests
     {
       RootPath = "./data"
     };
-    var resolver = new DatabasePathResolver(Options.Create(databaseOptions));
+    var resolver = new DatabasePathResolver(Microsoft.Extensions.Options.Options.Create(databaseOptions));
 
     // Act
     var paths = resolver.GetAllDatabasePaths();

--- a/tests/Radio.Configuration.Tests/Integration/SecretsConfigurationIntegrationTests.cs
+++ b/tests/Radio.Configuration.Tests/Integration/SecretsConfigurationIntegrationTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 using Radio.Configuration.Models;
 using Radio.Configuration.Secrets;
 
-namespace Radio.IntegrationTests.Secrets;
+namespace Radio.Configuration.Tests.Integration;
 
 /// <summary>
 /// Integration tests for secrets configuration system.
@@ -87,7 +87,7 @@ public class SecretsConfigurationIntegrationTests : IDisposable
   public async Task JsonSecretsProvider_StoreAndRetrieve_RoundTrips()
   {
     // Arrange
-    var options = Options.Create(new ConfigurationOptions
+    var options = Microsoft.Extensions.Options.Options.Create(new ConfigurationOptions
     {
       BasePath = TempDirectory,
       SecretsFileName = "test-secrets",
@@ -114,7 +114,7 @@ public class SecretsConfigurationIntegrationTests : IDisposable
   public async Task SecretsProvider_ResolveTagsAsync_ResolvesMultipleTags()
   {
     // Arrange
-    var options = Options.Create(new ConfigurationOptions
+    var options = Microsoft.Extensions.Options.Options.Create(new ConfigurationOptions
     {
       BasePath = TempDirectory,
       SecretsFileName = "test-secrets-resolve",
@@ -144,7 +144,7 @@ public class SecretsConfigurationIntegrationTests : IDisposable
   public async Task SecretsProvider_ResolveTagsAsync_PreservesUnknownTags()
   {
     // Arrange
-    var options = Options.Create(new ConfigurationOptions
+    var options = Microsoft.Extensions.Options.Options.Create(new ConfigurationOptions
     {
       BasePath = TempDirectory,
       SecretsFileName = "test-secrets-unknown",
@@ -169,7 +169,7 @@ public class SecretsConfigurationIntegrationTests : IDisposable
   public async Task SqliteSecretsProvider_StoreAndRetrieve_RoundTrips()
   {
     // Arrange
-    var configOptions = Options.Create(new Radio.Configuration.Models.ConfigurationOptions
+    var configOptions = Microsoft.Extensions.Options.Options.Create(new Radio.Configuration.Models.ConfigurationOptions
     {
       SecretsDatabasePath = Path.Combine(TempDirectory, "test-secrets.db")
     });
@@ -198,7 +198,7 @@ public class SecretsConfigurationIntegrationTests : IDisposable
   public async Task SecretsProvider_GenerateTag_CreatesUniqueIdentifiers()
   {
     // Arrange
-    var options = Options.Create(new ConfigurationOptions
+    var options = Microsoft.Extensions.Options.Options.Create(new ConfigurationOptions
     {
       BasePath = TempDirectory,
       SecretsFileName = "test-secrets-unique",
@@ -225,7 +225,7 @@ public class SecretsConfigurationIntegrationTests : IDisposable
   public async Task SecretsProvider_ListTagsAsync_ReturnsAllStoredTags()
   {
     // Arrange
-    var options = Options.Create(new ConfigurationOptions
+    var options = Microsoft.Extensions.Options.Options.Create(new ConfigurationOptions
     {
       BasePath = TempDirectory,
       SecretsFileName = "test-secrets-list",
@@ -255,7 +255,7 @@ public class SecretsConfigurationIntegrationTests : IDisposable
   public async Task SecretsProvider_DeleteSecretAsync_RemovesSecret()
   {
     // Arrange
-    var options = Options.Create(new ConfigurationOptions
+    var options = Microsoft.Extensions.Options.Options.Create(new ConfigurationOptions
     {
       BasePath = TempDirectory,
       SecretsFileName = "test-secrets-delete",
@@ -282,7 +282,7 @@ public class SecretsConfigurationIntegrationTests : IDisposable
   public void SecretsProvider_ContainsSecretTag_DetectsTags()
   {
     // Arrange
-    var options = Options.Create(new ConfigurationOptions
+    var options = Microsoft.Extensions.Options.Options.Create(new ConfigurationOptions
     {
       BasePath = TempDirectory,
       SecretsFileName = "test-secrets",
@@ -305,7 +305,7 @@ public class SecretsConfigurationIntegrationTests : IDisposable
   public async Task SecretsProvider_Persistence_SurvivesProviderRestart()
   {
     // Arrange
-    var options = Options.Create(new ConfigurationOptions
+    var options = Microsoft.Extensions.Options.Options.Create(new ConfigurationOptions
     {
       BasePath = TempDirectory,
       SecretsFileName = "test-secrets-persist",

--- a/tests/Radio.Configuration.Tests/Models/ConfigurationEntryTests.cs
+++ b/tests/Radio.Configuration.Tests/Models/ConfigurationEntryTests.cs
@@ -1,4 +1,4 @@
-namespace Radio.Infrastructure.Tests.Configuration;
+namespace Radio.Configuration.Tests.Models;
 
 using Radio.Configuration.Models;
 

--- a/tests/Radio.Configuration.Tests/Models/SecretTagTests.cs
+++ b/tests/Radio.Configuration.Tests/Models/SecretTagTests.cs
@@ -1,4 +1,4 @@
-namespace Radio.Infrastructure.Tests.Configuration;
+namespace Radio.Configuration.Tests.Models;
 
 using Radio.Configuration.Models;
 

--- a/tests/Radio.Configuration.Tests/Options/SecretsResolutionTests.cs
+++ b/tests/Radio.Configuration.Tests/Options/SecretsResolutionTests.cs
@@ -4,7 +4,7 @@ using Radio.Configuration.Abstractions;
 using Radio.Configuration.Options;
 using Xunit;
 
-namespace Radio.Infrastructure.Tests.Configuration;
+namespace Radio.Configuration.Tests.Options;
 
   public class SecretsResolutionTests
   {

--- a/tests/Radio.Configuration.Tests/Radio.Configuration.Tests.csproj
+++ b/tests/Radio.Configuration.Tests/Radio.Configuration.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Radio.Configuration\Radio.Configuration.csproj" />
+    <ProjectReference Include="..\..\src\Radio.Core\Radio.Core.csproj" />
+    <ProjectReference Include="..\..\src\Radio.Fingerprinting\Radio.Fingerprinting.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/Radio.Configuration.Tests/Secrets/CompositeSecretsProviderTests.cs
+++ b/tests/Radio.Configuration.Tests/Secrets/CompositeSecretsProviderTests.cs
@@ -1,4 +1,4 @@
-namespace Radio.Infrastructure.Tests.Configuration;
+namespace Radio.Configuration.Tests.Secrets;
 
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -23,7 +23,7 @@ public class CompositeSecretsProviderTests : IAsyncDisposable
 
     var dataProtection = DataProtectionProvider.Create("TestApp");
 
-    var configOptions1 = Options.Create(new ConfigurationOptions
+    var configOptions1 = Microsoft.Extensions.Options.Options.Create(new ConfigurationOptions
     {
       SecretsDatabasePath = Path.Combine(_testDirectory, "secrets.db")
     });
@@ -33,7 +33,7 @@ public class CompositeSecretsProviderTests : IAsyncDisposable
       dataProtection,
       NullLogger<SqliteSecretsProvider>.Instance);
 
-    var configOptions = Options.Create(new ConfigurationOptions
+    var configOptions = Microsoft.Extensions.Options.Options.Create(new ConfigurationOptions
     {
       BasePath = _testDirectory,
       SecretsFileName = "secrets"

--- a/tests/Radio.Configuration.Tests/Secrets/SecretsProviderTests.cs
+++ b/tests/Radio.Configuration.Tests/Secrets/SecretsProviderTests.cs
@@ -1,4 +1,4 @@
-namespace Radio.Infrastructure.Tests.Configuration;
+namespace Radio.Configuration.Tests.Secrets;
 
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -264,7 +264,7 @@ public class SecretsProviderTests : IDisposable
   private JsonSecretsProvider CreateJsonProvider()
   {
     return new JsonSecretsProvider(
-      Options.Create(_options),
+      Microsoft.Extensions.Options.Options.Create(_options),
       _dataProtection,
       NullLogger<JsonSecretsProvider>.Instance);
   }
@@ -272,7 +272,7 @@ public class SecretsProviderTests : IDisposable
   private SqliteSecretsProvider CreateSqliteProvider()
   {
     return new SqliteSecretsProvider(
-      Options.Create(_options),
+      Microsoft.Extensions.Options.Options.Create(_options),
       _dataProtection,
       NullLogger<SqliteSecretsProvider>.Instance);
   }

--- a/tests/Radio.Configuration.Tests/Stores/ConfigurationStoreTests.cs
+++ b/tests/Radio.Configuration.Tests/Stores/ConfigurationStoreTests.cs
@@ -1,4 +1,4 @@
-namespace Radio.Infrastructure.Tests.Configuration;
+namespace Radio.Configuration.Tests.Stores;
 
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
@@ -32,7 +32,7 @@ public class ConfigurationStoreTests : IDisposable
     };
 
     // Create a simple mock secrets provider that doesn't resolve anything
-    var optionsMock = Options.Create(_options);
+    var optionsMock = Microsoft.Extensions.Options.Options.Create(_options);
     var dataProtectionProvider = DataProtectionProvider.Create("TestApp");
     var logger = NullLogger<JsonSecretsProvider>.Instance;
     _mockSecretsProvider = new JsonSecretsProvider(optionsMock, dataProtectionProvider, logger);


### PR DESCRIPTION
## Summary
- Create dedicated `Radio.Configuration.Tests` project for the Radio.Configuration NuGet package
- Move 115 tests from 3 source projects into organized subdirectories
- Fix `Options` namespace collision with `Microsoft.Extensions.Options` in 6 files

### Files moved (11 files, 115 tests)
| Source | Destination | Tests |
|--------|------------|-------|
| Radio.Core.Tests/Configuration/DatabaseOptionsTests.cs | Radio.Configuration.Tests/ | 6 |
| Radio.Core.Tests/Configuration/DatabasePathResolverTests.cs | Radio.Configuration.Tests/ | 6 |
| Radio.Infrastructure.Tests/Configuration/ConfigurationBackupTests.cs | Backup/ | 9 |
| Radio.Infrastructure.Tests/Configuration/ConfigurationEntryTests.cs | Models/ | 5 |
| Radio.Infrastructure.Tests/Configuration/ConfigurationStoreTests.cs | Stores/ | 13 |
| Radio.Infrastructure.Tests/Configuration/CompositeSecretsProviderTests.cs | Secrets/ | 12 |
| Radio.Infrastructure.Tests/Configuration/SecretTagTests.cs | Models/ | 12 |
| Radio.Infrastructure.Tests/Configuration/SecretsProviderTests.cs | Secrets/ | 14 |
| Radio.Infrastructure.Tests/Configuration/SecretsResolutionTests.cs | Options/ | 1 |
| Radio.Infrastructure.Tests/Configuration/SqliteConfigurationProviderTests.cs | Bridge/ | 10 |
| Radio.IntegrationTests/Secrets/SecretsConfigurationIntegrationTests.cs | Integration/ | 11 |

### Files that stay (test Infrastructure code, not Configuration)
- DeviceOptionsResolverTests.cs, PreferencesPersistenceServiceTests.cs, UnifiedDatabaseBackupTests.cs

Part 2 of 4 in the test extraction series (Metrics → Configuration → Fingerprinting → Docs).

## Test plan
- [x] `dotnet build --configuration Release` — 0 errors
- [x] `Radio.Configuration.Tests` — 115/115 pass
- [x] Full test suite — all pass (1 pre-existing flaky WaveformComparison failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)