### PR TITLE
fix: Increase timing margins for flaky CI tests

### DIFF
--- a/tests/Radio.Infrastructure.Tests/Audio/Services/AudioPreferencePersistenceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Services/AudioPreferencePersistenceTests.cs
@@ -223,8 +223,8 @@ public class AudioPreferencePersistenceTests : IDisposable
     // Act
     _sut.ScheduleVolumePersist();
 
-    // Wait for the 500ms debounce timer to fire
-    await Task.Delay(800);
+    // Wait for the 500ms debounce timer to fire (generous margin for slow CI runners)
+    await Task.Delay(2000);
 
     // Assert — volume preferences were persisted
     _configManagerMock.Verify(m => m.SetValueAsync(

--- a/tests/Radio.Infrastructure.Tests/Platform/Bluetooth/BluetoothReconnectionLoopTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Platform/Bluetooth/BluetoothReconnectionLoopTests.cs
@@ -123,7 +123,9 @@ public class BluetoothReconnectionLoopTests
       isDeviceConnected: () => false);
 
     loop.Start("11:22:33:44:55:66");
-    await Task.Delay(200);
+
+    // Generous margin for slow CI runners where async loop may take time to schedule
+    await Task.Delay(1000);
 
     Assert.Equal("11:22:33:44:55:66", capturedAddress);
   }


### PR DESCRIPTION
## Summary
- Increased `ScheduleVolumePersist_PersistsAfterDebounce` delay from 800ms to 2000ms (500ms debounce + async callback needs margin on slow CI)
- Increased `Loop_CallsConnectFuncWithCorrectAddress` delay from 200ms to 1000ms (async loop needs scheduling time on slow CI)

## Test plan
- [x] Both tests pass locally
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)