### PR TITLE
fix: Eliminate all build warnings and clean up test output

### DIFF
--- a/src/Radio.API/Controllers/BluetoothController.cs
+++ b/src/Radio.API/Controllers/BluetoothController.cs
@@ -155,9 +155,13 @@ public class BluetoothController : ControllerBase
     [FromBody] BluetoothDeviceRequest? request = null)
   {
     if (!string.IsNullOrWhiteSpace(request?.DeviceAddress))
+    {
       await _bluetoothService.DisconnectAsync(request.DeviceAddress);
+    }
     else
+    {
       await _bluetoothService.DisconnectAsync();
+    }
     return Ok(BuildStatus());
   }
 

--- a/src/Radio.API/Services/AudioEngineInitializationService.cs
+++ b/src/Radio.API/Services/AudioEngineInitializationService.cs
@@ -533,7 +533,8 @@ public class AudioEngineInitializationService : IHostedService
   {
     try
     {
-      var repo = _serviceProvider.GetService<IPlayHistoryRepository>();
+      using var scope = _serviceProvider.CreateScope();
+      var repo = scope.ServiceProvider.GetService<IPlayHistoryRepository>();
       if (repo != null)
       {
         var closed = await repo.CloseOrphanedEntriesAsync(TimeSpan.FromMinutes(2), cancellationToken);

--- a/src/Radio.Configuration/Bridge/SqliteConfigurationProvider.cs
+++ b/src/Radio.Configuration/Bridge/SqliteConfigurationProvider.cs
@@ -39,14 +39,18 @@ public sealed class SqliteConfigurationProvider : ConfigurationProvider
       // Extract DB path from connection string to check existence
       var builder = new SqliteConnectionStringBuilder(_connectionString);
       if (!File.Exists(builder.DataSource))
+      {
         return;
+      }
 
       using var connection = new SqliteConnection(_connectionString);
       connection.Open();
 
       // Check if the table exists before querying
       if (!TableExists(connection))
+      {
         return;
+      }
 
       using var cmd = connection.CreateCommand();
       cmd.CommandText = $"SELECT Key, Value FROM {_tableName}";
@@ -103,7 +107,9 @@ public sealed class SqliteConfigurationProvider : ConfigurationProvider
   private static bool IsJsonObjectOrArray(string value)
   {
     if (string.IsNullOrWhiteSpace(value))
+    {
       return false;
+    }
 
     var trimmed = value.TrimStart();
     return trimmed.StartsWith('{') || trimmed.StartsWith('[');

--- a/src/Radio.Configuration/Models/SecretTag.cs
+++ b/src/Radio.Configuration/Models/SecretTag.cs
@@ -35,11 +35,15 @@ public sealed partial record SecretTag
   {
     tag = null;
     if (string.IsNullOrEmpty(value))
+    {
       return false;
+    }
 
     var match = TagPatternRegex().Match(value);
     if (!match.Success)
+    {
       return false;
+    }
 
     tag = new SecretTag
     {
@@ -53,7 +57,9 @@ public sealed partial record SecretTag
   public static IEnumerable<SecretTag> ExtractAll(string? value)
   {
     if (string.IsNullOrEmpty(value))
+    {
       yield break;
+    }
 
     foreach (Match match in TagPatternRegex().Matches(value))
     {

--- a/src/Radio.Configuration/Options/SecretResolvingPostConfigureOptions.cs
+++ b/src/Radio.Configuration/Options/SecretResolvingPostConfigureOptions.cs
@@ -25,14 +25,23 @@ public class SecretResolvingPostConfigureOptions<TOptions> : IPostConfigureOptio
 
     private void ResolveSecretsRecursive(object obj)
     {
-        if (obj == null) return;
+        if (obj == null)
+        {
+            return;
+        }
 
         var type = obj.GetType();
-        if (type.IsPrimitive || type == typeof(string) || type.IsValueType) return;
+        if (type.IsPrimitive || type == typeof(string) || type.IsValueType)
+        {
+            return;
+        }
 
         foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
-            if (!prop.CanRead) continue;
+            if (!prop.CanRead)
+            {
+                continue;
+            }
 
             if (prop.PropertyType == typeof(string) && prop.CanWrite)
             {

--- a/src/Radio.Configuration/Secrets/CompositeSecretsProvider.cs
+++ b/src/Radio.Configuration/Secrets/CompositeSecretsProvider.cs
@@ -39,7 +39,9 @@ public sealed class CompositeSecretsProvider : ISecretsProvider, IAsyncDisposabl
     // Try SQLite first
     var secret = await _sqliteProvider.GetSecretAsync(tag, ct);
     if (secret != null)
+    {
       return secret;
+    }
 
     // Fall back to JSON
     secret = await _jsonProvider.GetSecretAsync(tag, ct);
@@ -73,7 +75,9 @@ public sealed class CompositeSecretsProvider : ISecretsProvider, IAsyncDisposabl
     var jsonDeleted = await _jsonProvider.DeleteSecretAsync(tag, ct);
 
     if (sqliteDeleted || jsonDeleted)
+    {
       _changeTokenSource?.SignalChange();
+    }
 
     return sqliteDeleted || jsonDeleted;
   }
@@ -87,7 +91,9 @@ public sealed class CompositeSecretsProvider : ISecretsProvider, IAsyncDisposabl
     // Union, deduplicated
     var allTags = new HashSet<string>(sqliteTags);
     foreach (var tag in jsonTags)
+    {
       allTags.Add(tag);
+    }
 
     return allTags.ToList();
   }
@@ -102,7 +108,9 @@ public sealed class CompositeSecretsProvider : ISecretsProvider, IAsyncDisposabl
   public async Task<string> ResolveTagsAsync(string value, CancellationToken ct = default)
   {
     if (string.IsNullOrEmpty(value) || !ContainsSecretTag(value))
+    {
       return value;
+    }
 
     var result = value;
     foreach (var tag in SecretTag.ExtractAll(value))

--- a/src/Radio.Configuration/Secrets/JsonSecretsProvider.cs
+++ b/src/Radio.Configuration/Secrets/JsonSecretsProvider.cs
@@ -119,12 +119,18 @@ public sealed class JsonSecretsProvider : SecretsProviderBase, IDisposable
 
   private async Task EnsureLoadedAsync(CancellationToken ct)
   {
-    if (_isLoaded) return;
+    if (_isLoaded)
+    {
+      return;
+    }
 
     await _lock.WaitAsync(ct);
     try
     {
-      if (_isLoaded) return;
+      if (_isLoaded)
+      {
+        return;
+      }
       await LoadAsync(ct);
       _isLoaded = true;
     }
@@ -182,7 +188,10 @@ public sealed class JsonSecretsProvider : SecretsProviderBase, IDisposable
   /// <inheritdoc/>
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _lock.Dispose();
     _disposed = true;
   }

--- a/src/Radio.Configuration/Secrets/SecretsProviderBase.cs
+++ b/src/Radio.Configuration/Secrets/SecretsProviderBase.cs
@@ -68,7 +68,9 @@ public abstract class SecretsProviderBase : ISecretsProvider
   public async Task<string> ResolveTagsAsync(string value, CancellationToken ct = default)
   {
     if (string.IsNullOrEmpty(value) || !ContainsSecretTag(value))
+    {
       return value;
+    }
 
     var result = value;
     foreach (var tag in SecretTag.ExtractAll(value))

--- a/src/Radio.Configuration/Secrets/SqliteSecretsProvider.cs
+++ b/src/Radio.Configuration/Secrets/SqliteSecretsProvider.cs
@@ -125,13 +125,17 @@ public sealed class SqliteSecretsProvider : SecretsProviderBase, IAsyncDisposabl
   private async Task EnsureInitializedAsync(CancellationToken ct)
   {
     if (_tableCreated && _connection?.State == System.Data.ConnectionState.Open)
+    {
       return;
+    }
 
     await _lock.WaitAsync(ct);
     try
     {
       if (_tableCreated && _connection?.State == System.Data.ConnectionState.Open)
+      {
         return;
+      }
 
       await InitializeAsync(ct);
     }
@@ -184,7 +188,10 @@ public sealed class SqliteSecretsProvider : SecretsProviderBase, IAsyncDisposabl
   /// <inheritdoc/>
   public async ValueTask DisposeAsync()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
 
     if (_connection != null)
     {

--- a/src/Radio.Configuration/Services/ConfigurationManager.cs
+++ b/src/Radio.Configuration/Services/ConfigurationManager.cs
@@ -168,7 +168,9 @@ public sealed class ConfigurationManager : IConfigurationManager
     var entry = await store.GetEntryAsync(key, mode, ct);
 
     if (entry == null)
+    {
       return default;
+    }
 
     if (typeof(T) == typeof(string))
     {

--- a/src/Radio.Configuration/Stores/ConfigurationStoreFactory.cs
+++ b/src/Radio.Configuration/Stores/ConfigurationStoreFactory.cs
@@ -134,7 +134,9 @@ public sealed class ConfigurationStoreFactory : IConfigurationStoreFactory
   private List<string> ListJsonStores(string basePath)
   {
     if (!Directory.Exists(basePath))
+    {
       return new List<string>();
+    }
 
     var files = Directory.GetFiles(basePath, $"*{_options.JsonExtension}");
     var storeIds = new List<string>();

--- a/src/Radio.Configuration/Stores/JsonConfigurationStore.cs
+++ b/src/Radio.Configuration/Stores/JsonConfigurationStore.cs
@@ -55,10 +55,15 @@ public sealed class JsonConfigurationStore : ConfigurationStoreBase, IDisposable
     await _lock.WaitAsync(ct);
     try
     {
-      if (!_isLoaded) await LoadAsync(ct);
+      if (!_isLoaded)
+      {
+        await LoadAsync(ct);
+      }
 
       if (!_entries.TryGetValue(key, out var stored))
+      {
         return null;
+      }
 
       return await CreateEntryAsync(key, stored.Value, stored.Description, stored.LastModified, mode, ct);
     }
@@ -74,7 +79,10 @@ public sealed class JsonConfigurationStore : ConfigurationStoreBase, IDisposable
     await _lock.WaitAsync(ct);
     try
     {
-      if (!_isLoaded) await LoadAsync(ct);
+      if (!_isLoaded)
+      {
+        await LoadAsync(ct);
+      }
 
       var entries = new List<ConfigurationEntry>();
       foreach (var kvp in _entries)
@@ -95,7 +103,10 @@ public sealed class JsonConfigurationStore : ConfigurationStoreBase, IDisposable
     await _lock.WaitAsync(ct);
     try
     {
-      if (!_isLoaded) await LoadAsync(ct);
+      if (!_isLoaded)
+      {
+        await LoadAsync(ct);
+      }
 
       var prefix = NormalizeSectionPrefix(sectionPrefix);
       var entries = new List<ConfigurationEntry>();
@@ -118,7 +129,10 @@ public sealed class JsonConfigurationStore : ConfigurationStoreBase, IDisposable
     await _lock.WaitAsync(ct);
     try
     {
-      if (!_isLoaded) await LoadAsync(ct);
+      if (!_isLoaded)
+      {
+        await LoadAsync(ct);
+      }
 
       _entries[key] = new StoredEntry
       {
@@ -144,7 +158,10 @@ public sealed class JsonConfigurationStore : ConfigurationStoreBase, IDisposable
     await _lock.WaitAsync(ct);
     try
     {
-      if (!_isLoaded) await LoadAsync(ct);
+      if (!_isLoaded)
+      {
+        await LoadAsync(ct);
+      }
 
       foreach (var entry in entries)
       {
@@ -174,7 +191,10 @@ public sealed class JsonConfigurationStore : ConfigurationStoreBase, IDisposable
     await _lock.WaitAsync(ct);
     try
     {
-      if (!_isLoaded) await LoadAsync(ct);
+      if (!_isLoaded)
+      {
+        await LoadAsync(ct);
+      }
 
       if (_entries.Remove(key))
       {
@@ -199,7 +219,10 @@ public sealed class JsonConfigurationStore : ConfigurationStoreBase, IDisposable
     await _lock.WaitAsync(ct);
     try
     {
-      if (!_isLoaded) await LoadAsync(ct);
+      if (!_isLoaded)
+      {
+        await LoadAsync(ct);
+      }
 
       return _entries.ContainsKey(key);
     }
@@ -216,7 +239,9 @@ public sealed class JsonConfigurationStore : ConfigurationStoreBase, IDisposable
     try
     {
       if (!_isDirty)
+      {
         return true;
+      }
 
       await SaveInternalAsync(ct);
       return true;
@@ -313,7 +338,10 @@ public sealed class JsonConfigurationStore : ConfigurationStoreBase, IDisposable
   /// <inheritdoc/>
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _lock.Dispose();
     _disposed = true;
   }

--- a/src/Radio.Configuration/Stores/SqliteConfigurationStore.cs
+++ b/src/Radio.Configuration/Stores/SqliteConfigurationStore.cs
@@ -299,7 +299,9 @@ public sealed class SqliteConfigurationStore : ConfigurationStoreBase, IAsyncDis
   private async Task EnsureInitializedLocked(CancellationToken ct)
   {
     if (_tableCreated && _connection?.State == System.Data.ConnectionState.Open)
+    {
       return;
+    }
 
     await InitializeAsync(ct);
   }
@@ -347,7 +349,10 @@ public sealed class SqliteConfigurationStore : ConfigurationStoreBase, IAsyncDis
   /// <inheritdoc/>
   public async ValueTask DisposeAsync()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
 
     if (_connection != null)
     {

--- a/src/Radio.Fingerprinting/Data/SqlitePlayHistoryRepository.cs
+++ b/src/Radio.Fingerprinting/Data/SqlitePlayHistoryRepository.cs
@@ -199,7 +199,9 @@ public sealed class SqlitePlayHistoryRepository : IPlayHistoryRepository
       while (await reader.ReadAsync(ct))
       {
         if (!Enum.TryParse<PlaySource>(reader.GetString(0), out var source))
+        {
           continue; // Skip rows with unknown source types
+        }
         // SQLite COUNT returns 64-bit integer, guard for NULL
         playsBySource[source] = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetInt64(1));
       }

--- a/src/Radio.Fingerprinting/Services/BackgroundIdentificationService.cs
+++ b/src/Radio.Fingerprinting/Services/BackgroundIdentificationService.cs
@@ -193,7 +193,9 @@ public sealed class BackgroundIdentificationService : BackgroundService
         // Skip idle delay when there are no failures — the capture duration already throttles.
         // Only delay on SongRec backoff.
         if (_consecutiveSongRecFailures == 0)
+        {
           continue;
+        }
 
         using var delayCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
         _delayCts = delayCts;
@@ -442,7 +444,9 @@ public sealed class BackgroundIdentificationService : BackgroundService
     {
       _currentPhase = phase;
       if (error != null)
+      {
         _lastError = error;
+      }
       if (_currentEvent != null)
       {
         _currentEvent.Phase = phase;
@@ -470,7 +474,9 @@ public sealed class BackgroundIdentificationService : BackgroundService
         _currentSourceName = sourceName;
         _recentEvents.Add(_currentEvent);
         if (_recentEvents.Count > MaxRecentEvents)
+        {
           _recentEvents.RemoveAt(0);
+        }
         _eventsVersion++;
       }
     }
@@ -484,7 +490,10 @@ public sealed class BackgroundIdentificationService : BackgroundService
   {
     lock (_statusLock)
     {
-      if (_currentEvent == null) return;
+      if (_currentEvent == null)
+      {
+        return;
+      }
 
       _eventsVersion++;
 
@@ -528,7 +537,9 @@ public sealed class BackgroundIdentificationService : BackgroundService
       };
       _recentEvents.Add(_currentEvent);
       if (_recentEvents.Count > MaxRecentEvents)
+      {
         _recentEvents.RemoveAt(0);
+      }
     }
   }
 
@@ -540,7 +551,10 @@ public sealed class BackgroundIdentificationService : BackgroundService
   {
     lock (_statusLock)
     {
-      if (_currentEvent == null) return;
+      if (_currentEvent == null)
+      {
+        return;
+      }
 
       _eventsVersion++;
 
@@ -563,7 +577,9 @@ public sealed class BackgroundIdentificationService : BackgroundService
       };
       _recentEvents.Add(_currentEvent);
       if (_recentEvents.Count > MaxRecentEvents)
+      {
         _recentEvents.RemoveAt(0);
+      }
     }
   }
 
@@ -592,7 +608,10 @@ public sealed class BackgroundIdentificationService : BackgroundService
 
   private static double ComputeRate(List<DateTime> timestamps)
   {
-    if (timestamps.Count == 0) return 0;
+    if (timestamps.Count == 0)
+    {
+      return 0;
+    }
     var oldest = timestamps[0];
     var elapsed = (DateTime.UtcNow - oldest).TotalMinutes;
     return elapsed > 0 ? timestamps.Count / elapsed : 0;

--- a/src/Radio.Fingerprinting/Services/MetadataLookupService.cs
+++ b/src/Radio.Fingerprinting/Services/MetadataLookupService.cs
@@ -107,7 +107,9 @@ public sealed class MetadataLookupService : IMetadataLookupService
     string title, string artist, string? album = null, CancellationToken ct = default)
   {
     if (string.IsNullOrWhiteSpace(title) || string.IsNullOrWhiteSpace(artist))
+    {
       return null;
+    }
 
     try
     {
@@ -120,7 +122,9 @@ public sealed class MetadataLookupService : IMetadataLookupService
       var escapedArtist = Uri.EscapeDataString(artist);
       var query = $"recording:\"{escapedTitle}\" AND artist:\"{escapedArtist}\"";
       if (!string.IsNullOrWhiteSpace(album))
+      {
         query += $" AND release:\"{Uri.EscapeDataString(album)}\"";
+      }
 
       var mb = _options.MusicBrainz;
       var url = $"{mb.BaseUrl}/recording?query={query}&fmt=json&limit=5";
@@ -148,10 +152,16 @@ public sealed class MetadataLookupService : IMetadataLookupService
       // Try multiple recordings/releases — the first may not have cover art
       foreach (var recording in recordings)
       {
-        if (recording.Releases == null) continue;
+        if (recording.Releases == null)
+        {
+          continue;
+        }
         foreach (var release in recording.Releases)
         {
-          if (string.IsNullOrEmpty(release.Id)) continue;
+          if (string.IsNullOrEmpty(release.Id))
+          {
+            continue;
+          }
           var coverArtUrl = await GetCoverArtUrlAsync(release.Id, ct);
           if (!string.IsNullOrEmpty(coverArtUrl))
           {
@@ -226,7 +236,9 @@ public sealed class MetadataLookupService : IMetadataLookupService
   public async Task<string?> GetCoverArtByReleaseIdAsync(string releaseId, CancellationToken ct = default)
   {
     if (string.IsNullOrWhiteSpace(releaseId))
+    {
       return null;
+    }
 
     return await GetCoverArtUrlAsync(releaseId, ct);
   }

--- a/src/Radio.Fingerprinting/Services/SongRecRecognitionService.cs
+++ b/src/Radio.Fingerprinting/Services/SongRecRecognitionService.cs
@@ -44,9 +44,13 @@ public sealed class SongRecRecognitionService : ISongRecRecognitionService
     _songRecPath = ResolveSongRecPath(songRecOptions.SongRecPath);
 
     if (IsAvailable)
+    {
       _logger.LogInformation("SongRec available at: {SongRecPath}", _songRecPath);
+    }
     else
+    {
       _logger.LogWarning("SongRec binary not found. Install via: sudo add-apt-repository ppa:marin-m/songrec && sudo apt install songrec");
+    }
   }
 
   /// <inheritdoc/>
@@ -82,7 +86,9 @@ public sealed class SongRecRecognitionService : ISongRecRecognitionService
       // Run songrec recognize
       var result = await RunSongRecAsync(tempFile, ct);
       if (result == null)
+      {
         return null;
+      }
 
       // Parse track metadata from Shazam response
       return ParseResult(result);
@@ -174,7 +180,9 @@ public sealed class SongRecRecognitionService : ISongRecRecognitionService
   internal static TrackMetadata? ParseResult(SongRecResult result)
   {
     if (result.Track == null)
+    {
       return null;
+    }
 
     var track = result.Track;
 
@@ -186,25 +194,36 @@ public sealed class SongRecRecognitionService : ISongRecRecognitionService
     {
       foreach (var section in track.Sections)
       {
-        if (section.Metadata == null) continue;
+        if (section.Metadata == null)
+        {
+          continue;
+        }
         foreach (var meta in section.Metadata)
         {
           if (string.Equals(meta.Title, "Album", StringComparison.OrdinalIgnoreCase))
+          {
             album = meta.Text;
+          }
           else if (string.Equals(meta.Title, "Released", StringComparison.OrdinalIgnoreCase))
           {
             if (int.TryParse(meta.Text, out var year))
+            {
               releaseYear = year;
+            }
           }
           else if (string.Equals(meta.Title, "Genre", StringComparison.OrdinalIgnoreCase))
+          {
             genre = meta.Text;
+          }
         }
       }
     }
 
     // Genre: prefer sections metadata, fall back to track.genres.primary
     if (string.IsNullOrEmpty(genre))
+    {
       genre = track.Genres?.Primary;
+    }
 
     // Cover art: prefer high-res, fall back to standard
     string? coverArtUrl = track.Images?.CoverArtHq

--- a/src/Radio.Infrastructure/Audio/AlbumArtCacheService.cs
+++ b/src/Radio.Infrastructure/Audio/AlbumArtCacheService.cs
@@ -119,7 +119,9 @@ public sealed class AlbumArtCacheService : IAlbumArtCacheService, IDisposable
 
       var bytes = await response.Content.ReadAsByteArrayAsync();
       if (bytes.Length == 0)
+      {
         return null;
+      }
 
       // Detect MIME from Content-Type header or magic bytes
       var contentType = response.Content.Headers.ContentType?.MediaType;
@@ -141,11 +143,15 @@ public sealed class AlbumArtCacheService : IAlbumArtCacheService, IDisposable
   {
     // Sanitize: only allow alphanumeric, dash, underscore, dot
     if (string.IsNullOrWhiteSpace(filename) || filename.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+    {
       return null;
+    }
 
     // Prevent path traversal
     if (filename.Contains("..") || filename.Contains('/') || filename.Contains('\\'))
+    {
       return null;
+    }
 
     var filePath = Path.Combine(_cacheDir, filename);
     return File.Exists(filePath) ? filePath : null;
@@ -159,7 +165,9 @@ public sealed class AlbumArtCacheService : IAlbumArtCacheService, IDisposable
     try
     {
       if (!Directory.Exists(_cacheDir))
+      {
         return;
+      }
 
       var cutoff = DateTime.UtcNow - Ttl;
       var removed = 0;
@@ -205,20 +213,28 @@ public sealed class AlbumArtCacheService : IAlbumArtCacheService, IDisposable
   internal static string? DetectMimeFromBytes(byte[] data)
   {
     if (data.Length < 4)
+    {
       return null;
+    }
 
     // PNG: 0x89 0x50 0x4E 0x47
     if (data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47)
+    {
       return "image/png";
+    }
 
     // JPEG: 0xFF 0xD8
     if (data[0] == 0xFF && data[1] == 0xD8)
+    {
       return "image/jpeg";
+    }
 
     // WebP: RIFF....WEBP
     if (data.Length >= 12 && data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46
         && data[8] == 0x57 && data[9] == 0x45 && data[10] == 0x42 && data[11] == 0x50)
+    {
       return "image/webp";
+    }
 
     return null;
   }
@@ -246,7 +262,10 @@ public sealed class AlbumArtCacheService : IAlbumArtCacheService, IDisposable
 
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
     _cleanupTimer.Dispose();
     _httpClient.Dispose();

--- a/src/Radio.Infrastructure/Audio/Diagnostics/CaptureSession.cs
+++ b/src/Radio.Infrastructure/Audio/Diagnostics/CaptureSession.cs
@@ -71,11 +71,17 @@ public class CaptureSession
   /// <param name="samples">Audio samples to capture.</param>
   public void AddSamples(ReadOnlySpan<float> samples)
   {
-    if (!_isCapturing) return;
+    if (!_isCapturing)
+    {
+      return;
+    }
 
     lock (_lock)
     {
-      if (!_isCapturing) return;
+      if (!_isCapturing)
+      {
+        return;
+      }
 
       var remaining = _buffer.Length - _writePos;
       var toCopy = Math.Min(samples.Length, remaining);
@@ -90,7 +96,9 @@ public class CaptureSession
       _writePos += toCopy;
 
       if (_writePos >= _buffer.Length)
+      {
         _isCapturing = false; // Buffer full — auto-stop
+      }
     }
   }
 
@@ -122,7 +130,9 @@ public class CaptureSession
 
     var dir = Path.GetDirectoryName(filePath);
     if (!string.IsNullOrEmpty(dir))
+    {
       Directory.CreateDirectory(dir);
+    }
 
     // Inline WAV write to avoid dependency on Radio.AudioAnalysis
     using var fs = new FileStream(filePath, FileMode.Create);

--- a/src/Radio.Infrastructure/Audio/Diagnostics/DiagnosticCaptureService.cs
+++ b/src/Radio.Infrastructure/Audio/Diagnostics/DiagnosticCaptureService.cs
@@ -51,7 +51,9 @@ public class DiagnosticCaptureService
     lock (_captureLock)
     {
       if (IsCapturing)
+      {
         throw new InvalidOperationException("A capture is already in progress");
+      }
     }
 
     durationSeconds = Math.Clamp(durationSeconds, 1, MaxCaptureDurationSeconds);
@@ -107,7 +109,9 @@ public class DiagnosticCaptureService
 
       // Start all sessions
       foreach (var session in sessions.Values)
+      {
         session.Start();
+      }
 
       // Wait for the capture duration
       try
@@ -121,7 +125,9 @@ public class DiagnosticCaptureService
 
       // Stop all sessions
       foreach (var session in sessions.Values)
+      {
         session.Stop();
+      }
 
       // Detach hooks and taps
       if (activeGenerator != null)
@@ -131,7 +137,9 @@ public class DiagnosticCaptureService
       }
 
       if (postModifierTap != null && _audioEngine is SoundFlowAudioEngine sfEngine2)
+      {
         sfEngine2.RemoveDiagnosticModifier(postModifierTap);
+      }
 
       // Write WAV files
       var stageFiles = new Dictionary<string, string>();
@@ -177,7 +185,9 @@ public class DiagnosticCaptureService
 
       // Clean up tap if attached
       if (postModifierTap != null && _audioEngine is SoundFlowAudioEngine sfCleanup)
+      {
         sfCleanup.RemoveDiagnosticModifier(postModifierTap);
+      }
 
       return new CaptureResult
       {

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/Data/FingerprintDbContext.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/Data/FingerprintDbContext.cs
@@ -37,12 +37,18 @@ public sealed class FingerprintDbContext : IFingerprintDataConnection, IAsyncDis
   /// <param name="ct">Cancellation token.</param>
   public async Task InitializeAsync(CancellationToken ct = default)
   {
-    if (_initialized) return;
+    if (_initialized)
+    {
+      return;
+    }
 
     await _initLock.WaitAsync(ct);
     try
     {
-      if (_initialized) return;
+      if (_initialized)
+      {
+        return;
+      }
 
       var dbPath = _pathResolver.GetFingerprintingDatabasePath();
       var directory = Path.GetDirectoryName(dbPath);
@@ -295,7 +301,10 @@ public sealed class FingerprintDbContext : IFingerprintDataConnection, IAsyncDis
   /// <inheritdoc/>
   public async ValueTask DisposeAsync()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
 
     if (_connection != null)

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/SoundFlowAudioTap.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/SoundFlowAudioTap.cs
@@ -45,7 +45,10 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
     get
     {
       var activeSource = _audioManager.ActiveSource;
-      if (activeSource == null) return PlaySource.GenericUSB;
+      if (activeSource == null)
+      {
+        return PlaySource.GenericUSB;
+      }
       return activeSource.Type switch
       {
         AudioSourceType.Radio => PlaySource.Radio,
@@ -63,7 +66,9 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
     get
     {
       if (_audioManager.ActiveSource is FilePlayerAudioSource fileSource)
+      {
         return fileSource.CurrentFile;
+      }
       return null;
     }
   }
@@ -74,17 +79,24 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
     get
     {
       var source = _audioManager.ActiveSource;
-      if (source == null) return false;
+      if (source == null)
+      {
+        return false;
+      }
 
       // Bluetooth has a direct property
       if (source is BluetoothAudioSource btSource)
+      {
         return btSource.NeedsFingerprintingLookup;
+      }
 
       // FilePlayer uses metadata dictionary
       if (source is FilePlayerAudioSource fileSource)
       {
         if (fileSource.Metadata?.TryGetValue("NeedsFingerprintingLookup", out var val) == true)
+        {
           return val is bool b && b;
+        }
         return true; // Default: needs fingerprinting if flag not set
       }
 
@@ -100,7 +112,9 @@ public sealed class SoundFlowAudioTap : IAudioSampleProvider
     {
       // Engine must be running AND an active source must be actually playing
       if (_audioEngine.State != AudioEngineState.Running)
+      {
         return false;
+      }
 
       var activeSource = _audioManager.ActiveSource;
       return activeSource?.State == AudioSourceState.Playing;

--- a/src/Radio.Infrastructure/Audio/Outputs/CastDeviceCacheRepository.cs
+++ b/src/Radio.Infrastructure/Audio/Outputs/CastDeviceCacheRepository.cs
@@ -100,7 +100,9 @@ public sealed class CastDeviceCacheRepository
 
       var deleted = await cmd.ExecuteNonQueryAsync(ct);
       if (deleted > 0)
+      {
         _logger.LogDebug("Removed {Count} stale Cast devices from cache", deleted);
+      }
     }
     catch (Exception ex)
     {

--- a/src/Radio.Infrastructure/Audio/Outputs/DirectCastStreamingService.cs
+++ b/src/Radio.Infrastructure/Audio/Outputs/DirectCastStreamingService.cs
@@ -157,7 +157,9 @@ public sealed class DirectCastStreamingService : IAsyncDisposable
   public async Task<bool> SendPingAsync()
   {
     if (string.IsNullOrEmpty(_transportId))
+    {
       return false;
+    }
 
     try
     {
@@ -380,14 +382,22 @@ public sealed class DirectCastStreamingService : IAsyncDisposable
           {
             var hasNonZero = false;
             for (var b = totalRead - bytesRead; b < totalRead && !hasNonZero; b++)
-              if (pcmBuffer[b] != 0) hasNonZero = true;
+          {
+            if (pcmBuffer[b] != 0)
+            {
+              hasNonZero = true;
+            }
+          }
             _logger.LogDebug(
               "DirectCast: Read #{Call}: {BytesRead} bytes, nonZero: {NonZero}, availAfter: {Avail}, totalSoFar: {Total}/{Target}",
               readCalls, bytesRead, hasNonZero, tapReader.Available, totalRead, chunkBytes);
           }
         }
 
-        if (ct.IsCancellationRequested) break;
+        if (ct.IsCancellationRequested)
+        {
+          break;
+        }
 
         // Real-time pacing: wait until it's time to send this chunk.
         chunksSinceStart++;
@@ -404,11 +414,16 @@ public sealed class DirectCastStreamingService : IAsyncDisposable
           var isSilence = true;
           for (var i = 0; i < totalRead && isSilence; i++)
           {
-            if (pcmBuffer[i] != 0) isSilence = false;
+            if (pcmBuffer[i] != 0)
+            {
+              isSilence = false;
+            }
           }
 
           if (isSilence)
+          {
             Interlocked.Increment(ref _silenceChunks);
+          }
 
           if (chunksSinceStart <= 10 || isSilence != _lastChunkWasSilence)
           {
@@ -492,7 +507,10 @@ public sealed class DirectCastStreamingService : IAsyncDisposable
   /// </summary>
   private void ReportMetrics(double chunkRate)
   {
-    if (_metricsCollector == null) return;
+    if (_metricsCollector == null)
+    {
+      return;
+    }
 
     _metricsCollector.Gauge("audio.cast.direct.chunk_rate", chunkRate);
     _metricsCollector.Gauge("audio.cast.direct.chunks_sent", _totalChunksSent);
@@ -505,7 +523,10 @@ public sealed class DirectCastStreamingService : IAsyncDisposable
   /// <inheritdoc />
   public async ValueTask DisposeAsync()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
 
     _channel.MessageReceived -= OnChannelMessageReceived;

--- a/src/Radio.Infrastructure/Audio/Outputs/GoogleCastOutput.cs
+++ b/src/Radio.Infrastructure/Audio/Outputs/GoogleCastOutput.cs
@@ -716,7 +716,9 @@ public class GoogleCastOutput : AudioOutputBase
       // Build a new list from existing channels + our custom one
       var newList = new List<object>();
       foreach (var ch in existing)
+      {
         newList.Add(ch);
+      }
       newList.Add(channel);
 
       // Convert to array of the interface type
@@ -725,7 +727,9 @@ public class GoogleCastOutput : AudioOutputBase
       {
         var arr = Array.CreateInstance(interfaceType, newList.Count);
         for (int i = 0; i < newList.Count; i++)
+        {
           arr.SetValue(newList[i], i);
+        }
         prop.SetValue(client, arr);
       }
       else
@@ -862,7 +866,9 @@ public class GoogleCastOutput : AudioOutputBase
   public async Task<object> TestPlayUrlAsync(string url, string contentType)
   {
     if (_client == null)
+    {
       return new { success = false, error = "Not connected to a Cast device" };
+    }
 
     try
     {
@@ -884,7 +890,9 @@ public class GoogleCastOutput : AudioOutputBase
 
       var mediaChannel = _client.GetChannel<MediaChannel>();
       if (mediaChannel == null)
+      {
         return new { success = false, error = "MediaChannel not available" };
+      }
 
       var loadStatus = await mediaChannel.LoadAsync(media, true);
       _logger.LogInformation(
@@ -987,7 +995,10 @@ public class GoogleCastOutput : AudioOutputBase
   {
     var media = BuildMedia();
     var mediaChannel = _client!.GetChannel<MediaChannel>();
-    if (mediaChannel == null) return;
+    if (mediaChannel == null)
+    {
+      return;
+    }
 
     try
     {
@@ -1220,7 +1231,10 @@ public class GoogleCastOutput : AudioOutputBase
   /// </summary>
   private async Task DiagnoseStreamConnectivityAsync()
   {
-    if (string.IsNullOrEmpty(_streamUrl)) return;
+    if (string.IsNullOrEmpty(_streamUrl))
+    {
+      return;
+    }
 
     try
     {
@@ -1245,7 +1259,10 @@ public class GoogleCastOutput : AudioOutputBase
   /// </summary>
   private void SubscribeToReceiverStatus()
   {
-    if (_client == null) return;
+    if (_client == null)
+    {
+      return;
+    }
 
     var receiverChannel = _client.GetChannel<ReceiverChannel>();
     if (receiverChannel != null)
@@ -1260,7 +1277,10 @@ public class GoogleCastOutput : AudioOutputBase
   /// </summary>
   private void UnsubscribeFromReceiverStatus()
   {
-    if (_client == null) return;
+    if (_client == null)
+    {
+      return;
+    }
 
     var receiverChannel = _client.GetChannel<ReceiverChannel>();
     if (receiverChannel != null)
@@ -1274,7 +1294,10 @@ public class GoogleCastOutput : AudioOutputBase
   /// </summary>
   private async Task SyncInitialVolumeAsync()
   {
-    if (_client == null) return;
+    if (_client == null)
+    {
+      return;
+    }
 
     try
     {
@@ -1315,7 +1338,10 @@ public class GoogleCastOutput : AudioOutputBase
   /// </summary>
   private void OnReceiverStatusChanged(object? sender, ChromecastStatus status)
   {
-    if (status.Volume == null) return;
+    if (status.Volume == null)
+    {
+      return;
+    }
 
     var deviceVolume = (float)(status.Volume.Level ?? 0);
     var deviceMuted = status.Volume.Muted ?? false;
@@ -1333,7 +1359,10 @@ public class GoogleCastOutput : AudioOutputBase
     var volumeChanged = Math.Abs(deviceVolume - _lastSetVolume) > 0.01f;
     var muteChanged = deviceMuted != _lastSetMute;
 
-    if (!volumeChanged && !muteChanged) return;
+    if (!volumeChanged && !muteChanged)
+    {
+      return;
+    }
 
     _lastSetVolume = deviceVolume;
     _lastSetMute = deviceMuted;

--- a/src/Radio.Infrastructure/Audio/Outputs/HttpStreamOutput.cs
+++ b/src/Radio.Infrastructure/Audio/Outputs/HttpStreamOutput.cs
@@ -566,9 +566,13 @@ public class HttpStreamOutput : AudioOutputBase
     foreach (var ni in NetworkInterface.GetAllNetworkInterfaces())
     {
       if (ni.OperationalStatus != OperationalStatus.Up)
+      {
         continue;
+      }
       if (ni.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+      {
         continue;
+      }
 
       // Skip virtual adapters (Hyper-V, WSL, Docker, VPN tunnels)
       var desc = ni.Description.ToLowerInvariant();
@@ -583,10 +587,14 @@ public class HttpStreamOutput : AudioOutputBase
       {
         if (addr.Address.AddressFamily != AddressFamily.InterNetwork ||
             IPAddress.IsLoopback(addr.Address))
+        {
           continue;
+        }
 
         if (!isVirtual)
+        {
           return addr.Address.ToString();
+        }
 
         // Track virtual IP as last resort
         fallbackIp ??= addr.Address.ToString();

--- a/src/Radio.Infrastructure/Audio/Playlists/SqlitePlaylistRepository.cs
+++ b/src/Radio.Infrastructure/Audio/Playlists/SqlitePlaylistRepository.cs
@@ -72,7 +72,9 @@ public sealed class SqlitePlaylistRepository : IPlaylistRepository
     }
 
     if (playlist == null)
+    {
       return (null, Array.Empty<PlaylistItem>());
+    }
 
     // Get items
     using var itemsCmd = conn.CreateCommand();

--- a/src/Radio.Infrastructure/Audio/Services/AccurateDurationReader.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AccurateDurationReader.cs
@@ -21,7 +21,9 @@ public static class AccurateDurationReader
       using var tagFile = TagLib.File.Create(filePath);
       var duration = tagFile.Properties.Duration;
       if (duration > TimeSpan.Zero)
+      {
         return duration;
+      }
     }
     catch (Exception ex)
     {

--- a/src/Radio.Infrastructure/Audio/Services/AnnouncementService.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AnnouncementService.cs
@@ -148,9 +148,13 @@ public class AnnouncementService : IAnnouncementService
     finally
     {
       if (soundSource != null)
+      {
         await CleanupSourceAsync(soundSource);
+      }
       if (ttsSource != null)
+      {
         await CleanupSourceAsync(ttsSource);
+      }
       ClearActiveSource(ttsSource ?? soundSource);
     }
   }

--- a/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioManager.cs
@@ -155,11 +155,15 @@ public class AudioManager : IAudioManager, IAsyncDisposable
 
     // Restore volume/mute/balance from persisted preferences
     if (_preferencePersistence != null)
+    {
       await _preferencePersistence.RestoreVolumePreferencesAsync();
+    }
 
     // Restore per-source gain offsets from persisted preferences
     if (_preferencePersistence != null)
+    {
       await _preferencePersistence.RestoreSourceGainOffsetsAsync();
+    }
 
     _initialized = true;
     _logger.LogInformation("AudioManager initialized successfully");
@@ -450,7 +454,9 @@ public class AudioManager : IAudioManager, IAsyncDisposable
   private void OnSourceStateChanged(object? sender, AudioSourceStateChangedEventArgs e)
   {
     if (sender is not IAudioSource source)
+    {
       return;
+    }
 
     _logger.LogInformation(
       "Source state changed: {SourceName} ({SourceType}) {OldState} -> {NewState}, IsActiveSource={IsActive}",
@@ -464,7 +470,9 @@ public class AudioManager : IAudioManager, IAsyncDisposable
   private void OnDuckingLevelChanged(object? sender, DuckingLevelChangedEventArgs e)
   {
     if (_playbackService == null || _activeSource == null)
+    {
       return;
+    }
 
     // Convert duck level percentage (0-100) to multiplier (0.0-1.0)
     var multiplier = e.NewLevel / 100f;
@@ -482,7 +490,9 @@ public class AudioManager : IAudioManager, IAsyncDisposable
   private void OnDuckingStateChanged(object? sender, DuckingStateChangedEventArgs e)
   {
     if (_playbackService == null)
+    {
       return;
+    }
 
     if (e.IsDucking)
     {

--- a/src/Radio.Infrastructure/Audio/Services/AudioPreferencePersistence.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioPreferencePersistence.cs
@@ -45,7 +45,10 @@ public class AudioPreferencePersistence : IDisposable
   /// </summary>
   public void ScheduleVolumePersist()
   {
-    if (_configurationManager == null) return;
+    if (_configurationManager == null)
+    {
+      return;
+    }
 
     lock (_volumePersistLock)
     {
@@ -84,12 +87,16 @@ public class AudioPreferencePersistence : IDisposable
           var volEntry = await store.GetEntryAsync("AudioPreferences:MasterVolume");
           _logger.LogDebug("Config store volume entry: {Entry}", volEntry?.Value ?? "null");
           if (volEntry != null && int.TryParse(volEntry.Value, out var storedVol))
+          {
             volumePercent = storedVol;
+          }
 
           var muteEntry = await store.GetEntryAsync("AudioPreferences:IsMuted");
           _logger.LogDebug("Config store mute entry: {Entry}", muteEntry?.Value ?? "null");
           if (muteEntry != null && bool.TryParse(muteEntry.Value, out var storedMuted))
+          {
             isMuted = storedMuted;
+          }
         }
         catch (Exception ex)
         {
@@ -149,7 +156,10 @@ public class AudioPreferencePersistence : IDisposable
   /// </summary>
   private async Task PersistVolumePreferencesAsync()
   {
-    if (_configurationManager == null) return;
+    if (_configurationManager == null)
+    {
+      return;
+    }
 
     try
     {
@@ -274,7 +284,10 @@ public class AudioPreferencePersistence : IDisposable
   /// </summary>
   private void ScheduleSourceGainPersist()
   {
-    if (_configurationManager == null) return;
+    if (_configurationManager == null)
+    {
+      return;
+    }
 
     lock (_sourceGainPersistLock)
     {
@@ -292,7 +305,10 @@ public class AudioPreferencePersistence : IDisposable
   /// </summary>
   private async Task PersistSourceGainAsync()
   {
-    if (_configurationManager == null) return;
+    if (_configurationManager == null)
+    {
+      return;
+    }
 
     try
     {
@@ -322,7 +338,10 @@ public class AudioPreferencePersistence : IDisposable
 
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
 
     lock (_volumePersistLock)

--- a/src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs
+++ b/src/Radio.Infrastructure/Audio/Services/AudioSourceFactory.cs
@@ -205,7 +205,9 @@ public class AudioSourceFactory : IAudioSourceFactory
   private IAudioSource CreateTestToneSource()
   {
     if (_playbackService == null)
+    {
       throw new InvalidOperationException("SoundFlowPlaybackService is required for TestTone source");
+    }
 
     var logger = _loggerFactory.CreateLogger<TestToneAudioSource>();
     return new TestToneAudioSource(logger, _playbackService);

--- a/src/Radio.Infrastructure/Audio/Services/BluetoothAutoSwitchService.cs
+++ b/src/Radio.Infrastructure/Audio/Services/BluetoothAutoSwitchService.cs
@@ -41,7 +41,9 @@ public class BluetoothAutoSwitchService : IDisposable
   public async Task PreWarmBluetoothAsync(CancellationToken cancellationToken = default)
   {
     if (!_bluetoothOptions.CurrentValue.EnableOnStartup)
+    {
       return;
+    }
 
     _logger.LogInformation("Pre-initializing Bluetooth source (EnableOnStartup=true)");
     var audioManager = _getAudioManager();
@@ -56,7 +58,9 @@ public class BluetoothAutoSwitchService : IDisposable
     try
     {
       if (!_bluetoothOptions.CurrentValue.AutoSwitchOnConnect)
+      {
         return;
+      }
 
       if (!_bluetoothService.IsAvailable)
       {
@@ -81,7 +85,10 @@ public class BluetoothAutoSwitchService : IDisposable
 
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
 
     _bluetoothService.DeviceConnected -= OnBluetoothDeviceConnected;

--- a/src/Radio.Infrastructure/Audio/Services/PlayHistoryTracker.cs
+++ b/src/Radio.Infrastructure/Audio/Services/PlayHistoryTracker.cs
@@ -87,15 +87,21 @@ public class PlayHistoryTracker : IDisposable
     try
     {
       if (sender is not IAudioSource source)
+      {
         return;
+      }
 
       // Only record when transitioning to Playing state
       if (e.NewState != AudioSourceState.Playing)
+      {
         return;
+      }
 
       // Only track primary sources that are the active source
       if (source != _getActiveSource())
+      {
         return;
+      }
 
       _logger.LogInformation(
         "Source {SourceName} transitioned to Playing, recording play history",
@@ -142,7 +148,9 @@ public class PlayHistoryTracker : IDisposable
       string? btDeviceName = null;
       if (playSource == PlaySource.Bluetooth && source is IPrimaryAudioSource ps2 &&
           ps2.Metadata?.TryGetValue("Device", out var deviceObj) == true)
+      {
         btDeviceName = deviceObj?.ToString();
+      }
 
       if (playSource == PlaySource.Bluetooth &&
           IsPlaceholderMetadata(newTitle, newArtist, playSource, btDeviceName))
@@ -168,9 +176,13 @@ public class PlayHistoryTracker : IDisposable
           ps.Metadata.TryGetValue(StandardMetadataKeys.Duration, out var durObj))
       {
         if (durObj is TimeSpan ts)
+        {
           durationSeconds = (int)ts.TotalSeconds;
+        }
         else if (double.TryParse(durObj?.ToString(), out var durVal))
+        {
           durationSeconds = (int)durVal;
+        }
       }
 
       // Check for a recent entry from the same source to upsert against
@@ -284,12 +296,17 @@ public class PlayHistoryTracker : IDisposable
   private static bool IsPlaceholderMetadata(
     string? title, string? artist, PlaySource source, string? btDeviceName = null)
   {
-    if (string.IsNullOrWhiteSpace(title)) return true;
+    if (string.IsNullOrWhiteSpace(title))
+    {
+      return true;
+    }
 
     // BT device name (e.g., "Pixel 8 Pro") used as title before AVRCP arrives
     if (source == PlaySource.Bluetooth && btDeviceName != null &&
         string.Equals(title, btDeviceName, StringComparison.OrdinalIgnoreCase))
+    {
       return true;
+    }
 
     // Source-type fallback artists indicate no real metadata was available
     var fallbackArtist = source switch
@@ -302,7 +319,9 @@ public class PlayHistoryTracker : IDisposable
       _ => null
     };
     if (fallbackArtist != null && string.Equals(artist, fallbackArtist, StringComparison.OrdinalIgnoreCase))
+    {
       return true;
+    }
 
     // Source-type fallback titles (static readonly arrays to avoid per-call allocations)
     var fallbackTitles = source switch
@@ -314,7 +333,9 @@ public class PlayHistoryTracker : IDisposable
       _ => Array.Empty<string>()
     };
     if (fallbackTitles.Any(f => string.Equals(title, f, StringComparison.OrdinalIgnoreCase)))
+    {
       return true;
+    }
 
     return false;
   }
@@ -348,10 +369,22 @@ public class PlayHistoryTracker : IDisposable
     }
 
     // Strip default placeholders so we can apply better fallbacks
-    if (title == StandardMetadataKeys.DefaultTitle) title = null;
-    if (artist == StandardMetadataKeys.DefaultArtist) artist = null;
-    if (album == StandardMetadataKeys.DefaultAlbum) album = null;
-    if (coverArt == StandardMetadataKeys.DefaultAlbumArtUrl) coverArt = null;
+    if (title == StandardMetadataKeys.DefaultTitle)
+    {
+      title = null;
+    }
+    if (artist == StandardMetadataKeys.DefaultArtist)
+    {
+      artist = null;
+    }
+    if (album == StandardMetadataKeys.DefaultAlbum)
+    {
+      album = null;
+    }
+    if (coverArt == StandardMetadataKeys.DefaultAlbumArtUrl)
+    {
+      coverArt = null;
+    }
 
     // Source-specific fallbacks for title
     if (string.IsNullOrWhiteSpace(title))
@@ -409,7 +442,9 @@ public class PlayHistoryTracker : IDisposable
     if (source is IPrimaryAudioSource primary && primary.Metadata != null)
     {
       if (primary.Metadata.TryGetValue("Frequency", out var freq) && freq != null)
+      {
         return freq.ToString()!;
+      }
     }
     return "Radio";
   }
@@ -432,13 +467,19 @@ public class PlayHistoryTracker : IDisposable
     else if (source is IPrimaryAudioSource ps && ps.Metadata != null)
     {
       if (ps.Metadata.TryGetValue("Frequency", out var f))
+      {
         freq = f?.ToString() ?? "";
+      }
     }
 
     if (!string.IsNullOrEmpty(station))
+    {
       return $"{band} / {freq} / {station}";
+    }
     if (!string.IsNullOrEmpty(freq))
+    {
       return $"{band} / {freq}";
+    }
     return "Radio";
   }
 
@@ -461,7 +502,9 @@ public class PlayHistoryTracker : IDisposable
   private static string GetFilePlayerTitle(IAudioSource source)
   {
     if (source is FilePlayerAudioSource filePlayer && !string.IsNullOrEmpty(filePlayer.CurrentFile))
+    {
       return System.IO.Path.GetFileNameWithoutExtension(filePlayer.CurrentFile);
+    }
     return "File Player";
   }
 
@@ -488,7 +531,9 @@ public class PlayHistoryTracker : IDisposable
   {
     var activeSource = _getActiveSource();
     if (activeSource == null)
+    {
       return;
+    }
 
     try
     {
@@ -510,7 +555,9 @@ public class PlayHistoryTracker : IDisposable
         // Persist the identified track metadata so the DB row exists for JOIN queries
         var metadataRepository = scope.ServiceProvider.GetService<ITrackMetadataRepository>();
         if (metadataRepository != null)
+        {
           await metadataRepository.StoreAsync(e.Track);
+        }
 
         // Update the existing entry with fingerprinting data
         var updatedEntry = existingEntry with
@@ -548,7 +595,9 @@ public class PlayHistoryTracker : IDisposable
   {
     var activeSource = _getActiveSource();
     if (activeSource == null)
+    {
       return;
+    }
 
     try
     {
@@ -647,15 +696,22 @@ public class PlayHistoryTracker : IDisposable
   {
     // Only handle if we have real metadata and the active source is Bluetooth
     if (e == null || string.IsNullOrEmpty(e.Title) || string.IsNullOrEmpty(e.Artist))
+    {
       return;
+    }
     if (_getActiveSource()?.Type != AudioSourceType.Bluetooth)
+    {
       return;
+    }
 
     try
     {
       using var scope = _serviceScopeFactory.CreateScope();
       var playHistoryRepository = scope.ServiceProvider.GetService<IPlayHistoryRepository>();
-      if (playHistoryRepository == null) return;
+      if (playHistoryRepository == null)
+      {
+        return;
+      }
       var metadataRepository = scope.ServiceProvider.GetService<ITrackMetadataRepository>();
 
       // Dedup: skip if this exact title+artist was recently played (5-min window
@@ -713,13 +769,17 @@ public class PlayHistoryTracker : IDisposable
       // Case 2: Already up to date — skip
       if (string.Equals(existingTitle, e.Title, StringComparison.OrdinalIgnoreCase) &&
           string.Equals(existingArtist, e.Artist, StringComparison.OrdinalIgnoreCase))
+      {
         return;
+      }
 
       // Get BT device name for placeholder detection (e.g., "Pixel 8 Pro")
       string? btDeviceName = null;
       if (_getActiveSource() is IPrimaryAudioSource btSource &&
           btSource.Metadata?.TryGetValue("Device", out var devObj) == true)
+      {
         btDeviceName = devObj?.ToString();
+      }
 
       // Case 3: Current entry is a placeholder (device name) — update in place
       if (entry.Source == PlaySource.Bluetooth &&
@@ -727,7 +787,9 @@ public class PlayHistoryTracker : IDisposable
       {
         metadata = metadata with { Id = entry.TrackMetadataId ?? metadata.Id };
         if (metadataRepository != null)
+        {
           await metadataRepository.StoreAsync(metadata);
+        }
 
         var updatedEntry = entry with
         {
@@ -773,7 +835,9 @@ public class PlayHistoryTracker : IDisposable
     BluetoothPlaybackMetadata btMeta)
   {
     if (metadataRepository != null)
+    {
       await metadataRepository.StoreAsync(metadata);
+    }
 
     int? durationSeconds = btMeta.Duration > TimeSpan.Zero
       ? (int)btMeta.Duration.TotalSeconds
@@ -805,7 +869,10 @@ public class PlayHistoryTracker : IDisposable
 
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
 
     // Finalize any in-flight play history entry before unsubscribing

--- a/src/Radio.Infrastructure/Audio/Services/TTSFactory.cs
+++ b/src/Radio.Infrastructure/Audio/Services/TTSFactory.cs
@@ -123,14 +123,18 @@ public class TTSFactory : ITTSFactory, IDisposable
     CancellationToken cancellationToken = default)
   {
     if (engine == TTSEngine.ESpeak)
+    {
       return await GetESpeakVoicesAsync(cancellationToken);
+    }
 
     // For cloud engines, return cached voices from DB (sorted by favorites + price tier)
     if (_voiceRepository != null)
     {
       var cached = await _voiceRepository.GetCachedVoicesAsync(engine, cancellationToken);
       if (cached.Count > 0)
+      {
         return SortVoices(cached);
+      }
     }
 
     // No cache — return empty list (user must click "Scan for Voices")
@@ -143,7 +147,9 @@ public class TTSFactory : ITTSFactory, IDisposable
     CancellationToken cancellationToken = default)
   {
     if (_voiceRepository == null)
+    {
       throw new InvalidOperationException("Voice repository not available");
+    }
 
     var voices = engine switch
     {
@@ -162,7 +168,9 @@ public class TTSFactory : ITTSFactory, IDisposable
     TTSEngine engine, string voiceId, CancellationToken cancellationToken = default)
   {
     if (_voiceRepository == null)
+    {
       throw new InvalidOperationException("Voice repository not available");
+    }
     await _voiceRepository.AddFavoriteAsync(engine, voiceId, cancellationToken);
   }
 
@@ -171,7 +179,9 @@ public class TTSFactory : ITTSFactory, IDisposable
     TTSEngine engine, string voiceId, CancellationToken cancellationToken = default)
   {
     if (_voiceRepository == null)
+    {
       throw new InvalidOperationException("Voice repository not available");
+    }
     await _voiceRepository.RemoveFavoriteAsync(engine, voiceId, cancellationToken);
   }
 
@@ -199,8 +209,14 @@ public class TTSFactory : ITTSFactory, IDisposable
 
   private static int GetLanguageRank(string language)
   {
-    if (language.StartsWith("en-US", StringComparison.OrdinalIgnoreCase)) return 0;
-    if (language.StartsWith("en-GB", StringComparison.OrdinalIgnoreCase)) return 1;
+    if (language.StartsWith("en-US", StringComparison.OrdinalIgnoreCase))
+    {
+      return 0;
+    }
+    if (language.StartsWith("en-GB", StringComparison.OrdinalIgnoreCase))
+    {
+      return 1;
+    }
     return 2;
   }
 
@@ -390,7 +406,9 @@ public class TTSFactory : ITTSFactory, IDisposable
       ["name"] = voice
     };
     if (modelName != null)
+    {
       voiceParams["modelName"] = modelName;
+    }
 
     var requestBody = new Dictionary<string, object>
     {
@@ -573,8 +591,10 @@ public class TTSFactory : ITTSFactory, IDisposable
   {
     var apiKey = _secrets.CurrentValue.GoogleAPIKey;
     if (string.IsNullOrEmpty(apiKey) || apiKey.Contains("${secret:"))
+    {
       throw new InvalidOperationException(
         "Google TTS API key is not configured. Set it via System Configuration → Secrets.");
+    }
 
     using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
 
@@ -670,7 +690,10 @@ public class TTSFactory : ITTSFactory, IDisposable
   private static string? GetGoogleModelName(string voiceName)
   {
     var parts = voiceName.Split('-');
-    if (parts.Length < 3) return null;
+    if (parts.Length < 3)
+    {
+      return null;
+    }
 
     // The voice type is the 3rd segment: en-US-{Type}-{Variant}
     var voiceType = parts[2];
@@ -698,8 +721,10 @@ public class TTSFactory : ITTSFactory, IDisposable
   {
     var secrets = _secrets.CurrentValue;
     if (string.IsNullOrEmpty(secrets.AzureAPIKey) || string.IsNullOrEmpty(secrets.AzureRegion))
+    {
       throw new InvalidOperationException(
         "Azure TTS API key or region is not configured. Set them via System Configuration → Secrets.");
+    }
 
     using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
     httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", secrets.AzureAPIKey);

--- a/src/Radio.Infrastructure/Audio/Services/VisualizationModeService.cs
+++ b/src/Radio.Infrastructure/Audio/Services/VisualizationModeService.cs
@@ -25,13 +25,13 @@ public class VisualizationModeService
   /// <summary>Current visualization mode name.</summary>
   public string CurrentMode
   {
-    get { lock (_lock) return _currentMode; }
+    get { lock (_lock) { return _currentMode; } }
   }
 
   /// <summary>Whether visualization is enabled.</summary>
   public bool IsEnabled
   {
-    get { lock (_lock) return _isEnabled; }
+    get { lock (_lock) { return _isEnabled; } }
   }
 
   /// <summary>Fired when the visualization mode or enabled state changes.</summary>
@@ -46,7 +46,10 @@ public class VisualizationModeService
     lock (_lock)
     {
       var currentIndex = Array.IndexOf(Modes, _currentMode);
-      if (currentIndex < 0) currentIndex = 0;
+      if (currentIndex < 0)
+      {
+        currentIndex = 0;
+      }
 
       var newIndex = ((currentIndex + direction) % Modes.Length + Modes.Length) % Modes.Length;
       _currentMode = Modes[newIndex];

--- a/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
@@ -146,7 +146,9 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
         Name = $"Buffered Generator ({typeof(T).Name})";
 
         if (_metricsCollector != null)
+        {
             _metricsTags = new Dictionary<string, string> { ["type"] = typeof(T).Name };
+        }
 
         _logger.LogDebug(
             "BufferedSoundGenerator created: Type={Type}, OutputSampleRate={SampleRate}Hz, OutputChannels={Channels}, MaxBufferSamples={MaxBuffer}, Strategy={Strategy}",
@@ -171,7 +173,10 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
     /// <param name="samples">The samples to add.</param>
     public void AddSamples(ReadOnlySpan<T> samples)
     {
-        if (_isDisposed) return;
+        if (_isDisposed)
+        {
+            return;
+        }
 
         // Defense-in-depth: truncate to frame boundary to prevent L/R channel shift.
         // PipeWire BT transport can deliver non-frame-aligned chunks during packet gaps.
@@ -179,7 +184,10 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
         if (channelCount > 1 && samples.Length % channelCount != 0)
         {
             var aligned = samples.Length / channelCount * channelCount;
-            if (aligned <= 0) return;
+            if (aligned <= 0)
+            {
+                return;
+            }
             samples = samples.Slice(0, aligned);
         }
 
@@ -192,7 +200,10 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
             Monitor.Enter(_bufferLock);
             lockWaitMs = (double)(Stopwatch.GetTimestamp() - waitStart) / Stopwatch.Frequency * 1000.0;
             _addSamplesContentionCount++;
-            if (lockWaitMs > _maxAddSamplesLockWaitMs) _maxAddSamplesLockWaitMs = lockWaitMs;
+            if (lockWaitMs > _maxAddSamplesLockWaitMs)
+            {
+                _maxAddSamplesLockWaitMs = lockWaitMs;
+            }
         }
         try
         {
@@ -203,7 +214,10 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
                     Monitor.Wait(_bufferLock);
                 }
 
-                if (_isDisposed) return;
+                if (_isDisposed)
+                {
+                    return;
+                }
             }
 
             _totalSamplesReceived += samples.Length;
@@ -238,7 +252,9 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
         // Diagnostic capture hook — invoked outside the lock to avoid extending lock hold time.
         // The capture callback does a fast span copy into CaptureSession's own buffer.
         if (typeof(T) == typeof(float))
+        {
             DiagnosticInputCapture?.Invoke(System.Runtime.InteropServices.MemoryMarshal.Cast<T, float>(samples));
+        }
     }
 
     /// <summary>
@@ -253,8 +269,14 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
         {
             var intervalMs = (double)(callbackStartTicks - _lastGenerateAudioTimestamp)
                 / Stopwatch.Frequency * 1000.0;
-            if (intervalMs > _maxCallbackIntervalMs) _maxCallbackIntervalMs = intervalMs;
-            if (intervalMs < _minCallbackIntervalMs) _minCallbackIntervalMs = intervalMs;
+            if (intervalMs > _maxCallbackIntervalMs)
+            {
+                _maxCallbackIntervalMs = intervalMs;
+            }
+            if (intervalMs < _minCallbackIntervalMs)
+            {
+                _minCallbackIntervalMs = intervalMs;
+            }
             // Expected quantum is buffer.Length / (sampleRate * channels) * 1000
             // At 512 samples / (48000 * 2) = ~5.33ms per channel, ~10.67ms total
             // Flag anything > 2x expected as a missed deadline
@@ -309,7 +331,9 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
                 / Stopwatch.Frequency * 1000.0;
             _generateAudioContentionCount++;
             if (generateLockWaitMs > _maxGenerateAudioLockWaitMs)
+            {
                 _maxGenerateAudioLockWaitMs = generateLockWaitMs;
+            }
         }
         try
         {
@@ -346,8 +370,14 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
             _totalSamplesOutput += toRead;
 
             // Track min/max buffer levels between log intervals
-            if (_count < _minBufferSinceLastLog) _minBufferSinceLastLog = _count;
-            if (_count > _maxBufferSinceLastLog) _maxBufferSinceLastLog = _count;
+            if (_count < _minBufferSinceLastLog)
+            {
+                _minBufferSinceLastLog = _count;
+            }
+            if (_count > _maxBufferSinceLastLog)
+            {
+                _maxBufferSinceLastLog = _count;
+            }
 
             if (_overflowStrategy == BufferOverflowStrategy.Block && toRead > 0)
             {
@@ -361,7 +391,9 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
 
         // Diagnostic output capture hook — invoked outside the lock.
         if (samplesWritten > 0)
+        {
             DiagnosticOutputCapture?.Invoke(buffer.Slice(0, samplesWritten));
+        }
 
         // Clock drift compensation: when the buffer is draining faster than the
         // producer fills it (e.g., BT clock vs ALSA clock drift), push back the
@@ -393,7 +425,10 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
                 if (sinceLastLog >= 1.0 || _lastUnderrunLogTime == default)
                 {
                     int buffered;
-                    lock (_bufferLock) { buffered = _count; }
+                    lock (_bufferLock)
+                    {
+                        buffered = _count;
+                    }
                     _logger.LogWarning(
                         "⚠️ Buffer underrun ({Type}): {Count} underruns, {Deficit} zero samples in last {Interval:F1}s " +
                         "(buffer: {Buffered}/{Capacity}, total underruns: {TotalUnderruns})",
@@ -411,7 +446,10 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
 
         var executionMs = (double)(Stopwatch.GetTimestamp() - callbackStartTicks)
             / Stopwatch.Frequency * 1000.0;
-        if (executionMs > _maxCallbackExecutionMs) _maxCallbackExecutionMs = executionMs;
+        if (executionMs > _maxCallbackExecutionMs)
+        {
+            _maxCallbackExecutionMs = executionMs;
+        }
     }
 
     /// <summary>
@@ -426,15 +464,24 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
         if (_lastDriftCheckTime == default)
         {
             _lastDriftCheckTime = now;
-            lock (_bufferLock) { _lastDriftCheckLevel = _count; }
+            lock (_bufferLock)
+            {
+                _lastDriftCheckLevel = _count;
+            }
             return;
         }
 
         // Check every ~2 seconds to smooth out transient jitter
-        if ((now - _lastDriftCheckTime).TotalSeconds < 2.0) return;
+        if ((now - _lastDriftCheckTime).TotalSeconds < 2.0)
+        {
+            return;
+        }
 
         int currentLevel;
-        lock (_bufferLock) { currentLevel = _count; }
+        lock (_bufferLock)
+        {
+            currentLevel = _count;
+        }
 
         _driftCheckCount++;
 

--- a/src/Radio.Infrastructure/Audio/SoundFlow/LimiterModifier.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/LimiterModifier.cs
@@ -44,7 +44,10 @@ public class LimiterModifier : SoundModifier
   /// </summary>
   public LimiterStats? GetAndResetStats()
   {
-    if (_totalSamples == 0) return null;
+    if (_totalSamples == 0)
+    {
+        return null;
+    }
 
     var stats = new LimiterStats
     {
@@ -71,7 +74,9 @@ public class LimiterModifier : SoundModifier
 
     // Fast path: below threshold, pass through unchanged
     if (abs <= _threshold)
-      return sample;
+    {
+        return sample;
+    }
 
     // Soft-knee: threshold + (1 - threshold) * tanh((|x| - threshold) / (1 - threshold))
     // This is continuous at the threshold (tanh(0) = 0) and asymptotes to ±1.0.
@@ -79,9 +84,15 @@ public class LimiterModifier : SoundModifier
     var limited = _threshold + headroom * MathF.Tanh((abs - _threshold) / headroom);
 
     _limitedSamples++;
-    if (abs > _maxInputAbs) _maxInputAbs = abs;
+    if (abs > _maxInputAbs)
+    {
+        _maxInputAbs = abs;
+    }
     var reduction = (abs - limited) / abs;
-    if (reduction > _maxReduction) _maxReduction = reduction;
+    if (reduction > _maxReduction)
+    {
+        _maxReduction = reduction;
+    }
 
     return sample >= 0 ? limited : -limited;
   }

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SineToneGenerator.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SineToneGenerator.cs
@@ -53,11 +53,15 @@ public class SineToneGenerator : SoundComponent
 
       // Right channel: rightHz sine
       if (channels > 1)
+      {
         buffer[idx + 1] = (float)(Math.Sin(2.0 * Math.PI * _rightHz * n / _sampleRate) * _amplitude);
+      }
 
       // Fill any extra channels with silence
       for (var ch = 2; ch < channels; ch++)
+      {
         buffer[idx + ch] = 0f;
+      }
     }
   }
 }

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
@@ -306,9 +306,15 @@ public class SoundFlowAudioEngine : IAudioEngine
       // Periodically log limiter engagement stats (every 30s)
       _limiterStatsTimer = new Timer(_ =>
       {
-        if (_limiterModifier == null) return;
+        if (_limiterModifier == null)
+        {
+            return;
+        }
         var stats = _limiterModifier.GetAndResetStats();
-        if (stats == null) return;
+        if (stats == null)
+        {
+            return;
+        }
         var s = stats.Value;
         if (s.LimitedSamples > 0)
         {
@@ -460,7 +466,9 @@ public class SoundFlowAudioEngine : IAudioEngine
   internal AudioPlaybackDevice? GetPlaybackDevice()
   {
     if (_playbackDevice != null)
-      return _playbackDevice;
+    {
+        return _playbackDevice;
+    }
 
     // Attempt lazy recovery if engine is running but device is missing
     if (_engine != null && (State == AudioEngineState.Ready || State == AudioEngineState.Running))
@@ -602,7 +610,10 @@ public class SoundFlowAudioEngine : IAudioEngine
   /// </summary>
   private void AttachModifiersToPlaybackDevice()
   {
-    if (_playbackDevice == null) return;
+    if (_playbackDevice == null)
+    {
+        return;
+    }
 
     // Balance modifier (first in chain)
     if (_balanceModifier != null)
@@ -658,7 +669,10 @@ public class SoundFlowAudioEngine : IAudioEngine
   /// </summary>
   internal void AddDiagnosticModifier(SoundModifier modifier)
   {
-    if (_playbackDevice == null) return;
+    if (_playbackDevice == null)
+    {
+        return;
+    }
     _playbackDevice.MasterMixer.AddModifier(modifier);
     _logger.LogDebug("Diagnostic modifier {Name} attached to mixer", modifier.Name);
   }
@@ -668,7 +682,10 @@ public class SoundFlowAudioEngine : IAudioEngine
   /// </summary>
   internal void RemoveDiagnosticModifier(SoundModifier modifier)
   {
-    if (_playbackDevice == null) return;
+    if (_playbackDevice == null)
+    {
+        return;
+    }
     _playbackDevice.MasterMixer.RemoveModifier(modifier);
     _logger.LogDebug("Diagnostic modifier {Name} removed from mixer", modifier.Name);
   }
@@ -679,7 +696,10 @@ public class SoundFlowAudioEngine : IAudioEngine
   /// </summary>
   internal static BufferedSoundGenerator<float>? GetGeneratorFromSource(IAudioSource? source)
   {
-    if (source == null) return null;
+    if (source == null)
+    {
+        return null;
+    }
     try
     {
       return source.GetSoundComponent() as BufferedSoundGenerator<float>;
@@ -760,7 +780,10 @@ public class SoundFlowAudioEngine : IAudioEngine
 
   private void CheckForDeviceChanges(object? state)
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+        return;
+    }
 
     try
     {
@@ -818,7 +841,10 @@ public class SoundFlowAudioEngine : IAudioEngine
   /// <inheritdoc/>
   public async ValueTask DisposeAsync()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+        return;
+    }
 
     _disposed = true;
     State = AudioEngineState.Disposed;

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowDeviceManager.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowDeviceManager.cs
@@ -292,7 +292,9 @@ public class SoundFlowDeviceManager : IAudioDeviceManager
     {
       var device = _cachedInputDevices.Find(d => d.Id == deviceId);
       if (device == null)
+      {
         throw new InvalidOperationException($"Input device '{deviceId}' not found");
+      }
 
       _selectedInputDeviceId = deviceId;
       _logger.LogInformation("Selected input device: {DeviceId} ({DeviceName})", device.Id, device.Name);
@@ -357,9 +359,13 @@ public class SoundFlowDeviceManager : IAudioDeviceManager
   {
     // Per-device name overrides take precedence
     if (_displayOptions.HiddenDeviceNames.Contains(deviceName, StringComparer.OrdinalIgnoreCase))
-      return true;
+    {
+        return true;
+    }
     if (_displayOptions.VisibleDeviceNames.Contains(deviceName, StringComparer.OrdinalIgnoreCase))
-      return false;
+    {
+        return false;
+    }
 
     // Fall back to regex patterns
     return _hiddenPatterns.Any(p => p.IsMatch(deviceName));
@@ -370,14 +376,18 @@ public class SoundFlowDeviceManager : IAudioDeviceManager
     // Per-device name overrides take precedence
     if (_displayOptions.DeviceFriendlyNames.TryGetValue(rawName, out var overrideName) &&
         !string.IsNullOrEmpty(overrideName))
-      return overrideName;
+    {
+        return overrideName;
+    }
 
     // Fall back to substring match
     foreach (var mapping in _displayOptions.FriendlyNames)
     {
       if (!string.IsNullOrEmpty(mapping.Pattern) &&
           rawName.Contains(mapping.Pattern, StringComparison.OrdinalIgnoreCase))
+      {
         return mapping.FriendlyName;
+      }
     }
     return rawName;
   }
@@ -721,9 +731,13 @@ public class SoundFlowDeviceManager : IAudioDeviceManager
 
         // Preserve hidden patterns from existing config if not overridden in store
         if (hiddenPatterns != null)
+        {
           options.HiddenDevicePatterns = hiddenPatterns;
+        }
         else
+        {
           options.HiddenDevicePatterns = _displayOptions.HiddenDevicePatterns;
+        }
 
         ReloadDisplaySettingsInternal(options);
         _logger.LogInformation(
@@ -803,9 +817,13 @@ public class SoundFlowDeviceManager : IAudioDeviceManager
       .ToList();
 
     if (patterns.Count > 0)
+    {
       _logger.LogInformation("Device filtering: {Count} hidden pattern(s) active", patterns.Count);
+    }
     if (options.FriendlyNames.Count > 0)
+    {
       _logger.LogInformation("Device friendly names: {Count} mapping(s) configured", options.FriendlyNames.Count);
+    }
 
     return patterns;
   }

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowPlaybackService.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowPlaybackService.cs
@@ -205,7 +205,9 @@ public class SoundFlowPlaybackService : IDisposable
     try
     {
       if (dataProvider is IDisposable disposable)
+      {
         disposable.Dispose();
+      }
     }
     catch { /* ignore */ }
 
@@ -723,7 +725,10 @@ public class SoundFlowPlaybackService : IDisposable
   public void StopAll()
   {
     // Don't throw if disposed - just return
-    if (_disposed) return;
+    if (_disposed)
+    {
+        return;
+    }
 
     List<string> sourceIds;
     lock (_playersLock)
@@ -745,7 +750,10 @@ public class SoundFlowPlaybackService : IDisposable
   /// <inheritdoc/>
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+        return;
+    }
 
     _audioEngine.PlaybackDeviceSwitched -= OnPlaybackDeviceSwitched;
 

--- a/src/Radio.Infrastructure/Audio/SoundFlow/TappedOutputStream.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/TappedOutputStream.cs
@@ -96,7 +96,9 @@ internal sealed class TappedOutputStream : Stream
     lock (_lock)
     {
       if (!_readerPositions.TryGetValue(readerId, out var readPos))
+      {
         return 0;
+      }
       return (_writePosition - readPos + _bufferSize) % _bufferSize;
     }
   }
@@ -156,12 +158,16 @@ internal sealed class TappedOutputStream : Stream
   internal int ReadForReader(string readerId, byte[] buffer, int offset, int count)
   {
     if (_disposed)
+    {
       throw new ObjectDisposedException(nameof(TappedOutputStream));
+    }
 
     lock (_lock)
     {
       if (!_readerPositions.TryGetValue(readerId, out var readPos))
+      {
         return 0;
+      }
 
       var available = (_writePosition - readPos + _bufferSize) % _bufferSize;
 
@@ -201,7 +207,10 @@ internal sealed class TappedOutputStream : Stream
   /// <param name="samples">The float samples to write.</param>
   public void WriteFromEngine(float[] samples)
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+        return;
+    }
 
     lock (_lock)
     {
@@ -224,7 +233,10 @@ internal sealed class TappedOutputStream : Stream
   /// <param name="count">The number of samples to write.</param>
   public void WriteFromEngine(Span<float> samples, int count)
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+        return;
+    }
 
     lock (_lock)
     {
@@ -284,8 +296,14 @@ internal sealed class TappedOutputStream : Stream
     // to avoid a syscall (DateTime.UtcNow) on every audio callback
     _lastWriteTime = now;
 
-    if (_metricsCollector == null) return;
-    if ((now - _lastMetricsTime).TotalSeconds < 10) return;
+    if (_metricsCollector == null)
+    {
+        return;
+    }
+    if ((now - _lastMetricsTime).TotalSeconds < 10)
+    {
+        return;
+    }
 
     var elapsed = _lastMetricsTime == DateTime.MinValue ? 10.0 : (now - _lastMetricsTime).TotalSeconds;
     var bytesWrittenSinceLast = _totalBytesWritten - _lastMetricsBytesWritten;
@@ -425,7 +443,9 @@ internal sealed class TappedOutputStreamReader : Stream
   public override int Read(byte[] buffer, int offset, int count)
   {
     if (_disposed)
+    {
       throw new ObjectDisposedException(nameof(TappedOutputStreamReader));
+    }
     return _parent.ReadForReader(_readerId, buffer, offset, count);
   }
 
@@ -440,7 +460,9 @@ internal sealed class TappedOutputStreamReader : Stream
     byte[] buffer, int offset, int count, CancellationToken cancellationToken)
   {
     if (_disposed)
+    {
       throw new ObjectDisposedException(nameof(TappedOutputStreamReader));
+    }
 
     var available = _parent.GetAvailableForReader(_readerId);
     var bytesRead = _parent.ReadForReader(_readerId, buffer, offset, count);

--- a/src/Radio.Infrastructure/Audio/Sources/AudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/AudioSourceBase.cs
@@ -42,7 +42,10 @@ public abstract class AudioSourceBase : IAudioSource, IAsyncDisposable
     get => _state;
     protected set
     {
-      if (_state == value) return;
+      if (_state == value)
+      {
+        return;
+      }
       var previousState = _state;
       _state = value;
       LogStateChange(previousState, value);
@@ -111,7 +114,10 @@ public abstract class AudioSourceBase : IAudioSource, IAsyncDisposable
   /// <inheritdoc/>
   public async ValueTask DisposeAsync()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
 
     await DisposeAsyncCore();
     State = AudioSourceState.Disposed;

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -82,7 +82,9 @@ public class BluetoothAudioSource : USBAudioSourceBase
     _bluetoothService.DeviceDisconnected += OnDeviceDisconnected;
 
     if (_identificationService != null)
+    {
       _identificationService.TrackIdentified += OnTrackIdentified;
+    }
   }
 
   public override string Name => "Bluetooth Audio";
@@ -287,7 +289,9 @@ public class BluetoothAudioSource : USBAudioSourceBase
     _bluetoothService.DeviceDisconnected -= OnDeviceDisconnected;
 
     if (_identificationService != null)
+    {
       _identificationService.TrackIdentified -= OnTrackIdentified;
+    }
 
     await _bluetoothService.StopAsync();
     await _bluetoothService.DisposeAsync();
@@ -508,15 +512,23 @@ public class BluetoothAudioSource : USBAudioSourceBase
       {
         await Task.Delay(TimeSpan.FromSeconds(retryDelaySeconds), ct);
 
-        if (_playbackId != null || State != AudioSourceState.Playing) return;
+        if (_playbackId != null || State != AudioSourceState.Playing)
+        {
+          return;
+        }
 
         Logger.LogDebug("BluetoothAudioSource: capture retry attempt {Attempt}/{Max}", i + 1, maxRetries);
         await TryReacquireCaptureAsync(ct);
-        if (_playbackId != null) return;
+        if (_playbackId != null)
+        {
+          return;
+        }
       }
 
       if (State == AudioSourceState.Playing && _playbackId == null)
+      {
         Logger.LogWarning("BluetoothAudioSource: capture retry exhausted after {Max} attempts", maxRetries);
+      }
     }
     catch (OperationCanceledException) { }
     catch (Exception ex)
@@ -534,8 +546,14 @@ public class BluetoothAudioSource : USBAudioSourceBase
   {
     try
     {
-      if (_bluetoothService.IsAudioManagedByPlatform) return;
-      if (_captureDevice != null || SoundComponent != null || _playbackId != null) return;
+      if (_bluetoothService.IsAudioManagedByPlatform)
+      {
+        return;
+      }
+      if (_captureDevice != null || SoundComponent != null || _playbackId != null)
+      {
+        return;
+      }
 
       var capture = await _bluetoothService.GetAudioCaptureDeviceAsync(ct);
       if (capture is AudioCaptureDevice audioCapture)
@@ -611,7 +629,10 @@ public class BluetoothAudioSource : USBAudioSourceBase
 
   private void OnMetadataChanged(object? sender, BluetoothPlaybackMetadata e)
   {
-    if (e == null) return;
+    if (e == null)
+    {
+      return;
+    }
 
     // Clear stale audio from the previous song so the new track is heard immediately
     // rather than draining 0.8-2.0s of buffered audio from the old song.
@@ -689,11 +710,17 @@ public class BluetoothAudioSource : USBAudioSourceBase
     if (FpOptions.UseShazamForAllSources)
     {
       if (!string.IsNullOrEmpty(e.Track.Title))
+      {
         MetadataInternal[StandardMetadataKeys.Title] = e.Track.Title;
+      }
       if (!string.IsNullOrEmpty(e.Track.Artist))
+      {
         MetadataInternal[StandardMetadataKeys.Artist] = e.Track.Artist;
+      }
       if (!string.IsNullOrEmpty(e.Track.Album))
+      {
         MetadataInternal[StandardMetadataKeys.Album] = e.Track.Album;
+      }
 
       if (!string.IsNullOrEmpty(e.Track.CoverArtUrl) && _serviceScopeFactory != null)
       {
@@ -798,7 +825,10 @@ public class BluetoothAudioSource : USBAudioSourceBase
 
       using var scope = _serviceScopeFactory!.CreateScope();
       var lookupService = scope.ServiceProvider.GetService<IMetadataLookupService>();
-      if (lookupService == null) return;
+      if (lookupService == null)
+      {
+        return;
+      }
 
       var coverArtUrl = await lookupService.GetCoverArtByReleaseIdAsync(releaseId);
       if (!string.IsNullOrEmpty(coverArtUrl))
@@ -842,12 +872,18 @@ public class BluetoothAudioSource : USBAudioSourceBase
   {
     try
     {
-      if (_serviceScopeFactory == null) return;
+      if (_serviceScopeFactory == null)
+      {
+        return;
+      }
 
       using var scope = _serviceScopeFactory.CreateScope();
       var playHistoryRepo = scope.ServiceProvider.GetService<IPlayHistoryRepository>();
       var metadataRepo = scope.ServiceProvider.GetService<ITrackMetadataRepository>();
-      if (playHistoryRepo == null || metadataRepo == null) return;
+      if (playHistoryRepo == null || metadataRepo == null)
+      {
+        return;
+      }
 
       // Find the most recent BT entry that matches this track
       var recentEntries = await playHistoryRepo.GetRecentAsync(5);
@@ -896,11 +932,15 @@ public class BluetoothAudioSource : USBAudioSourceBase
     {
       case BluetoothPlaybackStatus.Playing:
         if (State == AudioSourceState.Ready || State == AudioSourceState.Paused)
+        {
           State = AudioSourceState.Playing;
+        }
         // Phone started streaming — if source is active but has no capture, try to acquire.
         // This handles the case where the phone was paused when the source was activated.
         if (State == AudioSourceState.Playing && _playbackId == null && !_bluetoothService.IsAudioManagedByPlatform)
+        {
           _ = TryReacquireCaptureAsync();
+        }
         break;
       case BluetoothPlaybackStatus.Paused when State == AudioSourceState.Playing:
         State = AudioSourceState.Paused;

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
@@ -1717,7 +1717,10 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
   /// </summary>
   private async Task SaveQueueStateAsync(List<string> queueItems, int currentIndex)
   {
-    if (_configurationManager == null) return;
+    if (_configurationManager == null)
+    {
+      return;
+    }
 
     try
     {
@@ -1985,14 +1988,18 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
   private void ExtractEmbeddedAlbumArt(string filePath)
   {
     if (_albumArtCache == null)
+    {
       return;
+    }
 
     try
     {
       using var tagFile = TagLib.File.Create(filePath);
       var pictures = tagFile.Tag.Pictures;
       if (pictures == null || pictures.Length == 0)
+      {
         return;
+      }
 
       // Prefer FrontCover, fall back to first picture
       var picture = pictures.FirstOrDefault(p => p.Type == TagLib.PictureType.FrontCover)
@@ -2000,7 +2007,9 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
 
       var data = picture.Data?.Data;
       if (data == null || data.Length == 0)
+      {
         return;
+      }
 
       var mime = !string.IsNullOrEmpty(picture.MimeType) ? picture.MimeType : "image/jpeg";
       var cachedUrl = _albumArtCache.Save(data, mime);
@@ -2038,13 +2047,21 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
     if (FpOptions.UseShazamForAllSources && needsLookup)
     {
       if (!string.IsNullOrEmpty(track.Title))
+      {
         _metadata[StandardMetadataKeys.Title] = track.Title;
+      }
       if (!string.IsNullOrEmpty(track.Artist))
+      {
         _metadata[StandardMetadataKeys.Artist] = track.Artist;
+      }
       if (!string.IsNullOrEmpty(track.Album))
+      {
         _metadata[StandardMetadataKeys.Album] = track.Album;
+      }
       if (!string.IsNullOrEmpty(track.CoverArtUrl))
+      {
         _metadata[StandardMetadataKeys.AlbumArtUrl] = track.CoverArtUrl;
+      }
 
       _metadata["NeedsFingerprintingLookup"] = false;
       _metadata["IdentificationConfidence"] = e.Confidence;

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/PrimaryAudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/PrimaryAudioSourceBase.cs
@@ -129,7 +129,9 @@ public abstract class PrimaryAudioSourceBase : AudioSourceBase, IPrimaryAudioSou
   {
     ThrowIfDisposed();
     if (!SupportsNext)
+    {
       throw new NotSupportedException($"Audio source {Id} does not support skipping to next track.");
+    }
     return Task.CompletedTask;
   }
 
@@ -142,7 +144,9 @@ public abstract class PrimaryAudioSourceBase : AudioSourceBase, IPrimaryAudioSou
   {
     ThrowIfDisposed();
     if (!SupportsPrevious)
+    {
       throw new NotSupportedException($"Audio source {Id} does not support going to previous track.");
+    }
     return Task.CompletedTask;
   }
 
@@ -155,7 +159,9 @@ public abstract class PrimaryAudioSourceBase : AudioSourceBase, IPrimaryAudioSou
   {
     ThrowIfDisposed();
     if (!SupportsShuffle)
+    {
       throw new NotSupportedException($"Audio source {Id} does not support shuffle mode.");
+    }
     return Task.CompletedTask;
   }
 
@@ -168,7 +174,9 @@ public abstract class PrimaryAudioSourceBase : AudioSourceBase, IPrimaryAudioSou
   {
     ThrowIfDisposed();
     if (!SupportsRepeat)
+    {
       throw new NotSupportedException($"Audio source {Id} does not support repeat mode.");
+    }
     return Task.CompletedTask;
   }
 

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/SDRRadioAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/SDRRadioAudioSource.cs
@@ -99,7 +99,10 @@ public class SDRRadioAudioSource : PrimaryAudioSourceBase, Radio.Core.Interfaces
   /// </summary>
   private void OnAudioDataAvailable(object? sender, AudioDataEventArgs e)
   {
-    if (_soundGenerator == null) return;
+    if (_soundGenerator == null)
+    {
+      return;
+    }
 
     var sampleCount = e.SampleCount;
 

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/TestToneAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/TestToneAudioSource.cs
@@ -60,7 +60,9 @@ public class TestToneAudioSource : PrimaryAudioSourceBase
   {
     var engine = _playbackService.GetUnderlyingEngine();
     if (engine == null)
+    {
       throw new InvalidOperationException("Audio engine not available");
+    }
 
     var format = _playbackService.GetAudioFormat();
 

--- a/src/Radio.Infrastructure/Audio/Visualization/LevelMeter.cs
+++ b/src/Radio.Infrastructure/Audio/Visualization/LevelMeter.cs
@@ -100,7 +100,10 @@ internal sealed class LevelMeter
         samplePairs++;
       }
 
-      if (samplePairs == 0) return;
+      if (samplePairs == 0)
+      {
+        return;
+      }
 
       // Update peak with hold
       UpdatePeakWithHold(newLeftPeak, ref _leftPeak, ref _leftPeakHeld, ref _leftPeakHoldExpiry, now);
@@ -145,7 +148,10 @@ internal sealed class LevelMeter
   {
     get
     {
-      lock (_lock) return _leftPeak;
+      lock (_lock)
+      {
+        return _leftPeak;
+      }
     }
   }
 
@@ -156,7 +162,10 @@ internal sealed class LevelMeter
   {
     get
     {
-      lock (_lock) return _rightPeak;
+      lock (_lock)
+      {
+        return _rightPeak;
+      }
     }
   }
 
@@ -167,7 +176,10 @@ internal sealed class LevelMeter
   {
     get
     {
-      lock (_lock) return _leftRms;
+      lock (_lock)
+      {
+        return _leftRms;
+      }
     }
   }
 
@@ -178,7 +190,10 @@ internal sealed class LevelMeter
   {
     get
     {
-      lock (_lock) return _rightRms;
+      lock (_lock)
+      {
+        return _rightRms;
+      }
     }
   }
 
@@ -203,7 +218,10 @@ internal sealed class LevelMeter
   {
     get
     {
-      lock (_lock) return Math.Max(_leftPeak, _rightPeak);
+      lock (_lock)
+      {
+        return Math.Max(_leftPeak, _rightPeak);
+      }
     }
   }
 
@@ -214,7 +232,10 @@ internal sealed class LevelMeter
   {
     get
     {
-      lock (_lock) return (_leftRms + _rightRms) / 2f;
+      lock (_lock)
+      {
+        return (_leftRms + _rightRms) / 2f;
+      }
     }
   }
 

--- a/src/Radio.Infrastructure/Audio/Visualization/VisualizerService.cs
+++ b/src/Radio.Infrastructure/Audio/Visualization/VisualizerService.cs
@@ -94,7 +94,10 @@ public sealed class VisualizerService : IVisualizerService
     ThrowIfDisposed();
 
     // Skip all processing when no UI clients are connected
-    if (!_isProcessingEnabled) return;
+    if (!_isProcessingEnabled)
+    {
+      return;
+    }
 
     lock (_lock)
     {
@@ -115,7 +118,10 @@ public sealed class VisualizerService : IVisualizerService
     ThrowIfDisposed();
 
     // Skip all processing when no UI clients are connected
-    if (!_isProcessingEnabled) return;
+    if (!_isProcessingEnabled)
+    {
+      return;
+    }
 
     lock (_lock)
     {
@@ -224,7 +230,9 @@ public sealed class VisualizerService : IVisualizerService
 
     // Grow buffer if needed (rare — only if input exceeds initial FFTSize capacity)
     if (monoCount > _monoBuffer.Length)
+    {
       _monoBuffer = new float[monoCount];
+    }
 
     for (var i = 0; i < monoCount; i++)
     {
@@ -252,7 +260,10 @@ public sealed class VisualizerService : IVisualizerService
   /// <inheritdoc/>
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
 
     _disposed = true;
     _isActive = false;

--- a/src/Radio.Infrastructure/External/PhoneCallClient.cs
+++ b/src/Radio.Infrastructure/External/PhoneCallClient.cs
@@ -142,9 +142,13 @@ public class PhoneCallClient : IPhoneIntegrationService
   private Task OnConnectionClosed(Exception? error)
   {
     if (error != null)
+    {
       _logger.LogWarning(error, "RotaryPhone hub connection closed with error");
+    }
     else
+    {
       _logger.LogInformation("RotaryPhone hub connection closed");
+    }
 
     return Task.CompletedTask;
   }
@@ -152,7 +156,10 @@ public class PhoneCallClient : IPhoneIntegrationService
   /// <inheritdoc />
   public async ValueTask DisposeAsync()
   {
-    if (_isDisposed) return;
+    if (_isDisposed)
+    {
+      return;
+    }
     _isDisposed = true;
 
     if (_hubConnection != null)

--- a/src/Radio.Infrastructure/External/PhoneContactLookupService.cs
+++ b/src/Radio.Infrastructure/External/PhoneContactLookupService.cs
@@ -33,7 +33,9 @@ public class PhoneContactLookupService
   public async Task<string> FindCallerNameAsync(string phoneNumber, CancellationToken cancellationToken = default)
   {
     if (string.IsNullOrWhiteSpace(phoneNumber))
+    {
       return "Unknown caller";
+    }
 
     try
     {

--- a/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothReconnectionLoop.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothReconnectionLoop.cs
@@ -69,9 +69,15 @@ internal sealed class BluetoothReconnectionLoop : IDisposable
   /// </summary>
   public static TimeSpan CalculateBackoffDelay(int attempt, int baseMs, int maxMs)
   {
-    if (attempt <= 0) attempt = 1;
+    if (attempt <= 0)
+    {
+      attempt = 1;
+    }
     var delayMs = baseMs * (1 << Math.Min(attempt - 1, 30)); // prevent overflow
-    if (delayMs < 0 || delayMs > maxMs) delayMs = maxMs; // cap
+    if (delayMs < 0 || delayMs > maxMs)
+    {
+      delayMs = maxMs; // cap
+    }
     return TimeSpan.FromMilliseconds(delayMs);
   }
 
@@ -141,7 +147,10 @@ internal sealed class BluetoothReconnectionLoop : IDisposable
 
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
     Cancel();
   }

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Linux/BluezAgent.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Linux/BluezAgent.cs
@@ -124,12 +124,19 @@ internal sealed class BluezAgent : IAgent1
       // to avoid flooding the log when BlueZ retries A2DP connections
       var key = $"{device}:{uuid}";
       bool isFirst;
-      lock (_authorizedServices) { isFirst = _authorizedServices.Add(key); }
+      lock (_authorizedServices)
+      {
+        isFirst = _authorizedServices.Add(key);
+      }
 
       if (isFirst)
+      {
         _logger.LogInformation("Auto-authorizing Bluetooth service {UUID} for {Device}", uuid, device);
+      }
       else
+      {
         _logger.LogDebug("Re-authorizing Bluetooth service {UUID} for {Device}", uuid, device);
+      }
       return Task.CompletedTask;
     }
 
@@ -146,7 +153,10 @@ internal sealed class BluezAgent : IAgent1
     var path = devicePath.ToString();
     var devPrefix = "/dev_";
     var idx = path.LastIndexOf(devPrefix, StringComparison.Ordinal);
-    if (idx < 0) return null;
+    if (idx < 0)
+    {
+      return null;
+    }
     var mac = path[(idx + devPrefix.Length)..];
     return mac.Replace('_', ':');
   }

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Linux/BluezInterfaces.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Linux/BluezInterfaces.cs
@@ -4,103 +4,102 @@ using System.Threading;
 using System.Threading.Tasks;
 using Tmds.DBus;
 
-namespace Radio.Infrastructure.Platform.Bluetooth.Linux
+namespace Radio.Infrastructure.Platform.Bluetooth.Linux;
+
+[DBusInterface("org.freedesktop.DBus.ObjectManager")]
+public interface IObjectManager : IDBusObject
 {
-    [DBusInterface("org.freedesktop.DBus.ObjectManager")]
-    public interface IObjectManager : IDBusObject
-    {
-        Task<IDictionary<ObjectPath, IDictionary<string, IDictionary<string, object>>>> GetManagedObjectsAsync();
-        Task<IDisposable> WatchInterfacesAddedAsync(Action<(ObjectPath objectPath, IDictionary<string, IDictionary<string, object>> interfaces)> handler, Action<Exception>? onError = null);
-        Task<IDisposable> WatchInterfacesRemovedAsync(Action<(ObjectPath objectPath, string[] interfaces)> handler, Action<Exception>? onError = null);
-    }
+  Task<IDictionary<ObjectPath, IDictionary<string, IDictionary<string, object>>>> GetManagedObjectsAsync();
+  Task<IDisposable> WatchInterfacesAddedAsync(Action<(ObjectPath objectPath, IDictionary<string, IDictionary<string, object>> interfaces)> handler, Action<Exception>? onError = null);
+  Task<IDisposable> WatchInterfacesRemovedAsync(Action<(ObjectPath objectPath, string[] interfaces)> handler, Action<Exception>? onError = null);
+}
 
-    [DBusInterface("org.bluez.Adapter1")]
-    public interface IAdapter1 : IDBusObject
-    {
-        Task StartDiscoveryAsync();
-        Task StopDiscoveryAsync();
-        Task RemoveDeviceAsync(ObjectPath device);
-        Task<IDisposable> WatchPropertiesAsync(Action<PropertyChanges> handler);
-        Task<T> GetAsync<T>(string prop);
-        Task SetAsync(string prop, object val);
-    }
+[DBusInterface("org.bluez.Adapter1")]
+public interface IAdapter1 : IDBusObject
+{
+  Task StartDiscoveryAsync();
+  Task StopDiscoveryAsync();
+  Task RemoveDeviceAsync(ObjectPath device);
+  Task<IDisposable> WatchPropertiesAsync(Action<PropertyChanges> handler);
+  Task<T> GetAsync<T>(string prop);
+  Task SetAsync(string prop, object val);
+}
 
-    [DBusInterface("org.bluez.Device1")]
-    public interface IDevice1 : IDBusObject
-    {
-        Task ConnectAsync();
-        Task DisconnectAsync();
-        Task PairAsync();
-        Task CancelPairingAsync();
-        Task<IDisposable> WatchPropertiesAsync(Action<PropertyChanges> handler);
-        Task<T> GetAsync<T>(string prop);
-        Task SetAsync(string prop, object val);
-    }
+[DBusInterface("org.bluez.Device1")]
+public interface IDevice1 : IDBusObject
+{
+  Task ConnectAsync();
+  Task DisconnectAsync();
+  Task PairAsync();
+  Task CancelPairingAsync();
+  Task<IDisposable> WatchPropertiesAsync(Action<PropertyChanges> handler);
+  Task<T> GetAsync<T>(string prop);
+  Task SetAsync(string prop, object val);
+}
 
-    [DBusInterface("org.freedesktop.DBus.Properties")]
-    public interface IProperties : IDBusObject
-    {
-        Task<object> GetAsync(string interfaceName, string prop);
-        Task SetAsync(string interfaceName, string prop, object val);
-        Task<IDictionary<string, object>> GetAllAsync(string interfaceName);
-        Task<IDisposable> WatchPropertiesChangedAsync(Action<(string interfaceName, IDictionary<string, object> changed, string[] invalidated)> handler, Action<Exception>? onError = null);
-    }
+[DBusInterface("org.freedesktop.DBus.Properties")]
+public interface IProperties : IDBusObject
+{
+  Task<object> GetAsync(string interfaceName, string prop);
+  Task SetAsync(string interfaceName, string prop, object val);
+  Task<IDictionary<string, object>> GetAllAsync(string interfaceName);
+  Task<IDisposable> WatchPropertiesChangedAsync(Action<(string interfaceName, IDictionary<string, object> changed, string[] invalidated)> handler, Action<Exception>? onError = null);
+}
 
-    [DBusInterface("org.bluez.MediaPlayer1")]
-    public interface IMediaPlayer1 : IDBusObject
-    {
-        Task PlayAsync();
-        Task PauseAsync();
-        Task StopAsync();
-        Task NextAsync();
-        Task PreviousAsync();
-        Task FastForwardAsync();
-        Task RewindAsync();
-        Task<IDisposable> WatchPropertiesAsync(Action<PropertyChanges> handler);
-        Task<T> GetAsync<T>(string prop);
-        Task SetAsync(string prop, object val);
-    }
+[DBusInterface("org.bluez.MediaPlayer1")]
+public interface IMediaPlayer1 : IDBusObject
+{
+  Task PlayAsync();
+  Task PauseAsync();
+  Task StopAsync();
+  Task NextAsync();
+  Task PreviousAsync();
+  Task FastForwardAsync();
+  Task RewindAsync();
+  Task<IDisposable> WatchPropertiesAsync(Action<PropertyChanges> handler);
+  Task<T> GetAsync<T>(string prop);
+  Task SetAsync(string prop, object val);
+}
 
-    [DBusInterface("org.bluez.MediaTransport1")]
-    public interface IMediaTransport1 : IDBusObject
-    {
-        Task<IDisposable> WatchPropertiesAsync(Action<PropertyChanges> handler);
-        Task<T> GetAsync<T>(string prop);
-        Task SetAsync(string prop, object val);
-    }
+[DBusInterface("org.bluez.MediaTransport1")]
+public interface IMediaTransport1 : IDBusObject
+{
+  Task<IDisposable> WatchPropertiesAsync(Action<PropertyChanges> handler);
+  Task<T> GetAsync<T>(string prop);
+  Task SetAsync(string prop, object val);
+}
 
-    [DBusInterface("org.bluez.AgentManager1")]
-    public interface IAgentManager1 : IDBusObject
-    {
-        Task RegisterAgentAsync(ObjectPath agent, string capability);
-        Task UnregisterAgentAsync(ObjectPath agent);
-        Task RequestDefaultAgentAsync(ObjectPath agent);
-    }
+[DBusInterface("org.bluez.AgentManager1")]
+public interface IAgentManager1 : IDBusObject
+{
+  Task RegisterAgentAsync(ObjectPath agent, string capability);
+  Task UnregisterAgentAsync(ObjectPath agent);
+  Task RequestDefaultAgentAsync(ObjectPath agent);
+}
 
-    [DBusInterface("org.bluez.Agent1")]
-    public interface IAgent1 : IDBusObject
-    {
-        Task ReleaseAsync();
-        Task<string> RequestPinCodeAsync(ObjectPath device);
-        Task DisplayPinCodeAsync(ObjectPath device, string pincode);
-        Task<uint> RequestPasskeyAsync(ObjectPath device);
-        Task DisplayPasskeyAsync(ObjectPath device, uint passkey, ushort entered);
-        Task RequestConfirmationAsync(ObjectPath device, uint passkey);
-        Task RequestAuthorizationAsync(ObjectPath device);
-        Task AuthorizeServiceAsync(ObjectPath device, string uuid);
-        Task CancelAsync();
-    }
+[DBusInterface("org.bluez.Agent1")]
+public interface IAgent1 : IDBusObject
+{
+  Task ReleaseAsync();
+  Task<string> RequestPinCodeAsync(ObjectPath device);
+  Task DisplayPinCodeAsync(ObjectPath device, string pincode);
+  Task<uint> RequestPasskeyAsync(ObjectPath device);
+  Task DisplayPasskeyAsync(ObjectPath device, uint passkey, ushort entered);
+  Task RequestConfirmationAsync(ObjectPath device, uint passkey);
+  Task RequestAuthorizationAsync(ObjectPath device);
+  Task AuthorizeServiceAsync(ObjectPath device, string uuid);
+  Task CancelAsync();
+}
 
-    // Helper for property changes
-    public static class BluezConstants
-    {
-        public const string ServiceName = "org.bluez";
-        public const string AdapterInterface = "org.bluez.Adapter1";
-        public const string DeviceInterface = "org.bluez.Device1";
-        public const string MediaControlInterface = "org.bluez.MediaControl1";
-        public const string MediaTransportInterface = "org.bluez.MediaTransport1";
-        public const string MediaPlayerInterface = "org.bluez.MediaPlayer1";
-        public const string AgentManagerInterface = "org.bluez.AgentManager1";
-        public const string AgentPath = "/radio/bluetooth/agent";
-    }
+// Helper for property changes
+public static class BluezConstants
+{
+  public const string ServiceName = "org.bluez";
+  public const string AdapterInterface = "org.bluez.Adapter1";
+  public const string DeviceInterface = "org.bluez.Device1";
+  public const string MediaControlInterface = "org.bluez.MediaControl1";
+  public const string MediaTransportInterface = "org.bluez.MediaTransport1";
+  public const string MediaPlayerInterface = "org.bluez.MediaPlayer1";
+  public const string AgentManagerInterface = "org.bluez.AgentManager1";
+  public const string AgentPath = "/radio/bluetooth/agent";
 }

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -19,1905 +19,2001 @@ using SoundFlow.Enums;
 using SoundFlow.Structs;
 using Tmds.DBus;
 
-namespace Radio.Infrastructure.Platform.Bluetooth
+namespace Radio.Infrastructure.Platform.Bluetooth;
+
+internal sealed class LinuxBluetoothService : IBluetoothService
 {
-    internal sealed class LinuxBluetoothService : IBluetoothService
+  private readonly ILogger _logger;
+  private readonly BluetoothOptions _options;
+  private readonly SoundFlowDeviceManager? _deviceManager;
+  private readonly SoundFlowPlaybackService? _playbackService;
+  private readonly IMetricsCollector? _metricsCollector;
+  private Connection? _connection;
+  private Linux.IObjectManager? _objectManager;
+  private Linux.IAdapter1? _adapter;
+  private IDisposable? _discoveryWatcher;
+  private MiniAudioEngine? _captureEngine;
+  private Process? _captureProcess;
+  private PipeWireNativeStream? _nativeStream;
+  private CancellationTokenSource? _captureCts;
+  private object? _activeGenerator;
+  private string? _activeNodeName;
+  // Note: PipeWire's bluez5 module manages node volume from AVRCP transport
+  // automatically with proper cubic (perceptual) mapping. No pw-cli override needed.
+  private DateTime? _connectionStartTime;
+
+  // Player tracking
+  private Linux.IMediaPlayer1? _mediaPlayer;
+  private ObjectPath? _mediaPlayerPath;
+  private IDisposable? _playerPropertiesWatcher;
+
+  // Media transport (AVRCP volume)
+  private Linux.IMediaTransport1? _mediaTransport;
+  private ObjectPath? _mediaTransportPath;
+  private IDisposable? _transportPropertiesWatcher;
+
+  // Maps object path to device info
+  private readonly Dictionary<ObjectPath, BluetoothDeviceInfo> _deviceCache = new();
+  private readonly HashSet<ObjectPath> _watchedDevicePaths = new();
+  private readonly SemaphoreSlim _captureDeviceLock = new(1, 1);
+  private readonly object _mediaPlayerLock = new();
+  private bool _started;
+  private Linux.BluezAgent? _agent;
+  private bool _userInitiatedDisconnect;
+  private BluetoothReconnectionLoop? _reconnectionLoop;
+
+  public LinuxBluetoothService(
+    ILogger logger,
+    IOptions<BluetoothOptions> options,
+    SoundFlowDeviceManager? deviceManager = null,
+    IMetricsCollector? metricsCollector = null,
+    SoundFlowPlaybackService? playbackService = null)
+  {
+    _logger = logger;
+    _options = options.Value;
+    _deviceManager = deviceManager;
+    _metricsCollector = metricsCollector;
+    _playbackService = playbackService;
+  }
+
+  public bool IsAvailable => _connection != null && _adapter != null;
+  public BluetoothAdapterState State { get; private set; } = BluetoothAdapterState.Unknown;
+
+  public IReadOnlyList<BluetoothDeviceInfo> PairedDevices
+  {
+    get
     {
-        private readonly ILogger _logger;
-        private readonly BluetoothOptions _options;
-        private readonly SoundFlowDeviceManager? _deviceManager;
-        private readonly SoundFlowPlaybackService? _playbackService;
-        private readonly IMetricsCollector? _metricsCollector;
-        private Connection? _connection;
-        private Linux.IObjectManager? _objectManager;
-        private Linux.IAdapter1? _adapter;
-        private IDisposable? _discoveryWatcher;
-        private MiniAudioEngine? _captureEngine;
-        private Process? _captureProcess;
-        private PipeWireNativeStream? _nativeStream;
-        private CancellationTokenSource? _captureCts;
-        private object? _activeGenerator;
-        private string? _activeNodeName;
-        // Note: PipeWire's bluez5 module manages node volume from AVRCP transport
-        // automatically with proper cubic (perceptual) mapping. No pw-cli override needed.
-        private DateTime? _connectionStartTime;
+      lock (_deviceCache)
+      {
+        return _deviceCache.Values.Where(d => d.IsPaired).ToList();
+      }
+    }
+  }
 
-        // Player tracking
-        private Linux.IMediaPlayer1? _mediaPlayer;
-        private ObjectPath? _mediaPlayerPath;
-        private IDisposable? _playerPropertiesWatcher;
+  public IReadOnlyList<BluetoothDeviceInfo> DiscoveredDevices
+  {
+    get
+    {
+      lock (_deviceCache)
+      {
+        return _deviceCache.Values.ToList();
+      }
+    }
+  }
 
-        // Media transport (AVRCP volume)
-        private Linux.IMediaTransport1? _mediaTransport;
-        private ObjectPath? _mediaTransportPath;
-        private IDisposable? _transportPropertiesWatcher;
+  public bool IsDiscovering { get; private set; }
 
-        // Maps object path to device info
-        private readonly Dictionary<ObjectPath, BluetoothDeviceInfo> _deviceCache = new();
-        private readonly HashSet<ObjectPath> _watchedDevicePaths = new();
-        private readonly SemaphoreSlim _captureDeviceLock = new(1, 1);
-        private readonly object _mediaPlayerLock = new();
-        private bool _started;
-        private Linux.BluezAgent? _agent;
-        private bool _userInitiatedDisconnect;
-        private BluetoothReconnectionLoop? _reconnectionLoop;
+  public bool IsAudioManagedByPlatform => false;
 
-        public LinuxBluetoothService(
-            ILogger logger,
-            IOptions<BluetoothOptions> options,
-            SoundFlowDeviceManager? deviceManager = null,
-            IMetricsCollector? metricsCollector = null,
-            SoundFlowPlaybackService? playbackService = null)
+  public BluetoothDeviceInfo? ConnectedDevice
+  {
+    get
+    {
+      lock (_deviceCache)
+      {
+        return _deviceCache.Values.FirstOrDefault(d => d.IsConnected);
+      }
+    }
+  }
+
+  public event EventHandler<BluetoothAdapterStateChangedEventArgs>? StateChanged;
+  public event EventHandler<BluetoothDeviceConnectedEventArgs>? DeviceConnected;
+  public event EventHandler<BluetoothDeviceDisconnectedEventArgs>? DeviceDisconnected;
+  public event EventHandler<BluetoothDeviceDiscoveredEventArgs>? DeviceDiscovered;
+  public event EventHandler<BluetoothPlaybackMetadata>? MetadataChanged;
+  public event EventHandler<BluetoothPlaybackStatus>? PlaybackStatusChanged;
+  public event EventHandler<TimeSpan>? PositionChanged;
+  public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged;
+  public float? DeviceVolume { get; private set; }
+
+  public async Task SetDeviceVolumeAsync(float volume)
+  {
+    if (_mediaTransport == null)
+    {
+      _logger.LogDebug("No media transport attached, cannot set BT volume");
+      return;
+    }
+
+    try
+    {
+      var bluezVolume = (ushort)Math.Clamp((int)(volume * 127f), 0, 127);
+      await _mediaTransport.SetAsync("Volume", bluezVolume);
+      DeviceVolume = volume;
+      _logger.LogDebug("Set BT AVRCP volume to {Volume:P0} (BlueZ: {Raw}/127)", volume, bluezVolume);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to set BT AVRCP volume via MediaTransport1");
+    }
+  }
+
+  public async Task NextTrackAsync(CancellationToken cancellationToken = default)
+  {
+    if (_mediaPlayer == null)
+    {
+      _logger.LogWarning("No MPRIS media player attached, cannot skip to next track. " +
+        "MediaPlayer D-Bus interface not found — phone may not expose AVRCP controller");
+      return;
+    }
+    try
+    {
+      await _mediaPlayer.NextAsync();
+      _logger.LogInformation("AVRCP: Sent Next command via D-Bus ({Path})", _mediaPlayerPath);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to send AVRCP Next command via D-Bus ({Path})", _mediaPlayerPath);
+    }
+  }
+
+  public async Task PreviousTrackAsync(CancellationToken cancellationToken = default)
+  {
+    if (_mediaPlayer == null)
+    {
+      _logger.LogWarning("No MPRIS media player attached, cannot go to previous track. " +
+        "MediaPlayer D-Bus interface not found — phone may not expose AVRCP controller");
+      return;
+    }
+    try
+    {
+      await _mediaPlayer.PreviousAsync();
+      _logger.LogInformation("AVRCP: Sent Previous command via D-Bus ({Path})", _mediaPlayerPath);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to send AVRCP Previous command via D-Bus ({Path})", _mediaPlayerPath);
+    }
+  }
+
+  public async Task<bool> StartAsync(string deviceName, CancellationToken cancellationToken = default)
+  {
+    if (_started)
+    {
+      _logger.LogDebug("Bluetooth service already started, skipping duplicate StartAsync call");
+      return IsAvailable;
+    }
+    _started = true;
+
+    try
+    {
+      _connection = new Connection(Address.System);
+      await _connection.ConnectAsync();
+      
+      _objectManager = _connection.CreateProxy<Linux.IObjectManager>(Linux.BluezConstants.ServiceName, "/");
+      var objects = await _objectManager.GetManagedObjectsAsync();
+
+      // Find adapter — prefer PreferredAdapterAddress if configured
+      var preferredAddress = _options.PreferredAdapterAddress;
+      Linux.IAdapter1? fallbackAdapter = null;
+      ObjectPath? fallbackPath = null;
+
+      foreach (var obj in objects)
+      {
+        if (!obj.Value.ContainsKey(Linux.BluezConstants.AdapterInterface))
         {
-            _logger = logger;
-            _options = options.Value;
-            _deviceManager = deviceManager;
-            _metricsCollector = metricsCollector;
-            _playbackService = playbackService;
+          continue;
         }
 
-        public bool IsAvailable => _connection != null && _adapter != null;
-        public BluetoothAdapterState State { get; private set; } = BluetoothAdapterState.Unknown;
+        var candidate = _connection.CreateProxy<Linux.IAdapter1>(Linux.BluezConstants.ServiceName, obj.Key);
 
-        public IReadOnlyList<BluetoothDeviceInfo> PairedDevices
+        if (!string.IsNullOrEmpty(preferredAddress))
         {
-            get
+          try
+          {
+            var addr = await candidate.GetAsync<string>("Address");
+            if (string.Equals(addr, preferredAddress, StringComparison.OrdinalIgnoreCase))
             {
-                lock (_deviceCache)
-                {
-                    return _deviceCache.Values.Where(d => d.IsPaired).ToList();
-                }
+              _adapter = candidate;
+              _logger.LogInformation("Selected preferred Bluetooth adapter {Address} at {Path}",
+                addr, obj.Key);
+              break;
             }
+          }
+          catch (Exception ex)
+          {
+            _logger.LogWarning(ex, "Could not read address from adapter at {Path}", obj.Key);
+          }
         }
 
-        public IReadOnlyList<BluetoothDeviceInfo> DiscoveredDevices
+        // Keep the first adapter as fallback
+        fallbackAdapter ??= candidate;
+        fallbackPath ??= obj.Key;
+      }
+
+      if (_adapter == null && fallbackAdapter != null)
+      {
+        _adapter = fallbackAdapter;
+        if (!string.IsNullOrEmpty(preferredAddress))
         {
-            get
-            {
-                lock (_deviceCache)
-                {
-                    return _deviceCache.Values.ToList();
-                }
-            }
+          _logger.LogWarning("Preferred adapter {PreferredAddress} not found, falling back to {Path}",
+            preferredAddress, fallbackPath);
+        }
+        else
+        {
+          _logger.LogInformation("Selected Bluetooth adapter at {Path}", fallbackPath);
+        }
+      }
+
+      if (_adapter == null)
+      {
+        _logger.LogError("No Bluetooth adapter found.");
+        State = BluetoothAdapterState.Error;
+        return false;
+      }
+
+      // Set powered
+      await _adapter.SetAsync("Powered", true);
+      if (!string.IsNullOrEmpty(deviceName))
+      {
+        await _adapter.SetAsync("Alias", deviceName);
+      }
+      
+      await _adapter.SetAsync("DiscoverableTimeout", (uint)0);
+      await _adapter.SetAsync("Discoverable", true);
+      await _adapter.SetAsync("PairableTimeout", (uint)0);
+      await _adapter.SetAsync("Pairable", true);
+
+      // Register a BlueZ Agent to handle pairing requests automatically.
+      // Without an agent, pairing fails with "incorrect PIN or passkey" because
+      // BlueZ has no one to delegate the pairing decision to.
+      await RegisterAgentAsync();
+
+      // Watch for new interfaces (device connects/disconnects)
+      _discoveryWatcher = await _objectManager.WatchInterfacesAddedAsync(OnInterfaceAdded);
+
+      // Set up property watchers on all existing devices so we detect
+      // reconnections from already-paired phones.
+      await WatchExistingDevicesAsync();
+
+      // If a device is already connected at startup, hide discoverability
+      if (ConnectedDevice != null)
+      {
+        await SetDiscoverableAsync(false);
+      }
+
+      State = BluetoothAdapterState.On;
+      StateChanged?.Invoke(this, new BluetoothAdapterStateChangedEventArgs { NewState = State });
+      return true;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to start Bluetooth service");
+      State = BluetoothAdapterState.Error;
+      return false;
+    }
+  }
+
+  public async Task StopAsync(CancellationToken cancellationToken = default)
+  {
+    StopCaptureSubprocess();
+    _captureEngine?.Dispose();
+    _captureEngine = null;
+
+    if (_adapter != null)
+    {
+      try
+      {
+        await _adapter.SetAsync("Powered", false);
+        State = BluetoothAdapterState.Off;
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "Error stopping Bluetooth adapter");
+      }
+    }
+
+    _started = false;
+  }
+
+  public async Task StartDiscoveryAsync(CancellationToken cancellationToken = default)
+  {
+    if (_adapter == null || _objectManager == null)
+    {
+      return;
+    }
+    try
+    {
+      await _adapter.StartDiscoveryAsync();
+      IsDiscovering = true;
+      _metricsCollector?.Increment("bluetooth.discovery_sessions");
+
+      // InterfacesAdded watcher is already set up in StartAsync — no need to
+      // create a duplicate here (the old one would leak, and both would fire
+      // events causing duplicate DeviceConnected/AttachMediaPlayer calls).
+
+      // Scan for existing players that appeared before discovery started
+      await CheckForMediaPlayersAsync();
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to start discovery");
+    }
+  }
+
+  public async Task StopDiscoveryAsync()
+  {
+    if (_adapter == null)
+    {
+      return;
+    }
+    try
+    {
+      await _adapter.StopDiscoveryAsync();
+      IsDiscovering = false;
+      _discoveryWatcher?.Dispose();
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to stop discovery");
+    }
+  }
+  
+  /// <summary>
+  /// Scans BlueZ for existing Device1 objects and sets up property watchers
+  /// so that reconnections from already-paired phones are detected even
+  /// without an explicit StartDiscoveryAsync call.
+  /// </summary>
+  private async Task WatchExistingDevicesAsync()
+  {
+    if (_objectManager == null)
+    {
+      return;
+    }
+
+    try
+    {
+      var objects = await _objectManager.GetManagedObjectsAsync();
+      foreach (var obj in objects)
+      {
+        if (!obj.Value.ContainsKey(Linux.BluezConstants.DeviceInterface))
+        {
+          continue;
         }
 
-        public bool IsDiscovering { get; private set; }
+        var props = obj.Value[Linux.BluezConstants.DeviceInterface];
+        var device = ParseDevice(obj.Key, props);
 
-        public bool IsAudioManagedByPlatform => false;
-
-        public BluetoothDeviceInfo? ConnectedDevice
+        lock (_deviceCache)
         {
-            get
-            {
-                lock (_deviceCache)
-                {
-                    return _deviceCache.Values.FirstOrDefault(d => d.IsConnected);
-                }
-            }
+          _deviceCache[obj.Key] = device;
         }
 
-        public event EventHandler<BluetoothAdapterStateChangedEventArgs>? StateChanged;
-        public event EventHandler<BluetoothDeviceConnectedEventArgs>? DeviceConnected;
-        public event EventHandler<BluetoothDeviceDisconnectedEventArgs>? DeviceDisconnected;
-        public event EventHandler<BluetoothDeviceDiscoveredEventArgs>? DeviceDiscovered;
-        public event EventHandler<BluetoothPlaybackMetadata>? MetadataChanged;
-        public event EventHandler<BluetoothPlaybackStatus>? PlaybackStatusChanged;
-        public event EventHandler<TimeSpan>? PositionChanged;
-        public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged;
-        public float? DeviceVolume { get; private set; }
+        // Watch property changes (Connected, etc.) on this device
+        _ = WatchDevicePropertiesAsync(obj.Key);
 
-        public async Task SetDeviceVolumeAsync(float volume)
+        if (device.IsConnected)
         {
-            if (_mediaTransport == null)
-            {
-                _logger.LogDebug("No media transport attached, cannot set BT volume");
-                return;
-            }
-
-            try
-            {
-                var bluezVolume = (ushort)Math.Clamp((int)(volume * 127f), 0, 127);
-                await _mediaTransport.SetAsync("Volume", bluezVolume);
-                DeviceVolume = volume;
-                _logger.LogDebug("Set BT AVRCP volume to {Volume:P0} (BlueZ: {Raw}/127)", volume, bluezVolume);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to set BT AVRCP volume via MediaTransport1");
-            }
+          _connectionStartTime = DateTime.UtcNow;
+          _metricsCollector?.Increment("bluetooth.devices_connected_total");
+          _metricsCollector?.Gauge("bluetooth.active_connections", 1);
+          _logger.LogInformation("Bluetooth device already connected: {DeviceName} ({Address})",
+            device.Name, device.Address);
+          DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = device });
         }
+      }
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to watch existing Bluetooth devices");
+    }
+  }
 
-        public async Task NextTrackAsync(CancellationToken cancellationToken = default)
+  private void OnInterfaceAdded((ObjectPath objectPath, IDictionary<string, IDictionary<string, object>> interfaces) change)
+  {
+    if (change.interfaces.ContainsKey(Linux.BluezConstants.DeviceInterface))
+    {
+      var props = change.interfaces[Linux.BluezConstants.DeviceInterface];
+      var device = ParseDevice(change.objectPath, props);
+
+      lock (_deviceCache)
+      {
+        _deviceCache[change.objectPath] = device;
+      }
+
+      DeviceDiscovered?.Invoke(this, new BluetoothDeviceDiscoveredEventArgs { Device = device });
+
+      if (device.IsConnected)
+      {
+        _connectionStartTime = DateTime.UtcNow;
+        _metricsCollector?.Increment("bluetooth.devices_connected_total");
+        _metricsCollector?.Gauge("bluetooth.active_connections", 1);
+        _logger.LogInformation("Bluetooth device connected: {DeviceName} ({Address})",
+          device.Name, device.Address);
+
+        // Hide adapter from other devices while one is connected
+        _ = SetDiscoverableAsync(false);
+
+        DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = device });
+      }
+
+      // Watch property changes on this device for connect/disconnect tracking
+      _ = WatchDevicePropertiesAsync(change.objectPath);
+    }
+
+    if (change.interfaces.ContainsKey(Linux.BluezConstants.MediaPlayerInterface))
+    {
+      _ = AttachMediaPlayerAsync(change.objectPath);
+    }
+
+    if (change.interfaces.ContainsKey(Linux.BluezConstants.MediaTransportInterface))
+    {
+      _ = AttachMediaTransportAsync(change.objectPath);
+    }
+  }
+
+  private async Task WatchDevicePropertiesAsync(ObjectPath devicePath)
+  {
+    if (_connection == null)
+    {
+      return;
+    }
+
+    // Prevent duplicate watchers — each fires DeviceConnected independently
+    lock (_watchedDevicePaths)
+    {
+      if (!_watchedDevicePaths.Add(devicePath))
+      {
+        _logger.LogDebug("Already watching device properties at {Path}, skipping", devicePath);
+        return;
+      }
+    }
+
+    try
+    {
+      var device = _connection.CreateProxy<Linux.IDevice1>(
+        Linux.BluezConstants.ServiceName, devicePath);
+
+      await device.WatchPropertiesAsync(changes =>
+      {
+        foreach (var prop in changes.Changed)
         {
-            if (_mediaPlayer == null)
-            {
-                _logger.LogWarning("No MPRIS media player attached, cannot skip to next track. " +
-                    "MediaPlayer D-Bus interface not found — phone may not expose AVRCP controller");
-                return;
-            }
-            try
-            {
-                await _mediaPlayer.NextAsync();
-                _logger.LogInformation("AVRCP: Sent Next command via D-Bus ({Path})", _mediaPlayerPath);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to send AVRCP Next command via D-Bus ({Path})", _mediaPlayerPath);
-            }
-        }
-
-        public async Task PreviousTrackAsync(CancellationToken cancellationToken = default)
-        {
-            if (_mediaPlayer == null)
-            {
-                _logger.LogWarning("No MPRIS media player attached, cannot go to previous track. " +
-                    "MediaPlayer D-Bus interface not found — phone may not expose AVRCP controller");
-                return;
-            }
-            try
-            {
-                await _mediaPlayer.PreviousAsync();
-                _logger.LogInformation("AVRCP: Sent Previous command via D-Bus ({Path})", _mediaPlayerPath);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to send AVRCP Previous command via D-Bus ({Path})", _mediaPlayerPath);
-            }
-        }
-
-        public async Task<bool> StartAsync(string deviceName, CancellationToken cancellationToken = default)
-        {
-            if (_started)
-            {
-                _logger.LogDebug("Bluetooth service already started, skipping duplicate StartAsync call");
-                return IsAvailable;
-            }
-            _started = true;
-
-            try
-            {
-                _connection = new Connection(Address.System);
-                await _connection.ConnectAsync();
-                
-                _objectManager = _connection.CreateProxy<Linux.IObjectManager>(Linux.BluezConstants.ServiceName, "/");
-                var objects = await _objectManager.GetManagedObjectsAsync();
-
-                // Find adapter — prefer PreferredAdapterAddress if configured
-                var preferredAddress = _options.PreferredAdapterAddress;
-                Linux.IAdapter1? fallbackAdapter = null;
-                ObjectPath? fallbackPath = null;
-
-                foreach (var obj in objects)
-                {
-                    if (!obj.Value.ContainsKey(Linux.BluezConstants.AdapterInterface))
-                        continue;
-
-                    var candidate = _connection.CreateProxy<Linux.IAdapter1>(Linux.BluezConstants.ServiceName, obj.Key);
-
-                    if (!string.IsNullOrEmpty(preferredAddress))
-                    {
-                        try
-                        {
-                            var addr = await candidate.GetAsync<string>("Address");
-                            if (string.Equals(addr, preferredAddress, StringComparison.OrdinalIgnoreCase))
-                            {
-                                _adapter = candidate;
-                                _logger.LogInformation("Selected preferred Bluetooth adapter {Address} at {Path}",
-                                    addr, obj.Key);
-                                break;
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex, "Could not read address from adapter at {Path}", obj.Key);
-                        }
-                    }
-
-                    // Keep the first adapter as fallback
-                    fallbackAdapter ??= candidate;
-                    fallbackPath ??= obj.Key;
-                }
-
-                if (_adapter == null && fallbackAdapter != null)
-                {
-                    _adapter = fallbackAdapter;
-                    if (!string.IsNullOrEmpty(preferredAddress))
-                    {
-                        _logger.LogWarning("Preferred adapter {PreferredAddress} not found, falling back to {Path}",
-                            preferredAddress, fallbackPath);
-                    }
-                    else
-                    {
-                        _logger.LogInformation("Selected Bluetooth adapter at {Path}", fallbackPath);
-                    }
-                }
-
-                if (_adapter == null)
-                {
-                    _logger.LogError("No Bluetooth adapter found.");
-                    State = BluetoothAdapterState.Error;
-                    return false;
-                }
-
-                // Set powered
-                await _adapter.SetAsync("Powered", true);
-                if (!string.IsNullOrEmpty(deviceName))
-                {
-                    await _adapter.SetAsync("Alias", deviceName);
-                }
-                
-                await _adapter.SetAsync("DiscoverableTimeout", (uint)0);
-                await _adapter.SetAsync("Discoverable", true);
-                await _adapter.SetAsync("PairableTimeout", (uint)0);
-                await _adapter.SetAsync("Pairable", true);
-
-                // Register a BlueZ Agent to handle pairing requests automatically.
-                // Without an agent, pairing fails with "incorrect PIN or passkey" because
-                // BlueZ has no one to delegate the pairing decision to.
-                await RegisterAgentAsync();
-
-                // Watch for new interfaces (device connects/disconnects)
-                _discoveryWatcher = await _objectManager.WatchInterfacesAddedAsync(OnInterfaceAdded);
-
-                // Set up property watchers on all existing devices so we detect
-                // reconnections from already-paired phones.
-                await WatchExistingDevicesAsync();
-
-                // If a device is already connected at startup, hide discoverability
-                if (ConnectedDevice != null)
-                    await SetDiscoverableAsync(false);
-
-                State = BluetoothAdapterState.On;
-                StateChanged?.Invoke(this, new BluetoothAdapterStateChangedEventArgs { NewState = State });
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to start Bluetooth service");
-                State = BluetoothAdapterState.Error;
-                return false;
-            }
-        }
-
-        public async Task StopAsync(CancellationToken cancellationToken = default)
-        {
-            StopCaptureSubprocess();
-            _captureEngine?.Dispose();
-            _captureEngine = null;
-
-            if (_adapter != null)
-            {
-                try
-                {
-                    await _adapter.SetAsync("Powered", false);
-                    State = BluetoothAdapterState.Off;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error stopping Bluetooth adapter");
-                }
-            }
-
-            _started = false;
-        }
-
-        public async Task StartDiscoveryAsync(CancellationToken cancellationToken = default)
-        {
-            if (_adapter == null || _objectManager == null) return;
-            try
-            {
-                await _adapter.StartDiscoveryAsync();
-                IsDiscovering = true;
-                _metricsCollector?.Increment("bluetooth.discovery_sessions");
-
-                // InterfacesAdded watcher is already set up in StartAsync — no need to
-                // create a duplicate here (the old one would leak, and both would fire
-                // events causing duplicate DeviceConnected/AttachMediaPlayer calls).
-
-                // Scan for existing players that appeared before discovery started
-                await CheckForMediaPlayersAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to start discovery");
-            }
-        }
-
-        public async Task StopDiscoveryAsync()
-        {
-            if (_adapter == null) return;
-            try
-            {
-                await _adapter.StopDiscoveryAsync();
-                IsDiscovering = false;
-                _discoveryWatcher?.Dispose();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to stop discovery");
-            }
-        }
-        
-        /// <summary>
-        /// Scans BlueZ for existing Device1 objects and sets up property watchers
-        /// so that reconnections from already-paired phones are detected even
-        /// without an explicit StartDiscoveryAsync call.
-        /// </summary>
-        private async Task WatchExistingDevicesAsync()
-        {
-            if (_objectManager == null) return;
-
-            try
-            {
-                var objects = await _objectManager.GetManagedObjectsAsync();
-                foreach (var obj in objects)
-                {
-                    if (!obj.Value.ContainsKey(Linux.BluezConstants.DeviceInterface))
-                        continue;
-
-                    var props = obj.Value[Linux.BluezConstants.DeviceInterface];
-                    var device = ParseDevice(obj.Key, props);
-
-                    lock (_deviceCache)
-                    {
-                        _deviceCache[obj.Key] = device;
-                    }
-
-                    // Watch property changes (Connected, etc.) on this device
-                    _ = WatchDevicePropertiesAsync(obj.Key);
-
-                    if (device.IsConnected)
-                    {
-                        _connectionStartTime = DateTime.UtcNow;
-                        _metricsCollector?.Increment("bluetooth.devices_connected_total");
-                        _metricsCollector?.Gauge("bluetooth.active_connections", 1);
-                        _logger.LogInformation("Bluetooth device already connected: {DeviceName} ({Address})",
-                            device.Name, device.Address);
-                        DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = device });
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to watch existing Bluetooth devices");
-            }
-        }
-
-        private void OnInterfaceAdded((ObjectPath objectPath, IDictionary<string, IDictionary<string, object>> interfaces) change)
-        {
-            if (change.interfaces.ContainsKey(Linux.BluezConstants.DeviceInterface))
-            {
-                var props = change.interfaces[Linux.BluezConstants.DeviceInterface];
-                var device = ParseDevice(change.objectPath, props);
-
-                lock (_deviceCache)
-                {
-                    _deviceCache[change.objectPath] = device;
-                }
-
-                DeviceDiscovered?.Invoke(this, new BluetoothDeviceDiscoveredEventArgs { Device = device });
-
-                if (device.IsConnected)
-                {
-                    _connectionStartTime = DateTime.UtcNow;
-                    _metricsCollector?.Increment("bluetooth.devices_connected_total");
-                    _metricsCollector?.Gauge("bluetooth.active_connections", 1);
-                    _logger.LogInformation("Bluetooth device connected: {DeviceName} ({Address})",
-                        device.Name, device.Address);
-
-                    // Hide adapter from other devices while one is connected
-                    _ = SetDiscoverableAsync(false);
-
-                    DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = device });
-                }
-
-                // Watch property changes on this device for connect/disconnect tracking
-                _ = WatchDevicePropertiesAsync(change.objectPath);
-            }
-
-            if (change.interfaces.ContainsKey(Linux.BluezConstants.MediaPlayerInterface))
-            {
-                _ = AttachMediaPlayerAsync(change.objectPath);
-            }
-
-            if (change.interfaces.ContainsKey(Linux.BluezConstants.MediaTransportInterface))
-            {
-                _ = AttachMediaTransportAsync(change.objectPath);
-            }
-        }
-
-        private async Task WatchDevicePropertiesAsync(ObjectPath devicePath)
-        {
-            if (_connection == null) return;
-
-            // Prevent duplicate watchers — each fires DeviceConnected independently
-            lock (_watchedDevicePaths)
-            {
-                if (!_watchedDevicePaths.Add(devicePath))
-                {
-                    _logger.LogDebug("Already watching device properties at {Path}, skipping", devicePath);
-                    return;
-                }
-            }
-
-            try
-            {
-                var device = _connection.CreateProxy<Linux.IDevice1>(
-                    Linux.BluezConstants.ServiceName, devicePath);
-
-                await device.WatchPropertiesAsync(changes =>
-                {
-                    foreach (var prop in changes.Changed)
-                    {
-                        if (prop.Key == "Connected" && prop.Value is bool connected)
-                        {
-                            BluetoothDeviceInfo? deviceInfo;
-                            lock (_deviceCache)
-                            {
-                                _deviceCache.TryGetValue(devicePath, out deviceInfo);
-                            }
-
-                            if (deviceInfo == null) return;
-
-                            // Update cache with new connection state
-                            var updatedDevice = new BluetoothDeviceInfo
-                            {
-                                Address = deviceInfo.Address,
-                                Name = deviceInfo.Name,
-                                IsPaired = deviceInfo.IsPaired,
-                                IsConnected = connected
-                            };
-
-                            lock (_deviceCache)
-                            {
-                                _deviceCache[devicePath] = updatedDevice;
-                            }
-
-                            if (connected)
-                            {
-                                _reconnectionLoop?.Cancel();
-                                _connectionStartTime = DateTime.UtcNow;
-                                _metricsCollector?.Increment("bluetooth.devices_connected_total");
-                                _metricsCollector?.Gauge("bluetooth.active_connections", 1);
-                                _logger.LogInformation("Bluetooth device connected: {DeviceName} ({Address})",
-                                    updatedDevice.Name, updatedDevice.Address);
-
-                                // Hide adapter from other devices while one is connected
-                                _ = SetDiscoverableAsync(false);
-
-                                DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = updatedDevice });
-                            }
-                            else
-                            {
-                                var wasUserInitiated = _userInitiatedDisconnect;
-                                _userInitiatedDisconnect = false;
-
-                                RecordDisconnectionMetrics();
-                                StopCaptureSubprocess();
-                                // Clean up media transport on disconnect
-                                _transportPropertiesWatcher?.Dispose();
-                                _transportPropertiesWatcher = null;
-                                _mediaTransport = null;
-                                _mediaTransportPath = null;
-                                DeviceVolume = null;
-
-                                _logger.LogInformation("Bluetooth device disconnected: {DeviceName} ({Address}) (user-initiated: {UserInitiated})",
-                                    updatedDevice.Name, updatedDevice.Address, wasUserInitiated);
-
-                                // Re-show adapter so other devices can discover and pair
-                                _ = SetDiscoverableAsync(true);
-
-                                DeviceDisconnected?.Invoke(this, new BluetoothDeviceDisconnectedEventArgs
-                                {
-                                    Device = updatedDevice,
-                                    UserInitiated = wasUserInitiated
-                                });
-
-                                // Start auto-reconnection for unexpected disconnects
-                                if (!wasUserInitiated && _options.AutoReconnect)
-                                {
-                                    _reconnectionLoop?.Dispose();
-                                    _reconnectionLoop = new BluetoothReconnectionLoop(
-                                        _logger, _options,
-                                        (addr, ct) => ConnectAsync(addr, ct),
-                                        () => ConnectedDevice != null,
-                                        _metricsCollector);
-                                    _reconnectionLoop.Start(updatedDevice.Address);
-                                }
-                            }
-                        }
-                    }
-                });
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to watch device properties at {Path}", devicePath);
-            }
-        }
-
-        private void RecordDisconnectionMetrics()
-        {
-            _metricsCollector?.Increment("bluetooth.devices_disconnected_total");
-            _metricsCollector?.Gauge("bluetooth.active_connections", 0);
-            if (_connectionStartTime.HasValue)
-            {
-                var duration = (DateTime.UtcNow - _connectionStartTime.Value).TotalSeconds;
-                _metricsCollector?.Gauge("bluetooth.connection_duration_seconds", duration);
-                _connectionStartTime = null;
-            }
-        }
-
-        private BluetoothDeviceInfo ParseDevice(ObjectPath path, IDictionary<string, object> props)
-        {
-            return new BluetoothDeviceInfo
-            {
-                Address = props.ContainsKey("Address") ? (string)props["Address"] : "Unknown",
-                Name = props.ContainsKey("Name") ? (string)props["Name"] : (props.ContainsKey("Alias") ? (string)props["Alias"] : "Unknown Device"),
-                IsPaired = props.ContainsKey("Paired") && (bool)props["Paired"],
-                IsConnected = props.ContainsKey("Connected") && (bool)props["Connected"]
-            };
-        }
-
-        public async Task<bool> PairDeviceAsync(string deviceAddress, CancellationToken cancellationToken = default)
-        {
-            if (_connection == null || _objectManager == null)
-            {
-                _logger.LogWarning("Cannot pair: Bluetooth service not started");
-                return false;
-            }
-
-            try
-            {
-                var devicePath = FindDevicePath(deviceAddress);
-                if (devicePath == null)
-                {
-                    _logger.LogWarning("Device {Address} not found for pairing", deviceAddress);
-                    return false;
-                }
-
-                var device = _connection.CreateProxy<Linux.IDevice1>(
-                    Linux.BluezConstants.ServiceName, devicePath.Value);
-                await device.PairAsync();
-                _metricsCollector?.Increment("bluetooth.pair_attempts", 1.0,
-                    new Dictionary<string, string> { { "result", "success" } });
-                _logger.LogInformation("Paired with device {Address}", deviceAddress);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _metricsCollector?.Increment("bluetooth.pair_attempts", 1.0,
-                    new Dictionary<string, string> { { "result", "failure" } });
-                _logger.LogError(ex, "Failed to pair with device {Address}", deviceAddress);
-                return false;
-            }
-        }
-
-        public async Task<bool> UnpairDeviceAsync(string deviceAddress, CancellationToken cancellationToken = default)
-        {
-            if (_connection == null || _adapter == null)
-            {
-                _logger.LogWarning("Cannot unpair: Bluetooth service not started");
-                return false;
-            }
-
-            try
-            {
-                var devicePath = FindDevicePath(deviceAddress);
-                if (devicePath == null)
-                {
-                    _logger.LogWarning("Device {Address} not found for unpairing", deviceAddress);
-                    return false;
-                }
-
-                await _adapter.RemoveDeviceAsync(devicePath.Value);
-                lock (_deviceCache)
-                {
-                    _deviceCache.Remove(devicePath.Value);
-                }
-                _logger.LogInformation("Unpaired device {Address}", deviceAddress);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to unpair device {Address}", deviceAddress);
-                return false;
-            }
-        }
-
-        public Task<bool> AcceptConnectionAsync(string deviceAddress, CancellationToken cancellationToken = default)
-        {
-            // BlueZ handles incoming connections automatically if Pairable is true
-            return Task.FromResult(true);
-        }
-
-        public async Task<bool> ConnectAsync(string deviceAddress, CancellationToken cancellationToken = default)
-        {
-            if (_connection == null)
-            {
-                _logger.LogWarning("Cannot connect: Bluetooth service not started");
-                return false;
-            }
-
-            try
-            {
-                var devicePath = FindDevicePath(deviceAddress);
-                if (devicePath == null)
-                {
-                    _logger.LogWarning("Device {Address} not found for connection", deviceAddress);
-                    return false;
-                }
-
-                var device = _connection.CreateProxy<Linux.IDevice1>(
-                    Linux.BluezConstants.ServiceName, devicePath.Value);
-
-                // BlueZ Connect() blocks for 30-60s when device is unreachable.
-                // Use a 15s timeout so the reconnection backoff loop can progress.
-                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                timeoutCts.CancelAfter(TimeSpan.FromSeconds(15));
-
-                await device.ConnectAsync().WaitAsync(timeoutCts.Token);
-                _logger.LogInformation("Initiated connection to device {Address}", deviceAddress);
-                return true;
-            }
-            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-            {
-                _logger.LogDebug("Connect to {Address} timed out after 15s", deviceAddress);
-                return false;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to connect to device {Address}", deviceAddress);
-                return false;
-            }
-        }
-
-        public async Task DisconnectAsync(CancellationToken cancellationToken = default)
-        {
-            var connected = ConnectedDevice;
-            if (connected == null || _connection == null)
-            {
-                return;
-            }
-
-            _userInitiatedDisconnect = true;
-            _reconnectionLoop?.Cancel();
-
-            try
-            {
-                var devicePath = FindDevicePath(connected.Address);
-                if (devicePath != null)
-                {
-                    var device = _connection.CreateProxy<Linux.IDevice1>(
-                        Linux.BluezConstants.ServiceName, devicePath.Value);
-                    await device.DisconnectAsync();
-                    _logger.LogInformation("Disconnected device {DeviceName} ({Address})",
-                        connected.Name, connected.Address);
-                }
-            }
-            catch (Exception ex)
-            {
-                _userInitiatedDisconnect = false; // reset on failure to prevent suppressing future reconnects
-                _logger.LogError(ex, "Failed to disconnect device {Address}", connected.Address);
-            }
-        }
-
-        public async Task DisconnectAsync(string deviceAddress, CancellationToken cancellationToken = default)
-        {
-            if (_connection == null) return;
-
-            // Only suppress auto-reconnect when disconnecting the active device.
-            // Disconnecting a paired-but-not-active device won't fire a Connected
-            // property-change event, so the flag would never be consumed/reset —
-            // permanently suppressing auto-reconnect.
-            var isActiveDevice = ConnectedDevice?.Address?.Equals(deviceAddress, StringComparison.OrdinalIgnoreCase) == true;
-            if (isActiveDevice)
-            {
-                _userInitiatedDisconnect = true;
-                _reconnectionLoop?.Cancel();
-            }
-
-            try
-            {
-                var devicePath = FindDevicePath(deviceAddress);
-                if (devicePath != null)
-                {
-                    var device = _connection.CreateProxy<Linux.IDevice1>(
-                        Linux.BluezConstants.ServiceName, devicePath.Value);
-                    await device.DisconnectAsync();
-                    _logger.LogInformation("Disconnected device {Address}", deviceAddress);
-                }
-            }
-            catch (Exception ex)
-            {
-                if (isActiveDevice)
-                {
-                    _userInitiatedDisconnect = false; // reset on failure to prevent suppressing future reconnects
-                }
-                _logger.LogError(ex, "Failed to disconnect device {Address}", deviceAddress);
-            }
-        }
-
-        private ObjectPath? FindDevicePath(string deviceAddress)
-        {
-            var normalizedAddress = deviceAddress.Replace(":", "_").ToUpperInvariant();
+          if (prop.Key == "Connected" && prop.Value is bool connected)
+          {
+            BluetoothDeviceInfo? deviceInfo;
             lock (_deviceCache)
             {
-                foreach (var kvp in _deviceCache)
-                {
-                    if (kvp.Value.Address.Replace(":", "_").Equals(normalizedAddress, StringComparison.OrdinalIgnoreCase)
-                        || kvp.Value.Address.Equals(deviceAddress, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return kvp.Key;
-                    }
-                }
-            }
-            return null;
-        }
-
-        public async Task<object?> GetAudioCaptureDeviceAsync(CancellationToken cancellationToken = default)
-        {
-            var connected = ConnectedDevice;
-            if (connected == null)
-            {
-                _logger.LogWarning("No connected Bluetooth device — cannot create audio capture");
-                return null;
+              _deviceCache.TryGetValue(devicePath, out deviceInfo);
             }
 
-            // If native stream or capture subprocess is already running, return cached generator
-            if (_nativeStream != null && _activeGenerator != null)
+            if (deviceInfo == null)
             {
-                _logger.LogDebug("Returning existing capture generator (native stream)");
-                return _activeGenerator;
-            }
-            if (_captureProcess != null && !_captureProcess.HasExited && _activeGenerator != null)
-            {
-                _logger.LogDebug("Returning existing capture generator (PID {Pid})", _captureProcess.Id);
-                return _activeGenerator;
+              return;
             }
 
-            // Wait for any concurrent search to complete (with timeout instead of zero-wait).
-            // Multiple callers race here: TryAcquireAudioCaptureAsync (from DeviceConnected event)
-            // and InitializeAsync (from auto-switch). Second caller should wait and get cached result.
-            if (!await _captureDeviceLock.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken))
+            // Update cache with new connection state
+            var updatedDevice = new BluetoothDeviceInfo
             {
-                _logger.LogWarning("Timeout waiting for capture device lock");
-                return null;
-            }
-
-            try
-            {
-                // Re-check after acquiring lock — another caller may have completed
-                if (_nativeStream != null && _activeGenerator != null)
-                {
-                    _logger.LogDebug("Capture already active after lock wait (native stream)");
-                    return _activeGenerator;
-                }
-                if (_captureProcess != null && !_captureProcess.HasExited && _activeGenerator != null)
-                {
-                    _logger.LogDebug("Capture already active after lock wait (PID {Pid})", _captureProcess.Id);
-                    return _activeGenerator;
-                }
-
-                return await SearchForCaptureDeviceAsync(connected, cancellationToken);
-            }
-            finally
-            {
-                _captureDeviceLock.Release();
-            }
-        }
-
-        private async Task<object?> SearchForCaptureDeviceAsync(
-            BluetoothDeviceInfo connected, CancellationToken cancellationToken)
-        {
-            // Cleanup previous capture
-            StopCaptureSubprocess();
-            _captureEngine?.Dispose();
-            _captureEngine = null;
-
-            if (_playbackService == null)
-            {
-                _logger.LogError("SoundFlowPlaybackService not available — cannot create BT capture bridge");
-                return null;
-            }
-
-            var engine = _playbackService.GetUnderlyingEngine();
-            var format = _playbackService.GetAudioFormat();
-            if (engine == null)
-            {
-                _logger.LogError("SoundFlow engine not available — cannot create BT capture bridge");
-                return null;
-            }
-
-            // Use pw-record to capture directly from the PipeWire bluez input node.
-            // PipeWire creates a node named "bluez_input.<ADDRESS>.<N>" when a BT A2DP
-            // source connects. pw-record --target captures from it directly — no ALSA
-            // bridge, .asoundrc, or null sink configuration needed.
-            const int maxRetries = 20;
-            const int retryDelayMs = 1000;
-
-            for (var attempt = 1; attempt <= maxRetries; attempt++)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                if (ConnectedDevice == null)
-                {
-                    _logger.LogWarning("Bluetooth device disconnected during capture device polling");
-                    return null;
-                }
-
-                try
-                {
-                    // Find the PipeWire node name for this BT device
-                    var (nodeName, nodeId, nodeSerial) = await FindPipeWireBluetoothNodeAsync(connected.Address, cancellationToken);
-                    if (nodeName == null)
-                    {
-                        _logger.LogDebug("PipeWire BT node not found for {Address} (attempt {Attempt}/{Max})",
-                            connected.Address, attempt, maxRetries);
-                        if (attempt < maxRetries)
-                            await Task.Delay(retryDelayMs, cancellationToken);
-                        continue;
-                    }
-
-                    _logger.LogInformation("Found PipeWire BT node: {Node} (id={NodeId}, serial={Serial}, attempt {Attempt})",
-                        nodeName, nodeId, nodeSerial, attempt);
-
-                    var generator = new BufferedSoundGenerator<float>(
-                        engine, format, _logger, maxBufferSeconds: 4.0f,
-                        metricsCollector: _metricsCollector);
-
-                    StartCaptureSubprocess(generator, format, nodeName, nodeSerial);
-
-                    // Give the stream a moment to connect
-                    await Task.Delay(500, cancellationToken);
-
-                    // Check if native stream or fallback process is running
-                    var isRunning = _nativeStream != null ||
-                        (_captureProcess != null && !_captureProcess.HasExited);
-
-                    if (isRunning)
-                    {
-                        _logger.LogInformation(
-                            "BT capture running (attempt {Attempt}/{Max}, mode={Mode}, target {Node})",
-                            attempt, maxRetries,
-                            _nativeStream != null ? "native" : "pw-record",
-                            nodeName);
-                        _activeGenerator = generator;
-                        _activeNodeName = nodeName;
-
-                        // Deferred task: disconnect auto-links and normalize volume
-                        // after PipeWire settles.
-                        var captureCt = _captureCts!.Token;
-                        var capturedNodeName = nodeName;
-                        var capturedNodeId = nodeId;
-                        _ = Task.Run(async () =>
-                        {
-                            try
-                            {
-                                await Task.Delay(1500, captureCt);
-
-                                // Disconnect PipeWire/WirePlumber auto-links from
-                                // bluez_input → default sink. Without this, BT audio
-                                // plays through both our pipeline AND directly to
-                                // speakers, causing an out-of-sync duplicate.
-                                DisconnectPipeWireBtAutoLinks(capturedNodeName);
-
-                                // Override PipeWire's AVRCP-managed node volume to 1.0.
-                                // PipeWire's bluez5 module applies cubic mapping from phone
-                                // AVRCP volume, making BT audio ~30% quieter than other sources.
-                                // We normalize the capture level here and control volume via
-                                // our own master volume and per-source gain instead.
-                                NormalizeBtNodeVolume(capturedNodeId);
-
-                                // For fallback pw-record mode, also do link management
-                                if (_nativeStream == null && _captureProcess != null)
-                                {
-                                    LinkPipeWireRecordToBtNode(capturedNodeName);
-                                }
-                            }
-                            catch (OperationCanceledException) { }
-                            catch (Exception ex)
-                            {
-                                _logger.LogDebug(ex, "Deferred link setup failed for node {NodeId}", nodeId);
-                            }
-                        }, captureCt);
-
-                        return generator;
-                    }
-
-                    // Capture failed immediately
-                    _logger.LogDebug("Capture exited early (attempt {Attempt}/{Max})", attempt, maxRetries);
-                    StopCaptureSubprocess();
-                }
-                catch (OperationCanceledException) { throw; }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, "BT capture attempt {Attempt} failed", attempt);
-                }
-
-                if (attempt < maxRetries)
-                {
-                    await Task.Delay(retryDelayMs, cancellationToken);
-                }
-            }
-
-            _logger.LogWarning("BT capture device not accessible after {MaxRetries} attempts", maxRetries);
-            _metricsCollector?.Increment("bluetooth.audio_capture_errors");
-            return null;
-        }
-
-        /// <summary>
-        /// Queries PipeWire for a bluez_input node matching the given BT address.
-        /// Returns (nodeName, pipeWireId) or (null, 0) if not found.
-        /// </summary>
-        private async Task<(string? NodeName, int PipeWireId, int PipeWireSerial)> FindPipeWireBluetoothNodeAsync(
-            string btAddress, CancellationToken cancellationToken)
-        {
-            // PipeWire names use underscores: "D4:3A:2C:64:87:9E" → "D4_3A_2C_64_87_9E"
-            var addressUnderscored = btAddress.Replace(':', '_');
-            var prefix = $"bluez_input.{addressUnderscored}";
-
-            try
-            {
-                var psi = new ProcessStartInfo
-                {
-                    FileName = "pw-cli",
-                    Arguments = "list-objects",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-
-                using var process = Process.Start(psi);
-                if (process == null)
-                {
-                    _logger.LogWarning("Failed to start pw-cli process");
-                    return (null, 0, 0);
-                }
-
-                var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-                var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
-                await process.WaitForExitAsync(cancellationToken);
-
-                if (process.ExitCode != 0 || output.Length == 0)
-                {
-                    _logger.LogDebug("pw-cli exit={ExitCode}, stdout={StdoutLen}b, stderr={Stderr}",
-                        process.ExitCode, output.Length,
-                        stderr.Length > 200 ? stderr[..200] : stderr.TrimEnd());
-                    return (null, 0, 0);
-                }
-
-                var result = ParsePwCliOutputForBtNode(output, prefix);
-
-                if (result.NodeName == null)
-                    _logger.LogDebug("pw-cli returned {Lines} lines but no node matching {Prefix}",
-                        output.Split('\n').Length, prefix);
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to query PipeWire for BT node");
-            }
-
-            return (null, 0, 0);
-        }
-
-        /// <summary>
-        /// Parses pw-cli list-objects output to find a bluez_input node matching the given prefix.
-        /// Extracted as a static method for testability.
-        /// </summary>
-        /// <remarks>
-        /// In pw-cli output, object.serial typically appears BEFORE node.name within the same
-        /// object block. We track the serial as we go and return it when the node.name matches,
-        /// rather than looking forward. We reset state on ANY new "id" line (not just Nodes)
-        /// to prevent cross-object serial leakage (e.g., picking up a Device serial).
-        /// </remarks>
-        internal static (string? NodeName, int PipeWireId, int PipeWireSerial) ParsePwCliOutputForBtNode(
-            string pwCliOutput, string nodeNamePrefix)
-        {
-            var lines = pwCliOutput.Split('\n');
-            var lastNodeId = 0;
-            var lastNodeSerial = 0;
-            var isCurrentObjectANode = false;
-            string? matchedNodeName = null;
-            var matchedNodeId = 0;
-
-            foreach (var line in lines)
-            {
-                var trimmed = line.Trim();
-
-                // Any "id X, type ..." line starts a new object — reset tracking state
-                if (trimmed.StartsWith("id ") && trimmed.Contains(", type PipeWire:Interface:"))
-                {
-                    // Reset match state if we cross into a new object without finding serial
-                    if (matchedNodeName != null)
-                        return (matchedNodeName, matchedNodeId, 0);
-
-                    isCurrentObjectANode = trimmed.Contains(":Node/");
-                    if (isCurrentObjectANode)
-                    {
-                        var commaIdx = trimmed.IndexOf(',');
-                        if (commaIdx > 3 && int.TryParse(trimmed[3..commaIdx], out var id))
-                            lastNodeId = id;
-                        lastNodeSerial = 0;
-                    }
-                    else
-                    {
-                        // Non-Node object: reset node tracking to prevent leakage
-                        lastNodeSerial = 0;
-                    }
-                    continue;
-                }
-
-                // Track object.serial for the current Node object
-                if (isCurrentObjectANode && trimmed.StartsWith("object.serial = "))
-                {
-                    var start = trimmed.IndexOf('"') + 1;
-                    var end = trimmed.LastIndexOf('"');
-                    if (start > 0 && end > start && int.TryParse(trimmed[start..end], out var serial))
-                        lastNodeSerial = serial;
-                }
-
-                // Check for matching node.name
-                if (isCurrentObjectANode && trimmed.StartsWith("node.name = ") && trimmed.Contains(nodeNamePrefix))
-                {
-                    var start = trimmed.IndexOf('"') + 1;
-                    var end = trimmed.LastIndexOf('"');
-                    if (start > 0 && end > start)
-                    {
-                        matchedNodeName = trimmed[start..end];
-                        matchedNodeId = lastNodeId;
-                        // If we already have the serial (appeared before node.name), return now
-                        if (lastNodeSerial > 0)
-                            return (matchedNodeName, matchedNodeId, lastNodeSerial);
-                        // Otherwise keep scanning this object's properties for the serial
-                    }
-                }
-
-                // If we matched the name but serial came after, catch it here
-                if (matchedNodeName != null && trimmed.StartsWith("object.serial = "))
-                {
-                    var start = trimmed.IndexOf('"') + 1;
-                    var end = trimmed.LastIndexOf('"');
-                    if (start > 0 && end > start && int.TryParse(trimmed[start..end], out var serial))
-                        return (matchedNodeName, matchedNodeId, serial);
-                }
-            }
-
-            // If we found the node but not the serial, return with serial=0
-            if (matchedNodeName != null)
-                return (matchedNodeName, matchedNodeId, 0);
-
-            return (null, 0, 0);
-        }
-
-        // Note: SetPipeWireNodeVolumeAsync removed — PipeWire's bluez5 module manages
-        // node volume from AVRCP transport natively with cubic perceptual mapping.
-        // Previously we forced volume=1.0 here, which defeated AVRCP and required
-        // the entire auto-gain learning system. Now we let PipeWire handle it.
-
-        private void StartCaptureSubprocess(
-            BufferedSoundGenerator<float> generator, AudioFormat format, string targetNode,
-            int targetSerial = 0)
-        {
-            StopCaptureSubprocess();
-
-            _captureCts = new CancellationTokenSource();
-
-            // Pre-fill the buffer with silence before the stream starts delivering data.
-            generator.PreFillSilence(0.5f);
-
-            // Use PipeWire native stream instead of pw-record subprocess.
-            // The native stream connects directly to the target node via libpipewire,
-            // eliminating subprocess churn and pw-link management entirely.
-            var nodeId = (uint)(targetSerial > 0 ? targetSerial : 0);
-            try
-            {
-                _nativeStream = new PipeWireNativeStream(
-                    nodeId,
-                    format.SampleRate,
-                    format.Channels,
-                    (samples, count) => generator.AddSamples(samples.AsSpan(0, count)),
-                    _logger);
-                _nativeStream.Start();
-                _logger.LogInformation(
-                    "Started PipeWire native capture (target node serial {Serial}, node name {Node})",
-                    nodeId, targetNode);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "PipeWire native stream failed, falling back to pw-record subprocess");
-                _nativeStream?.Dispose();
-                _nativeStream = null;
-                StartCaptureSubprocessFallback(generator, format, targetNode, targetSerial);
-            }
-        }
-
-        /// <summary>
-        /// Fallback to pw-record subprocess if native stream fails (e.g. missing libpw_helper.so).
-        /// </summary>
-        private void StartCaptureSubprocessFallback(
-            BufferedSoundGenerator<float> generator, AudioFormat format, string targetNode,
-            int targetSerial = 0)
-        {
-            var ct = _captureCts!.Token;
-            var targetArg = targetSerial > 0 ? targetSerial.ToString() : targetNode;
-            _captureProcess = Process.Start(new ProcessStartInfo
-            {
-                FileName = "stdbuf",
-                Arguments = $"-o0 pw-record -P node.autoconnect=false --target {targetArg} --rate {format.SampleRate} --channels {format.Channels} --format s16 -",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            });
-
-            if (_captureProcess == null)
-            {
-                _logger.LogError("Failed to start pw-record subprocess");
-                return;
-            }
-
-            _logger.LogInformation("Started pw-record capture fallback (PID {Pid}, target {Node})",
-                _captureProcess.Id, targetNode);
-
-            _ = Task.Run(async () =>
-            {
-                const int readBufferSize = 48000 * 2 * 2 / 10;
-                var buffer = new byte[readBufferSize];
-                var stream = _captureProcess.StandardOutput.BaseStream;
-                var pendingByte = -1;
-
-                try
-                {
-                    while (!ct.IsCancellationRequested)
-                    {
-                        var offset = 0;
-                        if (pendingByte >= 0)
-                        {
-                            buffer[0] = (byte)pendingByte;
-                            offset = 1;
-                            pendingByte = -1;
-                        }
-
-                        var bytesRead = await stream.ReadAsync(buffer, offset, buffer.Length - offset, ct);
-                        if (bytesRead == 0) break;
-
-                        var totalBytes = offset + bytesRead;
-                        if (totalBytes % 2 != 0)
-                        {
-                            pendingByte = buffer[totalBytes - 1];
-                            totalBytes--;
-                        }
-                        if (totalBytes < 2) continue;
-
-                        var sampleCount = totalBytes / 2;
-                        var floatSamples = ArrayPool<float>.Shared.Rent(sampleCount);
-                        try
-                        {
-                            var shorts = MemoryMarshal.Cast<byte, short>(buffer.AsSpan(0, totalBytes));
-                            for (var i = 0; i < shorts.Length; i++)
-                                floatSamples[i] = shorts[i] / 32768f;
-                            generator.AddSamples(floatSamples.AsSpan(0, sampleCount));
-                        }
-                        finally
-                        {
-                            ArrayPool<float>.Shared.Return(floatSamples);
-                        }
-                    }
-                }
-                catch (OperationCanceledException) { }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "pw-record capture feed loop ended");
-                }
-            }, ct);
-        }
-
-        public void StopAudioCapture()
-        {
-            StopCaptureSubprocess();
-        }
-
-        private void StopCaptureSubprocess()
-        {
-            _captureCts?.Cancel();
-            _captureCts?.Dispose();
-            _captureCts = null;
-            _activeGenerator = null;
-
-            // Stop native PipeWire stream
-            if (_nativeStream != null)
-            {
-                try { _nativeStream.Dispose(); }
-                catch (Exception ex) { _logger.LogDebug(ex, "Error stopping native PipeWire stream"); }
-                _nativeStream = null;
-            }
-
-            // Stop pw-record fallback subprocess
-            if (_captureProcess != null)
-            {
-                try
-                {
-                    if (!_captureProcess.HasExited)
-                    {
-                        _captureProcess.Kill();
-                        _captureProcess.WaitForExit(2000);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, "Error stopping capture subprocess");
-                }
-                _captureProcess.Dispose();
-                _captureProcess = null;
-            }
-
-            // Disconnect PipeWire's auto-link from the BT input node to the default
-            // output sink. PipeWire/WirePlumber automatically links bluez_input to the
-            // default audio output, which bypasses our application entirely.
-            if (_activeNodeName != null)
-            {
-                DisconnectPipeWireBtAutoLinks(_activeNodeName);
-                _activeNodeName = null;
-            }
-        }
-
-        /// <summary>
-        /// Manually links pw-record's input ports to the BT node's output ports.
-        /// WirePlumber overrides pw-record's --target flag and links it to the default
-        /// audio source instead. This method: (1) disconnects any existing links to
-        /// pw-record inputs, (2) creates explicit links from the BT node outputs.
-        /// </summary>
-        private void LinkPipeWireRecordToBtNode(string btNodeName)
-        {
-            try
-            {
-                // Disconnect whatever WirePlumber linked to pw-record
-                RunPipeWireLinkCommand($"-d alsa_input.usb-Generic_USB_Microphone_IM20000001-00.analog-stereo:capture_FL pw-record:input_FL");
-                RunPipeWireLinkCommand($"-d alsa_input.usb-Generic_USB_Microphone_IM20000001-00.analog-stereo:capture_FR pw-record:input_FR");
-
-                // Also try disconnecting from any other source that WirePlumber might link
-                // (Built-in Audio, other USB devices, etc.) by querying current links
-                DisconnectAllLinksToPort("pw-record:input_FL");
-                DisconnectAllLinksToPort("pw-record:input_FR");
-
-                // Create explicit links from BT node to pw-record
-                RunPipeWireLinkCommand($"{btNodeName}:output_FL pw-record:input_FL");
-                RunPipeWireLinkCommand($"{btNodeName}:output_FR pw-record:input_FR");
-
-                _logger.LogInformation("Linked pw-record to BT node {BtNode}", btNodeName);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to link pw-record to BT node {BtNode}", btNodeName);
-            }
-        }
-
-        /// <summary>
-        /// Disconnects all links connected to the given input port.
-        /// </summary>
-        private void DisconnectAllLinksToPort(string inputPort)
-        {
-            try
-            {
-                var psi = new ProcessStartInfo
-                {
-                    FileName = "pw-link",
-                    Arguments = "-l",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-
-                using var process = Process.Start(psi);
-                if (process == null) return;
-                var output = process.StandardOutput.ReadToEnd();
-                process.WaitForExit(3000);
-
-                // Parse: "portname\n  |<- sourceport" format
-                var lines = output.Split('\n');
-                var inTargetPort = false;
-
-                foreach (var rawLine in lines)
-                {
-                    var line = rawLine.TrimEnd();
-
-                    if (line.TrimStart() == inputPort || line.Trim() == inputPort)
-                    {
-                        inTargetPort = true;
-                        continue;
-                    }
-
-                    if (!line.StartsWith("  ") && line.Length > 0)
-                    {
-                        inTargetPort = false;
-                        continue;
-                    }
-
-                    if (inTargetPort && line.Contains("|<-"))
-                    {
-                        var sourcePort = line[(line.IndexOf("|<-") + 4)..].Trim();
-                        RunPipeWireLinkCommand($"-d {sourcePort} {inputPort}");
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to disconnect links to {Port}", inputPort);
-            }
-        }
-
-        /// <summary>
-        /// Runs a pw-link command with the given arguments.
-        /// </summary>
-        private void RunPipeWireLinkCommand(string arguments)
-        {
-            try
-            {
-                using var process = Process.Start(new ProcessStartInfo
-                {
-                    FileName = "pw-link",
-                    Arguments = arguments,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                });
-                process?.WaitForExit(3000);
-            }
-            catch { /* ignore */ }
-        }
-
-        /// <summary>
-        /// Checks whether pw-record is currently linked to the specified BT node.
-        /// Returns false if pw-record inputs are linked to a different source or not linked at all.
-        /// </summary>
-        private bool IsPwRecordLinkedToBtNode(string btNodeName)
-        {
-            try
-            {
-                var psi = new ProcessStartInfo
-                {
-                    FileName = "pw-link",
-                    Arguments = "-l",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-
-                using var process = Process.Start(psi);
-                if (process == null) return true; // assume ok if we can't check
-                var output = process.StandardOutput.ReadToEnd();
-                process.WaitForExit(3000);
-
-                // Look for "pw-record:input_FL" section with "|<- btNodeName:output_FL"
-                var lines = output.Split('\n');
-                var inPwRecordFL = false;
-
-                foreach (var rawLine in lines)
-                {
-                    var line = rawLine.TrimEnd();
-                    if (line.Trim() == "pw-record:input_FL")
-                    {
-                        inPwRecordFL = true;
-                        continue;
-                    }
-                    if (inPwRecordFL)
-                    {
-                        if (line.Contains("|<-") && line.Contains(btNodeName))
-                            return true;
-                        if (!line.StartsWith("  ") && line.Length > 0)
-                            break; // moved to next port, didn't find our link
-                    }
-                }
-
-                return false;
-            }
-            catch
-            {
-                return true; // assume ok if we can't check
-            }
-        }
-
-        /// <summary>
-        /// Disconnects PipeWire's automatic links from a bluez_input node to the
-        /// default audio output sink, preventing BT audio from bypassing our mixer.
-        /// </summary>
-        private void DisconnectPipeWireBtAutoLinks(string btNodeName)
-        {
-            try
-            {
-                // Query current links and find ones from this BT node to any output sink
-                var psi = new ProcessStartInfo
-                {
-                    FileName = "pw-link",
-                    Arguments = "-l",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-
-                using var process = Process.Start(psi);
-                if (process == null) return;
-
-                var output = process.StandardOutput.ReadToEnd();
-                process.WaitForExit(3000);
-
-                // Parse links: find output ports of the BT node that connect to a sink
-                // Format: "  |-> alsa_output.xxx:playback_FL"
-                // We look for lines under the BT node's output ports
-                var lines = output.Split('\n');
-                var inBtNode = false;
-                string? currentBtPort = null;
-
-                foreach (var rawLine in lines)
-                {
-                    var line = rawLine.TrimEnd();
-
-                    // Detect BT node output port headers (no leading whitespace beyond node name)
-                    if (line.StartsWith(btNodeName + ":"))
-                    {
-                        inBtNode = true;
-                        currentBtPort = line.TrimEnd();
-                        continue;
-                    }
-
-                    // Lines under a different node reset the flag
-                    if (!line.StartsWith(" ") && line.Length > 0)
-                    {
-                        inBtNode = false;
-                        currentBtPort = null;
-                        continue;
-                    }
-
-                    // Under BT node, find links to output sinks
-                    if (inBtNode && currentBtPort != null && line.Contains("|->"))
-                    {
-                        var targetPort = line.Substring(line.IndexOf("|->") + 4).Trim();
-                        if (targetPort.StartsWith("alsa_output."))
-                        {
-                            // Disconnect this link
-                            DisconnectPipeWireLink(currentBtPort, targetPort);
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to disconnect PipeWire BT auto-links for {NodeName}", btNodeName);
-            }
-        }
-
-        /// <summary>
-        /// Disconnects a single PipeWire link between two ports.
-        /// </summary>
-        private void DisconnectPipeWireLink(string outputPort, string inputPort)
-        {
-            try
-            {
-                var psi = new ProcessStartInfo
-                {
-                    FileName = "pw-link",
-                    Arguments = $"-d \"{outputPort}\" \"{inputPort}\"",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-
-                using var process = Process.Start(psi);
-                if (process == null) return;
-
-                process.WaitForExit(3000);
-
-                _logger.LogInformation(
-                    "Disconnected PipeWire auto-link: {Output} -> {Input}",
-                    outputPort, inputPort);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to disconnect PipeWire link {Output} -> {Input}",
-                    outputPort, inputPort);
-            }
-        }
-
-        /// <summary>
-        /// Overrides the PipeWire node volume of the BT input node to 1.0 (full scale).
-        /// PipeWire's bluez5 module applies AVRCP volume with cubic mapping, which makes
-        /// BT audio significantly quieter than other sources. We normalize capture volume
-        /// here and control output level via our own master volume + per-source gain.
-        /// </summary>
-        private void NormalizeBtNodeVolume(int pipeWireNodeId)
-        {
-            try
-            {
-                var psi = new ProcessStartInfo
-                {
-                    FileName = "wpctl",
-                    Arguments = $"set-volume {pipeWireNodeId} 1.0",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-
-                using var process = Process.Start(psi);
-                if (process == null)
-                {
-                    _logger.LogWarning("Failed to start wpctl for BT volume normalization");
-                    return;
-                }
-
-                var stderr = process.StandardError.ReadToEnd();
-                process.WaitForExit(3000);
-
-                if (process.ExitCode == 0)
-                {
-                    _logger.LogInformation(
-                        "Normalized BT node volume to 1.0 (PipeWire id={NodeId})", pipeWireNodeId);
-                }
-                else
-                {
-                    _logger.LogWarning(
-                        "wpctl set-volume failed (exit={ExitCode}): {Stderr}",
-                        process.ExitCode, stderr.Trim());
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to normalize BT node volume (PipeWire id={NodeId})", pipeWireNodeId);
-            }
-        }
-
-        private static DeviceInfo? FindBluetoothCaptureDevice(DeviceInfo[] devices, string connectedName)
-        {
-            // Strategy 1: Match the bt_capture null sink monitor.
-            // PipeWire config creates a virtual null sink called "bt_capture" and
-            // WirePlumber routes bluez_input streams to it. The monitor source
-            // (bt_capture.monitor) appears as a capture device in PulseAudio/MiniAudio.
-            foreach (var device in devices)
-            {
-                if (device.Name != null && device.Name.Contains("bt_capture", StringComparison.OrdinalIgnoreCase))
-                    return device;
-            }
-
-            // Strategy 2: Match by "bluez" prefix (direct PipeWire Bluetooth source)
-            foreach (var device in devices)
-            {
-                if (device.Name != null && device.Name.Contains("bluez", StringComparison.OrdinalIgnoreCase))
-                    return device;
-            }
-
-            // Strategy 3: Match by connected device name
-            foreach (var device in devices)
-            {
-                if (device.Name != null && device.Name.Contains(connectedName, StringComparison.OrdinalIgnoreCase))
-                    return device;
-            }
-
-            // Strategy 4: Match by "bluetooth" keyword
-            foreach (var device in devices)
-            {
-                if (device.Name != null && device.Name.Contains("bluetooth", StringComparison.OrdinalIgnoreCase))
-                    return device;
-            }
-
-            return null;
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            _reconnectionLoop?.Dispose();
-            _reconnectionLoop = null;
-            _playerPropertiesWatcher?.Dispose();
-            _transportPropertiesWatcher?.Dispose();
-            _discoveryWatcher?.Dispose();
-            _nativeStream?.Dispose();
-            _nativeStream = null;
-            _captureEngine?.Dispose();
-            _captureEngine = null;
-            await UnregisterAgentAsync();
-            await StopAsync();
-            _connection?.Dispose();
-        }
-
-        private async Task RegisterAgentAsync()
-        {
-            if (_connection == null) return;
-
-            try
-            {
-                _agent = new Linux.BluezAgent(_logger, _options.AutoAcceptConnections, () =>
-                {
-                    var device = ConnectedDevice;
-                    return (device?.Address, device?.Name);
-                });
-
-                // Export the agent object on D-Bus so BlueZ can call its methods
-                await _connection.RegisterObjectAsync(_agent);
-
-                var agentManager = _connection.CreateProxy<Linux.IAgentManager1>(
-                    Linux.BluezConstants.ServiceName, "/org/bluez");
-
-                // "NoInputNoOutput" capability enables Just Works pairing (no PIN prompt)
-                await agentManager.RegisterAgentAsync(_agent.ObjectPath, "NoInputNoOutput");
-                await agentManager.RequestDefaultAgentAsync(_agent.ObjectPath);
-
-                _logger.LogInformation("Bluetooth pairing agent registered (auto-accept: {AutoAccept})",
-                    _options.AutoAcceptConnections);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to register Bluetooth pairing agent — pairing may require manual acceptance");
-            }
-        }
-
-        /// <summary>
-        /// Toggles adapter discoverability for single-device exclusivity.
-        /// Hidden when a device is connected (prevents other phones from seeing the radio),
-        /// shown again on disconnect so new devices can pair.
-        /// </summary>
-        private async Task SetDiscoverableAsync(bool discoverable)
-        {
-            if (_adapter == null) return;
-
-            try
-            {
-                await _adapter.SetAsync("Discoverable", discoverable);
-                _logger.LogInformation("Bluetooth adapter discoverable: {Discoverable}", discoverable);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to set adapter discoverable to {Discoverable}", discoverable);
-            }
-        }
-
-        private async Task UnregisterAgentAsync()
-        {
-            if (_connection == null || _agent == null) return;
-
-            try
-            {
-                var agentManager = _connection.CreateProxy<Linux.IAgentManager1>(
-                    Linux.BluezConstants.ServiceName, "/org/bluez");
-                await agentManager.UnregisterAgentAsync(_agent.ObjectPath);
-                _connection.UnregisterObject(_agent);
-                _agent = null;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to unregister Bluetooth agent (may already be unregistered)");
-            }
-        }
-
-        private async Task CheckForMediaPlayersAsync()
-        {
-            try
-            {
-                if (_objectManager == null) return;
-                var objects = await _objectManager.GetManagedObjectsAsync();
-                foreach (var obj in objects)
-                {
-                    if (obj.Value.ContainsKey(Linux.BluezConstants.MediaPlayerInterface) && _mediaPlayer == null)
-                    {
-                        await AttachMediaPlayerAsync(obj.Key);
-                    }
-
-                    if (obj.Value.ContainsKey(Linux.BluezConstants.MediaTransportInterface) && _mediaTransport == null)
-                    {
-                        await AttachMediaTransportAsync(obj.Key);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to check for existing media players/transports");
-            }
-        }
-
-        private async Task AttachMediaPlayerAsync(ObjectPath objectPath)
-        {
-            try
-            {
-                if (_connection == null) return;
-
-                // Thread-safe dedup — multiple concurrent InterfacesAdded callbacks
-                // can race into this method for the same player path
-                lock (_mediaPlayerLock)
-                {
-                    if (_mediaPlayerPath == objectPath && _mediaPlayer != null)
-                    {
-                        _logger.LogDebug("Already attached to media player at {Path}, skipping", objectPath);
-                        return;
-                    }
-
-                    _playerPropertiesWatcher?.Dispose();
-                    _mediaPlayerPath = objectPath;
-                }
-                _mediaPlayer = _connection.CreateProxy<Linux.IMediaPlayer1>(Linux.BluezConstants.ServiceName, objectPath);
-                
-                _playerPropertiesWatcher = await _mediaPlayer.WatchPropertiesAsync(OnPlayerPropertiesChanged);
-                
-                // Get initial state
-                try
-                {
-                    var status = await _mediaPlayer.GetAsync<string>("Status");
-                    UpdatePlaybackStatus(status);
-                    
-                    var track = await _mediaPlayer.GetAsync<IDictionary<string, object>>("Track");
-                    UpdateMetadata(track);
-                }
-                catch (Exception ex)
-                {
-                    // Properties might not be available yet
-                    _logger.LogDebug($"Failed to get initial player state: {ex.Message}");
-                }
-
-                _logger.LogInformation($"Attached to Media Player at {objectPath}");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Failed to attach media player at {objectPath}");
-            }
-        }
-
-        private async Task AttachMediaTransportAsync(ObjectPath objectPath)
-        {
-            try
-            {
-                if (_connection == null) return;
-
-                if (_mediaTransportPath == objectPath && _mediaTransport != null)
-                {
-                    _logger.LogDebug("Already attached to media transport at {Path}", objectPath);
-                    return;
-                }
-
-                _transportPropertiesWatcher?.Dispose();
-                _mediaTransportPath = objectPath;
-                _mediaTransport = _connection.CreateProxy<Linux.IMediaTransport1>(
-                    Linux.BluezConstants.ServiceName, objectPath);
-
-                _transportPropertiesWatcher = await _mediaTransport.WatchPropertiesAsync(OnTransportPropertiesChanged);
-
-                // Read initial volume
-                try
-                {
-                    var volume = await _mediaTransport.GetAsync<ushort>("Volume");
-                    var normalized = volume / 127f;
-                    DeviceVolume = normalized;
-                    _logger.LogDebug("Initial BT transport volume: {Raw}/127 ({Normalized:P0})", volume, normalized);
-                }
-                catch
-                {
-                    // Volume property might not be available
-                }
-
-                _logger.LogInformation("Attached to MediaTransport1 at {Path}", objectPath);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to attach media transport at {Path}", objectPath);
-            }
-        }
-
-        private void OnTransportPropertiesChanged(PropertyChanges changes)
-        {
-            foreach (var prop in changes.Changed)
-            {
-                if (prop.Key == "Volume" && prop.Value is ushort volume)
-                {
-                    var normalized = volume / 127f;
-                    DeviceVolume = normalized;
-                    VolumeChanged?.Invoke(this, new BluetoothVolumeChangedEventArgs { Volume = normalized });
-                    _logger.LogDebug("BT AVRCP volume changed: {Raw}/127 ({Normalized:P0})", volume, normalized);
-                }
-            }
-        }
-
-        private void OnPlayerPropertiesChanged(PropertyChanges changes)
-        {
-            foreach (var prop in changes.Changed)
-            {
-                switch (prop.Key)
-                {
-                    case "Status":
-                        UpdatePlaybackStatus(prop.Value as string);
-                        break;
-                    case "Track":
-                         if (prop.Value is IDictionary<string, object> track)
-                         {
-                             UpdateMetadata(track);
-                         }
-                        break;
-                    case "Position":
-                         if (prop.Value is uint pos)
-                         {
-                             PositionChanged?.Invoke(this, TimeSpan.FromMilliseconds(pos));
-                         }
-                        break;
-                }
-            }
-        }
-
-        private void UpdatePlaybackStatus(string? statusStr)
-        {
-            if (string.IsNullOrEmpty(statusStr)) return;
-            
-            var status = statusStr.ToLower() switch
-            {
-                "playing" => BluetoothPlaybackStatus.Playing,
-                "paused" => BluetoothPlaybackStatus.Paused,
-                "stopped" => BluetoothPlaybackStatus.Stopped,
-                "forward-seek" => BluetoothPlaybackStatus.ForwardSeek,
-                "reverse-seek" => BluetoothPlaybackStatus.ReverseSeek,
-                "error" => BluetoothPlaybackStatus.Error,
-                _ => BluetoothPlaybackStatus.Stopped
-            };
-            
-            PlaybackStatusChanged?.Invoke(this, status);
-        }
-
-        private void UpdateMetadata(IDictionary<string, object> track)
-        {
-            if (track == null) return;
-
-            // MPRIS/BlueZ exposes album art via "ArtUrl" or "mpris:artUrl"
-            var artUrl = GetString(track, "ArtUrl");
-            if (string.IsNullOrEmpty(artUrl))
-            {
-                artUrl = GetString(track, "mpris:artUrl");
-            }
-
-            var meta = new BluetoothPlaybackMetadata
-            {
-                Title = GetString(track, "Title"),
-                Artist = GetString(track, "Artist"),
-                Album = GetString(track, "Album"),
-                Duration = track.ContainsKey("Duration")
-                    ? TimeSpan.FromMilliseconds(Convert.ToUInt32(track["Duration"]))
-                    : TimeSpan.Zero,
-                AlbumArtUrl = string.IsNullOrEmpty(artUrl) ? null : artUrl
+              Address = deviceInfo.Address,
+              Name = deviceInfo.Name,
+              IsPaired = deviceInfo.IsPaired,
+              IsConnected = connected
             };
 
-            _logger.LogDebug("AVRCP metadata: {Title} by {Artist} (album: {Album}, art: {HasArt})",
-                meta.Title, meta.Artist, meta.Album, !string.IsNullOrEmpty(meta.AlbumArtUrl));
-
-            MetadataChanged?.Invoke(this, meta);
-        }
-
-        private string GetString(IDictionary<string, object> dict, string key)
-        {
-            if (dict.TryGetValue(key, out var val) && val is string s)
+            lock (_deviceCache)
             {
-                return s;
+              _deviceCache[devicePath] = updatedDevice;
             }
-            return string.Empty;
+
+            if (connected)
+            {
+              _reconnectionLoop?.Cancel();
+              _connectionStartTime = DateTime.UtcNow;
+              _metricsCollector?.Increment("bluetooth.devices_connected_total");
+              _metricsCollector?.Gauge("bluetooth.active_connections", 1);
+              _logger.LogInformation("Bluetooth device connected: {DeviceName} ({Address})",
+                updatedDevice.Name, updatedDevice.Address);
+
+              // Hide adapter from other devices while one is connected
+              _ = SetDiscoverableAsync(false);
+
+              DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = updatedDevice });
+            }
+            else
+            {
+              var wasUserInitiated = _userInitiatedDisconnect;
+              _userInitiatedDisconnect = false;
+
+              RecordDisconnectionMetrics();
+              StopCaptureSubprocess();
+              // Clean up media transport on disconnect
+              _transportPropertiesWatcher?.Dispose();
+              _transportPropertiesWatcher = null;
+              _mediaTransport = null;
+              _mediaTransportPath = null;
+              DeviceVolume = null;
+
+              _logger.LogInformation("Bluetooth device disconnected: {DeviceName} ({Address}) (user-initiated: {UserInitiated})",
+                updatedDevice.Name, updatedDevice.Address, wasUserInitiated);
+
+              // Re-show adapter so other devices can discover and pair
+              _ = SetDiscoverableAsync(true);
+
+              DeviceDisconnected?.Invoke(this, new BluetoothDeviceDisconnectedEventArgs
+              {
+                Device = updatedDevice,
+                UserInitiated = wasUserInitiated
+              });
+
+              // Start auto-reconnection for unexpected disconnects
+              if (!wasUserInitiated && _options.AutoReconnect)
+              {
+                _reconnectionLoop?.Dispose();
+                _reconnectionLoop = new BluetoothReconnectionLoop(
+                  _logger, _options,
+                  (addr, ct) => ConnectAsync(addr, ct),
+                  () => ConnectedDevice != null,
+                  _metricsCollector);
+                _reconnectionLoop.Start(updatedDevice.Address);
+              }
+            }
+          }
         }
+      });
     }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Failed to watch device properties at {Path}", devicePath);
+    }
+  }
+
+  private void RecordDisconnectionMetrics()
+  {
+    _metricsCollector?.Increment("bluetooth.devices_disconnected_total");
+    _metricsCollector?.Gauge("bluetooth.active_connections", 0);
+    if (_connectionStartTime.HasValue)
+    {
+      var duration = (DateTime.UtcNow - _connectionStartTime.Value).TotalSeconds;
+      _metricsCollector?.Gauge("bluetooth.connection_duration_seconds", duration);
+      _connectionStartTime = null;
+    }
+  }
+
+  private BluetoothDeviceInfo ParseDevice(ObjectPath path, IDictionary<string, object> props)
+  {
+    return new BluetoothDeviceInfo
+    {
+      Address = props.ContainsKey("Address") ? (string)props["Address"] : "Unknown",
+      Name = props.ContainsKey("Name") ? (string)props["Name"] : (props.ContainsKey("Alias") ? (string)props["Alias"] : "Unknown Device"),
+      IsPaired = props.ContainsKey("Paired") && (bool)props["Paired"],
+      IsConnected = props.ContainsKey("Connected") && (bool)props["Connected"]
+    };
+  }
+
+  public async Task<bool> PairDeviceAsync(string deviceAddress, CancellationToken cancellationToken = default)
+  {
+    if (_connection == null || _objectManager == null)
+    {
+      _logger.LogWarning("Cannot pair: Bluetooth service not started");
+      return false;
+    }
+
+    try
+    {
+      var devicePath = FindDevicePath(deviceAddress);
+      if (devicePath == null)
+      {
+        _logger.LogWarning("Device {Address} not found for pairing", deviceAddress);
+        return false;
+      }
+
+      var device = _connection.CreateProxy<Linux.IDevice1>(
+        Linux.BluezConstants.ServiceName, devicePath.Value);
+      await device.PairAsync();
+      _metricsCollector?.Increment("bluetooth.pair_attempts", 1.0,
+        new Dictionary<string, string> { { "result", "success" } });
+      _logger.LogInformation("Paired with device {Address}", deviceAddress);
+      return true;
+    }
+    catch (Exception ex)
+    {
+      _metricsCollector?.Increment("bluetooth.pair_attempts", 1.0,
+        new Dictionary<string, string> { { "result", "failure" } });
+      _logger.LogError(ex, "Failed to pair with device {Address}", deviceAddress);
+      return false;
+    }
+  }
+
+  public async Task<bool> UnpairDeviceAsync(string deviceAddress, CancellationToken cancellationToken = default)
+  {
+    if (_connection == null || _adapter == null)
+    {
+      _logger.LogWarning("Cannot unpair: Bluetooth service not started");
+      return false;
+    }
+
+    try
+    {
+      var devicePath = FindDevicePath(deviceAddress);
+      if (devicePath == null)
+      {
+        _logger.LogWarning("Device {Address} not found for unpairing", deviceAddress);
+        return false;
+      }
+
+      await _adapter.RemoveDeviceAsync(devicePath.Value);
+      lock (_deviceCache)
+      {
+        _deviceCache.Remove(devicePath.Value);
+      }
+      _logger.LogInformation("Unpaired device {Address}", deviceAddress);
+      return true;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to unpair device {Address}", deviceAddress);
+      return false;
+    }
+  }
+
+  public Task<bool> AcceptConnectionAsync(string deviceAddress, CancellationToken cancellationToken = default)
+  {
+    // BlueZ handles incoming connections automatically if Pairable is true
+    return Task.FromResult(true);
+  }
+
+  public async Task<bool> ConnectAsync(string deviceAddress, CancellationToken cancellationToken = default)
+  {
+    if (_connection == null)
+    {
+      _logger.LogWarning("Cannot connect: Bluetooth service not started");
+      return false;
+    }
+
+    try
+    {
+      var devicePath = FindDevicePath(deviceAddress);
+      if (devicePath == null)
+      {
+        _logger.LogWarning("Device {Address} not found for connection", deviceAddress);
+        return false;
+      }
+
+      var device = _connection.CreateProxy<Linux.IDevice1>(
+        Linux.BluezConstants.ServiceName, devicePath.Value);
+
+      // BlueZ Connect() blocks for 30-60s when device is unreachable.
+      // Use a 15s timeout so the reconnection backoff loop can progress.
+      using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+      timeoutCts.CancelAfter(TimeSpan.FromSeconds(15));
+
+      await device.ConnectAsync().WaitAsync(timeoutCts.Token);
+      _logger.LogInformation("Initiated connection to device {Address}", deviceAddress);
+      return true;
+    }
+    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+    {
+      _logger.LogDebug("Connect to {Address} timed out after 15s", deviceAddress);
+      return false;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Failed to connect to device {Address}", deviceAddress);
+      return false;
+    }
+  }
+
+  public async Task DisconnectAsync(CancellationToken cancellationToken = default)
+  {
+    var connected = ConnectedDevice;
+    if (connected == null || _connection == null)
+    {
+      return;
+    }
+
+    _userInitiatedDisconnect = true;
+    _reconnectionLoop?.Cancel();
+
+    try
+    {
+      var devicePath = FindDevicePath(connected.Address);
+      if (devicePath != null)
+      {
+        var device = _connection.CreateProxy<Linux.IDevice1>(
+          Linux.BluezConstants.ServiceName, devicePath.Value);
+        await device.DisconnectAsync();
+        _logger.LogInformation("Disconnected device {DeviceName} ({Address})",
+          connected.Name, connected.Address);
+      }
+    }
+    catch (Exception ex)
+    {
+      _userInitiatedDisconnect = false; // reset on failure to prevent suppressing future reconnects
+      _logger.LogError(ex, "Failed to disconnect device {Address}", connected.Address);
+    }
+  }
+
+  public async Task DisconnectAsync(string deviceAddress, CancellationToken cancellationToken = default)
+  {
+    if (_connection == null)
+    {
+      return;
+    }
+
+    // Only suppress auto-reconnect when disconnecting the active device.
+    // Disconnecting a paired-but-not-active device won't fire a Connected
+    // property-change event, so the flag would never be consumed/reset —
+    // permanently suppressing auto-reconnect.
+    var isActiveDevice = ConnectedDevice?.Address?.Equals(deviceAddress, StringComparison.OrdinalIgnoreCase) == true;
+    if (isActiveDevice)
+    {
+      _userInitiatedDisconnect = true;
+      _reconnectionLoop?.Cancel();
+    }
+
+    try
+    {
+      var devicePath = FindDevicePath(deviceAddress);
+      if (devicePath != null)
+      {
+        var device = _connection.CreateProxy<Linux.IDevice1>(
+          Linux.BluezConstants.ServiceName, devicePath.Value);
+        await device.DisconnectAsync();
+        _logger.LogInformation("Disconnected device {Address}", deviceAddress);
+      }
+    }
+    catch (Exception ex)
+    {
+      if (isActiveDevice)
+      {
+        _userInitiatedDisconnect = false; // reset on failure to prevent suppressing future reconnects
+      }
+      _logger.LogError(ex, "Failed to disconnect device {Address}", deviceAddress);
+    }
+  }
+
+  private ObjectPath? FindDevicePath(string deviceAddress)
+  {
+    var normalizedAddress = deviceAddress.Replace(":", "_").ToUpperInvariant();
+    lock (_deviceCache)
+    {
+      foreach (var kvp in _deviceCache)
+      {
+        if (kvp.Value.Address.Replace(":", "_").Equals(normalizedAddress, StringComparison.OrdinalIgnoreCase)
+          || kvp.Value.Address.Equals(deviceAddress, StringComparison.OrdinalIgnoreCase))
+        {
+          return kvp.Key;
+        }
+      }
+    }
+    return null;
+  }
+
+  public async Task<object?> GetAudioCaptureDeviceAsync(CancellationToken cancellationToken = default)
+  {
+    var connected = ConnectedDevice;
+    if (connected == null)
+    {
+      _logger.LogWarning("No connected Bluetooth device — cannot create audio capture");
+      return null;
+    }
+
+    // If native stream or capture subprocess is already running, return cached generator
+    if (_nativeStream != null && _activeGenerator != null)
+    {
+      _logger.LogDebug("Returning existing capture generator (native stream)");
+      return _activeGenerator;
+    }
+    if (_captureProcess != null && !_captureProcess.HasExited && _activeGenerator != null)
+    {
+      _logger.LogDebug("Returning existing capture generator (PID {Pid})", _captureProcess.Id);
+      return _activeGenerator;
+    }
+
+    // Wait for any concurrent search to complete (with timeout instead of zero-wait).
+    // Multiple callers race here: TryAcquireAudioCaptureAsync (from DeviceConnected event)
+    // and InitializeAsync (from auto-switch). Second caller should wait and get cached result.
+    if (!await _captureDeviceLock.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken))
+    {
+      _logger.LogWarning("Timeout waiting for capture device lock");
+      return null;
+    }
+
+    try
+    {
+      // Re-check after acquiring lock — another caller may have completed
+      if (_nativeStream != null && _activeGenerator != null)
+      {
+        _logger.LogDebug("Capture already active after lock wait (native stream)");
+        return _activeGenerator;
+      }
+      if (_captureProcess != null && !_captureProcess.HasExited && _activeGenerator != null)
+      {
+        _logger.LogDebug("Capture already active after lock wait (PID {Pid})", _captureProcess.Id);
+        return _activeGenerator;
+      }
+
+      return await SearchForCaptureDeviceAsync(connected, cancellationToken);
+    }
+    finally
+    {
+      _captureDeviceLock.Release();
+    }
+  }
+
+  private async Task<object?> SearchForCaptureDeviceAsync(
+    BluetoothDeviceInfo connected, CancellationToken cancellationToken)
+  {
+    // Cleanup previous capture
+    StopCaptureSubprocess();
+    _captureEngine?.Dispose();
+    _captureEngine = null;
+
+    if (_playbackService == null)
+    {
+      _logger.LogError("SoundFlowPlaybackService not available — cannot create BT capture bridge");
+      return null;
+    }
+
+    var engine = _playbackService.GetUnderlyingEngine();
+    var format = _playbackService.GetAudioFormat();
+    if (engine == null)
+    {
+      _logger.LogError("SoundFlow engine not available — cannot create BT capture bridge");
+      return null;
+    }
+
+    // Use pw-record to capture directly from the PipeWire bluez input node.
+    // PipeWire creates a node named "bluez_input.<ADDRESS>.<N>" when a BT A2DP
+    // source connects. pw-record --target captures from it directly — no ALSA
+    // bridge, .asoundrc, or null sink configuration needed.
+    const int maxRetries = 20;
+    const int retryDelayMs = 1000;
+
+    for (var attempt = 1; attempt <= maxRetries; attempt++)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+
+      if (ConnectedDevice == null)
+      {
+        _logger.LogWarning("Bluetooth device disconnected during capture device polling");
+        return null;
+      }
+
+      try
+      {
+        // Find the PipeWire node name for this BT device
+        var (nodeName, nodeId, nodeSerial) = await FindPipeWireBluetoothNodeAsync(connected.Address, cancellationToken);
+        if (nodeName == null)
+        {
+          _logger.LogDebug("PipeWire BT node not found for {Address} (attempt {Attempt}/{Max})",
+            connected.Address, attempt, maxRetries);
+          if (attempt < maxRetries)
+          {
+            await Task.Delay(retryDelayMs, cancellationToken);
+          }
+          continue;
+        }
+
+        _logger.LogInformation("Found PipeWire BT node: {Node} (id={NodeId}, serial={Serial}, attempt {Attempt})",
+          nodeName, nodeId, nodeSerial, attempt);
+
+        var generator = new BufferedSoundGenerator<float>(
+          engine, format, _logger, maxBufferSeconds: 4.0f,
+          metricsCollector: _metricsCollector);
+
+        StartCaptureSubprocess(generator, format, nodeName, nodeSerial);
+
+        // Give the stream a moment to connect
+        await Task.Delay(500, cancellationToken);
+
+        // Check if native stream or fallback process is running
+        var isRunning = _nativeStream != null ||
+          (_captureProcess != null && !_captureProcess.HasExited);
+
+        if (isRunning)
+        {
+          _logger.LogInformation(
+            "BT capture running (attempt {Attempt}/{Max}, mode={Mode}, target {Node})",
+            attempt, maxRetries,
+            _nativeStream != null ? "native" : "pw-record",
+            nodeName);
+          _activeGenerator = generator;
+          _activeNodeName = nodeName;
+
+          // Deferred task: disconnect auto-links and normalize volume
+          // after PipeWire settles.
+          var captureCt = _captureCts!.Token;
+          var capturedNodeName = nodeName;
+          var capturedNodeId = nodeId;
+          _ = Task.Run(async () =>
+          {
+            try
+            {
+              await Task.Delay(1500, captureCt);
+
+              // Disconnect PipeWire/WirePlumber auto-links from
+              // bluez_input → default sink. Without this, BT audio
+              // plays through both our pipeline AND directly to
+              // speakers, causing an out-of-sync duplicate.
+              DisconnectPipeWireBtAutoLinks(capturedNodeName);
+
+              // Override PipeWire's AVRCP-managed node volume to 1.0.
+              // PipeWire's bluez5 module applies cubic mapping from phone
+              // AVRCP volume, making BT audio ~30% quieter than other sources.
+              // We normalize the capture level here and control volume via
+              // our own master volume and per-source gain instead.
+              NormalizeBtNodeVolume(capturedNodeId);
+
+              // For fallback pw-record mode, also do link management
+              if (_nativeStream == null && _captureProcess != null)
+              {
+                LinkPipeWireRecordToBtNode(capturedNodeName);
+              }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+              _logger.LogDebug(ex, "Deferred link setup failed for node {NodeId}", nodeId);
+            }
+          }, captureCt);
+
+          return generator;
+        }
+
+        // Capture failed immediately
+        _logger.LogDebug("Capture exited early (attempt {Attempt}/{Max})", attempt, maxRetries);
+        StopCaptureSubprocess();
+      }
+      catch (OperationCanceledException) { throw; }
+      catch (Exception ex)
+      {
+        _logger.LogDebug(ex, "BT capture attempt {Attempt} failed", attempt);
+      }
+
+      if (attempt < maxRetries)
+      {
+        await Task.Delay(retryDelayMs, cancellationToken);
+      }
+    }
+
+    _logger.LogWarning("BT capture device not accessible after {MaxRetries} attempts", maxRetries);
+    _metricsCollector?.Increment("bluetooth.audio_capture_errors");
+    return null;
+  }
+
+  /// <summary>
+  /// Queries PipeWire for a bluez_input node matching the given BT address.
+  /// Returns (nodeName, pipeWireId) or (null, 0) if not found.
+  /// </summary>
+  private async Task<(string? NodeName, int PipeWireId, int PipeWireSerial)> FindPipeWireBluetoothNodeAsync(
+    string btAddress, CancellationToken cancellationToken)
+  {
+    // PipeWire names use underscores: "D4:3A:2C:64:87:9E" → "D4_3A_2C_64_87_9E"
+    var addressUnderscored = btAddress.Replace(':', '_');
+    var prefix = $"bluez_input.{addressUnderscored}";
+
+    try
+    {
+      var psi = new ProcessStartInfo
+      {
+        FileName = "pw-cli",
+        Arguments = "list-objects",
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+      };
+
+      using var process = Process.Start(psi);
+      if (process == null)
+      {
+        _logger.LogWarning("Failed to start pw-cli process");
+        return (null, 0, 0);
+      }
+
+      var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+      var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
+      await process.WaitForExitAsync(cancellationToken);
+
+      if (process.ExitCode != 0 || output.Length == 0)
+      {
+        _logger.LogDebug("pw-cli exit={ExitCode}, stdout={StdoutLen}b, stderr={Stderr}",
+          process.ExitCode, output.Length,
+          stderr.Length > 200 ? stderr[..200] : stderr.TrimEnd());
+        return (null, 0, 0);
+      }
+
+      var result = ParsePwCliOutputForBtNode(output, prefix);
+
+      if (result.NodeName == null)
+      {
+        _logger.LogDebug("pw-cli returned {Lines} lines but no node matching {Prefix}",
+          output.Split('\n').Length, prefix);
+      }
+
+      return result;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to query PipeWire for BT node");
+    }
+
+    return (null, 0, 0);
+  }
+
+  /// <summary>
+  /// Parses pw-cli list-objects output to find a bluez_input node matching the given prefix.
+  /// Extracted as a static method for testability.
+  /// </summary>
+  /// <remarks>
+  /// In pw-cli output, object.serial typically appears BEFORE node.name within the same
+  /// object block. We track the serial as we go and return it when the node.name matches,
+  /// rather than looking forward. We reset state on ANY new "id" line (not just Nodes)
+  /// to prevent cross-object serial leakage (e.g., picking up a Device serial).
+  /// </remarks>
+  internal static (string? NodeName, int PipeWireId, int PipeWireSerial) ParsePwCliOutputForBtNode(
+    string pwCliOutput, string nodeNamePrefix)
+  {
+    var lines = pwCliOutput.Split('\n');
+    var lastNodeId = 0;
+    var lastNodeSerial = 0;
+    var isCurrentObjectANode = false;
+    string? matchedNodeName = null;
+    var matchedNodeId = 0;
+
+    foreach (var line in lines)
+    {
+      var trimmed = line.Trim();
+
+      // Any "id X, type ..." line starts a new object — reset tracking state
+      if (trimmed.StartsWith("id ") && trimmed.Contains(", type PipeWire:Interface:"))
+      {
+        // Reset match state if we cross into a new object without finding serial
+        if (matchedNodeName != null)
+        {
+          return (matchedNodeName, matchedNodeId, 0);
+        }
+
+        isCurrentObjectANode = trimmed.Contains(":Node/");
+        if (isCurrentObjectANode)
+        {
+          var commaIdx = trimmed.IndexOf(',');
+          if (commaIdx > 3 && int.TryParse(trimmed[3..commaIdx], out var id))
+          {
+            lastNodeId = id;
+          }
+          lastNodeSerial = 0;
+        }
+        else
+        {
+          // Non-Node object: reset node tracking to prevent leakage
+          lastNodeSerial = 0;
+        }
+        continue;
+      }
+
+      // Track object.serial for the current Node object
+      if (isCurrentObjectANode && trimmed.StartsWith("object.serial = "))
+      {
+        var start = trimmed.IndexOf('"') + 1;
+        var end = trimmed.LastIndexOf('"');
+        if (start > 0 && end > start && int.TryParse(trimmed[start..end], out var serial))
+        {
+          lastNodeSerial = serial;
+        }
+      }
+
+      // Check for matching node.name
+      if (isCurrentObjectANode && trimmed.StartsWith("node.name = ") && trimmed.Contains(nodeNamePrefix))
+      {
+        var start = trimmed.IndexOf('"') + 1;
+        var end = trimmed.LastIndexOf('"');
+        if (start > 0 && end > start)
+        {
+          matchedNodeName = trimmed[start..end];
+          matchedNodeId = lastNodeId;
+          // If we already have the serial (appeared before node.name), return now
+          if (lastNodeSerial > 0)
+          {
+            return (matchedNodeName, matchedNodeId, lastNodeSerial);
+          }
+          // Otherwise keep scanning this object's properties for the serial
+        }
+      }
+
+      // If we matched the name but serial came after, catch it here
+      if (matchedNodeName != null && trimmed.StartsWith("object.serial = "))
+      {
+        var start = trimmed.IndexOf('"') + 1;
+        var end = trimmed.LastIndexOf('"');
+        if (start > 0 && end > start && int.TryParse(trimmed[start..end], out var serial))
+        {
+          return (matchedNodeName, matchedNodeId, serial);
+        }
+      }
+    }
+
+    // If we found the node but not the serial, return with serial=0
+    if (matchedNodeName != null)
+    {
+      return (matchedNodeName, matchedNodeId, 0);
+    }
+
+    return (null, 0, 0);
+  }
+
+  // Note: SetPipeWireNodeVolumeAsync removed — PipeWire's bluez5 module manages
+  // node volume from AVRCP transport natively with cubic perceptual mapping.
+  // Previously we forced volume=1.0 here, which defeated AVRCP and required
+  // the entire auto-gain learning system. Now we let PipeWire handle it.
+
+  private void StartCaptureSubprocess(
+    BufferedSoundGenerator<float> generator, AudioFormat format, string targetNode,
+    int targetSerial = 0)
+  {
+    StopCaptureSubprocess();
+
+    _captureCts = new CancellationTokenSource();
+
+    // Pre-fill the buffer with silence before the stream starts delivering data.
+    generator.PreFillSilence(0.5f);
+
+    // Use PipeWire native stream instead of pw-record subprocess.
+    // The native stream connects directly to the target node via libpipewire,
+    // eliminating subprocess churn and pw-link management entirely.
+    var nodeId = (uint)(targetSerial > 0 ? targetSerial : 0);
+    try
+    {
+      _nativeStream = new PipeWireNativeStream(
+        nodeId,
+        format.SampleRate,
+        format.Channels,
+        (samples, count) => generator.AddSamples(samples.AsSpan(0, count)),
+        _logger);
+      _nativeStream.Start();
+      _logger.LogInformation(
+        "Started PipeWire native capture (target node serial {Serial}, node name {Node})",
+        nodeId, targetNode);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "PipeWire native stream failed, falling back to pw-record subprocess");
+      _nativeStream?.Dispose();
+      _nativeStream = null;
+      StartCaptureSubprocessFallback(generator, format, targetNode, targetSerial);
+    }
+  }
+
+  /// <summary>
+  /// Fallback to pw-record subprocess if native stream fails (e.g. missing libpw_helper.so).
+  /// </summary>
+  private void StartCaptureSubprocessFallback(
+    BufferedSoundGenerator<float> generator, AudioFormat format, string targetNode,
+    int targetSerial = 0)
+  {
+    var ct = _captureCts!.Token;
+    var targetArg = targetSerial > 0 ? targetSerial.ToString() : targetNode;
+    _captureProcess = Process.Start(new ProcessStartInfo
+    {
+      FileName = "stdbuf",
+      Arguments = $"-o0 pw-record -P node.autoconnect=false --target {targetArg} --rate {format.SampleRate} --channels {format.Channels} --format s16 -",
+      RedirectStandardOutput = true,
+      RedirectStandardError = true,
+      UseShellExecute = false,
+      CreateNoWindow = true
+    });
+
+    if (_captureProcess == null)
+    {
+      _logger.LogError("Failed to start pw-record subprocess");
+      return;
+    }
+
+    _logger.LogInformation("Started pw-record capture fallback (PID {Pid}, target {Node})",
+      _captureProcess.Id, targetNode);
+
+    _ = Task.Run(async () =>
+    {
+      const int readBufferSize = 48000 * 2 * 2 / 10;
+      var buffer = new byte[readBufferSize];
+      var stream = _captureProcess.StandardOutput.BaseStream;
+      var pendingByte = -1;
+
+      try
+      {
+        while (!ct.IsCancellationRequested)
+        {
+          var offset = 0;
+          if (pendingByte >= 0)
+          {
+            buffer[0] = (byte)pendingByte;
+            offset = 1;
+            pendingByte = -1;
+          }
+
+          var bytesRead = await stream.ReadAsync(buffer, offset, buffer.Length - offset, ct);
+          if (bytesRead == 0)
+          {
+            break;
+          }
+
+          var totalBytes = offset + bytesRead;
+          if (totalBytes % 2 != 0)
+          {
+            pendingByte = buffer[totalBytes - 1];
+            totalBytes--;
+          }
+          if (totalBytes < 2)
+          {
+            continue;
+          }
+
+          var sampleCount = totalBytes / 2;
+          var floatSamples = ArrayPool<float>.Shared.Rent(sampleCount);
+          try
+          {
+            var shorts = MemoryMarshal.Cast<byte, short>(buffer.AsSpan(0, totalBytes));
+            for (var i = 0; i < shorts.Length; i++)
+            {
+              floatSamples[i] = shorts[i] / 32768f;
+            }
+            generator.AddSamples(floatSamples.AsSpan(0, sampleCount));
+          }
+          finally
+          {
+            ArrayPool<float>.Shared.Return(floatSamples);
+          }
+        }
+      }
+      catch (OperationCanceledException) { }
+      catch (Exception ex)
+      {
+        _logger.LogWarning(ex, "pw-record capture feed loop ended");
+      }
+    }, ct);
+  }
+
+  public void StopAudioCapture()
+  {
+    StopCaptureSubprocess();
+  }
+
+  private void StopCaptureSubprocess()
+  {
+    _captureCts?.Cancel();
+    _captureCts?.Dispose();
+    _captureCts = null;
+    _activeGenerator = null;
+
+    // Stop native PipeWire stream
+    if (_nativeStream != null)
+    {
+      try { _nativeStream.Dispose(); }
+      catch (Exception ex) { _logger.LogDebug(ex, "Error stopping native PipeWire stream"); }
+      _nativeStream = null;
+    }
+
+    // Stop pw-record fallback subprocess
+    if (_captureProcess != null)
+    {
+      try
+      {
+        if (!_captureProcess.HasExited)
+        {
+          _captureProcess.Kill();
+          _captureProcess.WaitForExit(2000);
+        }
+      }
+      catch (Exception ex)
+      {
+        _logger.LogDebug(ex, "Error stopping capture subprocess");
+      }
+      _captureProcess.Dispose();
+      _captureProcess = null;
+    }
+
+    // Disconnect PipeWire's auto-link from the BT input node to the default
+    // output sink. PipeWire/WirePlumber automatically links bluez_input to the
+    // default audio output, which bypasses our application entirely.
+    if (_activeNodeName != null)
+    {
+      DisconnectPipeWireBtAutoLinks(_activeNodeName);
+      _activeNodeName = null;
+    }
+  }
+
+  /// <summary>
+  /// Manually links pw-record's input ports to the BT node's output ports.
+  /// WirePlumber overrides pw-record's --target flag and links it to the default
+  /// audio source instead. This method: (1) disconnects any existing links to
+  /// pw-record inputs, (2) creates explicit links from the BT node outputs.
+  /// </summary>
+  private void LinkPipeWireRecordToBtNode(string btNodeName)
+  {
+    try
+    {
+      // Disconnect whatever WirePlumber linked to pw-record
+      RunPipeWireLinkCommand($"-d alsa_input.usb-Generic_USB_Microphone_IM20000001-00.analog-stereo:capture_FL pw-record:input_FL");
+      RunPipeWireLinkCommand($"-d alsa_input.usb-Generic_USB_Microphone_IM20000001-00.analog-stereo:capture_FR pw-record:input_FR");
+
+      // Also try disconnecting from any other source that WirePlumber might link
+      // (Built-in Audio, other USB devices, etc.) by querying current links
+      DisconnectAllLinksToPort("pw-record:input_FL");
+      DisconnectAllLinksToPort("pw-record:input_FR");
+
+      // Create explicit links from BT node to pw-record
+      RunPipeWireLinkCommand($"{btNodeName}:output_FL pw-record:input_FL");
+      RunPipeWireLinkCommand($"{btNodeName}:output_FR pw-record:input_FR");
+
+      _logger.LogInformation("Linked pw-record to BT node {BtNode}", btNodeName);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Failed to link pw-record to BT node {BtNode}", btNodeName);
+    }
+  }
+
+  /// <summary>
+  /// Disconnects all links connected to the given input port.
+  /// </summary>
+  private void DisconnectAllLinksToPort(string inputPort)
+  {
+    try
+    {
+      var psi = new ProcessStartInfo
+      {
+        FileName = "pw-link",
+        Arguments = "-l",
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+      };
+
+      using var process = Process.Start(psi);
+      if (process == null)
+      {
+        return;
+      }
+      var output = process.StandardOutput.ReadToEnd();
+      process.WaitForExit(3000);
+
+      // Parse: "portname\n  |<- sourceport" format
+      var lines = output.Split('\n');
+      var inTargetPort = false;
+
+      foreach (var rawLine in lines)
+      {
+        var line = rawLine.TrimEnd();
+
+        if (line.TrimStart() == inputPort || line.Trim() == inputPort)
+        {
+          inTargetPort = true;
+          continue;
+        }
+
+        if (!line.StartsWith("  ") && line.Length > 0)
+        {
+          inTargetPort = false;
+          continue;
+        }
+
+        if (inTargetPort && line.Contains("|<-"))
+        {
+          var sourcePort = line[(line.IndexOf("|<-") + 4)..].Trim();
+          RunPipeWireLinkCommand($"-d {sourcePort} {inputPort}");
+        }
+      }
+    }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Failed to disconnect links to {Port}", inputPort);
+    }
+  }
+
+  /// <summary>
+  /// Runs a pw-link command with the given arguments.
+  /// </summary>
+  private void RunPipeWireLinkCommand(string arguments)
+  {
+    try
+    {
+      using var process = Process.Start(new ProcessStartInfo
+      {
+        FileName = "pw-link",
+        Arguments = arguments,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+      });
+      process?.WaitForExit(3000);
+    }
+    catch { /* ignore */ }
+  }
+
+  /// <summary>
+  /// Checks whether pw-record is currently linked to the specified BT node.
+  /// Returns false if pw-record inputs are linked to a different source or not linked at all.
+  /// </summary>
+  private bool IsPwRecordLinkedToBtNode(string btNodeName)
+  {
+    try
+    {
+      var psi = new ProcessStartInfo
+      {
+        FileName = "pw-link",
+        Arguments = "-l",
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+      };
+
+      using var process = Process.Start(psi);
+      if (process == null)
+      {
+        return true; // assume ok if we can't check
+      }
+      var output = process.StandardOutput.ReadToEnd();
+      process.WaitForExit(3000);
+
+      // Look for "pw-record:input_FL" section with "|<- btNodeName:output_FL"
+      var lines = output.Split('\n');
+      var inPwRecordFL = false;
+
+      foreach (var rawLine in lines)
+      {
+        var line = rawLine.TrimEnd();
+        if (line.Trim() == "pw-record:input_FL")
+        {
+          inPwRecordFL = true;
+          continue;
+        }
+        if (inPwRecordFL)
+        {
+          if (line.Contains("|<-") && line.Contains(btNodeName))
+          {
+            return true;
+          }
+          if (!line.StartsWith("  ") && line.Length > 0)
+          {
+            break; // moved to next port, didn't find our link
+          }
+        }
+      }
+
+      return false;
+    }
+    catch
+    {
+      return true; // assume ok if we can't check
+    }
+  }
+
+  /// <summary>
+  /// Disconnects PipeWire's automatic links from a bluez_input node to the
+  /// default audio output sink, preventing BT audio from bypassing our mixer.
+  /// </summary>
+  private void DisconnectPipeWireBtAutoLinks(string btNodeName)
+  {
+    try
+    {
+      // Query current links and find ones from this BT node to any output sink
+      var psi = new ProcessStartInfo
+      {
+        FileName = "pw-link",
+        Arguments = "-l",
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+      };
+
+      using var process = Process.Start(psi);
+      if (process == null)
+      {
+        return;
+      }
+
+      var output = process.StandardOutput.ReadToEnd();
+      process.WaitForExit(3000);
+
+      // Parse links: find output ports of the BT node that connect to a sink
+      // Format: "  |-> alsa_output.xxx:playback_FL"
+      // We look for lines under the BT node's output ports
+      var lines = output.Split('\n');
+      var inBtNode = false;
+      string? currentBtPort = null;
+
+      foreach (var rawLine in lines)
+      {
+        var line = rawLine.TrimEnd();
+
+        // Detect BT node output port headers (no leading whitespace beyond node name)
+        if (line.StartsWith(btNodeName + ":"))
+        {
+          inBtNode = true;
+          currentBtPort = line.TrimEnd();
+          continue;
+        }
+
+        // Lines under a different node reset the flag
+        if (!line.StartsWith(" ") && line.Length > 0)
+        {
+          inBtNode = false;
+          currentBtPort = null;
+          continue;
+        }
+
+        // Under BT node, find links to output sinks
+        if (inBtNode && currentBtPort != null && line.Contains("|->"))
+        {
+          var targetPort = line.Substring(line.IndexOf("|->") + 4).Trim();
+          if (targetPort.StartsWith("alsa_output."))
+          {
+            // Disconnect this link
+            DisconnectPipeWireLink(currentBtPort, targetPort);
+          }
+        }
+      }
+    }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Failed to disconnect PipeWire BT auto-links for {NodeName}", btNodeName);
+    }
+  }
+
+  /// <summary>
+  /// Disconnects a single PipeWire link between two ports.
+  /// </summary>
+  private void DisconnectPipeWireLink(string outputPort, string inputPort)
+  {
+    try
+    {
+      var psi = new ProcessStartInfo
+      {
+        FileName = "pw-link",
+        Arguments = $"-d \"{outputPort}\" \"{inputPort}\"",
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+      };
+
+      using var process = Process.Start(psi);
+      if (process == null)
+      {
+        return;
+      }
+
+      process.WaitForExit(3000);
+
+      _logger.LogInformation(
+        "Disconnected PipeWire auto-link: {Output} -> {Input}",
+        outputPort, inputPort);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Failed to disconnect PipeWire link {Output} -> {Input}",
+        outputPort, inputPort);
+    }
+  }
+
+  /// <summary>
+  /// Overrides the PipeWire node volume of the BT input node to 1.0 (full scale).
+  /// PipeWire's bluez5 module applies AVRCP volume with cubic mapping, which makes
+  /// BT audio significantly quieter than other sources. We normalize capture volume
+  /// here and control output level via our own master volume + per-source gain.
+  /// </summary>
+  private void NormalizeBtNodeVolume(int pipeWireNodeId)
+  {
+    try
+    {
+      var psi = new ProcessStartInfo
+      {
+        FileName = "wpctl",
+        Arguments = $"set-volume {pipeWireNodeId} 1.0",
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+      };
+
+      using var process = Process.Start(psi);
+      if (process == null)
+      {
+        _logger.LogWarning("Failed to start wpctl for BT volume normalization");
+        return;
+      }
+
+      var stderr = process.StandardError.ReadToEnd();
+      process.WaitForExit(3000);
+
+      if (process.ExitCode == 0)
+      {
+        _logger.LogInformation(
+          "Normalized BT node volume to 1.0 (PipeWire id={NodeId})", pipeWireNodeId);
+      }
+      else
+      {
+        _logger.LogWarning(
+          "wpctl set-volume failed (exit={ExitCode}): {Stderr}",
+          process.ExitCode, stderr.Trim());
+      }
+    }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Failed to normalize BT node volume (PipeWire id={NodeId})", pipeWireNodeId);
+    }
+  }
+
+  private static DeviceInfo? FindBluetoothCaptureDevice(DeviceInfo[] devices, string connectedName)
+  {
+    // Strategy 1: Match the bt_capture null sink monitor.
+    // PipeWire config creates a virtual null sink called "bt_capture" and
+    // WirePlumber routes bluez_input streams to it. The monitor source
+    // (bt_capture.monitor) appears as a capture device in PulseAudio/MiniAudio.
+    foreach (var device in devices)
+    {
+      if (device.Name != null && device.Name.Contains("bt_capture", StringComparison.OrdinalIgnoreCase))
+      {
+        return device;
+      }
+    }
+
+    // Strategy 2: Match by "bluez" prefix (direct PipeWire Bluetooth source)
+    foreach (var device in devices)
+    {
+      if (device.Name != null && device.Name.Contains("bluez", StringComparison.OrdinalIgnoreCase))
+      {
+        return device;
+      }
+    }
+
+    // Strategy 3: Match by connected device name
+    foreach (var device in devices)
+    {
+      if (device.Name != null && device.Name.Contains(connectedName, StringComparison.OrdinalIgnoreCase))
+      {
+        return device;
+      }
+    }
+
+    // Strategy 4: Match by "bluetooth" keyword
+    foreach (var device in devices)
+    {
+      if (device.Name != null && device.Name.Contains("bluetooth", StringComparison.OrdinalIgnoreCase))
+      {
+        return device;
+      }
+    }
+
+    return null;
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    _reconnectionLoop?.Dispose();
+    _reconnectionLoop = null;
+    _playerPropertiesWatcher?.Dispose();
+    _transportPropertiesWatcher?.Dispose();
+    _discoveryWatcher?.Dispose();
+    _nativeStream?.Dispose();
+    _nativeStream = null;
+    _captureEngine?.Dispose();
+    _captureEngine = null;
+    await UnregisterAgentAsync();
+    await StopAsync();
+    _connection?.Dispose();
+  }
+
+  private async Task RegisterAgentAsync()
+  {
+    if (_connection == null)
+    {
+      return;
+    }
+
+    try
+    {
+      _agent = new Linux.BluezAgent(_logger, _options.AutoAcceptConnections, () =>
+      {
+        var device = ConnectedDevice;
+        return (device?.Address, device?.Name);
+      });
+
+      // Export the agent object on D-Bus so BlueZ can call its methods
+      await _connection.RegisterObjectAsync(_agent);
+
+      var agentManager = _connection.CreateProxy<Linux.IAgentManager1>(
+        Linux.BluezConstants.ServiceName, "/org/bluez");
+
+      // "NoInputNoOutput" capability enables Just Works pairing (no PIN prompt)
+      await agentManager.RegisterAgentAsync(_agent.ObjectPath, "NoInputNoOutput");
+      await agentManager.RequestDefaultAgentAsync(_agent.ObjectPath);
+
+      _logger.LogInformation("Bluetooth pairing agent registered (auto-accept: {AutoAccept})",
+        _options.AutoAcceptConnections);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to register Bluetooth pairing agent — pairing may require manual acceptance");
+    }
+  }
+
+  /// <summary>
+  /// Toggles adapter discoverability for single-device exclusivity.
+  /// Hidden when a device is connected (prevents other phones from seeing the radio),
+  /// shown again on disconnect so new devices can pair.
+  /// </summary>
+  private async Task SetDiscoverableAsync(bool discoverable)
+  {
+    if (_adapter == null)
+    {
+      return;
+    }
+
+    try
+    {
+      await _adapter.SetAsync("Discoverable", discoverable);
+      _logger.LogInformation("Bluetooth adapter discoverable: {Discoverable}", discoverable);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to set adapter discoverable to {Discoverable}", discoverable);
+    }
+  }
+
+  private async Task UnregisterAgentAsync()
+  {
+    if (_connection == null || _agent == null)
+    {
+      return;
+    }
+
+    try
+    {
+      var agentManager = _connection.CreateProxy<Linux.IAgentManager1>(
+        Linux.BluezConstants.ServiceName, "/org/bluez");
+      await agentManager.UnregisterAgentAsync(_agent.ObjectPath);
+      _connection.UnregisterObject(_agent);
+      _agent = null;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Failed to unregister Bluetooth agent (may already be unregistered)");
+    }
+  }
+
+  private async Task CheckForMediaPlayersAsync()
+  {
+    try
+    {
+      if (_objectManager == null)
+      {
+        return;
+      }
+      var objects = await _objectManager.GetManagedObjectsAsync();
+      foreach (var obj in objects)
+      {
+        if (obj.Value.ContainsKey(Linux.BluezConstants.MediaPlayerInterface) && _mediaPlayer == null)
+        {
+          await AttachMediaPlayerAsync(obj.Key);
+        }
+
+        if (obj.Value.ContainsKey(Linux.BluezConstants.MediaTransportInterface) && _mediaTransport == null)
+        {
+          await AttachMediaTransportAsync(obj.Key);
+        }
+      }
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to check for existing media players/transports");
+    }
+  }
+
+  private async Task AttachMediaPlayerAsync(ObjectPath objectPath)
+  {
+    try
+    {
+      if (_connection == null)
+      {
+        return;
+      }
+
+      // Thread-safe dedup — multiple concurrent InterfacesAdded callbacks
+      // can race into this method for the same player path
+      lock (_mediaPlayerLock)
+      {
+        if (_mediaPlayerPath == objectPath && _mediaPlayer != null)
+        {
+          _logger.LogDebug("Already attached to media player at {Path}, skipping", objectPath);
+          return;
+        }
+
+        _playerPropertiesWatcher?.Dispose();
+        _mediaPlayerPath = objectPath;
+      }
+      _mediaPlayer = _connection.CreateProxy<Linux.IMediaPlayer1>(Linux.BluezConstants.ServiceName, objectPath);
+      
+      _playerPropertiesWatcher = await _mediaPlayer.WatchPropertiesAsync(OnPlayerPropertiesChanged);
+      
+      // Get initial state
+      try
+      {
+        var status = await _mediaPlayer.GetAsync<string>("Status");
+        UpdatePlaybackStatus(status);
+        
+        var track = await _mediaPlayer.GetAsync<IDictionary<string, object>>("Track");
+        UpdateMetadata(track);
+      }
+      catch (Exception ex)
+      {
+        // Properties might not be available yet
+        _logger.LogDebug($"Failed to get initial player state: {ex.Message}");
+      }
+
+      _logger.LogInformation($"Attached to Media Player at {objectPath}");
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, $"Failed to attach media player at {objectPath}");
+    }
+  }
+
+  private async Task AttachMediaTransportAsync(ObjectPath objectPath)
+  {
+    try
+    {
+      if (_connection == null)
+      {
+        return;
+      }
+
+      if (_mediaTransportPath == objectPath && _mediaTransport != null)
+      {
+        _logger.LogDebug("Already attached to media transport at {Path}", objectPath);
+        return;
+      }
+
+      _transportPropertiesWatcher?.Dispose();
+      _mediaTransportPath = objectPath;
+      _mediaTransport = _connection.CreateProxy<Linux.IMediaTransport1>(
+        Linux.BluezConstants.ServiceName, objectPath);
+
+      _transportPropertiesWatcher = await _mediaTransport.WatchPropertiesAsync(OnTransportPropertiesChanged);
+
+      // Read initial volume
+      try
+      {
+        var volume = await _mediaTransport.GetAsync<ushort>("Volume");
+        var normalized = volume / 127f;
+        DeviceVolume = normalized;
+        _logger.LogDebug("Initial BT transport volume: {Raw}/127 ({Normalized:P0})", volume, normalized);
+      }
+      catch
+      {
+        // Volume property might not be available
+      }
+
+      _logger.LogInformation("Attached to MediaTransport1 at {Path}", objectPath);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to attach media transport at {Path}", objectPath);
+    }
+  }
+
+  private void OnTransportPropertiesChanged(PropertyChanges changes)
+  {
+    foreach (var prop in changes.Changed)
+    {
+      if (prop.Key == "Volume" && prop.Value is ushort volume)
+      {
+        var normalized = volume / 127f;
+        DeviceVolume = normalized;
+        VolumeChanged?.Invoke(this, new BluetoothVolumeChangedEventArgs { Volume = normalized });
+        _logger.LogDebug("BT AVRCP volume changed: {Raw}/127 ({Normalized:P0})", volume, normalized);
+      }
+    }
+  }
+
+  private void OnPlayerPropertiesChanged(PropertyChanges changes)
+  {
+    foreach (var prop in changes.Changed)
+    {
+      switch (prop.Key)
+      {
+        case "Status":
+          UpdatePlaybackStatus(prop.Value as string);
+          break;
+        case "Track":
+          if (prop.Value is IDictionary<string, object> track)
+          {
+            UpdateMetadata(track);
+          }
+          break;
+        case "Position":
+          if (prop.Value is uint pos)
+          {
+            PositionChanged?.Invoke(this, TimeSpan.FromMilliseconds(pos));
+          }
+          break;
+      }
+    }
+  }
+
+  private void UpdatePlaybackStatus(string? statusStr)
+  {
+    if (string.IsNullOrEmpty(statusStr))
+    {
+      return;
+    }
+    
+    var status = statusStr.ToLower() switch
+    {
+      "playing" => BluetoothPlaybackStatus.Playing,
+      "paused" => BluetoothPlaybackStatus.Paused,
+      "stopped" => BluetoothPlaybackStatus.Stopped,
+      "forward-seek" => BluetoothPlaybackStatus.ForwardSeek,
+      "reverse-seek" => BluetoothPlaybackStatus.ReverseSeek,
+      "error" => BluetoothPlaybackStatus.Error,
+      _ => BluetoothPlaybackStatus.Stopped
+    };
+    
+    PlaybackStatusChanged?.Invoke(this, status);
+  }
+
+  private void UpdateMetadata(IDictionary<string, object> track)
+  {
+    if (track == null)
+    {
+      return;
+    }
+
+    // MPRIS/BlueZ exposes album art via "ArtUrl" or "mpris:artUrl"
+    var artUrl = GetString(track, "ArtUrl");
+    if (string.IsNullOrEmpty(artUrl))
+    {
+      artUrl = GetString(track, "mpris:artUrl");
+    }
+
+    var meta = new BluetoothPlaybackMetadata
+    {
+      Title = GetString(track, "Title"),
+      Artist = GetString(track, "Artist"),
+      Album = GetString(track, "Album"),
+      Duration = track.ContainsKey("Duration")
+        ? TimeSpan.FromMilliseconds(Convert.ToUInt32(track["Duration"]))
+        : TimeSpan.Zero,
+      AlbumArtUrl = string.IsNullOrEmpty(artUrl) ? null : artUrl
+    };
+
+    _logger.LogDebug("AVRCP metadata: {Title} by {Artist} (album: {Album}, art: {HasArt})",
+      meta.Title, meta.Artist, meta.Album, !string.IsNullOrEmpty(meta.AlbumArtUrl));
+
+    MetadataChanged?.Invoke(this, meta);
+  }
+
+  private string GetString(IDictionary<string, object> dict, string key)
+  {
+    if (dict.TryGetValue(key, out var val) && val is string s)
+    {
+      return s;
+    }
+    return string.Empty;
+  }
 }
+

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs
@@ -97,7 +97,10 @@ internal sealed class PipeWireNativeStream : IDisposable
   /// </summary>
   public void Start()
   {
-    if (_disposed) throw new ObjectDisposedException(nameof(PipeWireNativeStream));
+    if (_disposed)
+    {
+      throw new ObjectDisposedException(nameof(PipeWireNativeStream));
+    }
 
     // Keep a GCHandle to this so the native callback can find us
     _selfHandle = GCHandle.Alloc(this);
@@ -105,7 +108,9 @@ internal sealed class PipeWireNativeStream : IDisposable
     // Create thread loop
     _threadLoop = pw_thread_loop_new("radio-bt-capture", IntPtr.Zero);
     if (_threadLoop == IntPtr.Zero)
+    {
       throw new InvalidOperationException("Failed to create PipeWire thread loop");
+    }
 
     var loop = pw_thread_loop_get_loop(_threadLoop);
 
@@ -183,7 +188,10 @@ internal sealed class PipeWireNativeStream : IDisposable
   /// </summary>
   public void Stop()
   {
-    if (_threadLoop == IntPtr.Zero) return;
+    if (_threadLoop == IntPtr.Zero)
+    {
+      return;
+    }
 
     pw_thread_loop_lock(_threadLoop);
     try
@@ -204,8 +212,14 @@ internal sealed class PipeWireNativeStream : IDisposable
     pw_thread_loop_destroy(_threadLoop);
     _threadLoop = IntPtr.Zero;
 
-    if (_eventsHandle.IsAllocated) _eventsHandle.Free();
-    if (_selfHandle.IsAllocated) _selfHandle.Free();
+    if (_eventsHandle.IsAllocated)
+    {
+      _eventsHandle.Free();
+    }
+    if (_selfHandle.IsAllocated)
+    {
+      _selfHandle.Free();
+    }
 
     _logger.LogInformation("PipeWire native stream stopped");
   }
@@ -216,7 +230,10 @@ internal sealed class PipeWireNativeStream : IDisposable
   /// </summary>
   private static void OnProcess(IntPtr userData)
   {
-    if (userData == IntPtr.Zero) return;
+    if (userData == IntPtr.Zero)
+    {
+      return;
+    }
 
     PipeWireNativeStream? self;
     try
@@ -229,7 +246,10 @@ internal sealed class PipeWireNativeStream : IDisposable
       return;
     }
 
-    if (self == null || self._stream == IntPtr.Zero) return;
+    if (self == null || self._stream == IntPtr.Zero)
+    {
+      return;
+    }
 
     var processStart = Stopwatch.GetTimestamp();
 
@@ -238,29 +258,53 @@ internal sealed class PipeWireNativeStream : IDisposable
     {
       var intervalMs = (double)(processStart - self._lastOnProcessTimestamp)
         / Stopwatch.Frequency * 1000.0;
-      if (intervalMs > self._maxOnProcessIntervalMs) self._maxOnProcessIntervalMs = intervalMs;
-      if (intervalMs < self._minOnProcessIntervalMs) self._minOnProcessIntervalMs = intervalMs;
-      if (intervalMs < 1.0) self._onProcessBurstCount++;
+      if (intervalMs > self._maxOnProcessIntervalMs)
+      {
+        self._maxOnProcessIntervalMs = intervalMs;
+      }
+      if (intervalMs < self._minOnProcessIntervalMs)
+      {
+        self._minOnProcessIntervalMs = intervalMs;
+      }
+      if (intervalMs < 1.0)
+      {
+        self._onProcessBurstCount++;
+      }
     }
     self._lastOnProcessTimestamp = processStart;
     self._onProcessCount++;
 
     var pwBufPtr = pw_stream_dequeue_buffer(self._stream);
-    if (pwBufPtr == IntPtr.Zero) return;
+    if (pwBufPtr == IntPtr.Zero)
+    {
+      return;
+    }
 
     try
     {
       var pwBuf = Marshal.PtrToStructure<PwBuffer>(pwBufPtr);
-      if (pwBuf.Buffer == IntPtr.Zero) return;
+      if (pwBuf.Buffer == IntPtr.Zero)
+      {
+        return;
+      }
 
       var spaBuf = Marshal.PtrToStructure<SpaBuffer>(pwBuf.Buffer);
-      if (spaBuf.NDatas == 0 || spaBuf.Datas == IntPtr.Zero) return;
+      if (spaBuf.NDatas == 0 || spaBuf.Datas == IntPtr.Zero)
+      {
+        return;
+      }
 
       var spaData = Marshal.PtrToStructure<SpaData>(spaBuf.Datas);
-      if (spaData.Data == IntPtr.Zero || spaData.Chunk == IntPtr.Zero) return;
+      if (spaData.Data == IntPtr.Zero || spaData.Chunk == IntPtr.Zero)
+      {
+        return;
+      }
 
       var chunk = Marshal.PtrToStructure<SpaChunk>(spaData.Chunk);
-      if (chunk.Size == 0) return;
+      if (chunk.Size == 0)
+      {
+        return;
+      }
 
       // S16_LE: 2 bytes per sample, stereo = 4 bytes per frame.
       // PipeWire BT transport can deliver non-frame-aligned chunks during
@@ -271,7 +315,10 @@ internal sealed class PipeWireNativeStream : IDisposable
       var sampleCount = totalBytes / 2;
       sampleCount = sampleCount / self._channels * self._channels; // frame-align
 
-      if (sampleCount <= 0) return;
+      if (sampleCount <= 0)
+      {
+        return;
+      }
 
       // Convert S16_LE to float [-1.0, 1.0]
       // Use unsafe Span cast instead of per-sample Marshal.ReadInt16 to
@@ -284,7 +331,9 @@ internal sealed class PipeWireNativeStream : IDisposable
         {
           var s16Span = new ReadOnlySpan<short>((void*)dataPtr, sampleCount);
           for (var i = 0; i < sampleCount; i++)
+          {
             floatSamples[i] = s16Span[i] / 32768f;
+          }
         }
 
         self._onAudioData(floatSamples, sampleCount);
@@ -303,7 +352,10 @@ internal sealed class PipeWireNativeStream : IDisposable
       pw_stream_queue_buffer(self._stream, pwBufPtr);
 
       var execMs = (double)(Stopwatch.GetTimestamp() - processStart) / Stopwatch.Frequency * 1000.0;
-      if (execMs > self._maxOnProcessExecutionMs) self._maxOnProcessExecutionMs = execMs;
+      if (execMs > self._maxOnProcessExecutionMs)
+      {
+        self._maxOnProcessExecutionMs = execMs;
+      }
     }
 
     // Log OnProcess stats every 10 seconds
@@ -327,7 +379,10 @@ internal sealed class PipeWireNativeStream : IDisposable
 
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
     Stop();
   }

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Windows/WasapiLoopbackCaptureSource.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Windows/WasapiLoopbackCaptureSource.cs
@@ -169,7 +169,9 @@ internal sealed class WasapiLoopbackCaptureSource : IDisposable
   public bool IsSameDeviceAsDefault(string? soundFlowDeviceId)
   {
     if (string.IsNullOrEmpty(soundFlowDeviceId))
+    {
       return true; // Default device selected → same device
+    }
 
     try
     {
@@ -197,7 +199,9 @@ internal sealed class WasapiLoopbackCaptureSource : IDisposable
   private void OnDataAvailable(WaveInEventArgs e, BufferedSoundGenerator<float> generator)
   {
     if (e.BytesRecorded == 0)
+    {
       return;
+    }
 
     try
     {
@@ -243,7 +247,10 @@ internal sealed class WasapiLoopbackCaptureSource : IDisposable
 
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
     StopCapture();
   }

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Windows/WindowsA2dpSinkManager.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Windows/WindowsA2dpSinkManager.cs
@@ -428,7 +428,10 @@ internal sealed class WindowsA2dpSinkManager : IDisposable
 
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
 
     if (_deviceWatcher != null)

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Windows/WindowsMediaSessionWatcher.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Windows/WindowsMediaSessionWatcher.cs
@@ -69,7 +69,9 @@ internal sealed class WindowsMediaSessionWatcher : IDisposable
       var newSession = _sessionManager?.GetCurrentSession();
 
       if (newSession == _currentSession)
+      {
         return;
+      }
 
       // Detach from old session
       if (_currentSession != null)
@@ -122,12 +124,18 @@ internal sealed class WindowsMediaSessionWatcher : IDisposable
 
   private async Task ReadCurrentMediaPropertiesAsync()
   {
-    if (_currentSession == null) return;
+    if (_currentSession == null)
+    {
+      return;
+    }
 
     try
     {
       var props = await _currentSession.TryGetMediaPropertiesAsync();
-      if (props == null) return;
+      if (props == null)
+      {
+        return;
+      }
 
       string? albumArtUrl = null;
       if (props.Thumbnail != null)
@@ -171,12 +179,18 @@ internal sealed class WindowsMediaSessionWatcher : IDisposable
 
   private void ReadCurrentPlaybackInfo()
   {
-    if (_currentSession == null) return;
+    if (_currentSession == null)
+    {
+      return;
+    }
 
     try
     {
       var info = _currentSession.GetPlaybackInfo();
-      if (info == null) return;
+      if (info == null)
+      {
+        return;
+      }
 
       var status = info.PlaybackStatus switch
       {
@@ -197,12 +211,18 @@ internal sealed class WindowsMediaSessionWatcher : IDisposable
 
   private void ReadCurrentTimelineProperties()
   {
-    if (_currentSession == null) return;
+    if (_currentSession == null)
+    {
+      return;
+    }
 
     try
     {
       var timeline = _currentSession.GetTimelineProperties();
-      if (timeline == null) return;
+      if (timeline == null)
+      {
+        return;
+      }
 
       PositionChanged?.Invoke(this, timeline.Position);
     }
@@ -223,7 +243,9 @@ internal sealed class WindowsMediaSessionWatcher : IDisposable
       var bytes = memoryStream.ToArray();
 
       if (bytes.Length == 0)
+      {
         return null;
+      }
 
       // Detect MIME type from magic bytes
       var mime = AlbumArtCacheService.DetectMimeFromBytes(bytes) ?? "image/jpeg";
@@ -246,7 +268,10 @@ internal sealed class WindowsMediaSessionWatcher : IDisposable
 
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
 
     if (_currentSession != null)

--- a/src/Radio.Infrastructure/Platform/Input/HidRotaryEncoderService.cs
+++ b/src/Radio.Infrastructure/Platform/Input/HidRotaryEncoderService.cs
@@ -46,7 +46,10 @@ public class HidRotaryEncoderService : IRotaryEncoderService
   /// <inheritdoc />
   public Task StartAsync(CancellationToken cancellationToken = default)
   {
-    if (_disposed) throw new ObjectDisposedException(nameof(HidRotaryEncoderService));
+    if (_disposed)
+    {
+      throw new ObjectDisposedException(nameof(HidRotaryEncoderService));
+    }
 
     _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
     _readTask = ReadLoopAsync(_cts.Token);
@@ -164,7 +167,10 @@ public class HidRotaryEncoderService : IRotaryEncoderService
         return;
       }
 
-      if (bytesRead < 6) continue;
+      if (bytesRead < 6)
+      {
+        continue;
+      }
 
       ParseReport(buffer);
 
@@ -233,7 +239,10 @@ public class HidRotaryEncoderService : IRotaryEncoderService
   /// <inheritdoc />
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
     _cts?.Cancel();
     _cts?.Dispose();

--- a/src/Radio.Infrastructure/Platform/Input/RotaryEncoderActionRouter.cs
+++ b/src/Radio.Infrastructure/Platform/Input/RotaryEncoderActionRouter.cs
@@ -60,7 +60,9 @@ public class RotaryEncoderActionRouter : IDisposable
     {
       // If sleeping, wake on any encoder input and consume the event
       if (TryWakeFromSleep("encoder-turn"))
+      {
         return;
+      }
 
       switch (e.EncoderIndex)
       {
@@ -79,13 +81,18 @@ public class RotaryEncoderActionRouter : IDisposable
   private void OnButtonPressed(object? sender, EncoderButtonEventArgs e)
   {
     // Only act on press (not release)
-    if (!e.IsPressed) return;
+    if (!e.IsPressed)
+    {
+      return;
+    }
 
     try
     {
       // If sleeping, wake on any encoder input and consume the event
       if (TryWakeFromSleep("encoder-button"))
+      {
         return;
+      }
 
       switch (e.EncoderIndex)
       {
@@ -106,7 +113,10 @@ public class RotaryEncoderActionRouter : IDisposable
   /// </summary>
   private bool TryWakeFromSleep(string wakeSource)
   {
-    if (_sleepService == null || !_sleepService.IsSleeping) return false;
+    if (_sleepService == null || !_sleepService.IsSleeping)
+    {
+      return false;
+    }
 
     _ = _sleepService.WakeAsync(wakeSource);
     _logger.LogInformation("Woke from sleep via {WakeSource}", wakeSource);
@@ -152,9 +162,13 @@ public class RotaryEncoderActionRouter : IDisposable
       for (int i = 0; i < steps; i++)
       {
         if (delta > 0)
+        {
           await radio.StepFrequencyUpAsync();
+        }
         else
+        {
           await radio.StepFrequencyDownAsync();
+        }
       }
     }
     catch (Exception ex)
@@ -226,7 +240,10 @@ public class RotaryEncoderActionRouter : IDisposable
 
   public void Dispose()
   {
-    if (_disposed) return;
+    if (_disposed)
+    {
+      return;
+    }
     _disposed = true;
 
     _encoderService.EncoderTurned -= OnEncoderTurned;

--- a/src/Radio.Metrics/Repositories/SqliteMetricsRepository.cs
+++ b/src/Radio.Metrics/Repositories/SqliteMetricsRepository.cs
@@ -269,7 +269,9 @@ public sealed class SqliteMetricsRepository : IMetricsReader
   {
     var keyList = keys.ToList();
     if (keyList.Count == 0)
+    {
       return new Dictionary<string, double>();
+    }
 
     // For small key lists, run individual queries concurrently is fine.
     // Each GetAggregateAsync uses its own read connection.
@@ -285,7 +287,9 @@ public sealed class SqliteMetricsRepository : IMetricsReader
     foreach (var (key, value) in results)
     {
       if (value.HasValue)
+      {
         result[key] = value.Value;
+      }
     }
 
     return result;

--- a/src/Radio.Metrics/Services/SystemMonitorService.cs
+++ b/src/Radio.Metrics/Services/SystemMonitorService.cs
@@ -154,7 +154,10 @@ public sealed class SystemMonitorService : BackgroundService
         for (var i = 0; i < 10; i++)
         {
           var tempPath = $"/sys/class/thermal/thermal_zone{i}/temp";
-          if (!File.Exists(tempPath)) continue;
+          if (!File.Exists(tempPath))
+          {
+            continue;
+          }
 
           try
           {
@@ -164,7 +167,10 @@ public sealed class SystemMonitorService : BackgroundService
               var tempCelsius = tempMilliC / 1000.0;
 
               // Skip sentinel values (absolute zero = sensor unavailable)
-              if (tempCelsius < -100 || tempCelsius > 150) continue;
+              if (tempCelsius < -100 || tempCelsius > 150)
+              {
+                continue;
+              }
 
               _metricsCollector.Gauge("system.cpu_temp_celsius", tempCelsius);
               break; // Use the first valid reading

--- a/tests/Radio.API.Tests/TestSupport/CustomWebApplicationFactory.cs
+++ b/tests/Radio.API.Tests/TestSupport/CustomWebApplicationFactory.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Serilog;
+using Serilog.Events;
 
 namespace Radio.API.Tests.TestSupport;
 
@@ -16,6 +18,13 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProg
 {
   protected override void ConfigureWebHost(IWebHostBuilder builder)
   {
+    // Suppress Serilog console output during tests. The static Log.Logger is configured
+    // in Program.cs before WebApplicationFactory applies environment overrides, so we
+    // must replace it here to prevent noisy ERR/WRN stack traces in test output.
+    Log.Logger = new LoggerConfiguration()
+      .MinimumLevel.Fatal()
+      .CreateLogger();
+
     // Run the host in a test environment
     builder.UseEnvironment("Testing");
 

--- a/tests/Radio.AudioAnalysis.Tests/FrequencyAnalysisTests.cs
+++ b/tests/Radio.AudioAnalysis.Tests/FrequencyAnalysisTests.cs
@@ -39,7 +39,9 @@ public class FrequencyAnalysisTests
     // Generate a clipped sine (creates harmonics)
     var samples = WavFileHelper.GenerateMonoSineWave(440, 48000, 48000, 1.0f);
     for (int i = 0; i < samples.Length; i++)
+    {
       samples[i] = Math.Clamp(samples[i] * 2.0f, -1.0f, 1.0f); // Hard clip
+    }
 
     var stereo = new float[samples.Length * 2];
     for (int i = 0; i < samples.Length; i++)

--- a/tests/Radio.AudioAnalysis.Tests/WavFileHelperTests.cs
+++ b/tests/Radio.AudioAnalysis.Tests/WavFileHelperTests.cs
@@ -49,7 +49,9 @@ public class WavFileHelperTests
     // Cross-correlation should be low (different frequencies)
     double crossCorr = 0;
     for (int i = 0; i < left.Length; i++)
+    {
       crossCorr += left[i] * right[i];
+    }
     crossCorr /= left.Length;
     Assert.InRange(Math.Abs(crossCorr), 0, 0.1);
   }

--- a/tests/Radio.AudioAnalysis.Tests/WaveformComparisonTests.cs
+++ b/tests/Radio.AudioAnalysis.Tests/WaveformComparisonTests.cs
@@ -54,7 +54,9 @@ public class WaveformComparisonTests
     var reference = WavFileHelper.GenerateStereoSineWave(200, 300, 48000, 4800, 0.8f);
     var captured = new float[reference.Length];
     for (int i = 0; i < reference.Length; i++)
+    {
       captured[i] = reference[i] * 0.5f; // Half amplitude
+    }
 
     var report = WaveformComparison.Compare(reference, captured);
     Assert.InRange(report.GainRatio, 0.49f, 0.51f);
@@ -68,7 +70,9 @@ public class WaveformComparisonTests
     var captured = (float[])reference.Clone();
     // Insert silence gap
     for (int i = 1000; i < 1100; i++)
+    {
       captured[i] = 0f;
+    }
 
     var report = WaveformComparison.Compare(reference, captured);
     Assert.Contains(report.Events, e => e.Type == DistortionType.SilenceInsertion);

--- a/tests/Radio.Infrastructure.Tests/Audio/Diagnostics/WaveformComparisonTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Diagnostics/WaveformComparisonTests.cs
@@ -267,7 +267,7 @@ public class WaveformComparisonTests
   }
 
   [SkippableFact]
-  [Trait("Category", "CaptureAnalysis")]
+  [Trait("Category", "Integration")]
   public void AnalyzeBtCapture_InputVsOutput()
   {
     var captureDir = Path.Combine(
@@ -495,7 +495,7 @@ public class WaveformComparisonTests
   }
 
   [SkippableFact]
-  [Trait("Category", "CaptureAnalysis")]
+  [Trait("Category", "Integration")]
   public void AnalyzeBatchCaptures_10Runs()
   {
     var baseDir = Path.Combine(

--- a/tests/Radio.Infrastructure.Tests/Platform/Bluetooth/PipeWireNodeParsingTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Platform/Bluetooth/PipeWireNodeParsingTests.cs
@@ -11,7 +11,10 @@ public class PipeWireNodeParsingTests
   {
     var sb = new System.Text.StringBuilder();
     sb.AppendLine($"id {id}, type PipeWire:Interface:Node/3");
-    if (serial > 0) sb.AppendLine($"  object.serial = \"{serial}\"");
+    if (serial > 0)
+    {
+      sb.AppendLine($"  object.serial = \"{serial}\"");
+    }
     sb.Append($"  node.name = \"{nodeName}\"");
     return sb.ToString();
   }

--- a/tests/Radio.IntegrationTests/TestSupport/IntegrationTestWebApplicationFactory.cs
+++ b/tests/Radio.IntegrationTests/TestSupport/IntegrationTestWebApplicationFactory.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Radio.Core.Interfaces.Audio;
+using Serilog;
+using Serilog.Events;
 
 namespace Radio.IntegrationTests.TestSupport;
 
@@ -78,6 +80,12 @@ public class IntegrationTestWebApplicationFactory : WebApplicationFactory<Progra
 
   protected override void ConfigureWebHost(IWebHostBuilder builder)
   {
+    // Suppress Serilog console output during tests
+    Log.Logger = new LoggerConfiguration()
+      .MinimumLevel.Override("Microsoft", LogEventLevel.Fatal)
+      .MinimumLevel.Fatal()
+      .CreateLogger();
+
     builder.UseEnvironment("IntegrationTests");
 
     // Override configuration to use temp directory


### PR DESCRIPTION
## Summary
- Add braces to ~350 braceless control flow statements (IDE0011) across 63 files
- Convert 2 files to file-scoped namespaces (IDE0161): `LinuxBluetoothService.cs`, `BluezInterfaces.cs`
- Fix DI scope error in `AudioEngineInitializationService.CloseOrphanedPlayHistoryEntriesAsync` — was resolving scoped `IPlayHistoryRepository` from root provider
- Suppress Serilog console output in test factories (`CustomWebApplicationFactory`, `IntegrationTestWebApplicationFactory`) to eliminate noisy exception stack traces during test runs
- Change `CaptureAnalysis` diagnostic tests to `Integration` category so they're excluded from CI

## Test plan
- [x] Clean build: 0 warnings, 0 errors (was 593 warnings)
- [x] All 1,542 tests pass with clean output
- [x] No exception stack traces in test console output
- [x] CI filter excludes CaptureAnalysis tests (now Category=Integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)