### PR TITLE
fix: capture device lifecycle fix + instrumentation

### DIFF
--- a/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
@@ -100,6 +100,21 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
     // Pre-allocated metrics tags to avoid Dictionary allocation in LogStats
     private readonly Dictionary<string, string>? _metricsTags;
 
+    // Unique identity for lifecycle tracking across mixer add/remove/dispose
+    private static int _nextGeneratorId;
+
+    /// <summary>Unique ID for tracking this generator through its lifecycle.</summary>
+    public int GeneratorId { get; }
+
+    /// <summary>Total samples received via AddSamples (lifetime).</summary>
+    public long TotalSamplesReceived => _totalSamplesReceived;
+
+    /// <summary>Total samples output via GenerateAudio (lifetime).</summary>
+    public long TotalSamplesOutput => _totalSamplesOutput;
+
+    /// <summary>Whether this generator has been disposed.</summary>
+    public new bool IsDisposed => _isDisposed;
+
     // Clock drift compensation: when producer (e.g., BT/PipeWire) runs on a different
     // clock than consumer (MiniAudio/ALSA), the buffer slowly drains or fills. We
     // periodically check the buffer level and duplicate a frame of samples when the
@@ -130,6 +145,7 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
         IMetricsCollector? metricsCollector = null)
         : base(engine, format)
     {
+        GeneratorId = Interlocked.Increment(ref _nextGeneratorId);
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _metricsCollector = metricsCollector;
         _overflowStrategy = overflowStrategy;
@@ -150,9 +166,9 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
             _metricsTags = new Dictionary<string, string> { ["type"] = typeof(T).Name };
         }
 
-        _logger.LogDebug(
-            "BufferedSoundGenerator created: Type={Type}, OutputSampleRate={SampleRate}Hz, OutputChannels={Channels}, MaxBufferSamples={MaxBuffer}, Strategy={Strategy}",
-            typeof(T).Name, format.SampleRate, format.Channels, _maxBufferSamples, _overflowStrategy);
+        _logger.LogInformation(
+            "BufferedSoundGenerator #{GeneratorId} created: Type={Type}, OutputSampleRate={SampleRate}Hz, OutputChannels={Channels}, MaxBufferSamples={MaxBuffer}, Strategy={Strategy}",
+            GeneratorId, typeof(T).Name, format.SampleRate, format.Channels, _maxBufferSamples, _overflowStrategy);
     }
 
     /// <summary>
@@ -705,8 +721,8 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
             }
 
             _logger.LogInformation(
-                "BufferedSoundGenerator disposed. Total samples: received={Received}, output={Output}, dropped={Dropped}, compensated={Compensated}",
-                _totalSamplesReceived, _totalSamplesOutput, _totalSamplesDropped, _totalSamplesCompensated);
+                "BufferedSoundGenerator #{GeneratorId} disposed. Total samples: received={Received}, output={Output}, dropped={Dropped}, compensated={Compensated}",
+                GeneratorId, _totalSamplesReceived, _totalSamplesOutput, _totalSamplesDropped, _totalSamplesCompensated);
         }
         else
         {

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowPlaybackService.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowPlaybackService.cs
@@ -29,6 +29,16 @@ public class SoundFlowPlaybackService : IDisposable
   private readonly object _playersLock = new();
   private bool _disposed;
 
+  // Audio flow health monitoring
+  private CancellationTokenSource? _flowMonitorCts;
+  private readonly Dictionary<string, long> _lastOutputSamples = new();
+
+  /// <summary>
+  /// Fired when a generator is detected as stalled — receiving samples but not outputting.
+  /// The string parameter is the sourceId of the stalled component.
+  /// </summary>
+  public event Action<string>? GeneratorStalled;
+
   /// <summary>
   /// Initializes a new instance of the <see cref="SoundFlowPlaybackService"/> class.
   /// </summary>
@@ -41,6 +51,10 @@ public class SoundFlowPlaybackService : IDisposable
 
     // Re-attach active components/players when the playback device changes
     _audioEngine.PlaybackDeviceSwitched += OnPlaybackDeviceSwitched;
+
+    // Start audio flow health monitor
+    _flowMonitorCts = new CancellationTokenSource();
+    _ = MonitorAudioFlowAsync(_flowMonitorCts.Token);
   }
 
   /// <summary>
@@ -396,9 +410,10 @@ public class SoundFlowPlaybackService : IDisposable
       component.Volume = Math.Clamp(volume * compGainOffset * compDuckMult, AudioPreferencePersistence.MinGain, AudioPreferencePersistence.MaxGain);
 
       // Add to the playback device's mixer
+      var generatorId = (component as BufferedSoundGenerator<float>)?.GeneratorId;
       _logger.LogInformation(
-        "🔊 AUDIO ROUTING: Adding component '{ComponentName}' to SoundFlow mixer (SourceId={SourceId}, Volume={Volume:P0})",
-        component.Name ?? component.GetType().Name, sourceId, volume);
+        "🔊 AUDIO ROUTING: Adding component '{ComponentName}' to SoundFlow mixer (SourceId={SourceId}, Volume={Volume:P0}, GeneratorId={GeneratorId})",
+        component.Name ?? component.GetType().Name, sourceId, volume, generatorId?.ToString() ?? "n/a");
 
       playbackDevice.MasterMixer.AddComponent(component);
 
@@ -409,8 +424,8 @@ public class SoundFlowPlaybackService : IDisposable
       }
 
       _logger.LogInformation(
-        "🔊 AUDIO ROUTING COMPLETE: Component '{ComponentName}' now connected to audio output (SourceId={SourceId})",
-        component.Name ?? component.GetType().Name, sourceId);
+        "🔊 AUDIO ROUTING COMPLETE: Component '{ComponentName}' now connected to audio output (SourceId={SourceId}, GeneratorId={GeneratorId})",
+        component.Name ?? component.GetType().Name, sourceId, generatorId?.ToString() ?? "n/a");
       return true;
     }
     catch (Exception ex)
@@ -525,15 +540,16 @@ public class SoundFlowPlaybackService : IDisposable
       try
       {
         var componentName = component.Name ?? component.GetType().Name;
+        var generatorId = (component as BufferedSoundGenerator<float>)?.GeneratorId;
         _logger.LogInformation(
-          "🔇 AUDIO ROUTING: Removing component '{ComponentName}' from SoundFlow mixer (SourceId={SourceId})",
-          componentName, sourceId);
+          "🔇 AUDIO ROUTING: Removing component '{ComponentName}' from SoundFlow mixer (SourceId={SourceId}, GeneratorId={GeneratorId})",
+          componentName, sourceId, generatorId?.ToString() ?? "n/a");
 
         playbackDevice?.MasterMixer.RemoveComponent(component);
         component.Dispose();
         _logger.LogInformation(
-          "🔇 AUDIO ROUTING REMOVED: Component '{ComponentName}' disconnected from audio output (SourceId={SourceId})",
-          componentName, sourceId);
+          "🔇 AUDIO ROUTING REMOVED: Component '{ComponentName}' disconnected from audio output (SourceId={SourceId}, GeneratorId={GeneratorId})",
+          componentName, sourceId, generatorId?.ToString() ?? "n/a");
       }
       catch (Exception ex)
       {
@@ -742,6 +758,83 @@ public class SoundFlowPlaybackService : IDisposable
     }
   }
 
+  private async Task MonitorAudioFlowAsync(CancellationToken cancellationToken)
+  {
+    _logger.LogInformation("Audio flow health monitor started (interval: 10s)");
+
+    while (!cancellationToken.IsCancellationRequested)
+    {
+      try
+      {
+        await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+      }
+      catch (OperationCanceledException)
+      {
+        break;
+      }
+
+      try
+      {
+        KeyValuePair<string, SoundComponent>[] snapshot;
+        lock (_playersLock)
+        {
+          snapshot = _activeComponents.ToArray();
+        }
+
+        foreach (var (sourceId, component) in snapshot)
+        {
+          if (component is not BufferedSoundGenerator<float> generator)
+            continue;
+
+          if (generator.IsDisposed)
+          {
+            _logger.LogWarning(
+              "Audio flow monitor: disposed generator #{GeneratorId} still in active components for {SourceId}",
+              generator.GeneratorId, sourceId);
+            continue;
+          }
+
+          var currentOutput = generator.TotalSamplesOutput;
+          var currentReceived = generator.TotalSamplesReceived;
+
+          _lastOutputSamples.TryGetValue(sourceId, out var previousOutput);
+          _lastOutputSamples[sourceId] = currentOutput;
+
+          // Skip first check (no previous baseline)
+          if (previousOutput == 0)
+            continue;
+
+          var outputDelta = currentOutput - previousOutput;
+          var isReceiving = currentReceived > 0;
+
+          // Stalled: generator is in mixer, has received samples, but output hasn't increased
+          if (outputDelta == 0 && isReceiving && currentReceived > currentOutput)
+          {
+            _logger.LogError(
+              "🔴 STALLED GENERATOR: #{GeneratorId} for {SourceId} — received={Received}, output={Output}, delta=0 in last 10s. " +
+              "Generator is in mixer but SoundFlow is not reading from it.",
+              generator.GeneratorId, sourceId, currentReceived, currentOutput);
+
+            GeneratorStalled?.Invoke(sourceId);
+          }
+        }
+
+        // Clean up tracking for removed components
+        var activeIds = snapshot.Select(s => s.Key).ToHashSet();
+        foreach (var key in _lastOutputSamples.Keys.Except(activeIds).ToList())
+        {
+          _lastOutputSamples.Remove(key);
+        }
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "Error in audio flow health monitor");
+      }
+    }
+
+    _logger.LogInformation("Audio flow health monitor stopped");
+  }
+
   private void ThrowIfDisposed()
   {
     ObjectDisposedException.ThrowIf(_disposed, this);
@@ -756,6 +849,9 @@ public class SoundFlowPlaybackService : IDisposable
     }
 
     _audioEngine.PlaybackDeviceSwitched -= OnPlaybackDeviceSwitched;
+
+    _flowMonitorCts?.Cancel();
+    _flowMonitorCts?.Dispose();
 
     // Stop all first, then set disposed
     lock (_playersLock)

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -82,6 +82,11 @@ public class BluetoothAudioSource : USBAudioSourceBase
     _bluetoothService.DeviceDisconnected += OnDeviceDisconnected;
     _bluetoothService.CaptureStreamRecovered += OnCaptureStreamRecovered;
 
+    if (_playbackService != null)
+    {
+      _playbackService.GeneratorStalled += OnGeneratorStalled;
+    }
+
     if (_identificationService != null)
     {
       _identificationService.TrackIdentified += OnTrackIdentified;
@@ -290,6 +295,11 @@ public class BluetoothAudioSource : USBAudioSourceBase
     _bluetoothService.DeviceDisconnected -= OnDeviceDisconnected;
     _bluetoothService.CaptureStreamRecovered -= OnCaptureStreamRecovered;
 
+    if (_playbackService != null)
+    {
+      _playbackService.GeneratorStalled -= OnGeneratorStalled;
+    }
+
     if (_identificationService != null)
     {
       _identificationService.TrackIdentified -= OnTrackIdentified;
@@ -344,6 +354,38 @@ public class BluetoothAudioSource : USBAudioSourceBase
   {
     Logger.LogInformation("BluetoothAudioSource: capture stream recovered by pipeline monitor");
     _ = TryAcquireAudioCaptureAsync();
+  }
+
+  private void OnGeneratorStalled(string sourceId)
+  {
+    if (sourceId != _playbackId && sourceId != Id) return;
+
+    Logger.LogWarning(
+      "🔴 BluetoothAudioSource: generator stalled — attempting capture re-acquisition (PlaybackId={PlaybackId})",
+      _playbackId);
+
+    _ = Task.Run(async () =>
+    {
+      try
+      {
+        // Stop current capture
+        if (_playbackService != null && _playbackId != null)
+        {
+          await _playbackService.StopAsync(_playbackId, CancellationToken.None);
+          _playbackId = null;
+          _captureGenerator = null;
+          SoundComponent = null;
+        }
+
+        // Re-acquire capture device and route through mixer
+        await TryAcquireAudioCaptureAsync();
+        Logger.LogInformation("🟢 BluetoothAudioSource: capture pipeline recreated after stall");
+      }
+      catch (Exception ex)
+      {
+        Logger.LogError(ex, "Failed to recreate BT capture pipeline after stall");
+      }
+    });
   }
 
   private async Task TryAcquireAudioCaptureAsync()

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -433,6 +433,8 @@ public class BluetoothAudioSource : USBAudioSourceBase
         }
 
         _captureGenerator = new BufferedSoundGenerator<float>(engine, format, Logger, metricsCollector: MetricsCollector);
+        Logger.LogInformation("BluetoothAudioSource: created capture bridge generator #{GeneratorId}",
+          _captureGenerator.GeneratorId);
 
         // Pre-fill with silence to cushion against capture startup latency and
         // ongoing jitter from the audio capture device callback timing.
@@ -469,7 +471,9 @@ public class BluetoothAudioSource : USBAudioSourceBase
         if (success)
         {
           StopCaptureRetryLoop();
-          Logger.LogInformation("BluetoothAudioSource: capture generator added to mixer (PlaybackId={PlaybackId})", _playbackId);
+          Logger.LogInformation(
+            "BluetoothAudioSource: capture generator #{GeneratorId} added to mixer (PlaybackId={PlaybackId})",
+            generator.GeneratorId, _playbackId);
 
           // Start loopback capture on Windows (Linux pw-record is already running)
           if (_bluetoothService is WindowsBluetoothService winBt)

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -42,6 +42,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
   private TimeSpan? _btDuration;
   private bool _hasMediaPlayer;
   private CancellationTokenSource? _captureRetryCts;
+  private int _recoveryInProgress;
 
   /// <summary>Current fingerprinting options (live from IOptionsMonitor).</summary>
   private FingerprintingOptions FpOptions =>
@@ -359,31 +360,34 @@ public class BluetoothAudioSource : USBAudioSourceBase
   private void OnGeneratorStalled(string sourceId)
   {
     if (sourceId != _playbackId && sourceId != Id) return;
+    if (Interlocked.CompareExchange(ref _recoveryInProgress, 1, 0) != 0)
+    {
+      Logger.LogDebug("BluetoothAudioSource: stall recovery already in progress, skipping");
+      return;
+    }
 
     Logger.LogWarning(
-      "🔴 BluetoothAudioSource: generator stalled — attempting capture re-acquisition (PlaybackId={PlaybackId})",
+      "🔴 BluetoothAudioSource: generator stalled — recreating capture pipeline (PlaybackId={PlaybackId})",
       _playbackId);
 
     _ = Task.Run(async () =>
     {
       try
       {
-        // Stop current capture
-        if (_playbackService != null && _playbackId != null)
-        {
-          await _playbackService.StopAsync(_playbackId, CancellationToken.None);
-          _playbackId = null;
-          _captureGenerator = null;
-          SoundComponent = null;
-        }
-
-        // Re-acquire capture device and route through mixer
-        await TryAcquireAudioCaptureAsync();
+        // Use full StopCoreAsync to clean up all state (capture device, PipeWire stream,
+        // generator, event subscriptions) — partial cleanup would leave stale references
+        // that prevent TryAcquireAudioCaptureAsync from re-acquiring.
+        await StopCoreAsync(CancellationToken.None);
+        await PlayCoreAsync(CancellationToken.None);
         Logger.LogInformation("🟢 BluetoothAudioSource: capture pipeline recreated after stall");
       }
       catch (Exception ex)
       {
         Logger.LogError(ex, "Failed to recreate BT capture pipeline after stall");
+      }
+      finally
+      {
+        Interlocked.Exchange(ref _recoveryInProgress, 0);
       }
     });
   }

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
@@ -59,6 +59,12 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
     {
       _identificationService.TrackIdentified += OnTrackIdentified;
     }
+
+    // Subscribe to stalled generator detection for self-healing
+    if (_playbackService != null)
+    {
+      _playbackService.GeneratorStalled += OnGeneratorStalled;
+    }
   }
 
   /// <inheritdoc/>
@@ -402,6 +408,30 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
     }
   }
 
+  private void OnGeneratorStalled(string sourceId)
+  {
+    // Only handle stalls for our own playback
+    if (sourceId != _playbackId) return;
+
+    Logger.LogWarning(
+      "🔴 {SourceName}: generator stalled — recreating capture pipeline (PlaybackId={PlaybackId})",
+      Name, _playbackId);
+
+    _ = Task.Run(async () =>
+    {
+      try
+      {
+        await StopCoreAsync(CancellationToken.None);
+        await PlayCoreAsync(CancellationToken.None);
+        Logger.LogInformation("🟢 {SourceName}: capture pipeline recreated after stall", Name);
+      }
+      catch (Exception ex)
+      {
+        Logger.LogError(ex, "Failed to recreate capture pipeline for {SourceName} after stall", Name);
+      }
+    });
+  }
+
   /// <summary>
   /// Handles the TrackIdentified event from the fingerprinting service.
   /// Updates metadata with identified track information.
@@ -482,7 +512,11 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
   /// <inheritdoc/>
   protected override async ValueTask DisposeAsyncCore()
   {
-    // Unsubscribe from fingerprinting events
+    // Unsubscribe from events
+    if (_playbackService != null)
+    {
+      _playbackService.GeneratorStalled -= OnGeneratorStalled;
+    }
     if (_identificationService != null)
     {
       _identificationService.TrackIdentified -= OnTrackIdentified;

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
@@ -33,6 +33,7 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
   private int _audioCaptureCallCount = 0;
   private BufferedSoundGenerator<float>? _soundGenerator;
   private string? _playbackId;
+  private int _recoveryInProgress;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="USBAudioSourceBase"/> class.
@@ -410,8 +411,12 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
 
   private void OnGeneratorStalled(string sourceId)
   {
-    // Only handle stalls for our own playback
     if (sourceId != _playbackId) return;
+    if (Interlocked.CompareExchange(ref _recoveryInProgress, 1, 0) != 0)
+    {
+      Logger.LogDebug("{SourceName}: stall recovery already in progress, skipping", Name);
+      return;
+    }
 
     Logger.LogWarning(
       "🔴 {SourceName}: generator stalled — recreating capture pipeline (PlaybackId={PlaybackId})",
@@ -428,6 +433,10 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
       catch (Exception ex)
       {
         Logger.LogError(ex, "Failed to recreate capture pipeline for {SourceName} after stall", Name);
+      }
+      finally
+      {
+        Interlocked.Exchange(ref _recoveryInProgress, 0);
       }
     });
   }

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/USBAudioSourceBase.cs
@@ -302,11 +302,12 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
         var format = _playbackService.GetAudioFormat();
         _playbackId = $"usb-capture-{Id:N}";
 
-        if (_soundGenerator == null)
-        {
-          _soundGenerator = new BufferedSoundGenerator<float>(
-            engine, format, Logger, metricsCollector: MetricsCollector);
-        }
+        // Always create a fresh generator. The previous one was disposed by
+        // PlaybackService.StopAsync (called at the top of PlayComponentAsync).
+        // Reusing a disposed generator causes AddSamples to no-op and GenerateAudio
+        // to fill silence — the root cause of audio dropout after long uptime.
+        _soundGenerator = new BufferedSoundGenerator<float>(
+          engine, format, Logger, metricsCollector: MetricsCollector);
 
         var success = await _playbackService.PlayComponentAsync(
           _playbackId, _soundGenerator, Volume, cancellationToken);
@@ -314,8 +315,8 @@ public abstract class USBAudioSourceBase : PrimaryAudioSourceBase
         if (success)
         {
           Logger.LogInformation(
-            "🔊 {SourceName} audio routed to playback output (PlaybackId={PlaybackId})",
-            Name, _playbackId);
+            "🔊 {SourceName} audio routed to playback output (PlaybackId={PlaybackId}, GeneratorId={GeneratorId})",
+            Name, _playbackId, _soundGenerator.GeneratorId);
         }
         else
         {


### PR DESCRIPTION
## Summary
- **Fix generator reuse bug**: `USBAudioSourceBase.PlayCoreAsync` now always creates a fresh `BufferedSoundGenerator` instead of reusing a potentially disposed one — the root cause of audio dropout after long uptime with source switches
- **Add GeneratorId tracking**: Each `BufferedSoundGenerator` gets a unique incrementing ID logged through creation, mixer add/remove, and disposal for full lifecycle traceability
- **Add audio flow health monitor**: `SoundFlowPlaybackService` runs a 10-second background check that detects stalled generators (receiving samples but not outputting) and fires a `GeneratorStalled` event
- **Self-healing**: Both `USBAudioSourceBase` and `BluetoothAudioSource` subscribe to `GeneratorStalled` and automatically recreate their capture pipelines

## Test Plan
- [ ] Full solution builds with 0 errors
- [ ] All tests pass (~1,637 passing, 2 pre-existing failures unrelated to changes)
- [ ] Deploy and verify GeneratorId appears in logs (`BufferedSoundGenerator #N created/disposed`)
- [ ] Verify flow monitor logs: `Audio flow health monitor started (interval: 10s)`
- [ ] Source switching (BT → Radio → Vinyl → BT) creates incrementing generator IDs
- [ ] Long-running validation (24h+) with periodic source switching — no audio dropout

🤖 Generated with [Claude Code](https://claude.com/claude-code)