### PR TITLE
test: Extract Radio.Fingerprinting.Tests project (Phase 3/4)

### DIFF
--- a/RadioConsole.sln
+++ b/RadioConsole.sln
@@ -53,6 +53,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radio.Metrics.Tests", "test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radio.Configuration.Tests", "tests\Radio.Configuration.Tests\Radio.Configuration.Tests.csproj", "{22F2CDB8-4450-4C72-8667-80BB20F60B3F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radio.Fingerprinting.Tests", "tests\Radio.Fingerprinting.Tests\Radio.Fingerprinting.Tests.csproj", "{8BF0F36E-0812-44AE-8567-595F11CB0BB8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -327,6 +329,18 @@ Global
 		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Release|x64.Build.0 = Release|Any CPU
 		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Release|x86.ActiveCfg = Release|Any CPU
 		{22F2CDB8-4450-4C72-8667-80BB20F60B3F}.Release|x86.Build.0 = Release|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Debug|x64.Build.0 = Debug|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Debug|x86.Build.0 = Debug|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Release|x64.ActiveCfg = Release|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Release|x64.Build.0 = Release|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Release|x86.ActiveCfg = Release|Any CPU
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -354,5 +368,6 @@ Global
 		{82818C12-06D6-49A3-885D-C2DF885FC94B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{60DB543F-7498-4404-A9B5-E09988B60F9C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{22F2CDB8-4450-4C72-8667-80BB20F60B3F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{8BF0F36E-0812-44AE-8567-595F11CB0BB8} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/Radio.Fingerprinting/Radio.Fingerprinting.csproj
+++ b/src/Radio.Fingerprinting/Radio.Fingerprinting.csproj
@@ -31,5 +31,6 @@
     <InternalsVisibleTo Include="Radio.Infrastructure" />
     <InternalsVisibleTo Include="Radio.Infrastructure.Tests" />
     <InternalsVisibleTo Include="Radio.IntegrationTests" />
+    <InternalsVisibleTo Include="Radio.Fingerprinting.Tests" />
   </ItemGroup>
 </Project>

--- a/src/Radio.Infrastructure/Radio.Infrastructure.csproj
+++ b/src/Radio.Infrastructure/Radio.Infrastructure.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Radio.Infrastructure.Tests" />
     <InternalsVisibleTo Include="Radio.IntegrationTests" />
+    <InternalsVisibleTo Include="Radio.Fingerprinting.Tests" />
   </ItemGroup>
   <!-- Conditional compilation: exclude platform-specific Bluetooth files -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/Radio.Fingerprinting.Tests/Data/SqliteFingerprintCacheRepositoryTests.cs
+++ b/tests/Radio.Fingerprinting.Tests/Data/SqliteFingerprintCacheRepositoryTests.cs
@@ -8,7 +8,7 @@ using Radio.Fingerprinting;
 using Radio.Fingerprinting.Abstractions;
 using Radio.Fingerprinting.Data;
 
-namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
+namespace Radio.Fingerprinting.Tests.Data;
 
 /// <summary>
 /// Unit tests for the SqliteFingerprintCacheRepository class.

--- a/tests/Radio.Fingerprinting.Tests/Data/SqlitePlayHistoryRepositoryTests.cs
+++ b/tests/Radio.Fingerprinting.Tests/Data/SqlitePlayHistoryRepositoryTests.cs
@@ -8,7 +8,7 @@ using Radio.Fingerprinting;
 using Radio.Fingerprinting.Abstractions;
 using Radio.Fingerprinting.Data;
 
-namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
+namespace Radio.Fingerprinting.Tests.Data;
 
 /// <summary>
 /// Unit tests for the SqlitePlayHistoryRepository class.

--- a/tests/Radio.Fingerprinting.Tests/Integration/CoverArtPipelineIntegrationTests.cs
+++ b/tests/Radio.Fingerprinting.Tests/Integration/CoverArtPipelineIntegrationTests.cs
@@ -7,10 +7,10 @@ using Radio.Core.Configuration;
 using Radio.Fingerprinting;
 using Radio.Fingerprinting.Services;
 using Radio.Infrastructure.Audio.Fingerprinting;
-using Radio.IntegrationTests.TestSupport;
+using Radio.Fingerprinting.Tests.TestSupport;
 using Xunit.Abstractions;
 
-namespace Radio.IntegrationTests.Fingerprinting;
+namespace Radio.Fingerprinting.Tests.Integration;
 
 /// <summary>
 /// Integration tests for the Cover Art Archive pipeline.

--- a/tests/Radio.Fingerprinting.Tests/Integration/EndToEndFingerprintingIntegrationTests.cs
+++ b/tests/Radio.Fingerprinting.Tests/Integration/EndToEndFingerprintingIntegrationTests.cs
@@ -6,13 +6,13 @@ using Radio.Core.Configuration;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
 using Radio.Infrastructure.Audio.Fingerprinting.Data;
-using Radio.IntegrationTests.TestSupport;
+using Radio.Fingerprinting.Tests.TestSupport;
 using Radio.Fingerprinting.Data;
 using Radio.Fingerprinting.Abstractions;
 using Radio.Fingerprinting.Services;
 using Radio.Fingerprinting;
 
-namespace Radio.IntegrationTests.Fingerprinting;
+namespace Radio.Fingerprinting.Tests.Integration;
 
 /// <summary>
 /// End-to-end integration tests for the fingerprinting system.

--- a/tests/Radio.Fingerprinting.Tests/Integration/FingerprintingConfigurationIntegrationTests.cs
+++ b/tests/Radio.Fingerprinting.Tests/Integration/FingerprintingConfigurationIntegrationTests.cs
@@ -8,9 +8,9 @@ using Radio.Infrastructure.Audio.Fingerprinting.Data;
 using Radio.Fingerprinting;
 using Radio.Fingerprinting.Abstractions;
 using Radio.Fingerprinting.Data;
-using Radio.IntegrationTests.TestSupport;
+using Radio.Fingerprinting.Tests.TestSupport;
 
-namespace Radio.IntegrationTests.Fingerprinting;
+namespace Radio.Fingerprinting.Tests.Integration;
 
 /// <summary>
 /// Integration tests for fingerprinting system configuration and database setup.

--- a/tests/Radio.Fingerprinting.Tests/Integration/PlayHistoryRecordingIntegrationTests.cs
+++ b/tests/Radio.Fingerprinting.Tests/Integration/PlayHistoryRecordingIntegrationTests.cs
@@ -9,7 +9,7 @@ using Radio.Infrastructure.Audio.Fingerprinting.Data;
 using Radio.Fingerprinting.Data;
 using Radio.Fingerprinting.Abstractions;
 
-namespace Radio.IntegrationTests.PlayHistory;
+namespace Radio.Fingerprinting.Tests.Integration;
 
 /// <summary>
 /// Integration tests for play history recording functionality.

--- a/tests/Radio.Fingerprinting.Tests/Radio.Fingerprinting.Tests.csproj
+++ b/tests/Radio.Fingerprinting.Tests/Radio.Fingerprinting.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Radio.Fingerprinting\Radio.Fingerprinting.csproj" />
+    <ProjectReference Include="..\..\src\Radio.Infrastructure\Radio.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\Radio.Core\Radio.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/Radio.Fingerprinting.Tests/Services/BackgroundIdentificationServiceSongChangeTests.cs
+++ b/tests/Radio.Fingerprinting.Tests/Services/BackgroundIdentificationServiceSongChangeTests.cs
@@ -9,7 +9,7 @@ using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Fingerprinting.Services;
 using Radio.Fingerprinting;
 
-namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
+namespace Radio.Fingerprinting.Tests.Services;
 
 /// <summary>
 /// Tests for song change detection in BackgroundIdentificationService.

--- a/tests/Radio.Fingerprinting.Tests/Services/BackgroundIdentificationServiceStatusTests.cs
+++ b/tests/Radio.Fingerprinting.Tests/Services/BackgroundIdentificationServiceStatusTests.cs
@@ -8,7 +8,7 @@ using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Fingerprinting.Services;
 using Radio.Fingerprinting;
 
-namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
+namespace Radio.Fingerprinting.Tests.Services;
 
 /// <summary>
 /// Tests for fingerprint status tracking and event log aggregation in BackgroundIdentificationService.

--- a/tests/Radio.Fingerprinting.Tests/Services/MetadataLookupServiceTests.cs
+++ b/tests/Radio.Fingerprinting.Tests/Services/MetadataLookupServiceTests.cs
@@ -7,7 +7,7 @@ using Radio.Infrastructure.Audio.Fingerprinting;
 using Radio.Fingerprinting.Services;
 using Radio.Fingerprinting;
 
-namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
+namespace Radio.Fingerprinting.Tests.Services;
 
 /// <summary>
 /// Unit tests for the MetadataLookupService class (cover art search functionality).

--- a/tests/Radio.Fingerprinting.Tests/Services/SongRecRecognitionServiceTests.cs
+++ b/tests/Radio.Fingerprinting.Tests/Services/SongRecRecognitionServiceTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 using Radio.Fingerprinting.Services;
 using Radio.Fingerprinting;
 
-namespace Radio.Infrastructure.Tests.Audio.Fingerprinting;
+namespace Radio.Fingerprinting.Tests.Services;
 
 public class SongRecRecognitionServiceTests
 {

--- a/tests/Radio.Fingerprinting.Tests/TestSupport/MockAudioSampleProvider.cs
+++ b/tests/Radio.Fingerprinting.Tests/TestSupport/MockAudioSampleProvider.cs
@@ -1,0 +1,137 @@
+using Radio.Core.Interfaces.Audio;
+using Radio.Core.Models.Audio;
+
+namespace Radio.Fingerprinting.Tests.TestSupport;
+
+/// <summary>
+/// Mock audio sample provider for integration tests.
+/// Returns configurable test audio samples without requiring real audio hardware.
+/// </summary>
+public class MockAudioSampleProvider : IAudioSampleProvider
+{
+  private bool _isActive = false;
+  private string _sourceName = "MockAudioSource";
+  private PlaySource _sourceType = PlaySource.File;
+  private Func<TimeSpan, float[]>? _sampleGenerator;
+
+  /// <summary>
+  /// Gets whether the mock source is currently active.
+  /// </summary>
+  public bool IsActive => _isActive;
+
+  /// <summary>
+  /// Gets the name of the audio source.
+  /// </summary>
+  public string SourceName => _sourceName;
+
+  /// <summary>
+  /// Gets the source type for play history.
+  /// </summary>
+  public PlaySource SourceType => _sourceType;
+
+  /// <summary>
+  /// Gets or sets the source file path for file-based sources.
+  /// </summary>
+  public string? SourceFilePath { get; set; }
+
+  /// <summary>
+  /// Gets or sets whether the source needs fingerprinting identification.
+  /// </summary>
+  public bool NeedsFingerprintingLookup { get; set; } = true;
+
+  /// <summary>
+  /// Sets the mock source as active and configures its properties.
+  /// </summary>
+  public void SetActive(bool active, string? sourceName = null, PlaySource? sourceType = null)
+  {
+    _isActive = active;
+    if (sourceName != null)
+    {
+      _sourceName = sourceName;
+    }
+
+    if (sourceType != null)
+    {
+      _sourceType = sourceType.Value;
+    }
+  }
+
+  /// <summary>
+  /// Sets a custom sample generator function.
+  /// </summary>
+  public void SetSampleGenerator(Func<TimeSpan, float[]> generator)
+  {
+    _sampleGenerator = generator;
+  }
+
+  /// <summary>
+  /// Generates a sine wave of the specified duration.
+  /// </summary>
+  public static float[] GenerateSineWave(TimeSpan duration, int sampleRate = 48000, int channels = 2, double frequency = 440.0)
+  {
+    var totalSamples = (int)(duration.TotalSeconds * sampleRate * channels);
+    var samples = new float[totalSamples];
+    var samplesPerChannel = totalSamples / channels;
+
+    for (int i = 0; i < samplesPerChannel; i++)
+    {
+      var value = (float)Math.Sin(2 * Math.PI * frequency * i / sampleRate);
+      for (int ch = 0; ch < channels; ch++)
+      {
+        samples[i * channels + ch] = value * 0.5f; // 50% amplitude
+      }
+    }
+
+    return samples;
+  }
+
+  /// <summary>
+  /// Generates silence of the specified duration.
+  /// </summary>
+  public static float[] GenerateSilence(TimeSpan duration, int sampleRate = 48000, int channels = 2)
+  {
+    var totalSamples = (int)(duration.TotalSeconds * sampleRate * channels);
+    return new float[totalSamples];
+  }
+
+  /// <summary>
+  /// Generates white noise of the specified duration.
+  /// </summary>
+  public static float[] GenerateWhiteNoise(TimeSpan duration, int sampleRate = 48000, int channels = 2)
+  {
+    var random = new Random(42); // Deterministic for tests
+    var totalSamples = (int)(duration.TotalSeconds * sampleRate * channels);
+    var samples = new float[totalSamples];
+
+    for (int i = 0; i < totalSamples; i++)
+    {
+      samples[i] = (float)(random.NextDouble() * 2 - 1) * 0.3f;
+    }
+
+    return samples;
+  }
+
+  public Task<AudioSampleBuffer?> CaptureAsync(TimeSpan duration, CancellationToken ct = default)
+  {
+    if (!_isActive)
+    {
+      return Task.FromResult<AudioSampleBuffer?>(null);
+    }
+
+    var sampleRate = 48000;
+    var channels = 2;
+    var samples = _sampleGenerator?.Invoke(duration)
+      ?? GenerateSineWave(duration, sampleRate, channels);
+
+    var buffer = new AudioSampleBuffer
+    {
+      Samples = samples,
+      SampleRate = sampleRate,
+      Channels = channels,
+      Duration = duration,
+      SourceName = _sourceName
+    };
+
+    return Task.FromResult<AudioSampleBuffer?>(buffer);
+  }
+}

--- a/tests/Radio.Fingerprinting.Tests/TestSupport/MockMetadataLookupService.cs
+++ b/tests/Radio.Fingerprinting.Tests/TestSupport/MockMetadataLookupService.cs
@@ -1,0 +1,27 @@
+using Radio.Core.Interfaces.Audio;
+using Radio.Core.Models.Audio;
+
+namespace Radio.Fingerprinting.Tests.TestSupport;
+
+/// <summary>
+/// Mock metadata lookup service for integration tests.
+/// Returns configurable cover art results without requiring external API calls.
+/// </summary>
+public class MockMetadataLookupService : IMetadataLookupService
+{
+  /// <summary>
+  /// Gets or sets the cover art URL to return from SearchCoverArtByTextAsync.
+  /// </summary>
+  public string? CoverArtUrl { get; set; }
+
+  public Task<string?> SearchCoverArtByTextAsync(
+    string title, string artist, string? album = null, CancellationToken ct = default)
+  {
+    return Task.FromResult(CoverArtUrl);
+  }
+
+  public Task<string?> GetCoverArtByReleaseIdAsync(string releaseId, CancellationToken ct = default)
+  {
+    return Task.FromResult(CoverArtUrl);
+  }
+}

--- a/tests/Radio.Fingerprinting.Tests/TestSupport/NetworkAvailabilityHelper.cs
+++ b/tests/Radio.Fingerprinting.Tests/TestSupport/NetworkAvailabilityHelper.cs
@@ -1,0 +1,72 @@
+using System.Net.Sockets;
+
+namespace Radio.Fingerprinting.Tests.TestSupport;
+
+/// <summary>
+/// Helper for integration tests that depend on external HTTP services.
+/// Performs a lightweight TCP connectivity check and caches the result
+/// so it's only done once per test run. Tests call RequireExternalNetwork()
+/// at the top of [SkippableFact] methods to gracefully skip in CI/CD
+/// environments without network access.
+/// </summary>
+public static class NetworkAvailabilityHelper
+{
+  private static bool? _isAvailable;
+  private static readonly object Lock = new();
+
+  /// <summary>
+  /// Checks whether external network services are reachable.
+  /// Result is cached for the lifetime of the test run.
+  /// </summary>
+  public static bool IsExternalNetworkAvailable
+  {
+    get
+    {
+      if (_isAvailable.HasValue)
+      {
+        return _isAvailable.Value;
+      }
+
+      lock (Lock)
+      {
+        if (_isAvailable.HasValue)
+        {
+          return _isAvailable.Value;
+        }
+
+        _isAvailable = CheckConnectivity();
+        return _isAvailable.Value;
+      }
+    }
+  }
+
+  /// <summary>
+  /// Call at the start of a [SkippableFact] test method to skip when
+  /// external network services are unreachable (e.g., in CI/CD).
+  /// </summary>
+  public static void RequireExternalNetwork()
+    => Skip.IfNot(IsExternalNetworkAvailable,
+      "External network not available — skipping (CI/CD environment)");
+
+  private static bool CheckConnectivity()
+  {
+    // Try a TCP connection to musicbrainz.org:443 with a short timeout.
+    // This is lightweight (no TLS handshake, no HTTP overhead) and tests
+    // real network connectivity to the services our integration tests use.
+    try
+    {
+      using var client = new TcpClient();
+      var connectTask = client.ConnectAsync("musicbrainz.org", 443);
+      if (connectTask.Wait(TimeSpan.FromSeconds(3)))
+      {
+        return true;
+      }
+
+      return false;
+    }
+    catch
+    {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Create dedicated `Radio.Fingerprinting.Tests` project for the Radio.Fingerprinting NuGet package
- Move 95 tests (94 pass, 1 skipped) from 2 source projects into organized subdirectories
- Copy TestSupport helpers for integration tests
- Add `InternalsVisibleTo` for new test project in Radio.Fingerprinting and Radio.Infrastructure csprojs

### Files moved (10 files, 95 tests)
| Source | Destination | Tests |
|--------|------------|-------|
| Radio.Infrastructure.Tests/.../SqliteFingerprintCacheRepositoryTests.cs | Data/ | 9 |
| Radio.Infrastructure.Tests/.../SqlitePlayHistoryRepositoryTests.cs | Data/ | 24 |
| Radio.Infrastructure.Tests/.../MetadataLookupServiceTests.cs | Services/ | 6 |
| Radio.Infrastructure.Tests/.../SongRecRecognitionServiceTests.cs | Services/ | 11 |
| Radio.Infrastructure.Tests/.../BackgroundIdentificationServiceSongChangeTests.cs | Services/ | 4 |
| Radio.Infrastructure.Tests/.../BackgroundIdentificationServiceStatusTests.cs | Services/ | 13 |
| Radio.IntegrationTests/.../EndToEndFingerprintingIntegrationTests.cs | Integration/ | 8 |
| Radio.IntegrationTests/.../FingerprintingConfigurationIntegrationTests.cs | Integration/ | 10 |
| Radio.IntegrationTests/.../CoverArtPipelineIntegrationTests.cs | Integration/ | 2 |
| Radio.IntegrationTests/.../PlayHistoryRecordingIntegrationTests.cs | Integration/ | 8 |

### Files that stay (test Infrastructure code, not Fingerprinting)
- SDRRadioAudioSourceFingerprintingTests.cs, FilePlayerAudioSourceTests.cs, BluetoothAudioSourceTests.cs

Part 3 of 4 in the test extraction series (Metrics → Configuration → Fingerprinting → Docs).

## Test plan
- [x] `dotnet build --configuration Release` — 0 errors
- [x] `Radio.Fingerprinting.Tests` — 94 passed, 1 skipped (network-dependent SkippableFact)
- [x] Full test suite — all pass (1 pre-existing flaky WaveformComparison failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)