### PR TITLE
fix: harden PhoneHubService and PhonePage event safety

### DIFF
--- a/src/Radio.Web/Components/Pages/PhonePage.razor
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor
@@ -226,6 +226,7 @@
   private string _dialDigits = "";
   private bool _isAvailable;
   private bool _disposed;
+  private bool _polling;
   private System.Timers.Timer? _pollTimer;
 
   protected override async Task OnInitializedAsync()
@@ -260,7 +261,8 @@
 
   private async Task PollStatusAsync()
   {
-    if (_disposed) return;
+    if (_disposed || _polling) return;
+    _polling = true;
     try
     {
       var available = await PhoneApi.IsAvailableAsync();
@@ -280,6 +282,7 @@
       }
     }
     catch { /* Polling failure is non-fatal */ }
+    finally { _polling = false; }
   }
 
   // SignalR event handlers

--- a/src/Radio.Web/Services/Hub/PhoneHubService.cs
+++ b/src/Radio.Web/Services/Hub/PhoneHubService.cs
@@ -10,7 +10,9 @@ public class PhoneHubService : IAsyncDisposable
 {
   private readonly ILogger<PhoneHubService> _logger;
   private readonly IConfiguration _configuration;
+  private readonly SemaphoreSlim _connectionLock = new(1, 1);
   private HubConnection? _hubConnection;
+  private CancellationTokenSource? _retryCts;
 
   public event Action<string, string>? CallStateChanged;
   public event Action<string, string>? IncomingCall;
@@ -27,67 +29,116 @@ public class PhoneHubService : IAsyncDisposable
 
   public async Task StartAsync()
   {
-    var hubUrl = _configuration.GetValue<string>("RotaryPhone:HubUrl") ?? "http://localhost:5004/hub";
-
-    _hubConnection = new HubConnectionBuilder()
-      .WithUrl(hubUrl)
-      .WithAutomaticReconnect(new[] { TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5),
-        TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30) })
-      .Build();
-
-    _hubConnection.On<string, string>("CallStateChanged", (phoneId, state) =>
+    if (!await _connectionLock.WaitAsync(0))
     {
-      _logger.LogDebug("Phone call state changed: {PhoneId} → {State}", phoneId, state);
-      CallStateChanged?.Invoke(phoneId, state);
-    });
-
-    _hubConnection.On<string, string>("IncomingCall", (phoneId, phoneNumber) =>
-    {
-      _logger.LogInformation("Incoming call from {PhoneNumber}", phoneNumber);
-      IncomingCall?.Invoke(phoneId, phoneNumber);
-    });
-
-    _hubConnection.On("CallHistoryUpdated", () =>
-    {
-      CallHistoryUpdated?.Invoke();
-    });
-
-    _hubConnection.On<object>("SystemStatusChanged", (status) =>
-    {
-      SystemStatusChanged?.Invoke(status);
-    });
-
-    _hubConnection.Reconnecting += ex =>
-    {
-      _logger.LogWarning(ex, "Phone hub reconnecting...");
-      return Task.CompletedTask;
-    };
-
-    _hubConnection.Reconnected += connectionId =>
-    {
-      _logger.LogInformation("Phone hub reconnected: {ConnectionId}", connectionId);
-      return Task.CompletedTask;
-    };
-
-    _hubConnection.Closed += ex =>
-    {
-      _logger.LogWarning(ex, "Phone hub connection closed");
-      return Task.CompletedTask;
-    };
+      _logger.LogDebug("Phone hub connection already in progress");
+      return;
+    }
 
     try
     {
-      await _hubConnection.StartAsync();
-      _logger.LogInformation("Connected to RotaryPhone hub at {Url}", hubUrl);
+      if (_hubConnection != null)
+      {
+        return;
+      }
+
+      var hubUrl = _configuration.GetValue<string>("RotaryPhone:HubUrl") ?? "http://localhost:5004/hub";
+
+      _hubConnection = new HubConnectionBuilder()
+        .WithUrl(hubUrl)
+        .WithAutomaticReconnect(new[] { TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5),
+          TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30) })
+        .Build();
+
+      _hubConnection.On<string, string>("CallStateChanged", (phoneId, state) =>
+      {
+        _logger.LogDebug("Phone call state changed: {PhoneId} → {State}", phoneId, state);
+        CallStateChanged?.Invoke(phoneId, state);
+      });
+
+      _hubConnection.On<string, string>("IncomingCall", (phoneId, phoneNumber) =>
+      {
+        _logger.LogInformation("Incoming call from {PhoneNumber}", phoneNumber);
+        IncomingCall?.Invoke(phoneId, phoneNumber);
+      });
+
+      _hubConnection.On("CallHistoryUpdated", () =>
+      {
+        CallHistoryUpdated?.Invoke();
+      });
+
+      _hubConnection.On<object>("SystemStatusChanged", (status) =>
+      {
+        SystemStatusChanged?.Invoke(status);
+      });
+
+      _hubConnection.Reconnecting += ex =>
+      {
+        _logger.LogWarning(ex, "Phone hub reconnecting...");
+        return Task.CompletedTask;
+      };
+
+      _hubConnection.Reconnected += connectionId =>
+      {
+        _logger.LogInformation("Phone hub reconnected: {ConnectionId}", connectionId);
+        return Task.CompletedTask;
+      };
+
+      _hubConnection.Closed += ex =>
+      {
+        _logger.LogWarning(ex, "Phone hub connection closed");
+        return Task.CompletedTask;
+      };
+
+      try
+      {
+        await _hubConnection.StartAsync();
+        _logger.LogInformation("Connected to RotaryPhone hub at {Url}", hubUrl);
+      }
+      catch (Exception ex)
+      {
+        _logger.LogWarning(ex, "Failed to connect to RotaryPhone hub at {Url} — will retry in background", hubUrl);
+        StartRetryLoop(hubUrl);
+      }
     }
-    catch (Exception ex)
+    finally
     {
-      _logger.LogWarning(ex, "Failed to connect to RotaryPhone hub at {Url} — phone features unavailable", hubUrl);
+      _connectionLock.Release();
     }
+  }
+
+  private void StartRetryLoop(string hubUrl)
+  {
+    _retryCts = new CancellationTokenSource();
+    _ = Task.Run(async () =>
+    {
+      var delays = new[] { 10, 30, 60 };
+      for (int attempt = 0; !_retryCts.Token.IsCancellationRequested; attempt++)
+      {
+        var delaySec = delays[Math.Min(attempt, delays.Length - 1)];
+        await Task.Delay(TimeSpan.FromSeconds(delaySec), _retryCts.Token);
+        try
+        {
+          if (_hubConnection?.State == HubConnectionState.Disconnected)
+          {
+            await _hubConnection.StartAsync(_retryCts.Token);
+            _logger.LogInformation("Connected to RotaryPhone hub at {Url} (retry #{Attempt})", hubUrl, attempt + 1);
+            return;
+          }
+        }
+        catch (Exception ex)
+        {
+          _logger.LogDebug(ex, "Phone hub retry #{Attempt} failed", attempt + 1);
+        }
+      }
+    }, _retryCts.Token);
   }
 
   public async Task StopAsync()
   {
+    _retryCts?.Cancel();
+    _retryCts?.Dispose();
+    _retryCts = null;
     if (_hubConnection != null)
     {
       await _hubConnection.DisposeAsync();
@@ -98,5 +149,6 @@ public class PhoneHubService : IAsyncDisposable
   public async ValueTask DisposeAsync()
   {
     await StopAsync();
+    _connectionLock.Dispose();
   }
 }


### PR DESCRIPTION
## Summary
- Rewrites PhoneHubService with SemaphoreSlim idempotency guard and background retry loop (10s/30s/60s backoff) for initial connection failures
- Adds `_polling` reentrancy guard to PhonePage timer callback to prevent overlapping status polls
- Addresses review feedback from PR #341

## Test plan
- [x] Radio.Web builds with 0 warnings
- [x] All 127 Radio.Web.Tests pass
- [ ] Manual: verify PhoneHubService retries when RotaryPhone API is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)