### PR TITLE
fix: Search filter applies to directories in file browser

### DIFF
--- a/src/Radio.Web/Components/Dialogs/FileBrowserDialog.razor
+++ b/src/Radio.Web/Components/Dialogs/FileBrowserDialog.razor
@@ -198,7 +198,7 @@
           }
         </div>
       }
-      else if (!_directories.Any() && !FilteredFiles.Any())
+      else if (!FilteredDirectories.Any() && !FilteredFiles.Any())
       {
         <div style="flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 32px;">
           <MudIcon Icon="@Icons.Material.Filled.FolderOff" Style="font-size: 64px; opacity: 0.4;" />
@@ -211,7 +211,7 @@
       {
         <div class="file-browser-list">
           @* Directories first *@
-          @foreach (var dir in _directories)
+          @foreach (var dir in FilteredDirectories)
           {
             <div class="file-item list-item-touch" @onclick="@(() => NavigateToFolderAsync(dir.Name))">
               <MudIcon Icon="@Icons.Material.Filled.Folder" Color="Color.Warning" />
@@ -349,6 +349,20 @@
   private List<DriveInfoDto> _drives = new();
   private List<BookmarkDto> _bookmarks = new();
   private MudTextField<string>? _pathTextField;
+
+  private IEnumerable<FileItemDto> FilteredDirectories
+  {
+    get
+    {
+      var dirs = _directories.AsEnumerable();
+      if (!string.IsNullOrWhiteSpace(_searchText))
+      {
+        var search = _searchText.Trim();
+        dirs = dirs.Where(d => d.Name.Contains(search, StringComparison.OrdinalIgnoreCase));
+      }
+      return dirs;
+    }
+  }
 
   private IEnumerable<FileItemDto> FilteredFiles
   {


### PR DESCRIPTION
## Summary
- Search text box in file browser dialog now filters both directories and files
- Previously only files were filtered via `FilteredFiles`, while directories rendered unfiltered from `_directories`
- Added `FilteredDirectories` computed property matching by directory name (case-insensitive)
- Empty state check updated to use `FilteredDirectories` so "No matching files" shows correctly when search excludes everything

## Test plan
- [ ] Build: 0 warnings, 0 errors
- [ ] Web tests: 116/116 pass
- [ ] Deploy to Ubuntu and verify: type in search box while viewing a folder with subdirectories — directories should filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)