### PR TITLE
feat: BT audio reliability infrastructure — auto-setup, self-healing, health checks

### DIFF
--- a/deploy/common/99-protect-bluez-lua
+++ b/deploy/common/99-protect-bluez-lua
@@ -1,0 +1,5 @@
+// Protect Radio Console WirePlumber patches from being overwritten by apt upgrades.
+// Re-applies bluez.lua patch and verifies WP configs after any wireplumber package update.
+DPkg::Post-Invoke {
+  "if dpkg -l wireplumber 2>/dev/null | grep -q '^ii'; then /opt/radio-console/radio-bt-setup.sh --patch-only 2>&1 | logger -t radio-bt-apt-hook; fi";
+};

--- a/deploy/common/bt-music-devices.conf
+++ b/deploy/common/bt-music-devices.conf
@@ -1,0 +1,5 @@
+# Devices that should only be paired on hci0 (music adapter).
+# One MAC per line. If found paired on hci1 (voice), pairing is removed.
+D4:3A:2C:64:87:9E  # Pixel 8 Pro
+D4:3A:2C:99:52:BE  # Pixel 7 Pro
+6C:2F:8A:E6:ED:10  # Tab A7 Lite

--- a/deploy/common/radio-api.service
+++ b/deploy/common/radio-api.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Radio Console API (audio engine, REST, SignalR)
-After=network.target sound.target bluetooth.target avahi-daemon.service radio-pipewire-access.service
-Wants=avahi-daemon.service radio-pipewire-access.service
+After=network.target sound.target bluetooth.target avahi-daemon.service radio-pipewire-access.service radio-bt-setup.service
+Wants=avahi-daemon.service radio-pipewire-access.service radio-bt-setup.service
 
 [Service]
 Type=simple

--- a/deploy/common/radio-bt-setup.service
+++ b/deploy/common/radio-bt-setup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Radio Console Bluetooth Setup (adapter config, PipeWire defaults)
+After=bluetooth.target
+Before=radio-api.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/radio-console/radio-bt-setup.sh
+RemainAfterExit=yes
+User=root
+SyslogIdentifier=radio-bt-setup
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/common/radio-bt-setup.sh
+++ b/deploy/common/radio-bt-setup.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# radio-bt-setup.sh — Post-boot BT adapter setup for Radio Console.
+# Runs as root (oneshot systemd service) before radio-api starts.
+# Sets adapter aliases, discoverable state, PipeWire default sink,
+# and verifies WirePlumber patches are intact.
+#
+# Usage:
+#   radio-bt-setup.sh              # Full setup (boot)
+#   radio-bt-setup.sh --patch-only # Only verify patches (APT hook)
+
+set -euo pipefail
+
+MUSIC_ADAPTER_PATH="/org/bluez/hci0"
+MUSIC_ADAPTER_MAC="78:20:51:F5:FB:A7"
+MUSIC_ADAPTER_ALIAS="Grandpas Radio"
+
+VOICE_ADAPTER_PATH="/org/bluez/hci1"
+VOICE_ADAPTER_ALIAS="Grandpas Phone"
+VOICE_ADAPTER_MAC="10:91:D1:FE:00:46"
+
+MUSIC_DEVICES_CONF="/opt/radio-console/config/bt-music-devices.conf"
+BLUEZ_LUA="/usr/share/wireplumber/scripts/monitors/bluez.lua"
+BLUEZ_LUA_BAK="/usr/share/wireplumber/scripts/monitors/bluez.lua.bak"
+WP_BT_DIR="/etc/wireplumber/bluetooth.lua.d"
+PW_USER="mmack"
+PW_UID="1000"
+DEFAULT_SINK="alsa_output.pci-0000_00_1f.3.analog-stereo"
+
+PATCH_ONLY=false
+if [[ "${1:-}" == "--patch-only" ]]; then
+  PATCH_ONLY=true
+fi
+
+log() { logger -t radio-bt-setup "$1"; echo "[radio-bt-setup] $1"; }
+
+# --- Step 5: Verify bluez.lua patch ---
+verify_bluez_patch() {
+  if [[ ! -f "$BLUEZ_LUA" ]]; then
+    log "WARNING: $BLUEZ_LUA not found — WirePlumber may not be installed"
+    return
+  fi
+
+  if grep -q 'if true or properties\["api.bluez5.connection"\]' "$BLUEZ_LUA"; then
+    log "bluez.lua patch: OK"
+  else
+    log "WARNING: bluez.lua patch missing — applying now"
+    # Create backup if one doesn't exist
+    [[ -f "$BLUEZ_LUA_BAK" ]] || cp "$BLUEZ_LUA" "$BLUEZ_LUA_BAK"
+    # Apply the patch: replace the connection check with always-true
+    sed -i 's/if properties\["api.bluez5.connection"\] == "connected" then/-- PipeWire 1.0.7 quirk: api.bluez5.connection may report "disconnected"\n  -- even when BlueZ Connected=true. Always activate to let profile policy decide.\n  if true or properties["api.bluez5.connection"] == "connected" then/' "$BLUEZ_LUA"
+    log "bluez.lua patch applied — restarting wireplumber"
+    sudo -u "$PW_USER" XDG_RUNTIME_DIR="/run/user/$PW_UID" systemctl --user restart wireplumber || true
+  fi
+}
+
+# --- Step 6: Verify WP custom configs ---
+verify_wp_configs() {
+  local missing=0
+  for f in 85-disable-hfp-hf.lua 87-bt-adapter-select.lua 89-bt-autoconnect.lua 90-disable-bt-input-autolink.lua; do
+    if [[ ! -f "$WP_BT_DIR/$f" ]]; then
+      log "WARNING: Missing WP config: $WP_BT_DIR/$f"
+      missing=$((missing + 1))
+    fi
+  done
+  if [[ $missing -eq 0 ]]; then
+    log "WP bluetooth configs: OK (4/4 present)"
+  else
+    log "WARNING: $missing WP bluetooth config(s) missing — BT audio may not work correctly"
+  fi
+}
+
+# If --patch-only, just verify patches and exit
+if $PATCH_ONLY; then
+  log "Running in patch-only mode (APT hook)"
+  verify_bluez_patch
+  verify_wp_configs
+  log "Patch verification complete"
+  exit 0
+fi
+
+# --- Step 1: Wait for BlueZ + specific adapter ---
+log "Waiting for BlueZ adapter $MUSIC_ADAPTER_MAC..."
+for i in $(seq 1 30); do
+  ADDR=$(busctl call org.bluez "$MUSIC_ADAPTER_PATH" org.freedesktop.DBus.Properties Get ss org.bluez.Adapter1 Address 2>/dev/null | grep -oP '"[^"]*"' | tr -d '"' || true)
+  if [[ "$ADDR" == "$MUSIC_ADAPTER_MAC" ]]; then
+    log "BlueZ adapter $MUSIC_ADAPTER_MAC ready (attempt $i)"
+    break
+  fi
+  if [[ $i -eq 30 ]]; then
+    log "ERROR: BlueZ adapter $MUSIC_ADAPTER_MAC not ready after 30s — aborting"
+    exit 1
+  fi
+  sleep 1
+done
+
+# --- Step 2: Set adapter aliases and discoverable state ---
+log "Configuring adapter aliases and discoverable state..."
+
+busctl call org.bluez "$MUSIC_ADAPTER_PATH" org.freedesktop.DBus.Properties Set ssv org.bluez.Adapter1 Alias s "$MUSIC_ADAPTER_ALIAS" 2>/dev/null && \
+  log "hci0 alias: $MUSIC_ADAPTER_ALIAS" || log "WARNING: Failed to set hci0 alias"
+
+busctl call org.bluez "$MUSIC_ADAPTER_PATH" org.freedesktop.DBus.Properties Set ssv org.bluez.Adapter1 Discoverable b true 2>/dev/null && \
+  log "hci0 discoverable: on" || log "WARNING: Failed to set hci0 discoverable"
+
+# hci1 may not exist (single-adapter setups) — don't fail
+if busctl call org.bluez "$VOICE_ADAPTER_PATH" org.freedesktop.DBus.Properties Get ss org.bluez.Adapter1 Address 2>/dev/null >/dev/null; then
+  busctl call org.bluez "$VOICE_ADAPTER_PATH" org.freedesktop.DBus.Properties Set ssv org.bluez.Adapter1 Alias s "$VOICE_ADAPTER_ALIAS" 2>/dev/null && \
+    log "hci1 alias: $VOICE_ADAPTER_ALIAS" || log "WARNING: Failed to set hci1 alias"
+
+  busctl call org.bluez "$VOICE_ADAPTER_PATH" org.freedesktop.DBus.Properties Set ssv org.bluez.Adapter1 Discoverable b false 2>/dev/null && \
+    log "hci1 discoverable: off" || log "WARNING: Failed to set hci1 discoverable"
+else
+  log "hci1 not present — skipping voice adapter config"
+fi
+
+# --- Step 3: Remove stale hci1 music pairings ---
+DELETIONS=0
+if [[ -f "$MUSIC_DEVICES_CONF" ]]; then
+  while IFS= read -r line; do
+    # Skip comments and blank lines
+    MAC=$(echo "$line" | sed 's/#.*//' | xargs)
+    [[ -z "$MAC" ]] && continue
+
+    PAIRING_DIR="/var/lib/bluetooth/$VOICE_ADAPTER_MAC/$MAC"
+    if [[ -d "$PAIRING_DIR" ]]; then
+      log "Removing stale hci1 pairing for $MAC"
+      rm -rf "$PAIRING_DIR"
+      DELETIONS=$((DELETIONS + 1))
+    fi
+  done < "$MUSIC_DEVICES_CONF"
+
+  if [[ $DELETIONS -gt 0 ]]; then
+    log "Removed $DELETIONS stale pairing(s) from hci1 — restarting BlueZ"
+    systemctl restart bluetooth
+    # Wait for BlueZ to come back
+    sleep 2
+  else
+    log "No stale hci1 pairings found"
+  fi
+else
+  log "No music devices config at $MUSIC_DEVICES_CONF — skipping pairing cleanup"
+fi
+
+# --- Step 4: Set default PipeWire sink ---
+log "Setting default PipeWire sink to $DEFAULT_SINK..."
+for i in $(seq 1 30); do
+  if sudo -u "$PW_USER" XDG_RUNTIME_DIR="/run/user/$PW_UID" pactl set-default-sink "$DEFAULT_SINK" 2>/dev/null; then
+    log "PipeWire default sink: $DEFAULT_SINK (attempt $i)"
+    break
+  fi
+  if [[ $i -eq 30 ]]; then
+    log "WARNING: Failed to set PipeWire default sink after 30s — PipeWire may not be running yet"
+  fi
+  sleep 1
+done
+
+# --- Steps 5-6: Verify patches ---
+verify_bluez_patch
+verify_wp_configs
+
+# --- Step 7: Summary ---
+log "BT setup complete: adapters configured, $DELETIONS stale pairings removed, PipeWire sink set, patches verified"

--- a/deploy/common/radio-bt-setup.sh
+++ b/deploy/common/radio-bt-setup.sh
@@ -134,6 +134,15 @@ if [[ -f "$MUSIC_DEVICES_CONF" ]]; then
     systemctl restart bluetooth
     # Wait for BlueZ to come back
     sleep 2
+    # Re-apply adapter config — BlueZ restart resets Discoverable state
+    log "Re-applying adapter config after BlueZ restart..."
+    busctl call org.bluez "$MUSIC_ADAPTER_PATH" org.freedesktop.DBus.Properties Set ssv org.bluez.Adapter1 Alias s "$MUSIC_ADAPTER_ALIAS" 2>/dev/null || true
+    busctl call org.bluez "$MUSIC_ADAPTER_PATH" org.freedesktop.DBus.Properties Set ssv org.bluez.Adapter1 Discoverable b true 2>/dev/null || true
+    if busctl call org.bluez "$VOICE_ADAPTER_PATH" org.freedesktop.DBus.Properties Get ss org.bluez.Adapter1 Address 2>/dev/null >/dev/null; then
+      busctl call org.bluez "$VOICE_ADAPTER_PATH" org.freedesktop.DBus.Properties Set ssv org.bluez.Adapter1 Alias s "$VOICE_ADAPTER_ALIAS" 2>/dev/null || true
+      busctl call org.bluez "$VOICE_ADAPTER_PATH" org.freedesktop.DBus.Properties Set ssv org.bluez.Adapter1 Discoverable b false 2>/dev/null || true
+    fi
+    log "Adapter config re-applied after BlueZ restart"
   else
     log "No stale hci1 pairings found"
   fi

--- a/deploy/debian-x64/setup.sh
+++ b/deploy/debian-x64/setup.sh
@@ -226,6 +226,41 @@ systemctl enable radio-api.service
 systemctl enable radio-web.service
 echo "Services installed and enabled (radio-api, radio-web)"
 
+# Install radio-bt-setup (BT adapter config, PipeWire defaults, patch verification)
+BT_SETUP_SRC="$SCRIPT_DIR/../common/radio-bt-setup.sh"
+if [ -f "$BT_SETUP_SRC" ]; then
+  cp "$BT_SETUP_SRC" /opt/radio-console/radio-bt-setup.sh
+  chmod +x /opt/radio-console/radio-bt-setup.sh
+  echo "  Installed radio-bt-setup.sh"
+fi
+
+BT_SERVICE_SRC="$SCRIPT_DIR/../common/radio-bt-setup.service"
+if [ -f "$BT_SERVICE_SRC" ]; then
+  cp "$BT_SERVICE_SRC" /etc/systemd/system/radio-bt-setup.service
+  systemctl daemon-reload
+  systemctl enable radio-bt-setup.service
+  echo "  Installed and enabled radio-bt-setup.service"
+fi
+
+# Install BT music devices config (if not already present — don't overwrite user edits)
+BT_CONF_SRC="$SCRIPT_DIR/../common/bt-music-devices.conf"
+if [ -f "$BT_CONF_SRC" ]; then
+  mkdir -p /opt/radio-console/config
+  if [ ! -f /opt/radio-console/config/bt-music-devices.conf ]; then
+    cp "$BT_CONF_SRC" /opt/radio-console/config/bt-music-devices.conf
+    echo "  Installed bt-music-devices.conf"
+  else
+    echo "  bt-music-devices.conf already exists — skipping (won't overwrite)"
+  fi
+fi
+
+# Install APT hook to protect WirePlumber patches
+APT_HOOK_SRC="$SCRIPT_DIR/../common/99-protect-bluez-lua"
+if [ -f "$APT_HOOK_SRC" ]; then
+  cp "$APT_HOOK_SRC" /etc/apt/apt.conf.d/99-protect-bluez-lua
+  echo "  Installed APT hook for bluez.lua patch protection"
+fi
+
 # ---- 7. Audio Quality Tuning ----
 echo ""
 echo "[7/8] Configuring audio quality tuning..."

--- a/src/Radio.API/Health/BluetoothHealthCheck.cs
+++ b/src/Radio.API/Health/BluetoothHealthCheck.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Radio.Core.Interfaces.Audio;
+
+namespace Radio.API.Health;
+
+/// <summary>
+/// Health check that reports the status of the Bluetooth audio pipeline.
+/// </summary>
+public class BluetoothHealthCheck : IHealthCheck
+{
+  private readonly IBluetoothService _bluetoothService;
+
+  public BluetoothHealthCheck(IBluetoothService bluetoothService)
+  {
+    _bluetoothService = bluetoothService;
+  }
+
+  public Task<HealthCheckResult> CheckHealthAsync(
+    HealthCheckContext context,
+    CancellationToken cancellationToken = default)
+  {
+    var status = _bluetoothService.PipelineStatus;
+    var connected = _bluetoothService.ConnectedDevice;
+
+    var data = new Dictionary<string, object>
+    {
+      ["pipelineStatus"] = status.ToString(),
+      ["connectedDevice"] = connected != null
+        ? $"{connected.Name} ({connected.Address})"
+        : "none",
+    };
+
+    var result = status switch
+    {
+      BluetoothPipelineStatus.Healthy => HealthCheckResult.Healthy(
+        "Bluetooth pipeline active", data),
+      BluetoothPipelineStatus.Inactive => HealthCheckResult.Healthy(
+        "Bluetooth is disabled", data),
+      BluetoothPipelineStatus.Degraded => HealthCheckResult.Degraded(
+        "No Bluetooth device connected", null, data),
+      BluetoothPipelineStatus.Broken => HealthCheckResult.Unhealthy(
+        "Device connected but capture stream missing", null, data),
+      _ => HealthCheckResult.Unhealthy("Unknown pipeline state", null, data)
+    };
+
+    return Task.FromResult(result);
+  }
+}

--- a/src/Radio.API/Program.cs
+++ b/src/Radio.API/Program.cs
@@ -79,7 +79,8 @@ builder.Services.AddSignalR(options =>
 
 // Add health checks
 builder.Services.AddHealthChecks()
-  .AddCheck<Radio.API.Health.AudioEngineHealthCheck>("audio-engine");
+  .AddCheck<Radio.API.Health.AudioEngineHealthCheck>("audio-engine")
+  .AddCheck<Radio.API.Health.BluetoothHealthCheck>("bluetooth-pipeline");
 
 builder.Services.AddManagedConfiguration(builder.Configuration);
 builder.Services.AddMetrics(builder.Configuration);

--- a/src/Radio.API/Services/AudioEngineInitializationService.cs
+++ b/src/Radio.API/Services/AudioEngineInitializationService.cs
@@ -191,12 +191,14 @@ public class AudioEngineInitializationService : IHostedService
       {
         // Physical output device
         string? outputToUse = null;
+        string? preferredDeviceName = null;
         if (!string.IsNullOrEmpty(preferredOutputId))
         {
           var preferredOutput = outputDevices.FirstOrDefault(d => d.Id == preferredOutputId);
           if (preferredOutput != null)
           {
             outputToUse = preferredOutput.Id;
+            preferredDeviceName = preferredOutput.Name;
             _logger.LogInformation("Using preferred output device: {DeviceName}", preferredOutput.Name);
           }
           else
@@ -211,6 +213,7 @@ public class AudioEngineInitializationService : IHostedService
           if (defaultOutput != null)
           {
             outputToUse = defaultOutput.Id;
+            preferredDeviceName = defaultOutput.Name;
             _logger.LogInformation("Using default output device: {DeviceName}", defaultOutput.Name);
           }
         }
@@ -225,6 +228,43 @@ public class AudioEngineInitializationService : IHostedService
           catch (Exception ex)
           {
             _logger.LogWarning(ex, "Failed to set output device");
+          }
+
+          // Verify the output device actually connected to the correct PipeWire node.
+          // After PipeWire restarts, MiniAudio device indices may shift, causing the
+          // wrong device to be selected even though the ID matches.
+          try
+          {
+            var currentDevices = await _deviceManager.GetOutputDevicesAsync(cancellationToken);
+            var selectedId = _deviceManager.GetSelectedOutputDeviceId();
+            var activeDevice = selectedId != null
+              ? currentDevices.FirstOrDefault(d => d.Id == selectedId)
+              : null;
+            if (activeDevice != null && preferredDeviceName != null &&
+                !activeDevice.Name.Contains(preferredDeviceName, StringComparison.OrdinalIgnoreCase))
+            {
+              _logger.LogWarning(
+                "Output device mismatch: expected \"{Expected}\" but connected to \"{Actual}\" — searching by name",
+                preferredDeviceName, activeDevice.Name);
+
+              var correctDevice = currentDevices.FirstOrDefault(d =>
+                d.Name.Contains(preferredDeviceName, StringComparison.OrdinalIgnoreCase));
+              if (correctDevice != null)
+              {
+                _logger.LogInformation("Found correct device \"{Name}\" at ID {Id} — switching",
+                  correctDevice.Name, correctDevice.Id);
+                await _deviceManager.SetOutputDeviceAsync(correctDevice.Id, cancellationToken);
+              }
+              else
+              {
+                _logger.LogWarning("Could not find device matching \"{Name}\" — using current device",
+                  preferredDeviceName);
+              }
+            }
+          }
+          catch (Exception ex)
+          {
+            _logger.LogWarning(ex, "Output device verification failed — continuing with current device");
           }
         }
       }

--- a/src/Radio.Core/Interfaces/Audio/IBluetoothService.cs
+++ b/src/Radio.Core/Interfaces/Audio/IBluetoothService.cs
@@ -108,6 +108,12 @@ public interface IBluetoothService : IAsyncDisposable
   /// <summary>Event raised when new device discovered.</summary>
   event EventHandler<BluetoothDeviceDiscoveredEventArgs>? DeviceDiscovered;
 
+  /// <summary>
+  /// Raised when the pipeline monitor successfully recovers a lost capture stream.
+  /// Subscribers should re-attach the capture generator to their audio mixer.
+  /// </summary>
+  event EventHandler? CaptureStreamRecovered;
+
   /// <summary>Event raised when playback metadata changes (Track, Artist, etc.).</summary>
   event EventHandler<BluetoothPlaybackMetadata>? MetadataChanged;
 

--- a/src/Radio.Core/Interfaces/Audio/IBluetoothService.cs
+++ b/src/Radio.Core/Interfaces/Audio/IBluetoothService.cs
@@ -148,6 +148,29 @@ public interface IBluetoothService : IAsyncDisposable
 
   /// <summary>Last disconnect reason for UI display. Null if no disconnect has occurred.</summary>
   BluetoothDisconnectReason? LastDisconnectReason { get; }
+
+  /// <summary>
+  /// Gets the current health status of the Bluetooth audio pipeline.
+  /// </summary>
+  BluetoothPipelineStatus PipelineStatus { get; }
+}
+
+/// <summary>
+/// Describes the health of the Bluetooth audio capture pipeline.
+/// </summary>
+public enum BluetoothPipelineStatus
+{
+  /// <summary>BT is disabled or not started.</summary>
+  Inactive,
+
+  /// <summary>No device connected — waiting for connection.</summary>
+  Degraded,
+
+  /// <summary>Device connected and capture stream active.</summary>
+  Healthy,
+
+  /// <summary>Device connected but capture stream is missing or broken.</summary>
+  Broken
 }
 
 /// <summary>Bluetooth adapter states.</summary>

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -80,6 +80,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
     _bluetoothService.PositionChanged += OnPositionChanged;
     _bluetoothService.DeviceConnected += OnDeviceConnected;
     _bluetoothService.DeviceDisconnected += OnDeviceDisconnected;
+    _bluetoothService.CaptureStreamRecovered += OnCaptureStreamRecovered;
 
     if (_identificationService != null)
     {
@@ -287,6 +288,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
     _bluetoothService.PositionChanged -= OnPositionChanged;
     _bluetoothService.DeviceConnected -= OnDeviceConnected;
     _bluetoothService.DeviceDisconnected -= OnDeviceDisconnected;
+    _bluetoothService.CaptureStreamRecovered -= OnCaptureStreamRecovered;
 
     if (_identificationService != null)
     {
@@ -335,6 +337,12 @@ public class BluetoothAudioSource : USBAudioSourceBase
     NeedsFingerprintingLookup = true;
 
     // Attempt to acquire audio capture device now that a device is connected
+    _ = TryAcquireAudioCaptureAsync();
+  }
+
+  private void OnCaptureStreamRecovered(object? sender, EventArgs e)
+  {
+    Logger.LogInformation("BluetoothAudioSource: capture stream recovered by pipeline monitor");
     _ = TryAcquireAudioCaptureAsync();
   }
 

--- a/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothServiceFactory.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothServiceFactory.cs
@@ -86,6 +86,7 @@ internal sealed class NullBluetoothService : IBluetoothService
   public bool IsReconnecting => false;
   public void CancelReconnection() { }
   public BluetoothDisconnectReason? LastDisconnectReason => null;
+  public BluetoothPipelineStatus PipelineStatus => BluetoothPipelineStatus.Inactive;
 
   public Task<bool> StartAsync(string deviceName, CancellationToken cancellationToken = default)
   {

--- a/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothServiceFactory.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothServiceFactory.cs
@@ -79,6 +79,7 @@ internal sealed class NullBluetoothService : IBluetoothService
   public event EventHandler<BluetoothPlaybackStatus>? PlaybackStatusChanged { add { } remove { } }
   public event EventHandler<TimeSpan>? PositionChanged { add { } remove { } }
   public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged { add { } remove { } }
+  public event EventHandler? CaptureStreamRecovered { add { } remove { } }
   public float? DeviceVolume => null;
   public Task SetDeviceVolumeAsync(float volume) => Task.CompletedTask;
   public Task NextTrackAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -62,6 +62,8 @@ internal sealed class LinuxBluetoothService : IBluetoothService
   private bool _userInitiatedDisconnect;
   private BluetoothReconnectionLoop? _reconnectionLoop;
   private readonly BluetoothMgmtMonitor? _mgmtMonitor;
+  private CancellationTokenSource? _pipelineMonitorCts;
+  private int _pipelineRecoveryFailures;
 
   public LinuxBluetoothService(
     ILogger logger,
@@ -151,7 +153,72 @@ internal sealed class LinuxBluetoothService : IBluetoothService
   public event EventHandler<BluetoothPlaybackStatus>? PlaybackStatusChanged;
   public event EventHandler<TimeSpan>? PositionChanged;
   public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged;
+  public event EventHandler? CaptureStreamRecovered;
   public float? DeviceVolume { get; private set; }
+
+  private async Task MonitorBtPipelineAsync(CancellationToken cancellationToken)
+  {
+    _logger.LogInformation("BT pipeline monitor started (interval: 30s)");
+
+    while (!cancellationToken.IsCancellationRequested)
+    {
+      try
+      {
+        await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+      }
+      catch (OperationCanceledException)
+      {
+        break;
+      }
+
+      try
+      {
+        var connected = ConnectedDevice;
+        if (connected == null)
+        {
+          _pipelineRecoveryFailures = 0;
+          continue;
+        }
+
+        if (_nativeStream != null || _captureProcess is { HasExited: false })
+        {
+          _pipelineRecoveryFailures = 0;
+          continue;
+        }
+
+        if (_pipelineRecoveryFailures >= 3)
+        {
+          continue; // Already logged error, stop retrying
+        }
+
+        _pipelineRecoveryFailures++;
+        _logger.LogWarning(
+          "BT device connected but capture stream missing (attempt {Attempt}/3) — attempting recovery",
+          _pipelineRecoveryFailures);
+
+        // Must use GetAudioCaptureDeviceAsync (not SearchForCaptureDeviceAsync directly)
+        // because it acquires _captureDeviceLock to prevent races with BluetoothAudioSource.
+        var generator = await GetAudioCaptureDeviceAsync(cancellationToken);
+        if (generator != null)
+        {
+          _logger.LogInformation("BT pipeline recovery successful — capture stream re-established");
+          _pipelineRecoveryFailures = 0;
+          CaptureStreamRecovered?.Invoke(this, EventArgs.Empty);
+        }
+        else if (_pipelineRecoveryFailures >= 3)
+        {
+          _logger.LogError(
+            "BT pipeline recovery failed 3 times — giving up until next device connect/disconnect cycle");
+        }
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "Error in BT pipeline monitor");
+      }
+    }
+
+    _logger.LogInformation("BT pipeline monitor stopped");
+  }
 
   public async Task SetDeviceVolumeAsync(float volume)
   {
@@ -340,6 +407,11 @@ internal sealed class LinuxBluetoothService : IBluetoothService
 
       State = BluetoothAdapterState.On;
       StateChanged?.Invoke(this, new BluetoothAdapterStateChangedEventArgs { NewState = State });
+
+      // Start pipeline health monitor
+      _pipelineMonitorCts = new CancellationTokenSource();
+      _ = MonitorBtPipelineAsync(_pipelineMonitorCts.Token);
+
       return true;
     }
     catch (Exception ex)
@@ -455,6 +527,7 @@ internal sealed class LinuxBluetoothService : IBluetoothService
           _metricsCollector?.Gauge("bluetooth.active_connections", 1);
           _logger.LogInformation("Bluetooth device already connected: {DeviceName} ({Address})",
             device.Name, device.Address);
+          _pipelineRecoveryFailures = 0;
           DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = device });
         }
       }
@@ -490,6 +563,7 @@ internal sealed class LinuxBluetoothService : IBluetoothService
         // Hide adapter from other devices while one is connected
         _ = SetDiscoverableAsync(false);
 
+        _pipelineRecoveryFailures = 0;
         DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = device });
       }
 
@@ -574,6 +648,7 @@ internal sealed class LinuxBluetoothService : IBluetoothService
               // Hide adapter from other devices while one is connected
               _ = SetDiscoverableAsync(false);
 
+              _pipelineRecoveryFailures = 0;
               DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = updatedDevice });
             }
             else
@@ -610,6 +685,7 @@ internal sealed class LinuxBluetoothService : IBluetoothService
               // Re-show adapter so other devices can discover and pair
               _ = SetDiscoverableAsync(true);
 
+              _pipelineRecoveryFailures = 0;
               DeviceDisconnected?.Invoke(this, new BluetoothDeviceDisconnectedEventArgs
               {
                 Device = updatedDevice,
@@ -1773,6 +1849,10 @@ internal sealed class LinuxBluetoothService : IBluetoothService
 
   public async ValueTask DisposeAsync()
   {
+    _pipelineMonitorCts?.Cancel();
+    _pipelineMonitorCts?.Dispose();
+    _pipelineMonitorCts = null;
+
     _reconnectionLoop?.Dispose();
     _reconnectionLoop = null;
     _playerPropertiesWatcher?.Dispose();

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -130,6 +130,19 @@ internal sealed class LinuxBluetoothService : IBluetoothService
     }
   }
 
+  public BluetoothPipelineStatus PipelineStatus
+  {
+    get
+    {
+      if (!_started) return BluetoothPipelineStatus.Inactive;
+      var connected = ConnectedDevice;
+      if (connected == null) return BluetoothPipelineStatus.Degraded;
+      if (_nativeStream != null || _captureProcess is { HasExited: false })
+        return BluetoothPipelineStatus.Healthy;
+      return BluetoothPipelineStatus.Broken;
+    }
+  }
+
   public event EventHandler<BluetoothAdapterStateChangedEventArgs>? StateChanged;
   public event EventHandler<BluetoothDeviceConnectedEventArgs>? DeviceConnected;
   public event EventHandler<BluetoothDeviceDisconnectedEventArgs>? DeviceDisconnected;

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -422,7 +422,7 @@ internal sealed class LinuxBluetoothService : IBluetoothService
           preExistingDevice.Name);
         for (var i = 0; i < 200; i++) // 200 * 25ms = 5s
         {
-          await Task.Delay(25);
+          await Task.Delay(25, cancellationToken);
           if (ConnectedDevice != null)
           {
             _logger.LogInformation("Device {Device} reconnected after {Ms}ms",
@@ -474,6 +474,11 @@ internal sealed class LinuxBluetoothService : IBluetoothService
 
   public async Task StopAsync(CancellationToken cancellationToken = default)
   {
+    // Stop pipeline monitor before other cleanup to prevent recovery attempts during shutdown
+    _pipelineMonitorCts?.Cancel();
+    _pipelineMonitorCts?.Dispose();
+    _pipelineMonitorCts = null;
+
     StopCaptureSubprocess();
     _captureEngine?.Dispose();
     _captureEngine = null;

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -382,10 +382,60 @@ internal sealed class LinuxBluetoothService : IBluetoothService
       await _adapter.SetAsync("PairableTimeout", (uint)0);
       await _adapter.SetAsync("Pairable", true);
 
+      // Check for pre-existing device connections before agent registration.
+      // Registering an agent can briefly disconnect devices on some BlueZ versions.
+      BluetoothDeviceInfo? preExistingDevice = null;
+      try
+      {
+        var existingObjects = await _objectManager!.GetManagedObjectsAsync();
+        foreach (var obj in existingObjects)
+        {
+          if (!obj.Value.ContainsKey(Linux.BluezConstants.DeviceInterface))
+            continue;
+
+          var props = obj.Value[Linux.BluezConstants.DeviceInterface];
+          var device = ParseDevice(obj.Key, props);
+          if (device.IsConnected)
+          {
+            preExistingDevice = device;
+            _logger.LogInformation(
+              "Pre-existing BT connection detected: {Name} ({Address}) — agent registration may briefly disconnect it",
+              device.Name, device.Address);
+            break;
+          }
+        }
+      }
+      catch (Exception ex)
+      {
+        _logger.LogWarning(ex, "Failed to check for pre-existing BT connections");
+      }
+
       // Register a BlueZ Agent to handle pairing requests automatically.
       // Without an agent, pairing fails with "incorrect PIN or passkey" because
       // BlueZ has no one to delegate the pairing decision to.
       await RegisterAgentAsync();
+
+      // If a device was connected before agent registration, poll for its reconnection
+      if (preExistingDevice != null)
+      {
+        _logger.LogInformation("Waiting up to 5s for {Device} to reconnect after agent registration...",
+          preExistingDevice.Name);
+        for (var i = 0; i < 200; i++) // 200 * 25ms = 5s
+        {
+          await Task.Delay(25);
+          if (ConnectedDevice != null)
+          {
+            _logger.LogInformation("Device {Device} reconnected after {Ms}ms",
+              preExistingDevice.Name, (i + 1) * 25);
+            break;
+          }
+        }
+        if (ConnectedDevice == null)
+        {
+          _logger.LogWarning("Device {Device} did not reconnect within 5s — reconnection loop will handle it",
+            preExistingDevice.Name);
+        }
+      }
 
       // Watch for new interfaces (device connects/disconnects)
       _discoveryWatcher = await _objectManager.WatchInterfacesAddedAsync(OnInterfaceAdded);

--- a/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
@@ -41,6 +41,7 @@ public sealed class MockBluetoothService : IBluetoothService
         public event EventHandler<BluetoothPlaybackStatus>? PlaybackStatusChanged;
         public event EventHandler<TimeSpan>? PositionChanged { add { } remove { } }
         public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged { add { } remove { } }
+        public event EventHandler? CaptureStreamRecovered { add { } remove { } }
         public float? DeviceVolume => null;
         public Task SetDeviceVolumeAsync(float volume) => Task.CompletedTask;
         public Task NextTrackAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
@@ -48,6 +48,7 @@ public sealed class MockBluetoothService : IBluetoothService
         public bool IsReconnecting => false;
         public void CancelReconnection() { }
         public BluetoothDisconnectReason? LastDisconnectReason => null;
+        public BluetoothPipelineStatus PipelineStatus => BluetoothPipelineStatus.Inactive;
 
         public Task<bool> StartAsync(string deviceName, CancellationToken cancellationToken = default)
         {

--- a/src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs
@@ -240,6 +240,8 @@ internal sealed class WindowsBluetoothService : IBluetoothService
     public float? DeviceVolume => null;
 #endif
 
+    public event EventHandler? CaptureStreamRecovered { add { } remove { } }
+
     public Task SetDeviceVolumeAsync(float volume)
     {
       // AVRCP absolute volume set is not yet implemented for Windows.

--- a/src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs
@@ -265,6 +265,7 @@ internal sealed class WindowsBluetoothService : IBluetoothService
     public bool IsReconnecting => false;
     public void CancelReconnection() { }
     public BluetoothDisconnectReason? LastDisconnectReason => null;
+    public BluetoothPipelineStatus PipelineStatus => BluetoothPipelineStatus.Inactive;
 
     private void CheckState(object? state)
     {

--- a/tests/Radio.API.Tests/Health/BluetoothHealthCheckTests.cs
+++ b/tests/Radio.API.Tests/Health/BluetoothHealthCheckTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Moq;
+using Radio.API.Health;
+using Radio.Core.Interfaces.Audio;
+
+namespace Radio.API.Tests.Health;
+
+public class BluetoothHealthCheckTests
+{
+  private readonly Mock<IBluetoothService> _mockBtService = new();
+
+  private BluetoothHealthCheck CreateSut() => new(_mockBtService.Object);
+
+  [Fact]
+  public async Task Returns_Healthy_When_Pipeline_Healthy()
+  {
+    _mockBtService.Setup(s => s.PipelineStatus).Returns(BluetoothPipelineStatus.Healthy);
+    _mockBtService.Setup(s => s.ConnectedDevice).Returns(
+      new BluetoothDeviceInfo { Name = "Pixel 8 Pro", Address = "D4:3A:2C:64:87:9E", IsConnected = true });
+
+    var result = await CreateSut().CheckHealthAsync(
+      new HealthCheckContext { Registration = new HealthCheckRegistration("bt", CreateSut(), null, null) });
+
+    Assert.Equal(HealthStatus.Healthy, result.Status);
+  }
+
+  [Fact]
+  public async Task Returns_Degraded_When_No_Device_Connected()
+  {
+    _mockBtService.Setup(s => s.PipelineStatus).Returns(BluetoothPipelineStatus.Degraded);
+    _mockBtService.Setup(s => s.ConnectedDevice).Returns((BluetoothDeviceInfo?)null);
+
+    var result = await CreateSut().CheckHealthAsync(
+      new HealthCheckContext { Registration = new HealthCheckRegistration("bt", CreateSut(), null, null) });
+
+    Assert.Equal(HealthStatus.Degraded, result.Status);
+  }
+
+  [Fact]
+  public async Task Returns_Unhealthy_When_Pipeline_Broken()
+  {
+    _mockBtService.Setup(s => s.PipelineStatus).Returns(BluetoothPipelineStatus.Broken);
+    _mockBtService.Setup(s => s.ConnectedDevice).Returns(
+      new BluetoothDeviceInfo { Name = "Pixel 8 Pro", Address = "D4:3A:2C:64:87:9E", IsConnected = true });
+
+    var result = await CreateSut().CheckHealthAsync(
+      new HealthCheckContext { Registration = new HealthCheckRegistration("bt", CreateSut(), null, null) });
+
+    Assert.Equal(HealthStatus.Unhealthy, result.Status);
+  }
+
+  [Fact]
+  public async Task Returns_Healthy_When_Inactive()
+  {
+    _mockBtService.Setup(s => s.PipelineStatus).Returns(BluetoothPipelineStatus.Inactive);
+
+    var result = await CreateSut().CheckHealthAsync(
+      new HealthCheckContext { Registration = new HealthCheckRegistration("bt", CreateSut(), null, null) });
+
+    Assert.Equal(HealthStatus.Healthy, result.Status);
+  }
+
+  [Fact]
+  public async Task Reports_Connected_Device_In_Data()
+  {
+    _mockBtService.Setup(s => s.PipelineStatus).Returns(BluetoothPipelineStatus.Healthy);
+    _mockBtService.Setup(s => s.ConnectedDevice).Returns(
+      new BluetoothDeviceInfo { Name = "Pixel 8 Pro", Address = "D4:3A:2C:64:87:9E", IsConnected = true });
+
+    var result = await CreateSut().CheckHealthAsync(
+      new HealthCheckContext { Registration = new HealthCheckRegistration("bt", CreateSut(), null, null) });
+
+    Assert.Equal("Pixel 8 Pro (D4:3A:2C:64:87:9E)", result.Data["connectedDevice"]);
+  }
+}


### PR DESCRIPTION
## Summary

Eliminates manual BT audio recovery steps after reboot, deploy, or power outage. Every debugging session we've had follows the same pattern: adapter names reset, discoverable state is wrong, PipeWire doesn't see connections, wrong startup order breaks the capture pipeline. This PR automates all of it.

**Three components:**

- **Post-boot setup script** (`radio-bt-setup.sh` + systemd service) — runs before radio-api, configures BT adapter aliases/discoverable state, removes stale cross-adapter pairings, sets PipeWire default sink, verifies WirePlumber patches are intact
- **APT hook** (`99-protect-bluez-lua`) — re-applies the PipeWire 1.0.7 bluez.lua patch after WirePlumber upgrades
- **Radio.API resilience** — Bluetooth pipeline health check endpoint, 30-second self-healing monitor that recovers lost capture streams, output device verification at startup (prevents wrong speaker after PipeWire restart), graceful agent re-registration that detects pre-existing connections

## Changes

### Deploy Infrastructure
- `deploy/common/radio-bt-setup.sh` — Post-boot BT setup script (busctl D-Bus calls, pactl, sed patching)
- `deploy/common/radio-bt-setup.service` — Systemd oneshot, After=bluetooth.target, Before=radio-api
- `deploy/common/bt-music-devices.conf` — Configurable list of music-only device MACs
- `deploy/common/99-protect-bluez-lua` — APT DPkg::Post-Invoke hook
- `deploy/common/radio-api.service` — Added radio-bt-setup dependency
- `deploy/debian-x64/setup.sh` — Installs BT setup infrastructure

### Radio.API Code
- `BluetoothPipelineStatus` enum (Inactive/Degraded/Healthy/Broken)
- `BluetoothHealthCheck` — health check at `/health` reporting BT pipeline state
- `MonitorBtPipelineAsync` — 30s monitor, 3-retry recovery via `GetAudioCaptureDeviceAsync`
- `CaptureStreamRecovered` event — `BluetoothAudioSource` re-attaches capture on recovery
- Output device name verification in `ApplyStartupPreferencesAsync`
- Pre-existing connection detection + 5s reconnection polling around agent registration

### Tests
- 5 new unit tests for `BluetoothHealthCheck` (all pipeline states + data reporting)

## Test plan

- [ ] `dotnet build --configuration Release` — 0 errors
- [ ] `dotnet test --configuration Release` — all tests pass (1 pre-existing failure in `AudioEngineInitializationServiceTests`)
- [ ] Deploy to Ubuntu, run `sudo /opt/radio-console/radio-bt-setup.sh` manually
- [ ] Verify `--patch-only` mode works
- [ ] Verify `/health` endpoint includes `bluetooth-pipeline` check
- [ ] Restart radio-api with phone connected — verify "Pre-existing BT connection" log and fast reconnection
- [ ] Wait for BT timeout/disconnect — verify 30s monitor recovers capture stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)