### PR TITLE
fix: AVRCP metadata at startup + dual-adapter boundary docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,21 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Cross-Service Boundary (IMPORTANT)
+
+This service shares the Ubuntu box (`radio`) with RotaryPhone. **Read before any BT/audio work:**
+
+**`D:\prj\RotaryPhone\docs\prompts\RADIO-CONSOLE-BT-AUDIO-BOUNDARY.md`** — Defines which BT adapter, profiles, and WirePlumber configs each service owns. Violating these boundaries will break the other service's audio.
+
+Key rules:
+- Radio Console owns **TP-Link UB500** (`hci0`, `78:20:51:F5:FB:A7`) for music/A2DP
+- RotaryPhone owns **Intel AX201** (`hci1`, `10:91:D1:FE:00:46`) for voice/HFP
+- Radio Console manages all `/etc/wireplumber/bluetooth.lua.d/` configs
+- Always `bluetoothctl select 78:20:51:F5:FB:A7` before any bluetoothctl commands
+- If you need to change any boundary, update the boundary doc first
+
+To request changes from the RotaryPhone session, update the boundary doc's Change Log and optionally create a prompt file at `D:\prj\RotaryPhone\docs\prompts/`. See the boundary doc's "Passing Work Between Sessions" section for the full protocol.
+
 ## Project Overview
 
 **Grandpa Anderson's Console Radio Remade** - A modern audio command center restoring vintage console radio functionality with modern capabilities (Bluetooth A2DP, streaming, smart home events, Chromecast audio).

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -314,6 +314,11 @@ internal sealed class LinuxBluetoothService : IBluetoothService
       // reconnections from already-paired phones.
       await WatchExistingDevicesAsync();
 
+      // Attach to any media players/transports that already exist (e.g. phone
+      // was connected before radio-api started). Without this, AVRCP metadata
+      // updates won't be received until the next InterfacesAdded event.
+      await CheckForMediaPlayersAsync();
+
       // If a device is already connected at startup, hide discoverability
       if (ConnectedDevice != null)
       {


### PR DESCRIPTION
## Summary
- **AVRCP metadata fix**: `LinuxBluetoothService.StartAsync()` now calls `CheckForMediaPlayersAsync()` after `WatchExistingDevicesAsync()`, so pre-existing AVRCP media players are attached when radio-api starts with a phone already connected. Without this, D-Bus `PropertiesChanged` signals were never watched and metadata updates were silently dropped.
- **Cross-service boundary docs**: Added boundary section to `CLAUDE.md` referencing the shared boundary doc (`RotaryPhone/docs/prompts/RADIO-CONSOLE-BT-AUDIO-BOUNDARY.md`) for dual BT adapter coordination between Radio Console (music/A2DP on TP-Link hci0) and RotaryPhone (voice/HFP on Intel hci1).

## Test plan
- [x] Deploy to Ubuntu, connect phone, verify AVRCP metadata updates live in Web UI
- [x] Verify `wpctl status` shows full pipeline: `bluez_input → radio-bt-stream`, `Radio.API → SN6140 speakers`
- [x] Confirm WirePlumber only shows TP-Link adapter devices (Intel adapter isolated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)