### PR TITLE
feat: PBAP phonebook contact sync for caller ID

### DIFF
--- a/design/INTEGRATIONS.md
+++ b/design/INTEGRATIONS.md
@@ -254,16 +254,59 @@ Expected response (200 OK):
 
 If the API is unavailable or returns no match, the raw phone number is used in the announcement.
 
+### PBAP Contact Sync
+
+Radio.API can download contacts from the connected phone's phonebook via Bluetooth PBAP (Phone Book Access Profile). These contacts are used for caller ID resolution during incoming calls.
+
+**How it works:**
+1. A Python helper script (`pbap_download.py`) manages the D-Bus session bus connection to BlueZ's obexd
+2. It creates an OBEX PBAP session, selects the internal phonebook, and downloads all contacts as a VCF file
+3. The VCF is parsed (vCard 2.1/3.0 with quoted-printable decoding) and stored in SQLite
+4. Phone number lookup uses exact match first, then last-7-digit suffix matching for fuzzy resolution
+5. After sync, the BT connection is automatically restored (OBEX teardown causes a temporary disconnect)
+
+**Prerequisites:**
+- `bluez-obexd` installed and enabled as a user service: `systemctl --user enable --now obex`
+- `python3` with `dbus-python` and `PyGObject` packages (standard on Ubuntu)
+- `DBUS_SESSION_BUS_ADDRESS` environment variable set in the radio-api systemd service
+- Phone must be paired and have granted PBAP access (Android prompts on first access)
+
+**Configuration** (`appsettings.json` → `Bluetooth:Pbap`):
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `AutoSyncOnConnect` | Automatically sync contacts when a phone connects | `true` |
+| `SyncStaleThresholdHours` | Hours before contacts are considered stale and re-synced | `24` |
+| `TransferTimeoutSeconds` | Max seconds to wait for PBAP transfer to complete | `30` |
+
+**REST API** (`/api/bluetooth/pbap`):
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/sync?deviceAddress=XX:XX:XX:XX:XX:XX` | Trigger manual sync (uses connected device if omitted) |
+| `GET` | `/contacts?deviceAddress=XX:XX:XX:XX:XX:XX` | List synced contacts for a device |
+| `GET` | `/lookup?phoneNumber=5551234567` | Look up a contact by phone number |
+| `GET` | `/status` | Sync status for all devices |
+
+**Operational notes:**
+- PBAP sync causes a brief BT audio interruption (~5 seconds) as OBEX uses a separate RFCOMM channel
+- The service uses `PrivateTmp=true` in systemd, so temp files are written to `/opt/radio-console/data/` (not `/tmp`) to avoid mount namespace mismatch with obexd
+- A `SemaphoreSlim` prevents concurrent sync attempts from auto-sync and manual API calls
+- On first connect from a new phone, Android will prompt to allow phonebook access — the user must approve on the phone
+
 ### How It Works
 
 When an incoming call is detected (`Ringing` state):
 
-1. The `PhoneCallIntegrationService` looks up the caller name (from the SignalR event, or via the contacts API)
+1. The `PhoneCallIntegrationService` looks up the caller name:
+   - First checks PBAP contacts (local SQLite, synced from phone's phonebook)
+   - Falls back to the RotaryPhone contacts REST API
 2. If a ring sound file exists at `RingSoundPath`, it plays the sound followed by a TTS announcement (e.g., "Incoming call from John Smith")
 3. If no ring sound, just the TTS announcement plays
 4. Audio ducking lowers the main audio during the announcement
-5. When the call ends (`Ended` or `Idle`), the announcement stops and audio returns to normal
-6. Call state changes are broadcast to the Web UI in real-time via SignalR
+5. The resolved caller name is reported back to RotaryPhone via SignalR (`ReportCallerResolved`)
+6. When the call ends (`Ended` or `Idle`), the announcement stops and audio returns to normal
+7. Call state changes are broadcast to the Web UI in real-time via SignalR
 
 ### Troubleshooting
 
@@ -396,7 +439,11 @@ Status indicators update in real-time via SignalR — no page refresh needed.
 │                                 → VisualizationModeService      │
 │                                                                 │
 │  PhoneCallIntegrationService ← IPhoneIntegrationService (SignalR)│
-│    └→ PhoneContactLookupService (REST)                          │
+│    └→ PhoneContactLookupService (PBAP SQLite + REST fallback)   │
+│                                                                 │
+│  PbapSyncService ← IPbapSyncService (D-Bus OBEX via Python)     │
+│    └→ PbapContactRepository (SQLite)                            │
+│    └→ VCardParser                                               │
 │    └→ IAnnouncementService → ITTSFactory + IDuckingService      │
 │                                                                 │
 │  NotificationsController                                        │
@@ -433,12 +480,17 @@ Status indicators update in real-time via SignalR — no page refresh needed.
 | Infrastructure | `Platform/Input/HidRotaryEncoderService.cs` | USB HID reader + event firing |
 | Infrastructure | `Platform/Input/RotaryEncoderActionRouter.cs` | Maps encoder events → audio actions |
 | Infrastructure | `External/PhoneCallClient.cs` | SignalR client for RotaryPhone hub |
-| Infrastructure | `External/PhoneContactLookupService.cs` | REST client for contacts lookup |
+| Infrastructure | `External/PhoneContactLookupService.cs` | PBAP + REST contact lookup |
+| Infrastructure | `Bluetooth/PbapSyncService.cs` | PBAP sync service (D-Bus OBEX) |
+| Infrastructure | `Bluetooth/PbapContactRepository.cs` | SQLite contact storage |
+| Infrastructure | `Bluetooth/VCardParser.cs` | vCard 2.1/3.0 parser |
+| Infrastructure | `Bluetooth/pbap_download.py` | Python D-Bus OBEX helper script |
 | Infrastructure | `Audio/Services/AnnouncementService.cs` | TTS + ducking orchestration |
 | Infrastructure | `Audio/Services/VisualizationModeService.cs` | Viz mode cycling for encoder 3 |
 | API | `Controllers/NotificationsController.cs` | `POST /api/notifications/announce` |
 | API | `Controllers/IntegrationsController.cs` | `GET /api/integrations/{encoder,phone}/status` |
 | API | `Services/RotaryEncoderHostedService.cs` | Encoder lifecycle management |
-| API | `Services/PhoneCallIntegrationService.cs` | Phone call event handling |
+| API | `Services/PhoneCallIntegrationService.cs` | Phone call event handling + caller ID |
+| API | `Controllers/PbapController.cs` | PBAP sync/contacts/lookup REST endpoints |
 | Web | `Services/ApiClients/IntegrationsApiService.cs` | HTTP client for status endpoints |
 | Web | `Components/Pages/SystemConfigPage.razor` | Integrations tab UI |

--- a/src/Radio.API/Controllers/PbapController.cs
+++ b/src/Radio.API/Controllers/PbapController.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc;
+using Radio.Core.Interfaces.Audio;
+using Radio.Core.Interfaces.Bluetooth;
+using Radio.Core.Utilities;
+
+namespace Radio.API.Controllers;
+
+[ApiController]
+[Route("api/bluetooth/pbap")]
+public class PbapController : ControllerBase
+{
+  private readonly IPbapSyncService _syncService;
+  private readonly IPbapContactRepository _contactRepo;
+  private readonly IBluetoothService _bluetoothService;
+
+  public PbapController(
+    IPbapSyncService syncService,
+    IPbapContactRepository contactRepo,
+    IBluetoothService bluetoothService)
+  {
+    _syncService = syncService;
+    _contactRepo = contactRepo;
+    _bluetoothService = bluetoothService;
+  }
+
+  [HttpPost("sync")]
+  public async Task<IActionResult> SyncContacts([FromQuery] string? deviceAddress, CancellationToken ct)
+  {
+    deviceAddress ??= _bluetoothService.ConnectedDevice?.Address;
+    if (string.IsNullOrEmpty(deviceAddress))
+      return BadRequest("No device address specified and no device currently connected");
+
+    var result = await _syncService.SyncContactsAsync(deviceAddress, ct);
+    return Ok(result);
+  }
+
+  [HttpGet("contacts")]
+  public async Task<IActionResult> GetContacts([FromQuery] string deviceAddress, CancellationToken ct)
+  {
+    if (string.IsNullOrEmpty(deviceAddress))
+      return BadRequest("deviceAddress is required");
+
+    var contacts = await _contactRepo.GetContactsAsync(deviceAddress, ct);
+    return Ok(contacts);
+  }
+
+  [HttpGet("lookup")]
+  public async Task<IActionResult> LookupNumber([FromQuery] string phoneNumber, CancellationToken ct)
+  {
+    var deviceAddress = _bluetoothService.ConnectedDevice?.Address;
+    if (string.IsNullOrEmpty(deviceAddress))
+      return NotFound("No device currently connected");
+
+    var normalized = PhoneNumberNormalizer.Normalize(phoneNumber);
+    var contact = await _contactRepo.FindByPhoneNumberAsync(deviceAddress, normalized, ct);
+
+    if (contact == null)
+      return NotFound($"No contact found for {phoneNumber}");
+
+    return Ok(new { contact.DisplayName, PhoneNumber = phoneNumber });
+  }
+
+  [HttpGet("status")]
+  public async Task<IActionResult> GetStatus()
+  {
+    var status = await _syncService.GetSyncStatusAsync();
+    return Ok(status);
+  }
+}

--- a/src/Radio.API/Services/PhoneCallIntegrationService.cs
+++ b/src/Radio.API/Services/PhoneCallIntegrationService.cs
@@ -143,6 +143,19 @@ public class PhoneCallIntegrationService : BackgroundService
     {
       _logger.LogError(ex, "Error playing incoming call announcement");
     }
+
+    // Send resolved name back to RotaryPhone for UI/logging
+    if (!string.IsNullOrEmpty(e.PhoneNumber))
+    {
+      try
+      {
+        await _phoneClient.ReportCallerResolvedAsync(e.PhoneNumber, callerName);
+      }
+      catch (Exception ex)
+      {
+        _logger.LogWarning(ex, "Failed to send resolved caller name to RotaryPhone");
+      }
+    }
   }
 
   private async Task BroadcastPhoneStateAsync(PhoneCallStateChangedEventArgs e)

--- a/src/Radio.API/appsettings.json
+++ b/src/Radio.API/appsettings.json
@@ -208,7 +208,12 @@
     "AutoReconnect": true,
     "ReconnectBaseDelayMs": 3000,
     "ReconnectMaxDelayMs": 60000,
-    "MaxReconnectAttempts": 20
+    "MaxReconnectAttempts": 20,
+    "Pbap": {
+      "AutoSyncOnConnect": true,
+      "SyncStaleThresholdHours": 24,
+      "TransferTimeoutSeconds": 30
+    }
   },
   "BluetoothPreferences": {
     "LastConnectedDevice": "",

--- a/src/Radio.Core/Configuration/PbapOptions.cs
+++ b/src/Radio.Core/Configuration/PbapOptions.cs
@@ -1,0 +1,10 @@
+namespace Radio.Core.Configuration;
+
+public class PbapOptions
+{
+  public const string SectionName = "Bluetooth:Pbap";
+
+  public bool AutoSyncOnConnect { get; set; } = true;
+  public int SyncStaleThresholdHours { get; set; } = 24;
+  public int TransferTimeoutSeconds { get; set; } = 30;
+}

--- a/src/Radio.Core/Interfaces/Bluetooth/IPbapContactRepository.cs
+++ b/src/Radio.Core/Interfaces/Bluetooth/IPbapContactRepository.cs
@@ -1,0 +1,12 @@
+using Radio.Core.Models;
+
+namespace Radio.Core.Interfaces.Bluetooth;
+
+public interface IPbapContactRepository
+{
+  Task UpsertContactsAsync(string deviceAddress, List<PbapContact> contacts, CancellationToken ct = default);
+  Task<PbapContact?> FindByPhoneNumberAsync(string deviceAddress, string normalizedNumber, CancellationToken ct = default);
+  Task<List<PbapContact>> GetContactsAsync(string deviceAddress, CancellationToken ct = default);
+  Task<List<(string DeviceAddress, int ContactCount, DateTime? LastSynced)>> GetSyncSummaryAsync(string? deviceAddress = null, CancellationToken ct = default);
+  Task DeleteContactsAsync(string deviceAddress, CancellationToken ct = default);
+}

--- a/src/Radio.Core/Interfaces/Bluetooth/IPbapSyncService.cs
+++ b/src/Radio.Core/Interfaces/Bluetooth/IPbapSyncService.cs
@@ -1,0 +1,28 @@
+namespace Radio.Core.Interfaces.Bluetooth;
+
+public interface IPbapSyncService
+{
+  Task<PbapSyncResult> SyncContactsAsync(string deviceAddress, CancellationToken ct = default);
+  Task<PbapSyncStatus> GetSyncStatusAsync(string? deviceAddress = null);
+}
+
+public class PbapSyncResult
+{
+  public bool Success { get; set; }
+  public int ContactCount { get; set; }
+  public string? ErrorMessage { get; set; }
+}
+
+public class PbapSyncStatus
+{
+  public List<DeviceSyncInfo> Devices { get; set; } = new();
+}
+
+public class DeviceSyncInfo
+{
+  public string DeviceAddress { get; set; } = string.Empty;
+  public string? DeviceName { get; set; }
+  public int ContactCount { get; set; }
+  public DateTime? LastSynced { get; set; }
+  public bool IsStale { get; set; }
+}

--- a/src/Radio.Core/Interfaces/External/IPhoneIntegrationService.cs
+++ b/src/Radio.Core/Interfaces/External/IPhoneIntegrationService.cs
@@ -23,6 +23,9 @@ public interface IPhoneIntegrationService : IAsyncDisposable
   /// <summary>Stop the SignalR connection.</summary>
   Task StopAsync(CancellationToken cancellationToken = default);
 
+  /// <summary>Send resolved caller name back to RotaryPhone for UI/logging.</summary>
+  Task ReportCallerResolvedAsync(string phoneNumber, string resolvedName, CancellationToken ct = default);
+
   /// <summary>Fired when the phone call state changes.</summary>
   event EventHandler<PhoneCallStateChangedEventArgs>? CallStateChanged;
 }

--- a/src/Radio.Core/Models/PbapContact.cs
+++ b/src/Radio.Core/Models/PbapContact.cs
@@ -1,0 +1,7 @@
+namespace Radio.Core.Models;
+
+public class PbapContact
+{
+  public string DisplayName { get; set; } = string.Empty;
+  public List<string> PhoneNumbers { get; set; } = new();
+}

--- a/src/Radio.Core/Utilities/PhoneNumberNormalizer.cs
+++ b/src/Radio.Core/Utilities/PhoneNumberNormalizer.cs
@@ -1,0 +1,26 @@
+namespace Radio.Core.Utilities;
+
+public static class PhoneNumberNormalizer
+{
+  public static string Normalize(string phoneNumber)
+  {
+    if (string.IsNullOrWhiteSpace(phoneNumber))
+      return string.Empty;
+
+    var digits = new string(phoneNumber.Where(char.IsDigit).ToArray());
+
+    // Strip leading '1' for 11-digit US numbers
+    if (digits.Length == 11 && digits[0] == '1')
+      digits = digits[1..];
+
+    return digits;
+  }
+
+  public static string GetLast7(string normalizedNumber)
+  {
+    if (normalizedNumber.Length <= 7)
+      return normalizedNumber;
+
+    return normalizedNumber[^7..];
+  }
+}

--- a/src/Radio.Infrastructure/Bluetooth/PbapContactRepository.cs
+++ b/src/Radio.Infrastructure/Bluetooth/PbapContactRepository.cs
@@ -1,0 +1,235 @@
+using Microsoft.Data.Sqlite;
+using Radio.Core.Interfaces.Bluetooth;
+using Radio.Core.Models;
+using Radio.Core.Utilities;
+
+namespace Radio.Infrastructure.Bluetooth;
+
+public class PbapContactRepository : IPbapContactRepository
+{
+  private readonly string _connectionString;
+  private readonly SqliteConnection? _sharedConnection; // for testing with in-memory DB
+
+  public PbapContactRepository(string connectionString)
+  {
+    _connectionString = connectionString;
+  }
+
+  /// <summary>Test-only constructor for in-memory SQLite.</summary>
+  internal PbapContactRepository(SqliteConnection sharedConnection)
+  {
+    _sharedConnection = sharedConnection;
+    _connectionString = sharedConnection.ConnectionString;
+  }
+
+  private SqliteConnection GetConnection()
+  {
+    if (_sharedConnection != null) return _sharedConnection;
+    var conn = new SqliteConnection(_connectionString);
+    conn.Open();
+    return conn;
+  }
+
+  private void ReturnConnection(SqliteConnection conn)
+  {
+    // Don't dispose shared test connections
+    if (conn != _sharedConnection) conn.Dispose();
+  }
+
+  public async Task InitializeAsync()
+  {
+    var conn = GetConnection();
+    try
+    {
+      using var cmd = conn.CreateCommand();
+      cmd.CommandText = """
+          CREATE TABLE IF NOT EXISTS PbapContacts (
+              Id INTEGER PRIMARY KEY AUTOINCREMENT,
+              DeviceAddress TEXT NOT NULL,
+              DisplayName TEXT NOT NULL,
+              PhoneNumber TEXT NOT NULL,
+              LastSynced DATETIME NOT NULL,
+              UNIQUE(DeviceAddress, PhoneNumber)
+          );
+          CREATE INDEX IF NOT EXISTS IX_PbapContacts_DeviceAddress ON PbapContacts(DeviceAddress);
+          CREATE INDEX IF NOT EXISTS IX_PbapContacts_PhoneNumber ON PbapContacts(PhoneNumber);
+          """;
+      await cmd.ExecuteNonQueryAsync();
+    }
+    finally
+    {
+      ReturnConnection(conn);
+    }
+  }
+
+  public async Task UpsertContactsAsync(string deviceAddress, List<PbapContact> contacts, CancellationToken ct = default)
+  {
+    var conn = GetConnection();
+    try
+    {
+      using var transaction = conn.BeginTransaction();
+
+      // Delete existing contacts for this device
+      using (var delCmd = conn.CreateCommand())
+      {
+        delCmd.CommandText = "DELETE FROM PbapContacts WHERE DeviceAddress = @addr";
+        delCmd.Parameters.AddWithValue("@addr", deviceAddress);
+        await delCmd.ExecuteNonQueryAsync(ct);
+      }
+
+      // Insert new contacts (one row per phone number)
+      var now = DateTime.UtcNow;
+      foreach (var contact in contacts)
+      {
+        foreach (var number in contact.PhoneNumbers)
+        {
+          using var insCmd = conn.CreateCommand();
+          insCmd.CommandText = """
+              INSERT OR REPLACE INTO PbapContacts (DeviceAddress, DisplayName, PhoneNumber, LastSynced)
+              VALUES (@addr, @name, @phone, @synced)
+              """;
+          insCmd.Parameters.AddWithValue("@addr", deviceAddress);
+          insCmd.Parameters.AddWithValue("@name", contact.DisplayName);
+          insCmd.Parameters.AddWithValue("@phone", number);
+          insCmd.Parameters.AddWithValue("@synced", now.ToString("o"));
+          await insCmd.ExecuteNonQueryAsync(ct);
+        }
+      }
+
+      transaction.Commit();
+    }
+    finally
+    {
+      ReturnConnection(conn);
+    }
+  }
+
+  public async Task<PbapContact?> FindByPhoneNumberAsync(string deviceAddress, string normalizedNumber, CancellationToken ct = default)
+  {
+    var conn = GetConnection();
+    try
+    {
+      // Try exact match first
+      using (var cmd = conn.CreateCommand())
+      {
+        cmd.CommandText = "SELECT DisplayName FROM PbapContacts WHERE DeviceAddress = @addr AND PhoneNumber = @phone LIMIT 1";
+        cmd.Parameters.AddWithValue("@addr", deviceAddress);
+        cmd.Parameters.AddWithValue("@phone", normalizedNumber);
+        var result = await cmd.ExecuteScalarAsync(ct);
+        if (result is string name)
+          return new PbapContact { DisplayName = name, PhoneNumbers = new() { normalizedNumber } };
+      }
+
+      // Try last-7 suffix match
+      var last7 = PhoneNumberNormalizer.GetLast7(normalizedNumber);
+      if (last7.Length == 7)
+      {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT DisplayName, PhoneNumber FROM PbapContacts
+            WHERE DeviceAddress = @addr AND PhoneNumber LIKE @suffix
+            LIMIT 1
+            """;
+        cmd.Parameters.AddWithValue("@addr", deviceAddress);
+        cmd.Parameters.AddWithValue("@suffix", "%" + last7);
+        using var reader = await cmd.ExecuteReaderAsync(ct);
+        if (await reader.ReadAsync(ct))
+        {
+          return new PbapContact
+          {
+            DisplayName = reader.GetString(0),
+            PhoneNumbers = new() { reader.GetString(1) }
+          };
+        }
+      }
+
+      return null;
+    }
+    finally
+    {
+      ReturnConnection(conn);
+    }
+  }
+
+  public async Task<List<PbapContact>> GetContactsAsync(string deviceAddress, CancellationToken ct = default)
+  {
+    var conn = GetConnection();
+    try
+    {
+      var contactMap = new Dictionary<string, PbapContact>();
+
+      using var cmd = conn.CreateCommand();
+      cmd.CommandText = "SELECT DisplayName, PhoneNumber FROM PbapContacts WHERE DeviceAddress = @addr ORDER BY DisplayName";
+      cmd.Parameters.AddWithValue("@addr", deviceAddress);
+
+      using var reader = await cmd.ExecuteReaderAsync(ct);
+      while (await reader.ReadAsync(ct))
+      {
+        var name = reader.GetString(0);
+        var phone = reader.GetString(1);
+
+        if (!contactMap.TryGetValue(name, out var contact))
+        {
+          contact = new PbapContact { DisplayName = name, PhoneNumbers = new() };
+          contactMap[name] = contact;
+        }
+        contact.PhoneNumbers.Add(phone);
+      }
+
+      return contactMap.Values.ToList();
+    }
+    finally
+    {
+      ReturnConnection(conn);
+    }
+  }
+
+  public async Task<List<(string DeviceAddress, int ContactCount, DateTime? LastSynced)>> GetSyncSummaryAsync(string? deviceAddress = null, CancellationToken ct = default)
+  {
+    var conn = GetConnection();
+    try
+    {
+      using var cmd = conn.CreateCommand();
+      var sql = "SELECT DeviceAddress, COUNT(*), MAX(LastSynced) FROM PbapContacts";
+      if (deviceAddress != null)
+      {
+        sql += " WHERE DeviceAddress = @addr";
+        cmd.Parameters.AddWithValue("@addr", deviceAddress);
+      }
+      sql += " GROUP BY DeviceAddress";
+      cmd.CommandText = sql;
+
+      var results = new List<(string, int, DateTime?)>();
+      using var reader = await cmd.ExecuteReaderAsync(ct);
+      while (await reader.ReadAsync(ct))
+      {
+        var addr = reader.GetString(0);
+        var count = reader.GetInt32(1);
+        DateTime? synced = reader.IsDBNull(2) ? null : DateTime.Parse(reader.GetString(2));
+        results.Add((addr, count, synced));
+      }
+
+      return results;
+    }
+    finally
+    {
+      ReturnConnection(conn);
+    }
+  }
+
+  public async Task DeleteContactsAsync(string deviceAddress, CancellationToken ct = default)
+  {
+    var conn = GetConnection();
+    try
+    {
+      using var cmd = conn.CreateCommand();
+      cmd.CommandText = "DELETE FROM PbapContacts WHERE DeviceAddress = @addr";
+      cmd.Parameters.AddWithValue("@addr", deviceAddress);
+      await cmd.ExecuteNonQueryAsync(ct);
+    }
+    finally
+    {
+      ReturnConnection(conn);
+    }
+  }
+}

--- a/src/Radio.Infrastructure/Bluetooth/PbapContactRepository.cs
+++ b/src/Radio.Infrastructure/Bluetooth/PbapContactRepository.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Data.Sqlite;
 using Radio.Core.Interfaces.Bluetooth;
 using Radio.Core.Models;
@@ -69,34 +70,44 @@ public class PbapContactRepository : IPbapContactRepository
     {
       using var transaction = conn.BeginTransaction();
 
-      // Delete existing contacts for this device
-      using (var delCmd = conn.CreateCommand())
+      try
       {
-        delCmd.CommandText = "DELETE FROM PbapContacts WHERE DeviceAddress = @addr";
-        delCmd.Parameters.AddWithValue("@addr", deviceAddress);
-        await delCmd.ExecuteNonQueryAsync(ct);
-      }
-
-      // Insert new contacts (one row per phone number)
-      var now = DateTime.UtcNow;
-      foreach (var contact in contacts)
-      {
-        foreach (var number in contact.PhoneNumbers)
+        // Delete existing contacts for this device
+        using (var delCmd = conn.CreateCommand())
         {
-          using var insCmd = conn.CreateCommand();
-          insCmd.CommandText = """
-              INSERT OR REPLACE INTO PbapContacts (DeviceAddress, DisplayName, PhoneNumber, LastSynced)
-              VALUES (@addr, @name, @phone, @synced)
-              """;
-          insCmd.Parameters.AddWithValue("@addr", deviceAddress);
-          insCmd.Parameters.AddWithValue("@name", contact.DisplayName);
-          insCmd.Parameters.AddWithValue("@phone", number);
-          insCmd.Parameters.AddWithValue("@synced", now.ToString("o"));
-          await insCmd.ExecuteNonQueryAsync(ct);
+          delCmd.Transaction = transaction;
+          delCmd.CommandText = "DELETE FROM PbapContacts WHERE DeviceAddress = @addr";
+          delCmd.Parameters.AddWithValue("@addr", deviceAddress);
+          await delCmd.ExecuteNonQueryAsync(ct);
         }
-      }
 
-      transaction.Commit();
+        // Insert new contacts (one row per phone number)
+        var now = DateTime.UtcNow;
+        foreach (var contact in contacts)
+        {
+          foreach (var number in contact.PhoneNumbers)
+          {
+            using var insCmd = conn.CreateCommand();
+            insCmd.Transaction = transaction;
+            insCmd.CommandText = """
+                INSERT OR REPLACE INTO PbapContacts (DeviceAddress, DisplayName, PhoneNumber, LastSynced)
+                VALUES (@addr, @name, @phone, @synced)
+                """;
+            insCmd.Parameters.AddWithValue("@addr", deviceAddress);
+            insCmd.Parameters.AddWithValue("@name", contact.DisplayName);
+            insCmd.Parameters.AddWithValue("@phone", number);
+            insCmd.Parameters.AddWithValue("@synced", now.ToString("o"));
+            await insCmd.ExecuteNonQueryAsync(ct);
+          }
+        }
+
+        transaction.Commit();
+      }
+      catch
+      {
+        transaction.Rollback();
+        throw;
+      }
     }
     finally
     {
@@ -205,7 +216,7 @@ public class PbapContactRepository : IPbapContactRepository
       {
         var addr = reader.GetString(0);
         var count = reader.GetInt32(1);
-        DateTime? synced = reader.IsDBNull(2) ? null : DateTime.Parse(reader.GetString(2));
+        DateTime? synced = reader.IsDBNull(2) ? null : DateTime.Parse(reader.GetString(2), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
         results.Add((addr, count, synced));
       }
 

--- a/src/Radio.Infrastructure/Bluetooth/PbapSyncService.cs
+++ b/src/Radio.Infrastructure/Bluetooth/PbapSyncService.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -13,6 +15,7 @@ public class PbapSyncService : BackgroundService, IPbapSyncService
   private readonly IPbapContactRepository _contactRepo;
   private readonly PbapOptions _options;
   private readonly ILogger<PbapSyncService> _logger;
+  private readonly SemaphoreSlim _syncLock = new(1, 1);
 
   public PbapSyncService(
     IBluetoothService bluetoothService,
@@ -71,30 +74,51 @@ public class PbapSyncService : BackgroundService, IPbapSyncService
   public async Task<PbapSyncResult> SyncContactsAsync(string deviceAddress, CancellationToken ct = default)
   {
     _logger.LogInformation("Starting PBAP sync for {Address}", deviceAddress);
+
+    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+    {
+      _logger.LogWarning("PBAP sync requires Linux with BlueZ/obexd — skipped on {OS}", RuntimeInformation.OSDescription);
+      return new PbapSyncResult { Success = false, ErrorMessage = "PBAP sync requires Linux" };
+    }
+
+    if (!await _syncLock.WaitAsync(TimeSpan.Zero, ct))
+    {
+      _logger.LogInformation("PBAP sync already in progress for another request — skipping");
+      return new PbapSyncResult { Success = false, ErrorMessage = "Sync already in progress" };
+    }
+
     string? tempFile = null;
 
     try
     {
-      // D-Bus OBEX session lifecycle:
-      // 1. Connect to session bus
-      // 2. CreateSession on org.bluez.obex.Client1 with { "Target": "PBAP" }
-      // 3. Get PhonebookAccess1 interface
-      // 4. Select("int", "pb")
-      // 5. PullAll(tempFile, filters) → Transfer object
-      // 6. Monitor Transfer1.Status via PropertiesChanged signal + TaskCompletionSource
-      // 7. On "complete": read temp file
+      // Use a path outside /tmp — the service runs with PrivateTmp=true, but obexd
+      // (separate user service) writes to the real filesystem. A /tmp path would be
+      // invisible across the mount namespace boundary.
+      var dataDir = Path.Combine(AppContext.BaseDirectory, "..", "data");
+      Directory.CreateDirectory(dataDir);
+      tempFile = Path.Combine(dataDir, $"pbap-sync-{deviceAddress.Replace(":", "")}-{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}.vcf");
 
-      tempFile = Path.Combine(Path.GetTempPath(), $"pbap-sync-{deviceAddress.Replace(":", "")}-{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}.vcf");
+      // Ensure obexd is running (user service)
+      await EnsureObexdRunningAsync(ct);
 
-      // D-Bus OBEX PBAP session not yet implemented — requires Linux + obexd.
-      // The structure is ready; the actual D-Bus calls will be implemented
-      // when tested on the target device with obexd running.
-      throw new NotImplementedException("D-Bus OBEX PBAP session not yet implemented — requires Linux + obexd");
-    }
-    catch (NotImplementedException)
-    {
-      _logger.LogWarning("PBAP D-Bus implementation pending — sync skipped for {Address}", deviceAddress);
-      return new PbapSyncResult { Success = false, ErrorMessage = "PBAP D-Bus not yet implemented" };
+      // Run the Python helper script that manages the D-Bus OBEX session lifetime.
+      // The script creates a PBAP session, selects the internal phonebook,
+      // downloads all contacts via PullAll, monitors the transfer, and exits.
+      await DownloadPhonebookAsync(deviceAddress, tempFile, ct);
+
+      if (!File.Exists(tempFile) || new FileInfo(tempFile).Length == 0)
+      {
+        _logger.LogWarning("PBAP download produced empty file for {Address}", deviceAddress);
+        return new PbapSyncResult { Success = true, ContactCount = 0 };
+      }
+
+      var result = await ProcessDownloadedVcfAsync(deviceAddress, tempFile, ct);
+
+      // OBEX session teardown causes a LocalHost disconnect, which suppresses
+      // auto-reconnect. Give BlueZ a moment to finish cleanup, then reconnect.
+      _ = ReconnectAfterSyncAsync(deviceAddress);
+
+      return result;
     }
     catch (Exception ex)
     {
@@ -103,13 +127,121 @@ public class PbapSyncService : BackgroundService, IPbapSyncService
     }
     finally
     {
-      // Clean up temp file
       if (tempFile != null && File.Exists(tempFile))
       {
         try { File.Delete(tempFile); }
         catch { /* best effort */ }
       }
+      _syncLock.Release();
     }
+  }
+
+  private async Task ReconnectAfterSyncAsync(string deviceAddress)
+  {
+    try
+    {
+      // Wait for OBEX/BlueZ to finish tearing down the PBAP RFCOMM channel
+      await Task.Delay(3000);
+      _logger.LogInformation("Reconnecting to {Address} after PBAP sync", deviceAddress);
+      await _bluetoothService.ConnectAsync(deviceAddress);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to reconnect after PBAP sync for {Address}", deviceAddress);
+    }
+  }
+
+  private async Task EnsureObexdRunningAsync(CancellationToken ct)
+  {
+    var psi = new ProcessStartInfo("systemctl", "--user is-active obex")
+    {
+      RedirectStandardOutput = true,
+      RedirectStandardError = true,
+      UseShellExecute = false,
+      CreateNoWindow = true
+    };
+
+    using var proc = Process.Start(psi);
+    if (proc == null) return;
+
+    var output = await proc.StandardOutput.ReadToEndAsync(ct);
+    await proc.WaitForExitAsync(ct);
+
+    if (proc.ExitCode != 0 || !output.Trim().Equals("active", StringComparison.OrdinalIgnoreCase))
+    {
+      _logger.LogInformation("Starting obexd user service");
+      var startPsi = new ProcessStartInfo("systemctl", "--user start obex")
+      {
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+      };
+
+      using var startProc = Process.Start(startPsi);
+      if (startProc != null)
+      {
+        await startProc.WaitForExitAsync(ct);
+        if (startProc.ExitCode != 0)
+        {
+          _logger.LogWarning("Failed to start obexd (exit code {Code})", startProc.ExitCode);
+        }
+        // Give obexd a moment to register on D-Bus
+        await Task.Delay(500, ct);
+      }
+    }
+  }
+
+  private async Task DownloadPhonebookAsync(string deviceAddress, string outputPath, CancellationToken ct)
+  {
+    // Locate the Python helper script — deployed to Bluetooth/ alongside the executable.
+    // Use AppContext.BaseDirectory (works with single-file publish, unlike Assembly.Location).
+    var scriptPath = Path.Combine(AppContext.BaseDirectory, "Bluetooth", "pbap_download.py");
+
+    if (!File.Exists(scriptPath))
+    {
+      throw new FileNotFoundException($"PBAP download script not found at {scriptPath}");
+    }
+
+    var timeout = _options.TransferTimeoutSeconds;
+    var psi = new ProcessStartInfo("python3", $"\"{scriptPath}\" \"{deviceAddress}\" \"{outputPath}\" {timeout}")
+    {
+      RedirectStandardOutput = true,
+      RedirectStandardError = true,
+      UseShellExecute = false,
+      CreateNoWindow = true
+    };
+
+    // Ensure DBUS_SESSION_BUS_ADDRESS is set for the session bus
+    if (!psi.Environment.ContainsKey("DBUS_SESSION_BUS_ADDRESS"))
+    {
+      var uid = Environment.GetEnvironmentVariable("UID")
+        ?? (Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR")?.Split('/').LastOrDefault());
+      var runtimeDir = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR") ?? $"/run/user/{uid ?? "1000"}";
+      psi.Environment["DBUS_SESSION_BUS_ADDRESS"] = $"unix:path={runtimeDir}/bus";
+    }
+
+    _logger.LogDebug("Running PBAP download: python3 {Script} {Address} {Output} {Timeout}",
+      scriptPath, deviceAddress, outputPath, timeout);
+
+    using var proc = Process.Start(psi)
+      ?? throw new InvalidOperationException("Failed to start PBAP download process");
+
+    using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+    timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeout + 10)); // script timeout + margin
+
+    var stdout = await proc.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+    var stderr = await proc.StandardError.ReadToEndAsync(timeoutCts.Token);
+
+    await proc.WaitForExitAsync(timeoutCts.Token);
+
+    if (proc.ExitCode != 0)
+    {
+      var errorDetail = !string.IsNullOrWhiteSpace(stderr) ? stderr.Trim() : stdout.Trim();
+      throw new InvalidOperationException($"PBAP download failed (exit {proc.ExitCode}): {errorDetail}");
+    }
+
+    _logger.LogInformation("PBAP download complete: {Result}", stdout.Trim());
   }
 
   /// <summary>

--- a/src/Radio.Infrastructure/Bluetooth/PbapSyncService.cs
+++ b/src/Radio.Infrastructure/Bluetooth/PbapSyncService.cs
@@ -13,29 +13,31 @@ public class PbapSyncService : BackgroundService, IPbapSyncService
 {
   private readonly IBluetoothService _bluetoothService;
   private readonly IPbapContactRepository _contactRepo;
-  private readonly PbapOptions _options;
+  private readonly IOptionsMonitor<PbapOptions> _optionsMonitor;
   private readonly ILogger<PbapSyncService> _logger;
   private readonly SemaphoreSlim _syncLock = new(1, 1);
+
+  private PbapOptions Options => _optionsMonitor.CurrentValue;
 
   public PbapSyncService(
     IBluetoothService bluetoothService,
     IPbapContactRepository contactRepo,
-    IOptions<PbapOptions> options,
+    IOptionsMonitor<PbapOptions> optionsMonitor,
     ILogger<PbapSyncService> logger)
   {
     _bluetoothService = bluetoothService;
     _contactRepo = contactRepo;
-    _options = options.Value;
+    _optionsMonitor = optionsMonitor;
     _logger = logger;
   }
 
   protected override Task ExecuteAsync(CancellationToken stoppingToken)
   {
-    if (_options.AutoSyncOnConnect)
+    if (Options.AutoSyncOnConnect)
     {
       _bluetoothService.DeviceConnected += OnDeviceConnected;
     }
-    _logger.LogInformation("PBAP sync service started (AutoSync={AutoSync})", _options.AutoSyncOnConnect);
+    _logger.LogInformation("PBAP sync service started (AutoSync={AutoSync})", Options.AutoSyncOnConnect);
     return Task.CompletedTask;
   }
 
@@ -55,7 +57,7 @@ public class PbapSyncService : BackgroundService, IPbapSyncService
       var summary = await _contactRepo.GetSyncSummaryAsync(address);
       var lastSynced = summary.FirstOrDefault().LastSynced;
 
-      if (lastSynced == null || (DateTime.UtcNow - lastSynced.Value).TotalHours >= _options.SyncStaleThresholdHours)
+      if (lastSynced == null || (DateTime.UtcNow - lastSynced.Value).TotalHours >= Options.SyncStaleThresholdHours)
       {
         _logger.LogInformation("PBAP sync needed for {Address} (last sync: {LastSync})", address, lastSynced?.ToString() ?? "never");
         await SyncContactsAsync(address);
@@ -203,7 +205,7 @@ public class PbapSyncService : BackgroundService, IPbapSyncService
       throw new FileNotFoundException($"PBAP download script not found at {scriptPath}");
     }
 
-    var timeout = _options.TransferTimeoutSeconds;
+    var timeout = Options.TransferTimeoutSeconds;
     var psi = new ProcessStartInfo("python3", $"\"{scriptPath}\" \"{deviceAddress}\" \"{outputPath}\" {timeout}")
     {
       RedirectStandardOutput = true,
@@ -281,7 +283,7 @@ public class PbapSyncService : BackgroundService, IPbapSyncService
           DeviceName = device?.Name,
           ContactCount = s.ContactCount,
           LastSynced = s.LastSynced,
-          IsStale = s.LastSynced == null || (DateTime.UtcNow - s.LastSynced.Value).TotalHours >= _options.SyncStaleThresholdHours
+          IsStale = s.LastSynced == null || (DateTime.UtcNow - s.LastSynced.Value).TotalHours >= Options.SyncStaleThresholdHours
         };
       }).ToList()
     };

--- a/src/Radio.Infrastructure/Bluetooth/PbapSyncService.cs
+++ b/src/Radio.Infrastructure/Bluetooth/PbapSyncService.cs
@@ -31,14 +31,17 @@ public class PbapSyncService : BackgroundService, IPbapSyncService
     _logger = logger;
   }
 
-  protected override Task ExecuteAsync(CancellationToken stoppingToken)
+  protected override async Task ExecuteAsync(CancellationToken stoppingToken)
   {
     if (Options.AutoSyncOnConnect)
     {
       _bluetoothService.DeviceConnected += OnDeviceConnected;
     }
     _logger.LogInformation("PBAP sync service started (AutoSync={AutoSync})", Options.AutoSyncOnConnect);
-    return Task.CompletedTask;
+
+    // Keep the background service alive — actual work is event-driven via DeviceConnected.
+    try { await Task.Delay(Timeout.Infinite, stoppingToken); }
+    catch (OperationCanceledException) { /* normal shutdown */ }
   }
 
   public override Task StopAsync(CancellationToken cancellationToken)

--- a/src/Radio.Infrastructure/Bluetooth/PbapSyncService.cs
+++ b/src/Radio.Infrastructure/Bluetooth/PbapSyncService.cs
@@ -1,0 +1,157 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Radio.Core.Configuration;
+using Radio.Core.Interfaces.Audio;
+using Radio.Core.Interfaces.Bluetooth;
+
+namespace Radio.Infrastructure.Bluetooth;
+
+public class PbapSyncService : BackgroundService, IPbapSyncService
+{
+  private readonly IBluetoothService _bluetoothService;
+  private readonly IPbapContactRepository _contactRepo;
+  private readonly PbapOptions _options;
+  private readonly ILogger<PbapSyncService> _logger;
+
+  public PbapSyncService(
+    IBluetoothService bluetoothService,
+    IPbapContactRepository contactRepo,
+    IOptions<PbapOptions> options,
+    ILogger<PbapSyncService> logger)
+  {
+    _bluetoothService = bluetoothService;
+    _contactRepo = contactRepo;
+    _options = options.Value;
+    _logger = logger;
+  }
+
+  protected override Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    if (_options.AutoSyncOnConnect)
+    {
+      _bluetoothService.DeviceConnected += OnDeviceConnected;
+    }
+    _logger.LogInformation("PBAP sync service started (AutoSync={AutoSync})", _options.AutoSyncOnConnect);
+    return Task.CompletedTask;
+  }
+
+  public override Task StopAsync(CancellationToken cancellationToken)
+  {
+    _bluetoothService.DeviceConnected -= OnDeviceConnected;
+    return base.StopAsync(cancellationToken);
+  }
+
+  private async void OnDeviceConnected(object? sender, BluetoothDeviceConnectedEventArgs e)
+  {
+    var address = e.Device.Address;
+    _logger.LogInformation("Device connected: {Address} — checking PBAP sync status", address);
+
+    try
+    {
+      var summary = await _contactRepo.GetSyncSummaryAsync(address);
+      var lastSynced = summary.FirstOrDefault().LastSynced;
+
+      if (lastSynced == null || (DateTime.UtcNow - lastSynced.Value).TotalHours >= _options.SyncStaleThresholdHours)
+      {
+        _logger.LogInformation("PBAP sync needed for {Address} (last sync: {LastSync})", address, lastSynced?.ToString() ?? "never");
+        await SyncContactsAsync(address);
+      }
+      else
+      {
+        _logger.LogDebug("PBAP contacts for {Address} are fresh (synced {LastSync})", address, lastSynced);
+      }
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Auto PBAP sync failed for {Address}", address);
+    }
+  }
+
+  public async Task<PbapSyncResult> SyncContactsAsync(string deviceAddress, CancellationToken ct = default)
+  {
+    _logger.LogInformation("Starting PBAP sync for {Address}", deviceAddress);
+    string? tempFile = null;
+
+    try
+    {
+      // D-Bus OBEX session lifecycle:
+      // 1. Connect to session bus
+      // 2. CreateSession on org.bluez.obex.Client1 with { "Target": "PBAP" }
+      // 3. Get PhonebookAccess1 interface
+      // 4. Select("int", "pb")
+      // 5. PullAll(tempFile, filters) → Transfer object
+      // 6. Monitor Transfer1.Status via PropertiesChanged signal + TaskCompletionSource
+      // 7. On "complete": read temp file
+
+      tempFile = Path.Combine(Path.GetTempPath(), $"pbap-sync-{deviceAddress.Replace(":", "")}-{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}.vcf");
+
+      // D-Bus OBEX PBAP session not yet implemented — requires Linux + obexd.
+      // The structure is ready; the actual D-Bus calls will be implemented
+      // when tested on the target device with obexd running.
+      throw new NotImplementedException("D-Bus OBEX PBAP session not yet implemented — requires Linux + obexd");
+    }
+    catch (NotImplementedException)
+    {
+      _logger.LogWarning("PBAP D-Bus implementation pending — sync skipped for {Address}", deviceAddress);
+      return new PbapSyncResult { Success = false, ErrorMessage = "PBAP D-Bus not yet implemented" };
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "PBAP sync failed for {Address}", deviceAddress);
+      return new PbapSyncResult { Success = false, ErrorMessage = ex.Message };
+    }
+    finally
+    {
+      // Clean up temp file
+      if (tempFile != null && File.Exists(tempFile))
+      {
+        try { File.Delete(tempFile); }
+        catch { /* best effort */ }
+      }
+    }
+  }
+
+  /// <summary>
+  /// Called after successful temp file download. Parses and stores contacts.
+  /// Extracted for testability — can be called directly in integration tests.
+  /// </summary>
+  internal async Task<PbapSyncResult> ProcessDownloadedVcfAsync(string deviceAddress, string vcfFilePath, CancellationToken ct = default)
+  {
+    var vcfContent = await File.ReadAllTextAsync(vcfFilePath, ct);
+    var contacts = VCardParser.Parse(vcfContent);
+
+    if (contacts.Count == 0)
+    {
+      _logger.LogWarning("No contacts parsed from PBAP download for {Address}", deviceAddress);
+      return new PbapSyncResult { Success = true, ContactCount = 0 };
+    }
+
+    await _contactRepo.UpsertContactsAsync(deviceAddress, contacts, ct);
+
+    _logger.LogInformation("PBAP sync complete for {Address}: {Count} contacts", deviceAddress, contacts.Count);
+    return new PbapSyncResult { Success = true, ContactCount = contacts.Count };
+  }
+
+  public async Task<PbapSyncStatus> GetSyncStatusAsync(string? deviceAddress = null)
+  {
+    var summary = await _contactRepo.GetSyncSummaryAsync(deviceAddress);
+    var pairedDevices = _bluetoothService.PairedDevices;
+
+    return new PbapSyncStatus
+    {
+      Devices = summary.Select(s =>
+      {
+        var device = pairedDevices?.FirstOrDefault(d => d.Address == s.DeviceAddress);
+        return new DeviceSyncInfo
+        {
+          DeviceAddress = s.DeviceAddress,
+          DeviceName = device?.Name,
+          ContactCount = s.ContactCount,
+          LastSynced = s.LastSynced,
+          IsStale = s.LastSynced == null || (DateTime.UtcNow - s.LastSynced.Value).TotalHours >= _options.SyncStaleThresholdHours
+        };
+      }).ToList()
+    };
+  }
+}

--- a/src/Radio.Infrastructure/Bluetooth/VCardParser.cs
+++ b/src/Radio.Infrastructure/Bluetooth/VCardParser.cs
@@ -54,11 +54,13 @@ public static class VCardParser
 
       if (!inCard) continue;
 
-      if (trimmed.StartsWith("FN", StringComparison.OrdinalIgnoreCase))
+      if (trimmed.StartsWith("FN:", StringComparison.OrdinalIgnoreCase)
+        || trimmed.StartsWith("FN;", StringComparison.OrdinalIgnoreCase))
       {
         currentName = ExtractFieldValue(trimmed);
       }
-      else if (trimmed.StartsWith("TEL", StringComparison.OrdinalIgnoreCase))
+      else if (trimmed.StartsWith("TEL:", StringComparison.OrdinalIgnoreCase)
+        || trimmed.StartsWith("TEL;", StringComparison.OrdinalIgnoreCase))
       {
         var raw = ExtractFieldValue(trimmed);
         var normalized = PhoneNumberNormalizer.Normalize(raw);

--- a/src/Radio.Infrastructure/Bluetooth/VCardParser.cs
+++ b/src/Radio.Infrastructure/Bluetooth/VCardParser.cs
@@ -1,0 +1,112 @@
+using System.Text;
+using Radio.Core.Models;
+using Radio.Core.Utilities;
+
+namespace Radio.Infrastructure.Bluetooth;
+
+public static class VCardParser
+{
+  public static List<PbapContact> Parse(string vcfContent)
+  {
+    if (string.IsNullOrWhiteSpace(vcfContent))
+      return new List<PbapContact>();
+
+    var contacts = new List<PbapContact>();
+
+    // Unfold continuation lines (RFC 2426: lines starting with space/tab are continuations)
+    var unfolded = vcfContent
+      .Replace("\r\n ", "")
+      .Replace("\r\n\t", "")
+      .Replace("\n ", "")
+      .Replace("\n\t", "");
+
+    var lines = unfolded.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+
+    string? currentName = null;
+    var currentNumbers = new List<string>();
+    var inCard = false;
+
+    foreach (var line in lines)
+    {
+      var trimmed = line.Trim();
+
+      if (trimmed.Equals("BEGIN:VCARD", StringComparison.OrdinalIgnoreCase))
+      {
+        inCard = true;
+        currentName = null;
+        currentNumbers = new List<string>();
+        continue;
+      }
+
+      if (trimmed.Equals("END:VCARD", StringComparison.OrdinalIgnoreCase))
+      {
+        if (inCard && currentName != null && currentNumbers.Count > 0)
+        {
+          contacts.Add(new PbapContact
+          {
+            DisplayName = currentName,
+            PhoneNumbers = currentNumbers
+          });
+        }
+        inCard = false;
+        continue;
+      }
+
+      if (!inCard) continue;
+
+      if (trimmed.StartsWith("FN", StringComparison.OrdinalIgnoreCase))
+      {
+        currentName = ExtractFieldValue(trimmed);
+      }
+      else if (trimmed.StartsWith("TEL", StringComparison.OrdinalIgnoreCase))
+      {
+        var raw = ExtractFieldValue(trimmed);
+        var normalized = PhoneNumberNormalizer.Normalize(raw);
+        if (!string.IsNullOrEmpty(normalized))
+          currentNumbers.Add(normalized);
+      }
+    }
+
+    return contacts;
+  }
+
+  private static string ExtractFieldValue(string line)
+  {
+    // Format: FIELD;PARAMS:VALUE or FIELD:VALUE
+    var colonIdx = line.IndexOf(':');
+    if (colonIdx < 0) return string.Empty;
+
+    var value = line[(colonIdx + 1)..].Trim();
+    var fieldPart = line[..colonIdx].ToUpperInvariant();
+
+    // Check for QUOTED-PRINTABLE encoding
+    if (fieldPart.Contains("ENCODING=QUOTED-PRINTABLE"))
+    {
+      value = DecodeQuotedPrintable(value);
+    }
+
+    return value;
+  }
+
+  private static string DecodeQuotedPrintable(string input)
+  {
+    var bytes = new List<byte>();
+    var i = 0;
+    while (i < input.Length)
+    {
+      if (input[i] == '=' && i + 2 < input.Length)
+      {
+        var hex = input.Substring(i + 1, 2);
+        if (byte.TryParse(hex, System.Globalization.NumberStyles.HexNumber, null, out var b))
+        {
+          bytes.Add(b);
+          i += 3;
+          continue;
+        }
+      }
+      bytes.Add((byte)input[i]);
+      i++;
+    }
+    return Encoding.UTF8.GetString(bytes.ToArray());
+  }
+}

--- a/src/Radio.Infrastructure/Bluetooth/pbap_download.py
+++ b/src/Radio.Infrastructure/Bluetooth/pbap_download.py
@@ -11,7 +11,6 @@ Requires: dbus-python, PyGObject (gi), bluez-obexd running as user service.
 """
 import sys
 import os
-import signal
 
 def main():
   if len(sys.argv) < 3:

--- a/src/Radio.Infrastructure/Bluetooth/pbap_download.py
+++ b/src/Radio.Infrastructure/Bluetooth/pbap_download.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Download phonebook contacts from a Bluetooth device via PBAP/OBEX D-Bus.
+
+Usage: pbap_download.py <device_address> <output_vcf_path> [timeout_seconds]
+
+Connects to the BlueZ OBEX daemon on the D-Bus session bus, creates a PBAP
+session, selects the internal phonebook, and downloads all contacts as a VCF
+file. Exits with code 0 on success, non-zero on failure.
+
+Requires: dbus-python, PyGObject (gi), bluez-obexd running as user service.
+"""
+import sys
+import os
+import signal
+
+def main():
+  if len(sys.argv) < 3:
+    print("Usage: pbap_download.py <device_address> <output_vcf_path> [timeout_seconds]", file=sys.stderr)
+    sys.exit(1)
+
+  device_address = sys.argv[1]
+  output_path = sys.argv[2]
+  timeout = int(sys.argv[3]) if len(sys.argv) > 3 else 30
+
+  import dbus
+  import dbus.mainloop.glib
+  from gi.repository import GLib
+
+  dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+
+  bus = dbus.SessionBus()
+  loop = GLib.MainLoop()
+  result = {'status': 'pending', 'error': None}
+  session_path = None
+
+  def cleanup_and_exit(code):
+    """Remove OBEX session and exit."""
+    if session_path:
+      try:
+        client = dbus.Interface(
+          bus.get_object('org.bluez.obex', '/org/bluez/obex'),
+          'org.bluez.obex.Client1'
+        )
+        client.RemoveSession(dbus.ObjectPath(session_path))
+      except Exception:
+        pass
+    sys.exit(code)
+
+  def on_timeout():
+    result['status'] = 'error'
+    result['error'] = 'Transfer timed out'
+    loop.quit()
+    return False
+
+  try:
+    # Create PBAP session
+    client = dbus.Interface(
+      bus.get_object('org.bluez.obex', '/org/bluez/obex'),
+      'org.bluez.obex.Client1'
+    )
+
+    session_path = str(client.CreateSession(device_address, {'Target': dbus.String('pbap')}))
+
+    # Get PhonebookAccess1 interface
+    session_obj = bus.get_object('org.bluez.obex', session_path)
+    pbap = dbus.Interface(session_obj, 'org.bluez.obex.PhonebookAccess1')
+
+    # Select internal phonebook
+    pbap.Select('int', 'pb')
+
+    # Download all contacts
+    transfer_path, props = pbap.PullAll(output_path, {})
+
+    initial_status = str(props.get('Status', ''))
+    if initial_status == 'complete':
+      result['status'] = 'complete'
+      print(f"OK: 0 bytes (immediate complete)", flush=True)
+      cleanup_and_exit(0)
+
+    # Monitor transfer via PropertiesChanged
+    transfer_obj = bus.get_object('org.bluez.obex', transfer_path)
+    transferred_bytes = [0]
+
+    def on_properties_changed(iface, changed, invalidated):
+      status = str(changed.get('Status', ''))
+      if 'Transferred' in changed:
+        transferred_bytes[0] = int(changed['Transferred'])
+      if status == 'complete':
+        result['status'] = 'complete'
+        loop.quit()
+      elif status == 'error':
+        result['status'] = 'error'
+        result['error'] = 'Transfer reported error'
+        loop.quit()
+
+    transfer_obj.connect_to_signal('PropertiesChanged', on_properties_changed)
+
+    # Set timeout
+    GLib.timeout_add_seconds(timeout, on_timeout)
+
+    # Run event loop until transfer completes or times out
+    loop.run()
+
+    if result['status'] == 'complete':
+      size = os.path.getsize(output_path) if os.path.exists(output_path) else 0
+      print(f"OK: {size} bytes", flush=True)
+      cleanup_and_exit(0)
+    else:
+      error_msg = result.get('error', 'Unknown error')
+      print(f"ERROR: {error_msg}", file=sys.stderr, flush=True)
+      cleanup_and_exit(1)
+
+  except dbus.exceptions.DBusException as e:
+    error_name = e.get_dbus_name() if hasattr(e, 'get_dbus_name') else ''
+    print(f"ERROR: D-Bus error: {error_name}: {e}", file=sys.stderr, flush=True)
+    cleanup_and_exit(2)
+  except Exception as e:
+    print(f"ERROR: {e}", file=sys.stderr, flush=True)
+    cleanup_and_exit(3)
+
+
+if __name__ == '__main__':
+  main()

--- a/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
+++ b/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
 using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
+using Radio.Core.Interfaces.Bluetooth;
 using Radio.Core.Interfaces.External;
 using Radio.Core.Interfaces.Input;
 using Radio.Infrastructure.Audio;
@@ -17,6 +18,7 @@ using Radio.Infrastructure.Audio.SoundFlow;
 using Radio.Infrastructure.Audio.Visualization;
 using Radio.Infrastructure.Configuration;
 using Radio.Configuration.Abstractions;
+using Radio.Infrastructure.Bluetooth;
 using Radio.Infrastructure.External;
 using Radio.Infrastructure.Platform.Input;
 using Radio.Metrics;
@@ -377,6 +379,22 @@ public static class AudioServiceExtensions
 
     // Register contact lookup service with HttpClient
     services.AddHttpClient<PhoneContactLookupService>();
+
+    // PBAP contact sync
+    services.Configure<PbapOptions>(configuration.GetSection(PbapOptions.SectionName));
+
+    var dbRootPath = configuration.GetValue<string>("Database:RootPath") ?? "./data";
+    var pbapDbPath = Path.Combine(dbRootPath, "pbap-contacts.db");
+    services.AddSingleton<IPbapContactRepository>(sp =>
+    {
+      var repo = new PbapContactRepository($"Data Source={pbapDbPath}");
+      repo.InitializeAsync().GetAwaiter().GetResult();
+      return repo;
+    });
+
+    services.AddSingleton<PbapSyncService>();
+    services.AddSingleton<IPbapSyncService>(sp => sp.GetRequiredService<PbapSyncService>());
+    services.AddHostedService(sp => sp.GetRequiredService<PbapSyncService>());
 
     return services;
   }

--- a/src/Radio.Infrastructure/External/PhoneCallClient.cs
+++ b/src/Radio.Infrastructure/External/PhoneCallClient.cs
@@ -104,6 +104,15 @@ public class PhoneCallClient : IPhoneIntegrationService
     }
   }
 
+  /// <inheritdoc />
+  public async Task ReportCallerResolvedAsync(string phoneNumber, string resolvedName, CancellationToken ct = default)
+  {
+    if (_hubConnection is not null && _hubConnection.State == HubConnectionState.Connected)
+    {
+      await _hubConnection.SendAsync("ReportCallerResolved", phoneNumber, resolvedName, ct);
+    }
+  }
+
   private void OnCallStateChanged(string state, string phoneNumber)
   {
     OnCallStateChangedWithName(state, phoneNumber, callerName: null);

--- a/src/Radio.Infrastructure/External/PhoneContactLookupService.cs
+++ b/src/Radio.Infrastructure/External/PhoneContactLookupService.cs
@@ -2,32 +2,42 @@ using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
+using Radio.Core.Interfaces.Audio;
+using Radio.Core.Interfaces.Bluetooth;
+using Radio.Core.Utilities;
 
 namespace Radio.Infrastructure.External;
 
 /// <summary>
 /// REST client for looking up contact names from the RotaryPhone contacts API.
 /// Falls back to the raw phone number if the API is unavailable or no match is found.
-/// Note: The RotaryPhone contacts API schema is assumed — expect mismatches during integration.
+/// Now checks PBAP-synced contacts first (local, fast) before hitting the REST API.
 /// </summary>
 public class PhoneContactLookupService
 {
   private readonly ILogger<PhoneContactLookupService> _logger;
   private readonly IOptionsMonitor<PhoneIntegrationOptions> _options;
   private readonly HttpClient _httpClient;
+  private readonly IPbapContactRepository? _pbapRepo;
+  private readonly IBluetoothService? _bluetoothService;
 
   public PhoneContactLookupService(
     ILogger<PhoneContactLookupService> logger,
     IOptionsMonitor<PhoneIntegrationOptions> options,
-    HttpClient httpClient)
+    HttpClient httpClient,
+    IPbapContactRepository? pbapRepo = null,
+    IBluetoothService? bluetoothService = null)
   {
     _logger = logger;
     _options = options;
     _httpClient = httpClient;
+    _pbapRepo = pbapRepo;
+    _bluetoothService = bluetoothService;
   }
 
   /// <summary>
   /// Look up a contact name by phone number.
+  /// Checks PBAP contacts first, then falls back to RotaryPhone REST API.
   /// Returns the contact name if found, otherwise the raw phone number.
   /// </summary>
   public async Task<string> FindCallerNameAsync(string phoneNumber, CancellationToken cancellationToken = default)
@@ -35,6 +45,29 @@ public class PhoneContactLookupService
     if (string.IsNullOrWhiteSpace(phoneNumber))
     {
       return "Unknown caller";
+    }
+
+    // Try PBAP contacts first (local, fast)
+    if (_pbapRepo != null && _bluetoothService != null)
+    {
+      try
+      {
+        var connectedDevice = _bluetoothService.ConnectedDevice;
+        if (connectedDevice != null)
+        {
+          var normalized = PhoneNumberNormalizer.Normalize(phoneNumber);
+          var contact = await _pbapRepo.FindByPhoneNumberAsync(connectedDevice.Address, normalized, cancellationToken);
+          if (contact != null)
+          {
+            _logger.LogInformation("PBAP contact found: {Number} → {Name}", phoneNumber, contact.DisplayName);
+            return contact.DisplayName;
+          }
+        }
+      }
+      catch (Exception ex)
+      {
+        _logger.LogWarning(ex, "PBAP contact lookup failed, falling through to REST lookup");
+      }
     }
 
     try

--- a/src/Radio.Infrastructure/Radio.Infrastructure.csproj
+++ b/src/Radio.Infrastructure/Radio.Infrastructure.csproj
@@ -56,4 +56,8 @@
     <ProjectReference Include="..\Radio.Metrics\Radio.Metrics.csproj" />
     <ProjectReference Include="..\RTLSDRCore\RTLSDRCore.csproj" />
   </ItemGroup>
+  <!-- PBAP download helper script — deployed alongside the assembly -->
+  <ItemGroup>
+    <None Include="Bluetooth\pbap_download.py" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/src/Radio.Web/Components/Pages/SystemConfigPage.razor
+++ b/src/Radio.Web/Components/Pages/SystemConfigPage.razor
@@ -1523,6 +1523,42 @@
                 <span>Loading configuration...</span>
               }
             </RadzenCard>
+
+            <!-- PBAP Contact Sync -->
+            <RadzenCard>
+              <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:12px">
+                <h6>Phone Book (PBAP) Sync</h6>
+                <RadzenButton Variant="Variant.Outlined" ButtonStyle="ButtonStyle.Primary" Size="ButtonSize.Small"
+                              Click="SavePbapConfigAsync" Icon="save"
+                              Disabled="@(_isSaving || _pbapConfig == null)" Text="Save" />
+              </div>
+              <small style="color:var(--rz-text-secondary-color)">Pull contacts from connected phone for caller ID announcements</small>
+              @if (_pbapConfig != null)
+              {
+                <RadzenRow style="margin-top:12px">
+                  <RadzenColumn Size="12" SizeMD="4">
+                    <div style="display:flex; align-items:center; gap:8px">
+                      <RadzenSwitch @bind-Value="_pbapConfig.AutoSyncOnConnect" />
+                      <span>Auto-sync on connect</span>
+                    </div>
+                  </RadzenColumn>
+                  <RadzenColumn Size="6" SizeMD="4">
+                    <RadzenNumeric TValue="int" @bind-Value="_pbapConfig.SyncStaleThresholdHours"
+                                   Min="1" Max="168" Style="width:100%" />
+                    <small>Re-sync interval (hours)</small>
+                  </RadzenColumn>
+                  <RadzenColumn Size="6" SizeMD="4">
+                    <RadzenNumeric TValue="int" @bind-Value="_pbapConfig.TransferTimeoutSeconds"
+                                   Min="5" Max="120" Style="width:100%" />
+                    <small>Transfer timeout (seconds)</small>
+                  </RadzenColumn>
+                </RadzenRow>
+              }
+              else
+              {
+                <span>Loading configuration...</span>
+              }
+            </RadzenCard>
           </div>
         </RadzenTabsItem>
 
@@ -1624,6 +1660,7 @@
   private PhoneIntegrationStatusDto? _phoneStatus;
   private RotaryEncoderConfigDto? _encoderConfig;
   private PhoneIntegrationConfigDto? _phoneConfig;
+  private PbapConfigDto? _pbapConfig;
   private string _testMessage = "";
   private int _testPriority = 8;
   private bool _isSendingNotification = false;
@@ -3139,6 +3176,7 @@
       _phoneStatus = await IntegrationsApi.GetPhoneStatusAsync();
       _encoderConfig = await ConfigApi.GetConfigurationAsync<RotaryEncoderConfigDto>("rotaryencoder") ?? new();
       _phoneConfig = await ConfigApi.GetConfigurationAsync<PhoneIntegrationConfigDto>("phoneintegration") ?? new();
+      _pbapConfig = await ConfigApi.GetConfigurationAsync<PbapConfigDto>("bluetooth:pbap") ?? new();
     }
     catch (Exception ex)
     {
@@ -3193,6 +3231,33 @@
     catch (Exception ex)
     {
       NotificationService.Notify(NotificationSeverity.Error, "Error", $"Error saving configuration: {ex.Message}");
+    }
+    finally
+    {
+      _isSaving = false;
+    }
+  }
+
+  private async Task SavePbapConfigAsync()
+  {
+    if (_pbapConfig == null) return;
+
+    _isSaving = true;
+    try
+    {
+      var success = await ConfigApi.UpdateConfigurationAsync("bluetooth:pbap", _pbapConfig);
+      if (success)
+      {
+        NotificationService.Notify(NotificationSeverity.Success, "Success", "PBAP configuration saved successfully");
+      }
+      else
+      {
+        NotificationService.Notify(NotificationSeverity.Error, "Error", "Failed to save PBAP configuration");
+      }
+    }
+    catch (Exception ex)
+    {
+      NotificationService.Notify(NotificationSeverity.Error, "Error", $"Error saving PBAP configuration: {ex.Message}");
     }
     finally
     {

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -815,6 +815,13 @@ public class PhoneIntegrationConfigDto
   public int ReconnectMaxDelayMs { get; set; }
 }
 
+public class PbapConfigDto
+{
+  public bool AutoSyncOnConnect { get; set; } = true;
+  public int SyncStaleThresholdHours { get; set; } = 24;
+  public int TransferTimeoutSeconds { get; set; } = 30;
+}
+
 // RotaryPhone.API DTOs (calls http://localhost:5004)
 
 public class PhoneSystemStatusDto

--- a/tests/Radio.Core.Tests/Utilities/PhoneNumberNormalizerTests.cs
+++ b/tests/Radio.Core.Tests/Utilities/PhoneNumberNormalizerTests.cs
@@ -1,0 +1,28 @@
+using Radio.Core.Utilities;
+
+namespace Radio.Core.Tests.Utilities;
+
+public class PhoneNumberNormalizerTests
+{
+  [Theory]
+  [InlineData("+1 (555) 123-4567", "5551234567")]
+  [InlineData("555.123.4567", "5551234567")]
+  [InlineData("15551234567", "5551234567")]     // 11-digit with leading 1
+  [InlineData("5551234567", "5551234567")]       // already 10 digits
+  [InlineData("+44 20 7946 0958", "442079460958")] // international, no strip
+  [InlineData("", "")]
+  [InlineData("  ", "")]
+  public void Normalize_ShouldStripNonDigitsAndLeading1(string input, string expected)
+  {
+    Assert.Equal(expected, PhoneNumberNormalizer.Normalize(input));
+  }
+
+  [Theory]
+  [InlineData("5551234567", "1234567")]
+  [InlineData("1234567", "1234567")]
+  [InlineData("123", "123")]
+  public void GetLast7_ShouldReturnTrailingDigits(string input, string expected)
+  {
+    Assert.Equal(expected, PhoneNumberNormalizer.GetLast7(input));
+  }
+}

--- a/tests/Radio.Infrastructure.Tests/Bluetooth/PbapContactRepositoryTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Bluetooth/PbapContactRepositoryTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.Data.Sqlite;
+using Radio.Core.Models;
+using Radio.Infrastructure.Bluetooth;
+
+namespace Radio.Infrastructure.Tests.Bluetooth;
+
+public class PbapContactRepositoryTests : IDisposable
+{
+  private readonly SqliteConnection _connection;
+  private readonly PbapContactRepository _repo;
+
+  public PbapContactRepositoryTests()
+  {
+    _connection = new SqliteConnection("Data Source=:memory:");
+    _connection.Open();
+    _repo = new PbapContactRepository(_connection);
+    _repo.InitializeAsync().GetAwaiter().GetResult();
+  }
+
+  public void Dispose() => _connection.Dispose();
+
+  [Fact]
+  public async Task UpsertAndFind_ExactMatch_ShouldReturnContact()
+  {
+    var contacts = new List<PbapContact>
+    {
+      new() { DisplayName = "John Smith", PhoneNumbers = new() { "5551234567" } }
+    };
+
+    await _repo.UpsertContactsAsync("AA:BB:CC:DD:EE:FF", contacts);
+    var result = await _repo.FindByPhoneNumberAsync("AA:BB:CC:DD:EE:FF", "5551234567");
+
+    Assert.NotNull(result);
+    Assert.Equal("John Smith", result!.DisplayName);
+  }
+
+  [Fact]
+  public async Task FindByPhoneNumber_Last7Fallback_ShouldMatch()
+  {
+    var contacts = new List<PbapContact>
+    {
+      new() { DisplayName = "Jane", PhoneNumbers = new() { "5551234567" } }
+    };
+
+    await _repo.UpsertContactsAsync("AA:BB:CC:DD:EE:FF", contacts);
+    // Query with different area code prefix, same last 7
+    var result = await _repo.FindByPhoneNumberAsync("AA:BB:CC:DD:EE:FF", "9991234567");
+
+    Assert.NotNull(result);
+    Assert.Equal("Jane", result!.DisplayName);
+  }
+
+  [Fact]
+  public async Task FindByPhoneNumber_WrongDevice_ShouldNotMatch()
+  {
+    var contacts = new List<PbapContact>
+    {
+      new() { DisplayName = "John", PhoneNumbers = new() { "5551234567" } }
+    };
+
+    await _repo.UpsertContactsAsync("AA:BB:CC:DD:EE:FF", contacts);
+    var result = await _repo.FindByPhoneNumberAsync("11:22:33:44:55:66", "5551234567");
+
+    Assert.Null(result);
+  }
+
+  [Fact]
+  public async Task Upsert_ShouldReplaceExistingContacts()
+  {
+    var v1 = new List<PbapContact>
+    {
+      new() { DisplayName = "Old Name", PhoneNumbers = new() { "5551234567" } }
+    };
+    var v2 = new List<PbapContact>
+    {
+      new() { DisplayName = "New Name", PhoneNumbers = new() { "5551234567" } }
+    };
+
+    await _repo.UpsertContactsAsync("AA:BB:CC:DD:EE:FF", v1);
+    await _repo.UpsertContactsAsync("AA:BB:CC:DD:EE:FF", v2);
+
+    var result = await _repo.FindByPhoneNumberAsync("AA:BB:CC:DD:EE:FF", "5551234567");
+    Assert.Equal("New Name", result!.DisplayName);
+  }
+
+  [Fact]
+  public async Task GetContacts_ShouldReturnAllForDevice()
+  {
+    var contacts = new List<PbapContact>
+    {
+      new() { DisplayName = "Alice", PhoneNumbers = new() { "1111111" } },
+      new() { DisplayName = "Bob", PhoneNumbers = new() { "2222222", "3333333" } }
+    };
+
+    await _repo.UpsertContactsAsync("AA:BB:CC:DD:EE:FF", contacts);
+    var result = await _repo.GetContactsAsync("AA:BB:CC:DD:EE:FF");
+
+    Assert.Equal(2, result.Count); // 2 contacts (Bob's numbers grouped)
+  }
+
+  [Fact]
+  public async Task DeleteContacts_ShouldRemoveAllForDevice()
+  {
+    var contacts = new List<PbapContact>
+    {
+      new() { DisplayName = "Alice", PhoneNumbers = new() { "1111111" } }
+    };
+
+    await _repo.UpsertContactsAsync("AA:BB:CC:DD:EE:FF", contacts);
+    await _repo.DeleteContactsAsync("AA:BB:CC:DD:EE:FF");
+
+    var result = await _repo.GetContactsAsync("AA:BB:CC:DD:EE:FF");
+    Assert.Empty(result);
+  }
+
+  [Fact]
+  public async Task GetSyncSummary_ShouldReturnCountAndTimestamp()
+  {
+    var contacts = new List<PbapContact>
+    {
+      new() { DisplayName = "Alice", PhoneNumbers = new() { "1111111", "2222222" } }
+    };
+
+    await _repo.UpsertContactsAsync("AA:BB:CC:DD:EE:FF", contacts);
+    var summary = await _repo.GetSyncSummaryAsync("AA:BB:CC:DD:EE:FF");
+
+    Assert.Single(summary);
+    Assert.Equal("AA:BB:CC:DD:EE:FF", summary[0].DeviceAddress);
+    Assert.Equal(2, summary[0].ContactCount); // 2 rows (2 phone numbers)
+    Assert.NotNull(summary[0].LastSynced);
+  }
+
+  [Fact]
+  public async Task GetSyncSummary_EmptyTable_ShouldReturnEmpty()
+  {
+    var summary = await _repo.GetSyncSummaryAsync();
+    Assert.Empty(summary);
+  }
+}

--- a/tests/Radio.Infrastructure.Tests/Bluetooth/PbapSyncServiceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Bluetooth/PbapSyncServiceTests.cs
@@ -1,0 +1,60 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Radio.Core.Configuration;
+using Radio.Core.Interfaces.Audio;
+using Radio.Infrastructure.Bluetooth;
+
+namespace Radio.Infrastructure.Tests.Bluetooth;
+
+public class PbapSyncServiceTests : IDisposable
+{
+  private readonly SqliteConnection _connection;
+  private readonly PbapContactRepository _repo;
+  private readonly PbapSyncService _service;
+
+  public PbapSyncServiceTests()
+  {
+    _connection = new SqliteConnection("Data Source=:memory:");
+    _connection.Open();
+    _repo = new PbapContactRepository(_connection);
+    _repo.InitializeAsync().GetAwaiter().GetResult();
+
+    var btService = new Mock<IBluetoothService>();
+    var options = Options.Create(new PbapOptions());
+
+    _service = new PbapSyncService(
+      btService.Object, _repo, options,
+      NullLogger<PbapSyncService>.Instance);
+  }
+
+  public void Dispose() => _connection.Dispose();
+
+  [Fact]
+  public async Task ProcessDownloadedVcf_ShouldParseAndStoreContacts()
+  {
+    // Arrange — write a temp VCF file
+    var vcf = "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Test User\r\nTEL:5551234567\r\nEND:VCARD\r\n";
+    var tempFile = Path.GetTempFileName();
+    await File.WriteAllTextAsync(tempFile, vcf);
+
+    try
+    {
+      // Act
+      var result = await _service.ProcessDownloadedVcfAsync("AA:BB:CC:DD:EE:FF", tempFile);
+
+      // Assert
+      Assert.True(result.Success);
+      Assert.Equal(1, result.ContactCount);
+
+      var contact = await _repo.FindByPhoneNumberAsync("AA:BB:CC:DD:EE:FF", "5551234567");
+      Assert.NotNull(contact);
+      Assert.Equal("Test User", contact!.DisplayName);
+    }
+    finally
+    {
+      File.Delete(tempFile);
+    }
+  }
+}

--- a/tests/Radio.Infrastructure.Tests/Bluetooth/PbapSyncServiceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Bluetooth/PbapSyncServiceTests.cs
@@ -22,10 +22,11 @@ public class PbapSyncServiceTests : IDisposable
     _repo.InitializeAsync().GetAwaiter().GetResult();
 
     var btService = new Mock<IBluetoothService>();
-    var options = Options.Create(new PbapOptions());
+    var optionsMonitor = new Mock<IOptionsMonitor<PbapOptions>>();
+    optionsMonitor.Setup(m => m.CurrentValue).Returns(new PbapOptions());
 
     _service = new PbapSyncService(
-      btService.Object, _repo, options,
+      btService.Object, _repo, optionsMonitor.Object,
       NullLogger<PbapSyncService>.Instance);
   }
 

--- a/tests/Radio.Infrastructure.Tests/Bluetooth/VCardParserTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Bluetooth/VCardParserTests.cs
@@ -1,0 +1,128 @@
+using Radio.Infrastructure.Bluetooth;
+
+namespace Radio.Infrastructure.Tests.Bluetooth;
+
+public class VCardParserTests
+{
+  [Fact]
+  public void Parse_SimpleVCard30_ShouldExtractNameAndNumber()
+  {
+    var vcf = """
+        BEGIN:VCARD
+        VERSION:3.0
+        FN:John Smith
+        TEL;TYPE=CELL:+1-555-123-4567
+        END:VCARD
+        """;
+
+    var contacts = VCardParser.Parse(vcf);
+
+    Assert.Single(contacts);
+    Assert.Equal("John Smith", contacts[0].DisplayName);
+    Assert.Single(contacts[0].PhoneNumbers);
+    Assert.Equal("5551234567", contacts[0].PhoneNumbers[0]);
+  }
+
+  [Fact]
+  public void Parse_MultipleNumbers_ShouldExtractAll()
+  {
+    var vcf = """
+        BEGIN:VCARD
+        VERSION:3.0
+        FN:Jane Doe
+        TEL;TYPE=HOME:(555) 987-6543
+        TEL;TYPE=CELL:555.111.2222
+        TEL;TYPE=WORK:15553334444
+        END:VCARD
+        """;
+
+    var contacts = VCardParser.Parse(vcf);
+
+    Assert.Single(contacts);
+    Assert.Equal(3, contacts[0].PhoneNumbers.Count);
+    Assert.Contains("9876543", contacts[0].PhoneNumbers.Select(p => p[^7..]));
+  }
+
+  [Fact]
+  public void Parse_MultipleContacts_ShouldParseAll()
+  {
+    var vcf = """
+        BEGIN:VCARD
+        VERSION:3.0
+        FN:Alice
+        TEL:1111111
+        END:VCARD
+        BEGIN:VCARD
+        VERSION:3.0
+        FN:Bob
+        TEL:2222222
+        END:VCARD
+        """;
+
+    var contacts = VCardParser.Parse(vcf);
+
+    Assert.Equal(2, contacts.Count);
+    Assert.Equal("Alice", contacts[0].DisplayName);
+    Assert.Equal("Bob", contacts[1].DisplayName);
+  }
+
+  [Fact]
+  public void Parse_VCard21WithQuotedPrintable_ShouldDecode()
+  {
+    var vcf = "BEGIN:VCARD\r\nVERSION:2.1\r\nFN;ENCODING=QUOTED-PRINTABLE:Jos=C3=A9 Garc=C3=ADa\r\nTEL:5551234567\r\nEND:VCARD";
+
+    var contacts = VCardParser.Parse(vcf);
+
+    Assert.Single(contacts);
+    Assert.Equal("José García", contacts[0].DisplayName);
+  }
+
+  [Fact]
+  public void Parse_NoFN_ShouldSkipContact()
+  {
+    var vcf = """
+        BEGIN:VCARD
+        VERSION:3.0
+        TEL:5551234567
+        END:VCARD
+        """;
+
+    var contacts = VCardParser.Parse(vcf);
+
+    Assert.Empty(contacts);
+  }
+
+  [Fact]
+  public void Parse_NoTEL_ShouldSkipContact()
+  {
+    var vcf = """
+        BEGIN:VCARD
+        VERSION:3.0
+        FN:No Phone
+        END:VCARD
+        """;
+
+    var contacts = VCardParser.Parse(vcf);
+
+    Assert.Empty(contacts);
+  }
+
+  [Fact]
+  public void Parse_LineFolding_ShouldUnfold()
+  {
+    // RFC 2426: continuation lines start with space or tab
+    var vcf = "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Very Long\r\n  Name Here\r\nTEL:5551234567\r\nEND:VCARD";
+
+    var contacts = VCardParser.Parse(vcf);
+
+    Assert.Single(contacts);
+    Assert.Equal("Very Long Name Here", contacts[0].DisplayName);
+  }
+
+  [Fact]
+  public void Parse_EmptyInput_ShouldReturnEmpty()
+  {
+    Assert.Empty(VCardParser.Parse(""));
+    Assert.Empty(VCardParser.Parse("   "));
+  }
+}


### PR DESCRIPTION
## Summary
- Add PBAP (Phone Book Access Profile) contact sync infrastructure to Radio.API
- When a Bluetooth phone connects, contacts can be synced via OBEX and stored in SQLite for fast caller ID lookup
- Incoming calls now resolve caller names from PBAP contacts first (local, fast), then fall back to RotaryPhone REST API
- Resolved caller names are sent back to RotaryPhone via SignalR for UI display

## What's Included

### Core (Radio.Core)
- `PhoneNumberNormalizer` — normalize phone numbers, strip formatting, US leading-1, last-7 suffix matching
- `PbapContact` model and `PbapOptions` configuration
- `IPbapContactRepository` and `IPbapSyncService` interfaces with result types

### Infrastructure (Radio.Infrastructure)
- `VCardParser` — parse vCard 2.1/3.0 with quoted-printable decoding and line folding
- `PbapContactRepository` — SQLite CRUD with exact + last-7 suffix phone number matching
- `PbapSyncService` — BackgroundService with auto-sync on BT connect, staleness checking, VCF processing
- `PhoneContactLookupService` augmented with PBAP lookup (checked before REST API)
- `PhoneCallClient` — new `ReportCallerResolvedAsync` method

### API (Radio.API)
- `PbapController` — REST endpoints: `POST sync`, `GET contacts`, `GET lookup`, `GET status`
- `PhoneCallIntegrationService` — sends resolved caller name back to RotaryPhone

### Web (Radio.Web)
- PBAP sync settings in Phone Integration config tab (auto-sync toggle, re-sync interval, transfer timeout)

### Tests
- 27 new tests across PhoneNumberNormalizer (10), VCardParser (8), PbapContactRepository (8), PbapSyncService (1)

## Architecture Notes
- D-Bus OBEX PBAP session is stubbed (`NotImplementedException`) — requires Linux + obexd for real sync
- `ProcessDownloadedVcfAsync` is extracted for testability — the parse/store pipeline is fully tested
- Parallel with RotaryPhone repo `feature/pbap-contact-sync` branch — coordinated deployment needed for E2E

## Test plan
- [x] All 27 new PBAP tests pass
- [x] Full solution builds (0 errors, warnings only)
- [x] 1,628 tests pass (1 pre-existing flaky WaveformComparison failure, unrelated)
- [ ] Deploy both repos to Ubuntu for E2E testing with real phone
- [ ] Verify PBAP sync triggers on BT connect
- [ ] Verify caller ID resolution with TTS announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)