### PR TITLE
feat: Bookmarked folders for file browser with UI management

### DIFF
--- a/src/Radio.API/Controllers/ConfigurationController.cs
+++ b/src/Radio.API/Controllers/ConfigurationController.cs
@@ -402,9 +402,23 @@ public class ConfigurationController : ControllerBase
   /// <summary>
   /// Parses a string config value to its proper JSON type (bool, long, double, or string).
   /// The configuration store persists all values as strings, but clients expect proper types.
+  /// JSON arrays and objects are preserved as JsonElement so they roundtrip correctly.
   /// </summary>
   private static object? ParseConfigValue(string value)
   {
+    // Detect JSON arrays or objects and preserve their structure
+    if (value.Length >= 2 && (value[0] == '[' || value[0] == '{'))
+    {
+      try
+      {
+        return System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(value);
+      }
+      catch (System.Text.Json.JsonException)
+      {
+        // Not valid JSON, fall through to primitive parsing
+      }
+    }
+
     if (bool.TryParse(value, out var boolVal))
     {
       return boolVal;

--- a/src/Radio.API/Controllers/FilesController.cs
+++ b/src/Radio.API/Controllers/FilesController.cs
@@ -436,6 +436,26 @@ public class FilesController : ControllerBase
   }
 
   /// <summary>
+  /// Gets the configured bookmarked directories with accessibility status.
+  /// </summary>
+  /// <returns>A list of bookmarked directories.</returns>
+  [HttpGet("bookmarks")]
+  [ProducesResponseType(typeof(List<BookmarkDto>), StatusCodes.Status200OK)]
+  public IActionResult GetBookmarks()
+  {
+    var options = _filePlayerOptions.CurrentValue;
+    var bookmarks = options.BookmarkedPaths.Select(b => new BookmarkDto
+    {
+      Path = b.Path,
+      Label = b.Label,
+      Tag = b.Tag,
+      IsAccessible = Directory.Exists(b.Path)
+    }).ToList();
+
+    return Ok(bookmarks);
+  }
+
+  /// <summary>
   /// Gets a list of available drives and their information.
   /// </summary>
   /// <returns>A list of available drives with their properties.</returns>
@@ -450,11 +470,21 @@ public class FilesController : ControllerBase
     {
       var drives = new List<DriveInfoDto>();
 
+      // Mount point prefixes that represent system internals (not useful for audio browsing)
+      var systemPrefixes = new[] { "/dev/", "/run/", "/sys/", "/proc/", "/snap/", "/boot/" };
+
       // Get all drives using System.IO.DriveInfo
       foreach (var drive in System.IO.DriveInfo.GetDrives())
       {
         try
         {
+          // Skip system pseudo-mounts on Linux (e.g., /dev/shm, /run, /dev/hugepages)
+          if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+              systemPrefixes.Any(p => drive.Name.StartsWith(p, StringComparison.Ordinal)))
+          {
+            continue;
+          }
+
           // Only include ready drives to avoid exceptions
           if (!drive.IsReady)
           {
@@ -760,8 +790,11 @@ public class FilesController : ControllerBase
         return true;
       }
 
-      // Check against additional allowed browse directories
-      foreach (var allowedDir in options.AllowedBrowseDirectories)
+      // Check against additional allowed browse directories and bookmarked paths
+      var allowedPaths = options.AllowedBrowseDirectories
+        .Concat(options.BookmarkedPaths.Select(b => b.Path));
+
+      foreach (var allowedDir in allowedPaths)
       {
         if (string.IsNullOrWhiteSpace(allowedDir))
         {

--- a/src/Radio.API/Models/FileDtos.cs
+++ b/src/Radio.API/Models/FileDtos.cs
@@ -267,3 +267,29 @@ public class DriveInfoDto
   /// </summary>
   public string? DriveFormat { get; set; }
 }
+
+/// <summary>
+/// DTO representing a bookmarked directory for quick access in the file browser.
+/// </summary>
+public class BookmarkDto
+{
+  /// <summary>
+  /// Gets or sets the absolute filesystem path.
+  /// </summary>
+  public required string Path { get; set; }
+
+  /// <summary>
+  /// Gets or sets the user-friendly label.
+  /// </summary>
+  public required string Label { get; set; }
+
+  /// <summary>
+  /// Gets or sets the purpose tag (e.g., "music", "sounds").
+  /// </summary>
+  public required string Tag { get; set; }
+
+  /// <summary>
+  /// Gets or sets whether the path is currently accessible on the filesystem.
+  /// </summary>
+  public bool IsAccessible { get; set; }
+}

--- a/src/Radio.API/appsettings.json
+++ b/src/Radio.API/appsettings.json
@@ -173,6 +173,18 @@
       ".aac",
       ".m4a",
       ".wma"
+    ],
+    "BookmarkedPaths": [
+      {
+        "Path": "/mnt/nas/music",
+        "Label": "NAS Music Library",
+        "Tag": "music"
+      },
+      {
+        "Path": "/opt/radio-console/media/audio",
+        "Label": "Local Audio Files",
+        "Tag": "sounds"
+      }
     ]
   },
   "FilePlayerPreferences": {

--- a/src/Radio.Core/Configuration/FilePlayerOptions.cs
+++ b/src/Radio.Core/Configuration/FilePlayerOptions.cs
@@ -27,4 +27,32 @@ public class FilePlayerOptions
   /// directories will be rejected. Empty array means only RootDirectory is allowed.
   /// </summary>
   public string[] AllowedBrowseDirectories { get; set; } = [];
+
+  /// <summary>
+  /// Gets or sets bookmarked directories that appear as quick-access entries in
+  /// the file browser. These paths are also implicitly allowed for browsing.
+  /// </summary>
+  public BookmarkedPath[] BookmarkedPaths { get; set; } = [];
+}
+
+/// <summary>
+/// A bookmarked directory for quick access in the file browser.
+/// </summary>
+public class BookmarkedPath
+{
+  /// <summary>
+  /// The absolute filesystem path to the directory.
+  /// </summary>
+  public string Path { get; set; } = "";
+
+  /// <summary>
+  /// A user-friendly label for the bookmark (e.g., "NAS Music", "Alert Sounds").
+  /// </summary>
+  public string Label { get; set; } = "";
+
+  /// <summary>
+  /// A tag indicating the bookmark's purpose. Used to select context-appropriate
+  /// defaults (e.g., "music" for queue browsing, "sounds" for event file selection).
+  /// </summary>
+  public string Tag { get; set; } = "";
 }

--- a/src/Radio.Web/Components/Dialogs/FileBrowserDialog.razor
+++ b/src/Radio.Web/Components/Dialogs/FileBrowserDialog.razor
@@ -30,7 +30,8 @@
               {
                 @foreach (var bookmark in _bookmarks)
                 {
-                  var isActive = _isAbsoluteMode && _absolutePath?.StartsWith(bookmark.Path) == true;
+                  var isActive = _isAbsoluteMode && (_absolutePath == bookmark.Path ||
+                    _absolutePath?.StartsWith(bookmark.Path.TrimEnd('/') + "/", StringComparison.OrdinalIgnoreCase) == true);
                   <div class="file-browser-location-item @(bookmark.IsAccessible ? "" : "file-browser-location-disabled")"
                        @onclick="@(() => NavigateToBookmark(bookmark))"
                        style="@(bookmark.IsAccessible ? "" : "opacity: 0.45; pointer-events: none;")">

--- a/src/Radio.Web/Components/Dialogs/FileBrowserDialog.razor
+++ b/src/Radio.Web/Components/Dialogs/FileBrowserDialog.razor
@@ -25,6 +25,38 @@
           {
             <div class="file-browser-location-overlay" @onclick="CloseLocationDropdown"></div>
             <div class="file-browser-location-dropdown" @onclick:stopPropagation="true">
+              @* Bookmarked folders — highlighted at top *@
+              @if (_bookmarks.Any())
+              {
+                @foreach (var bookmark in _bookmarks)
+                {
+                  var isActive = _isAbsoluteMode && _absolutePath?.StartsWith(bookmark.Path) == true;
+                  <div class="file-browser-location-item @(bookmark.IsAccessible ? "" : "file-browser-location-disabled")"
+                       @onclick="@(() => NavigateToBookmark(bookmark))"
+                       style="@(bookmark.IsAccessible ? "" : "opacity: 0.45; pointer-events: none;")">
+                    <MudIcon Icon="@Icons.Material.Filled.Star" Size="Size.Small"
+                             Color="Color.Warning" />
+                    <div style="flex: 1; min-width: 0;">
+                      <span style="font-weight: 500; color: var(--mud-palette-warning);">@bookmark.Label</span>
+                      <div style="font-size: 11px; color: var(--text-low); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                        @bookmark.Path
+                      </div>
+                    </div>
+                    @if (isActive)
+                    {
+                      <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small" Color="Color.Primary"
+                               Style="flex-shrink: 0;" />
+                    }
+                    @if (!bookmark.IsAccessible)
+                    {
+                      <MudIcon Icon="@Icons.Material.Filled.CloudOff" Size="Size.Small"
+                               Style="flex-shrink: 0; color: var(--text-low);" title="Not accessible" />
+                    }
+                  </div>
+                }
+                <div style="border-top: 1px solid var(--border-subtle); margin: 4px 0;"></div>
+              }
+              @* Media Library *@
               <div class="file-browser-location-item" @onclick="ReturnToMediaLibrary">
                 <MudIcon Icon="@Icons.Material.Filled.LibraryMusic" Size="Size.Small" Color="Color.Primary" />
                 <span>Media Library</span>
@@ -287,6 +319,12 @@
   [Parameter] public bool ShowPlayButton { get; set; }
   [Parameter] public EventCallback<List<string>> OnAddToQueue { get; set; }
 
+  /// <summary>
+  /// Tag to match against bookmark tags for selecting the initial default folder.
+  /// E.g., "music" opens the NAS music bookmark, "sounds" opens the local audio folder.
+  /// </summary>
+  [Parameter] public string? PreferredBookmarkTag { get; set; }
+
   private List<FileItemDto> _directories = new();
   private List<FileItemDto> _files = new();
   private bool _isLoading = true;
@@ -308,6 +346,7 @@
   private bool _isEditingPath;
   private bool _showLocationDropdown;
   private List<DriveInfoDto> _drives = new();
+  private List<BookmarkDto> _bookmarks = new();
   private MudTextField<string>? _pathTextField;
 
   private IEnumerable<FileItemDto> FilteredFiles
@@ -333,15 +372,63 @@
 
   protected override async Task OnInitializedAsync()
   {
-    // Load drives and media root in parallel
+    // Load drives, bookmarks, and media root in parallel
     var drivesTask = LoadDrivesAsync();
+    var bookmarksTask = LoadBookmarksAsync();
     var rootTask = LoadMediaRootAsync();
-    await Task.WhenAll(drivesTask, rootTask);
+    await Task.WhenAll(drivesTask, bookmarksTask, rootTask);
 
-    // Pass Subdirectory if provided, otherwise null lets the API use its configured root
-    _currentPath = Subdirectory;
-    UpdateRelativePath();
-    await LoadContentsAsync();
+    // Try to open the best default location:
+    // 1. If Subdirectory is set, use it (relative mode)
+    // 2. If a bookmark matches the preferred tag and is accessible, open it
+    // 3. If any bookmark is accessible, open the first one
+    // 4. Fall back to media library root
+    if (!string.IsNullOrEmpty(Subdirectory))
+    {
+      _currentPath = Subdirectory;
+      UpdateRelativePath();
+      await LoadContentsAsync();
+    }
+    else
+    {
+      var defaultBookmark = FindDefaultBookmark();
+      if (defaultBookmark != null)
+      {
+        _isAbsoluteMode = true;
+        _absolutePath = defaultBookmark.Path;
+        _driveRoot = "/";
+        _pathBarText = defaultBookmark.Path;
+        await LoadContentsAsync();
+      }
+      else
+      {
+        _currentPath = null;
+        UpdateRelativePath();
+        await LoadContentsAsync();
+      }
+    }
+  }
+
+  private BookmarkDto? FindDefaultBookmark()
+  {
+    if (!_bookmarks.Any())
+    {
+      return null;
+    }
+
+    // Prefer a bookmark matching the requested tag
+    if (!string.IsNullOrEmpty(PreferredBookmarkTag))
+    {
+      var tagged = _bookmarks.FirstOrDefault(b =>
+        b.IsAccessible && b.Tag.Equals(PreferredBookmarkTag, StringComparison.OrdinalIgnoreCase));
+      if (tagged != null)
+      {
+        return tagged;
+      }
+    }
+
+    // Fall back to first accessible bookmark
+    return _bookmarks.FirstOrDefault(b => b.IsAccessible);
   }
 
   private async Task LoadDrivesAsync()
@@ -350,11 +437,29 @@
     {
       var drives = await FileApi.GetDrivesAsync();
       if (drives != null)
+      {
         _drives = drives;
+      }
     }
     catch (Exception ex)
     {
       Logger.LogDebug(ex, "Failed to load drives");
+    }
+  }
+
+  private async Task LoadBookmarksAsync()
+  {
+    try
+    {
+      var bookmarks = await FileApi.GetBookmarksAsync();
+      if (bookmarks != null)
+      {
+        _bookmarks = bookmarks;
+      }
+    }
+    catch (Exception ex)
+    {
+      Logger.LogDebug(ex, "Failed to load bookmarks");
     }
   }
 
@@ -519,6 +624,17 @@
     _searchText = "";
     _errorMessage = null;
     await LoadContentsAsync();
+  }
+
+  private async Task NavigateToBookmark(BookmarkDto bookmark)
+  {
+    if (!bookmark.IsAccessible)
+    {
+      return;
+    }
+    _showLocationDropdown = false;
+    _driveRoot = "/";
+    await NavigateToAbsoluteAsync(bookmark.Path);
   }
 
   private async Task NavigateToDrive(string driveName)

--- a/src/Radio.Web/Components/Pages/SystemConfigPage.razor
+++ b/src/Radio.Web/Components/Pages/SystemConfigPage.razor
@@ -2732,8 +2732,12 @@
   {
     if (_filePlayerConfig == null) return;
 
-    // Remove bookmarks with empty paths before saving
+    // Remove bookmarks with empty paths before saving; auto-generate labels from path
     _filePlayerConfig.BookmarkedPaths.RemoveAll(b => string.IsNullOrWhiteSpace(b.Path));
+    foreach (var b in _filePlayerConfig.BookmarkedPaths.Where(b => string.IsNullOrWhiteSpace(b.Label)))
+    {
+      b.Label = b.Path.Split('/').LastOrDefault(s => !string.IsNullOrEmpty(s)) ?? b.Path;
+    }
 
     _isSaving = true;
     try

--- a/src/Radio.Web/Components/Pages/SystemConfigPage.razor
+++ b/src/Radio.Web/Components/Pages/SystemConfigPage.razor
@@ -631,6 +631,79 @@
                               InputMode="InputMode.text"
                               HelperText="Comma-separated file extensions (e.g., .mp3,.flac,.wav)" />
               </MudItem>
+
+              <!-- Bookmarked Paths -->
+              <MudItem xs="12">
+                <div style="display: flex; align-items: center; justify-content: space-between; margin-top: 8px; margin-bottom: 4px;">
+                  <MudText Typo="Typo.subtitle1" Style="font-weight: 600;">
+                    <MudIcon Icon="@Icons.Material.Filled.Star" Size="Size.Small" Color="Color.Warning"
+                             Style="vertical-align: middle; margin-right: 4px;" />
+                    Bookmarked Folders
+                  </MudText>
+                  <MudButton Variant="Variant.Text" Color="Color.Primary" Size="Size.Small"
+                             StartIcon="@Icons.Material.Filled.Add" OnClick="AddBookmark">
+                    Add Bookmark
+                  </MudButton>
+                </div>
+                <MudText Typo="Typo.caption" Style="color: var(--text-low); margin-bottom: 8px;">
+                  Quick-access folders shown at the top of the file browser. Tag with "music" for queue browsing or "sounds" for event file selection.
+                </MudText>
+
+                @if (_filePlayerConfig.BookmarkedPaths.Count == 0)
+                {
+                  <MudAlert Severity="Severity.Info" Variant="Variant.Text" Dense="true" Class="mb-2">
+                    No bookmarks configured. The file browser will open to the media library root.
+                  </MudAlert>
+                }
+                else
+                {
+                  @for (int i = 0; i < _filePlayerConfig.BookmarkedPaths.Count; i++)
+                  {
+                    var index = i;
+                    var bookmark = _filePlayerConfig.BookmarkedPaths[index];
+                    <MudPaper Outlined="true" Class="pa-3 mb-2" Style="background: rgba(255,255,255,0.02);">
+                      <MudGrid Spacing="2">
+                        <MudItem xs="12" md="5">
+                          <MudTextField T="string" @bind-Value="bookmark.Path" Label="Path"
+                                        Variant="Variant.Outlined" Margin="Margin.Dense"
+                                        InputMode="InputMode.text"
+                                        Placeholder="/mnt/nas/music" />
+                        </MudItem>
+                        <MudItem xs="12" md="3">
+                          <MudTextField T="string" @bind-Value="bookmark.Label" Label="Label"
+                                        Variant="Variant.Outlined" Margin="Margin.Dense"
+                                        InputMode="InputMode.text"
+                                        Placeholder="NAS Music Library" />
+                        </MudItem>
+                        <MudItem xs="8" md="2">
+                          <MudSelect T="string" @bind-Value="bookmark.Tag" Label="Tag"
+                                     Variant="Variant.Outlined" Margin="Margin.Dense" Dense="true">
+                            <MudSelectItem Value="@("music")">music</MudSelectItem>
+                            <MudSelectItem Value="@("sounds")">sounds</MudSelectItem>
+                            <MudSelectItem Value="@("")">none</MudSelectItem>
+                          </MudSelect>
+                        </MudItem>
+                        <MudItem xs="4" md="2" Style="display: flex; align-items: center; gap: 4px; justify-content: flex-end;">
+                          @if (index > 0)
+                          {
+                            <MudIconButton Icon="@Icons.Material.Filled.ArrowUpward" Size="Size.Small"
+                                           OnClick="@(() => MoveBookmarkUp(index))" title="Move up" />
+                          }
+                          @if (index < _filePlayerConfig.BookmarkedPaths.Count - 1)
+                          {
+                            <MudIconButton Icon="@Icons.Material.Filled.ArrowDownward" Size="Size.Small"
+                                           OnClick="@(() => MoveBookmarkDown(index))" title="Move down" />
+                          }
+                          <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                         Color="Color.Error"
+                                         OnClick="@(() => RemoveBookmark(index))" title="Remove bookmark" />
+                        </MudItem>
+                      </MudGrid>
+                    </MudPaper>
+                  }
+                }
+              </MudItem>
+
               <MudItem xs="12">
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveFilePlayerConfigAsync"
                            StartIcon="@Icons.Material.Filled.Save" Disabled="@_isSaving">
@@ -2292,7 +2365,8 @@
     var parameters = new DialogParameters
     {
       { "InitialSelection", _selectedSoundFile },
-      { "Subdirectory", (string?)null }
+      { "Subdirectory", (string?)null },
+      { "PreferredBookmarkTag", "sounds" }
     };
 
     var options = new DialogOptions
@@ -2657,6 +2731,10 @@
   private async Task SaveFilePlayerConfigAsync()
   {
     if (_filePlayerConfig == null) return;
+
+    // Remove bookmarks with empty paths before saving
+    _filePlayerConfig.BookmarkedPaths.RemoveAll(b => string.IsNullOrWhiteSpace(b.Path));
+
     _isSaving = true;
     try
     {
@@ -2666,6 +2744,37 @@
     }
     catch (Exception ex) { Snackbar.Add($"Error saving configuration: {ex.Message}", Severity.Error); }
     finally { _isSaving = false; }
+  }
+
+  private void AddBookmark()
+  {
+    _filePlayerConfig?.BookmarkedPaths.Add(new BookmarkedPathDto());
+  }
+
+  private void RemoveBookmark(int index)
+  {
+    if (_filePlayerConfig != null && index >= 0 && index < _filePlayerConfig.BookmarkedPaths.Count)
+    {
+      _filePlayerConfig.BookmarkedPaths.RemoveAt(index);
+    }
+  }
+
+  private void MoveBookmarkUp(int index)
+  {
+    if (_filePlayerConfig != null && index > 0 && index < _filePlayerConfig.BookmarkedPaths.Count)
+    {
+      (_filePlayerConfig.BookmarkedPaths[index - 1], _filePlayerConfig.BookmarkedPaths[index]) =
+        (_filePlayerConfig.BookmarkedPaths[index], _filePlayerConfig.BookmarkedPaths[index - 1]);
+    }
+  }
+
+  private void MoveBookmarkDown(int index)
+  {
+    if (_filePlayerConfig != null && index >= 0 && index < _filePlayerConfig.BookmarkedPaths.Count - 1)
+    {
+      (_filePlayerConfig.BookmarkedPaths[index], _filePlayerConfig.BookmarkedPaths[index + 1]) =
+        (_filePlayerConfig.BookmarkedPaths[index + 1], _filePlayerConfig.BookmarkedPaths[index]);
+    }
   }
 
   private async Task SaveFingerprintingConfigAsync()

--- a/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
+++ b/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
@@ -387,6 +387,7 @@
       { "AllowMultiSelect", true },
       { "AllowAddToQueue", true },
       { "ShowPlayButton", true },
+      { "PreferredBookmarkTag", "music" },
       { "OnAddToQueue", EventCallback.Factory.Create<List<string>>(this, HandleAddFilesToQueueAsync) }
     };
     var options = new DialogOptions

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -217,6 +217,13 @@ public record DriveInfoDto(
   string? DriveFormat
 );
 
+public record BookmarkDto(
+  string Path,
+  string Label,
+  string Tag,
+  bool IsAccessible
+);
+
 public record QueueFilesResponseDto(
   bool Success,
   string? Message,
@@ -661,6 +668,14 @@ public class FilePlayerConfigDto
   public string RootDirectory { get; set; } = "media/audio";
   public string SupportedExtensions { get; set; } = ".mp3,.flac,.wav,.ogg,.aac,.m4a,.wma";
   public string[] AllowedBrowseDirectories { get; set; } = [];
+  public List<BookmarkedPathDto> BookmarkedPaths { get; set; } = [];
+}
+
+public class BookmarkedPathDto
+{
+  public string Path { get; set; } = "";
+  public string Label { get; set; } = "";
+  public string Tag { get; set; } = "";
 }
 
 public class FingerprintingConfigDto

--- a/src/Radio.Web/Services/ApiClients/FileApiService.cs
+++ b/src/Radio.Web/Services/ApiClients/FileApiService.cs
@@ -147,4 +147,17 @@ public class FileApiService
       return null;
     }
   }
+
+  public async Task<List<BookmarkDto>?> GetBookmarksAsync(CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      return await _httpClient.GetFromJsonAsync<List<BookmarkDto>>("/api/files/bookmarks", cancellationToken);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to get bookmarks");
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- **File browser opens to default bookmarked folder** instead of showing empty content — uses configurable `BookmarkedPaths` in `FilePlayerOptions` with path/label/tag
- **Context-aware defaults**: Queue file browser prefers `music` tagged bookmark (NAS library), event file browser prefers `sounds` tagged bookmark (local audio files)
- **Bookmark management UI** added to System Config → File Player tab: add/remove/reorder bookmarks with path, label, and tag fields
- **Linux system mount filtering**: Drives like `/dev/*`, `/run/*`, `/sys/*` etc. excluded from folder picker
- **Config roundtrip fix**: `ParseConfigValue()` now preserves JSON arrays/objects so `BookmarkedPaths` survives save/load through the config store

## Changes
- `FilePlayerOptions` — new `BookmarkedPath` model with Path/Label/Tag
- `FilesController` — `GET /api/files/bookmarks` endpoint, path security allowlisting, mount filtering
- `FileBrowserDialog.razor` — bookmark-aware navigation, redesigned location dropdown with starred bookmarks
- `SystemConfigPage.razor` — bookmark CRUD UI (add/remove/move up/move down)
- `ConfigurationController` — `ParseConfigValue()` handles JSON arrays/objects for roundtrip correctness

## Test plan
- [ ] Build passes: `dotnet build --configuration Release` (verified: 0 warnings, 0 errors)
- [ ] All tests pass: API 223/223, Configuration 115/115, Web 116/116
- [ ] Deploy to Ubuntu and verify file browser opens to NAS music folder
- [ ] Verify bookmark management in System Config: add, edit, remove, reorder
- [ ] Verify event file dialog defaults to local audio files folder
- [ ] Verify system mounts filtered from folder picker on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)