### PR TITLE
feat: GV Bridge and GV Trunk UI integration

### DIFF
--- a/src/Radio.Web/Components/Pages/PhonePage.razor
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor
@@ -101,7 +101,7 @@
                   Text="@(_gvBridgeConnected ? "Connected" : "Disconnected")" />
                 @if (_gvExtensionVersion != null)
                 {
-                  <span class="status-detail">v@_gvExtensionVersion</span>
+                  <span class="status-detail">v@(_gvExtensionVersion)</span>
                 }
               </div>
               <div class="status-divider"></div>

--- a/src/Radio.Web/Components/Pages/PhonePage.razor
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor
@@ -398,6 +398,7 @@
   private List<PbapContactDto>? _pbapContacts;
   private bool _isSyncing;
   private bool _showSyncDropdown;
+  private int _pollCount;
 
   // GV Bridge/Trunk state
   private string _gvActiveMode = "";
@@ -468,8 +469,28 @@
     if (callState != null) _callState = callState;
     _contacts = await PhoneApi.GetContactsAsync();
     _callHistory = await PhoneApi.GetCallHistoryAsync();
+    await RefreshGvStatusAsync();
     RebuildMergedContacts();
     await InvokeAsync(StateHasChanged);
+  }
+
+  private async Task RefreshGvStatusAsync()
+  {
+    var bridgeTask = GvBridgeApi.GetStatusAsync();
+    var trunkTask = GvTrunkApi.GetStatusAsync();
+    await Task.WhenAll(bridgeTask, trunkTask);
+    var bridgeStatus = bridgeTask.Result;
+    if (bridgeStatus != null)
+    {
+      _gvBridgeConnected = bridgeStatus.ExtensionConnected;
+      _gvExtensionVersion = bridgeStatus.ExtensionVersion;
+      _gvActiveMode = bridgeStatus.ActiveMode;
+    }
+    var trunkStatus = trunkTask.Result;
+    if (trunkStatus != null)
+    {
+      _gvTrunkRegistered = trunkStatus.IsRegistered;
+    }
   }
 
   private async Task PollStatusAsync()
@@ -491,6 +512,11 @@
         var callState = await PhoneApi.GetCallStateAsync();
         if (callState != null) _callState = callState;
         _systemStatus = await PhoneApi.GetSystemStatusAsync();
+        // Refresh GV status every 6th poll (30s) as SignalR fallback
+        if (++_pollCount % 6 == 0)
+        {
+          await RefreshGvStatusAsync();
+        }
         if (!_disposed) await InvokeAsync(StateHasChanged);
       }
     }

--- a/src/Radio.Web/Components/Pages/PhonePage.razor
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor
@@ -1,6 +1,10 @@
 @page "/phone"
 @inject PhoneApiService PhoneApi
 @inject PhoneHubService PhoneHub
+@inject GvBridgeApiService GvBridgeApi
+@inject GvTrunkApiService GvTrunkApi
+@inject GvBridgeHubService GvBridgeHub
+@inject GvTrunkHubService GvTrunkHub
 @inject NotificationService NotificationService
 @inject PbapApiService PbapApi
 @inject BluetoothApiService BluetoothApi
@@ -55,6 +59,64 @@
                 @if (_systemStatus?.Ht801IpAddress != null)
                 {
                   <span class="status-detail">@_systemStatus.Ht801IpAddress</span>
+                }
+              </div>
+            </div>
+          </RadzenCard>
+
+          @* ── Call Path & GV Status ── *@
+          <RadzenCard class="phone-card call-path-card">
+            <h3 class="section-title section-title-cyan">CALL PATH</h3>
+            <div class="call-path-row">
+              @* Mode selector *@
+              <div class="call-path-modes">
+                <span class="status-column-label">ACTIVE MODE</span>
+                <div class="mode-buttons">
+                  <RadzenButton Text="Bluetooth"
+                    Icon="bluetooth"
+                    ButtonStyle="@(_gvActiveMode == "BluetoothHfp" ? ButtonStyle.Primary : ButtonStyle.Light)"
+                    Size="ButtonSize.Small"
+                    Click="@(() => SwitchModeAsync("BluetoothHfp"))"
+                    Disabled="@_switchingMode" />
+                  <RadzenButton Text="SIP Trunk"
+                    Icon="settings_phone"
+                    ButtonStyle="@(_gvActiveMode == "SipTrunk" ? ButtonStyle.Primary : ButtonStyle.Light)"
+                    Size="ButtonSize.Small"
+                    Click="@(() => SwitchModeAsync("SipTrunk"))"
+                    Disabled="@_switchingMode" />
+                  <RadzenButton Text="GV Browser"
+                    Icon="language"
+                    ButtonStyle="@(_gvActiveMode == "GVBrowser" ? ButtonStyle.Primary : ButtonStyle.Light)"
+                    Size="ButtonSize.Small"
+                    Click="@(() => SwitchModeAsync("GVBrowser"))"
+                    Disabled="@_switchingMode" />
+                </div>
+              </div>
+              <div class="status-divider"></div>
+              @* GV Bridge status *@
+              <div class="status-column">
+                <span class="status-column-label">CHROME EXTENSION</span>
+                <RadzenBadge
+                  BadgeStyle="@(_gvBridgeConnected ? BadgeStyle.Success : BadgeStyle.Danger)"
+                  Text="@(_gvBridgeConnected ? "Connected" : "Disconnected")" />
+                @if (_gvExtensionVersion != null)
+                {
+                  <span class="status-detail">v@_gvExtensionVersion</span>
+                }
+              </div>
+              <div class="status-divider"></div>
+              @* GV Trunk status *@
+              <div class="status-column">
+                <span class="status-column-label">SIP TRUNK</span>
+                <RadzenBadge
+                  BadgeStyle="@(_gvTrunkRegistered ? BadgeStyle.Success : BadgeStyle.Danger)"
+                  Text="@(_gvTrunkRegistered ? "Registered" : "Unregistered")" />
+                @if (!_gvTrunkRegistered)
+                {
+                  <RadzenButton Text="Re-register" Size="ButtonSize.ExtraSmall"
+                    ButtonStyle="ButtonStyle.Light"
+                    Click="@ReregisterTrunkAsync"
+                    Style="margin-top:4px" />
                 }
               </div>
             </div>
@@ -337,6 +399,13 @@
   private bool _isSyncing;
   private bool _showSyncDropdown;
 
+  // GV Bridge/Trunk state
+  private string _gvActiveMode = "";
+  private bool _gvBridgeConnected;
+  private string? _gvExtensionVersion;
+  private bool _gvTrunkRegistered;
+  private bool _switchingMode;
+
   protected override async Task OnInitializedAsync()
   {
     _isAvailable = await PhoneApi.IsAvailableAsync();
@@ -345,12 +414,28 @@
       await RefreshAllAsync();
     }
 
-    // Fetch BT and PBAP status for sync UI
+    // Fetch BT, PBAP, and GV status in parallel
     var btTask = BluetoothApi.GetStatusAsync();
     var pbapTask = PbapApi.GetSyncStatusAsync();
-    await Task.WhenAll(btTask, pbapTask);
+    var gvBridgeTask = GvBridgeApi.GetStatusAsync();
+    var gvTrunkTask = GvTrunkApi.GetStatusAsync();
+    await Task.WhenAll(btTask, pbapTask, gvBridgeTask, gvTrunkTask);
     _btStatus = btTask.Result;
     _pbapStatus = pbapTask.Result;
+
+    var bridgeStatus = gvBridgeTask.Result;
+    if (bridgeStatus != null)
+    {
+      _gvBridgeConnected = bridgeStatus.ExtensionConnected;
+      _gvExtensionVersion = bridgeStatus.ExtensionVersion;
+      _gvActiveMode = bridgeStatus.ActiveMode;
+    }
+
+    var trunkStatus = gvTrunkTask.Result;
+    if (trunkStatus != null)
+    {
+      _gvTrunkRegistered = trunkStatus.IsRegistered;
+    }
 
     // Load PBAP contacts — prefer connected device, fall back to most recently synced
     var pbapDeviceAddress = _btStatus?.ConnectedDevice?.Address
@@ -366,6 +451,9 @@
     PhoneHub.IncomingCall += OnIncomingCall;
     PhoneHub.CallHistoryUpdated += OnCallHistoryUpdated;
     PhoneHub.SystemStatusChanged += OnSystemStatusChanged;
+    GvBridgeHub.ExtensionConnectionChanged += OnExtensionConnectionChanged;
+    GvBridgeHub.ModeChanged += OnModeChanged;
+    GvTrunkHub.RegistrationChanged += OnRegistrationChanged;
 
     // Poll for status every 5 seconds as fallback
     _pollTimer = new System.Timers.Timer(5000);
@@ -450,6 +538,69 @@
       }
       catch { /* Non-fatal */ }
     });
+  }
+
+  // GV Bridge/Trunk event handlers
+
+  private void OnExtensionConnectionChanged(bool connected)
+  {
+    if (_disposed) return;
+    _gvBridgeConnected = connected;
+    _ = InvokeAsync(StateHasChanged);
+  }
+
+  private void OnModeChanged(string mode)
+  {
+    if (_disposed) return;
+    _gvActiveMode = mode;
+    _ = InvokeAsync(StateHasChanged);
+  }
+
+  private void OnRegistrationChanged(bool registered)
+  {
+    if (_disposed) return;
+    _gvTrunkRegistered = registered;
+    _ = InvokeAsync(StateHasChanged);
+  }
+
+  private async Task SwitchModeAsync(string mode)
+  {
+    if (_switchingMode || _gvActiveMode == mode) return;
+    _switchingMode = true;
+    try
+    {
+      var success = await GvBridgeApi.SetAdapterModeAsync(mode);
+      if (success)
+      {
+        _gvActiveMode = mode;
+        NotificationService.Notify(NotificationSeverity.Success, "Mode Changed",
+          $"Switched to {mode}");
+      }
+      else
+      {
+        NotificationService.Notify(NotificationSeverity.Error, "Mode Switch Failed",
+          $"Could not switch to {mode}");
+      }
+    }
+    finally
+    {
+      _switchingMode = false;
+    }
+  }
+
+  private async Task ReregisterTrunkAsync()
+  {
+    var success = await GvTrunkApi.ReregisterAsync();
+    if (success)
+    {
+      NotificationService.Notify(NotificationSeverity.Info, "Re-registration",
+        "SIP trunk re-registration initiated");
+    }
+    else
+    {
+      NotificationService.Notify(NotificationSeverity.Error, "Re-registration Failed",
+        "Could not initiate SIP trunk re-registration");
+    }
   }
 
   // Developer controls
@@ -641,5 +792,8 @@
     PhoneHub.IncomingCall -= OnIncomingCall;
     PhoneHub.CallHistoryUpdated -= OnCallHistoryUpdated;
     PhoneHub.SystemStatusChanged -= OnSystemStatusChanged;
+    GvBridgeHub.ExtensionConnectionChanged -= OnExtensionConnectionChanged;
+    GvBridgeHub.ModeChanged -= OnModeChanged;
+    GvTrunkHub.RegistrationChanged -= OnRegistrationChanged;
   }
 }

--- a/src/Radio.Web/Components/Pages/PhonePage.razor.css
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor.css
@@ -21,6 +21,7 @@
 }
 ::deep .section-title-green { color: var(--rz-success); }
 ::deep .section-title-amber { color: #e8a838; }
+::deep .section-title-cyan { color: #26c6da; }
 
 /* ── System Status Bar ── */
 ::deep .system-status-card { border-left: 3px solid var(--rz-success); }
@@ -55,6 +56,21 @@
   min-height: 36px;
   background: var(--rz-base-600);
 }
+
+/* ── Call Path Card ── */
+::deep .call-path-card { border-left: 3px solid #26c6da; }
+::deep .call-path-row {
+  display: flex;
+  align-items: flex-start;
+}
+::deep .call-path-modes {
+  flex: 1.5;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 16px 0 0;
+}
+::deep .mode-buttons { display: flex; gap: 8px; }
 
 /* ── Two-column Dashboard Layout ── */
 ::deep .dashboard-columns {

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -905,3 +905,52 @@ public class PbapContactDto
   public string DisplayName { get; set; } = "";
   public List<string> PhoneNumbers { get; set; } = [];
 }
+
+// GV Bridge DTOs (calls RotaryPhone.API /api/gvbridge)
+
+public class GvBridgeStatusDto
+{
+  public bool ExtensionConnected { get; set; }
+  public string? ExtensionVersion { get; set; }
+  public string ActiveMode { get; set; } = "";
+}
+
+public class GvAdapterModeDto
+{
+  public string ActiveMode { get; set; } = "";
+  public List<GvModeEntryDto> Modes { get; set; } = [];
+}
+
+public class GvModeEntryDto
+{
+  public string Mode { get; set; } = "";
+}
+
+public class GvSmsNotificationDto
+{
+  public string FromNumber { get; set; } = "";
+  public string? Body { get; set; }
+  public DateTime ReceivedAt { get; set; }
+  public string Type { get; set; } = "Sms"; // "Sms" or "MissedCall"
+}
+
+// GV Trunk DTOs (calls RotaryPhone.API /api/gvtrunk)
+
+public class GvTrunkStatusDto
+{
+  public bool IsRegistered { get; set; }
+  public string CallState { get; set; } = "Idle";
+  public int ActiveCallDurationSeconds { get; set; }
+}
+
+public class GvTrunkCallLogEntryDto
+{
+  public int Id { get; set; }
+  public DateTime StartedAt { get; set; }
+  public DateTime? EndedAt { get; set; }
+  public string Direction { get; set; } = "";
+  public string RemoteNumber { get; set; } = "";
+  public string Status { get; set; } = "";
+  public int? DurationSeconds { get; set; }
+  public string? Notes { get; set; }
+}

--- a/src/Radio.Web/Program.cs
+++ b/src/Radio.Web/Program.cs
@@ -304,12 +304,40 @@ builder.Services.AddHttpClient<PhoneApiService>(client =>
   return handler;
 });
 
-// All 14 API client services are now registered!
+// GV Bridge API client (same RotaryPhone service)
+builder.Services.AddHttpClient<GvBridgeApiService>(client =>
+{
+  client.BaseAddress = new Uri(phoneApiBaseUrl);
+  client.Timeout = TimeSpan.FromSeconds(10);
+})
+.AddHttpMessageHandler<ApiConnectionLoggingHandler>()
+.ConfigurePrimaryHttpMessageHandler(() =>
+{
+  var handler = new HttpClientHandler();
+  ConfigureHttpClientHandler(handler);
+  return handler;
+});
+
+// GV Trunk API client (same RotaryPhone service)
+builder.Services.AddHttpClient<GvTrunkApiService>(client =>
+{
+  client.BaseAddress = new Uri(phoneApiBaseUrl);
+  client.Timeout = TimeSpan.FromSeconds(10);
+})
+.AddHttpMessageHandler<ApiConnectionLoggingHandler>()
+.ConfigurePrimaryHttpMessageHandler(() =>
+{
+  var handler = new HttpClientHandler();
+  ConfigureHttpClientHandler(handler);
+  return handler;
+});
 
 // Register SignalR hub services as singletons (Phase 1 Task 1.3, Phase 10)
 builder.Services.AddSingleton<AudioStateHubService>();
 builder.Services.AddSingleton<AudioVisualizationHubService>();
 builder.Services.AddSingleton<PhoneHubService>();
+builder.Services.AddSingleton<GvBridgeHubService>();
+builder.Services.AddSingleton<GvTrunkHubService>();
 
 // Register centralized audio state store (subscribes to hub, caches state for components)
 builder.Services.AddSingleton<AudioStateStore>();
@@ -368,9 +396,13 @@ app.MapGet("/api/albumart/{filename}", async (string filename, IHttpClientFactor
 app.MapRazorComponents<Radio.Web.Components.App>()
   .AddInteractiveServerRenderMode();
 
-// Start RotaryPhone hub connection (non-blocking — logs warning if unavailable)
+// Start RotaryPhone hub connections (non-blocking — logs warning if unavailable)
 var phoneHub = app.Services.GetRequiredService<PhoneHubService>();
 _ = phoneHub.StartAsync();
+var gvBridgeHub = app.Services.GetRequiredService<GvBridgeHubService>();
+_ = gvBridgeHub.StartAsync();
+var gvTrunkHub = app.Services.GetRequiredService<GvTrunkHubService>();
+_ = gvTrunkHub.StartAsync();
 
 // Print startup header to console
 var logDirectory = Path.GetFullPath("logs");

--- a/src/Radio.Web/Services/ApiClients/GvBridgeApiService.cs
+++ b/src/Radio.Web/Services/ApiClients/GvBridgeApiService.cs
@@ -1,0 +1,114 @@
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Radio.Web.Models;
+
+namespace Radio.Web.Services.ApiClients;
+
+/// <summary>
+/// HTTP client for RotaryPhone.API GV Bridge endpoints.
+/// Provides access to Chrome extension status, connection mode switching, and SMS.
+/// </summary>
+public class GvBridgeApiService
+{
+  private readonly HttpClient _httpClient;
+  private readonly ILogger<GvBridgeApiService> _logger;
+  private static readonly JsonSerializerOptions JsonOptions = new()
+  {
+    PropertyNameCaseInsensitive = true
+  };
+
+  public GvBridgeApiService(HttpClient httpClient, ILogger<GvBridgeApiService> logger)
+  {
+    _httpClient = httpClient;
+    _logger = logger;
+  }
+
+  public async Task<bool> IsAvailableAsync(CancellationToken ct = default)
+  {
+    try
+    {
+      var status = await _httpClient.GetFromJsonAsync<GvBridgeStatusDto>(
+        "/api/gvbridge/status", JsonOptions, ct);
+      return status != null;
+    }
+    catch
+    {
+      return false;
+    }
+  }
+
+  public async Task<GvBridgeStatusDto?> GetStatusAsync(CancellationToken ct = default)
+  {
+    try
+    {
+      return await _httpClient.GetFromJsonAsync<GvBridgeStatusDto>(
+        "/api/gvbridge/status", JsonOptions, ct);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to get GV Bridge status");
+      return null;
+    }
+  }
+
+  public async Task<GvAdapterModeDto?> GetAdapterModeAsync(CancellationToken ct = default)
+  {
+    try
+    {
+      return await _httpClient.GetFromJsonAsync<GvAdapterModeDto>(
+        "/api/gvbridge/adapter/mode", JsonOptions, ct);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to get adapter mode");
+      return null;
+    }
+  }
+
+  public async Task<bool> SetAdapterModeAsync(string mode, CancellationToken ct = default)
+  {
+    try
+    {
+      var content = new StringContent(
+        JsonSerializer.Serialize(new { mode }), Encoding.UTF8, "application/json");
+      var response = await _httpClient.PutAsync("/api/gvbridge/adapter/mode", content, ct);
+      return response.IsSuccessStatusCode;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to set adapter mode to {Mode}", mode);
+      return false;
+    }
+  }
+
+  public async Task<List<GvSmsNotificationDto>?> GetRecentSmsAsync(CancellationToken ct = default)
+  {
+    try
+    {
+      return await _httpClient.GetFromJsonAsync<List<GvSmsNotificationDto>>(
+        "/api/gvbridge/sms", JsonOptions, ct);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to get recent SMS");
+      return null;
+    }
+  }
+
+  public async Task<bool> SendSmsAsync(string to, string body, CancellationToken ct = default)
+  {
+    try
+    {
+      var content = new StringContent(
+        JsonSerializer.Serialize(new { to, body }), Encoding.UTF8, "application/json");
+      var response = await _httpClient.PostAsync("/api/gvbridge/sms/send", content, ct);
+      return response.IsSuccessStatusCode;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to send SMS to {To}", to);
+      return false;
+    }
+  }
+}

--- a/src/Radio.Web/Services/ApiClients/GvTrunkApiService.cs
+++ b/src/Radio.Web/Services/ApiClients/GvTrunkApiService.cs
@@ -1,0 +1,112 @@
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Radio.Web.Models;
+
+namespace Radio.Web.Services.ApiClients;
+
+/// <summary>
+/// HTTP client for RotaryPhone.API GV Trunk endpoints.
+/// Provides access to SIP trunk status, call log, SMS notifications, and dialing.
+/// </summary>
+public class GvTrunkApiService
+{
+  private readonly HttpClient _httpClient;
+  private readonly ILogger<GvTrunkApiService> _logger;
+  private static readonly JsonSerializerOptions JsonOptions = new()
+  {
+    PropertyNameCaseInsensitive = true
+  };
+
+  public GvTrunkApiService(HttpClient httpClient, ILogger<GvTrunkApiService> logger)
+  {
+    _httpClient = httpClient;
+    _logger = logger;
+  }
+
+  public async Task<bool> IsAvailableAsync(CancellationToken ct = default)
+  {
+    try
+    {
+      var status = await _httpClient.GetFromJsonAsync<GvTrunkStatusDto>(
+        "/api/gvtrunk/status", JsonOptions, ct);
+      return status != null;
+    }
+    catch
+    {
+      return false;
+    }
+  }
+
+  public async Task<GvTrunkStatusDto?> GetStatusAsync(CancellationToken ct = default)
+  {
+    try
+    {
+      return await _httpClient.GetFromJsonAsync<GvTrunkStatusDto>(
+        "/api/gvtrunk/status", JsonOptions, ct);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to get GV Trunk status");
+      return null;
+    }
+  }
+
+  public async Task<List<GvTrunkCallLogEntryDto>?> GetCallHistoryAsync(CancellationToken ct = default)
+  {
+    try
+    {
+      return await _httpClient.GetFromJsonAsync<List<GvTrunkCallLogEntryDto>>(
+        "/api/gvtrunk/calls", JsonOptions, ct);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to get GV Trunk call history");
+      return null;
+    }
+  }
+
+  public async Task<List<GvSmsNotificationDto>?> GetRecentSmsAsync(CancellationToken ct = default)
+  {
+    try
+    {
+      return await _httpClient.GetFromJsonAsync<List<GvSmsNotificationDto>>(
+        "/api/gvtrunk/sms", JsonOptions, ct);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to get GV Trunk SMS notifications");
+      return null;
+    }
+  }
+
+  public async Task<bool> DialAsync(string number, CancellationToken ct = default)
+  {
+    try
+    {
+      var content = new StringContent(
+        JsonSerializer.Serialize(new { number }), Encoding.UTF8, "application/json");
+      var response = await _httpClient.PostAsync("/api/gvtrunk/dial", content, ct);
+      return response.IsSuccessStatusCode;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to dial {Number} via GV Trunk", number);
+      return false;
+    }
+  }
+
+  public async Task<bool> ReregisterAsync(CancellationToken ct = default)
+  {
+    try
+    {
+      var response = await _httpClient.PostAsync("/api/gvtrunk/reregister", null, ct);
+      return response.IsSuccessStatusCode;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to reregister GV Trunk");
+      return false;
+    }
+  }
+}

--- a/src/Radio.Web/Services/Hub/GvBridgeHubService.cs
+++ b/src/Radio.Web/Services/Hub/GvBridgeHubService.cs
@@ -1,0 +1,153 @@
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Radio.Web.Services.Hub;
+
+/// <summary>
+/// SignalR client that connects to RotaryPhone.API's GV Bridge hub for real-time
+/// extension connection status and call adapter mode change notifications.
+/// </summary>
+public class GvBridgeHubService : IAsyncDisposable
+{
+  private readonly ILogger<GvBridgeHubService> _logger;
+  private readonly IConfiguration _configuration;
+  private readonly SemaphoreSlim _connectionLock = new(1, 1);
+  private HubConnection? _hubConnection;
+  private CancellationTokenSource? _retryCts;
+
+  public event Action<bool>? ExtensionConnectionChanged;
+  public event Action<string>? ModeChanged;
+
+  public bool IsConnected => _hubConnection?.State == HubConnectionState.Connected;
+
+  public GvBridgeHubService(ILogger<GvBridgeHubService> logger, IConfiguration configuration)
+  {
+    _logger = logger;
+    _configuration = configuration;
+  }
+
+  public async Task StartAsync()
+  {
+    if (!await _connectionLock.WaitAsync(0))
+    {
+      _logger.LogDebug("GV Bridge hub connection already in progress");
+      return;
+    }
+
+    try
+    {
+      if (_hubConnection != null)
+      {
+        return;
+      }
+
+      var baseUrl = _configuration.GetValue<string>("RotaryPhone:ApiBaseUrl") ?? "http://radio:5004";
+      var hubUrl = $"{baseUrl.TrimEnd('/')}/hubs/gvbridge";
+
+      _hubConnection = new HubConnectionBuilder()
+        .WithUrl(hubUrl)
+        .WithAutomaticReconnect(new[] { TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5),
+          TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30) })
+        .Build();
+
+      _hubConnection.On<object>("ExtensionConnectionChanged", (data) =>
+      {
+        // Payload: { connected: bool }
+        if (data is System.Text.Json.JsonElement json && json.TryGetProperty("connected", out var prop))
+        {
+          var connected = prop.GetBoolean();
+          _logger.LogDebug("GV Bridge extension connection changed: {Connected}", connected);
+          ExtensionConnectionChanged?.Invoke(connected);
+        }
+      });
+
+      _hubConnection.On<object>("ModeChanged", (data) =>
+      {
+        // Payload: { activeMode: string }
+        if (data is System.Text.Json.JsonElement json && json.TryGetProperty("activeMode", out var prop))
+        {
+          var mode = prop.GetString() ?? "";
+          _logger.LogDebug("GV Bridge mode changed: {Mode}", mode);
+          ModeChanged?.Invoke(mode);
+        }
+      });
+
+      _hubConnection.Reconnecting += ex =>
+      {
+        _logger.LogWarning(ex, "GV Bridge hub reconnecting...");
+        return Task.CompletedTask;
+      };
+
+      _hubConnection.Reconnected += connectionId =>
+      {
+        _logger.LogInformation("GV Bridge hub reconnected: {ConnectionId}", connectionId);
+        return Task.CompletedTask;
+      };
+
+      _hubConnection.Closed += ex =>
+      {
+        _logger.LogWarning(ex, "GV Bridge hub connection closed");
+        return Task.CompletedTask;
+      };
+
+      try
+      {
+        await _hubConnection.StartAsync();
+        _logger.LogInformation("Connected to GV Bridge hub at {Url}", hubUrl);
+      }
+      catch (Exception ex)
+      {
+        _logger.LogWarning(ex, "Failed to connect to GV Bridge hub at {Url} — will retry in background", hubUrl);
+        StartRetryLoop(hubUrl);
+      }
+    }
+    finally
+    {
+      _connectionLock.Release();
+    }
+  }
+
+  private void StartRetryLoop(string hubUrl)
+  {
+    _retryCts = new CancellationTokenSource();
+    _ = Task.Run(async () =>
+    {
+      var delays = new[] { 10, 30, 60 };
+      for (int attempt = 0; !_retryCts.Token.IsCancellationRequested; attempt++)
+      {
+        var delaySec = delays[Math.Min(attempt, delays.Length - 1)];
+        await Task.Delay(TimeSpan.FromSeconds(delaySec), _retryCts.Token);
+        try
+        {
+          if (_hubConnection?.State == HubConnectionState.Disconnected)
+          {
+            await _hubConnection.StartAsync(_retryCts.Token);
+            _logger.LogInformation("Connected to GV Bridge hub at {Url} (retry #{Attempt})", hubUrl, attempt + 1);
+            return;
+          }
+        }
+        catch (Exception ex)
+        {
+          _logger.LogDebug(ex, "GV Bridge hub retry #{Attempt} failed", attempt + 1);
+        }
+      }
+    }, _retryCts.Token);
+  }
+
+  public async Task StopAsync()
+  {
+    _retryCts?.Cancel();
+    _retryCts?.Dispose();
+    _retryCts = null;
+    if (_hubConnection != null)
+    {
+      await _hubConnection.DisposeAsync();
+      _hubConnection = null;
+    }
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    await StopAsync();
+    _connectionLock.Dispose();
+  }
+}

--- a/src/Radio.Web/Services/Hub/GvTrunkHubService.cs
+++ b/src/Radio.Web/Services/Hub/GvTrunkHubService.cs
@@ -1,0 +1,166 @@
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Radio.Web.Services.Hub;
+
+/// <summary>
+/// SignalR client that connects to RotaryPhone.API's GV Trunk hub for real-time
+/// SIP registration, SMS, missed call, and call state notifications.
+/// </summary>
+public class GvTrunkHubService : IAsyncDisposable
+{
+  private readonly ILogger<GvTrunkHubService> _logger;
+  private readonly IConfiguration _configuration;
+  private readonly SemaphoreSlim _connectionLock = new(1, 1);
+  private HubConnection? _hubConnection;
+  private CancellationTokenSource? _retryCts;
+
+  public event Action<bool>? RegistrationChanged;
+  public event Action<object>? SmsReceived;
+  public event Action<object>? MissedCallReceived;
+  public event Action<string, string>? CallStateChanged;
+
+  public bool IsConnected => _hubConnection?.State == HubConnectionState.Connected;
+
+  public GvTrunkHubService(ILogger<GvTrunkHubService> logger, IConfiguration configuration)
+  {
+    _logger = logger;
+    _configuration = configuration;
+  }
+
+  public async Task StartAsync()
+  {
+    if (!await _connectionLock.WaitAsync(0))
+    {
+      _logger.LogDebug("GV Trunk hub connection already in progress");
+      return;
+    }
+
+    try
+    {
+      if (_hubConnection != null)
+      {
+        return;
+      }
+
+      var baseUrl = _configuration.GetValue<string>("RotaryPhone:ApiBaseUrl") ?? "http://radio:5004";
+      var hubUrl = $"{baseUrl.TrimEnd('/')}/hubs/gvtrunk";
+
+      _hubConnection = new HubConnectionBuilder()
+        .WithUrl(hubUrl)
+        .WithAutomaticReconnect(new[] { TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5),
+          TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30) })
+        .Build();
+
+      _hubConnection.On<object>("RegistrationChanged", (data) =>
+      {
+        if (data is System.Text.Json.JsonElement json && json.TryGetProperty("isRegistered", out var prop))
+        {
+          var registered = prop.GetBoolean();
+          _logger.LogDebug("GV Trunk registration changed: {Registered}", registered);
+          RegistrationChanged?.Invoke(registered);
+        }
+      });
+
+      _hubConnection.On<object>("SmsReceived", (notification) =>
+      {
+        _logger.LogDebug("GV Trunk SMS received");
+        SmsReceived?.Invoke(notification);
+      });
+
+      _hubConnection.On<object>("MissedCallReceived", (notification) =>
+      {
+        _logger.LogDebug("GV Trunk missed call received");
+        MissedCallReceived?.Invoke(notification);
+      });
+
+      _hubConnection.On<object>("CallStateChanged", (data) =>
+      {
+        if (data is System.Text.Json.JsonElement json)
+        {
+          var phoneId = json.TryGetProperty("phoneId", out var pidProp) ? pidProp.GetString() ?? "" : "";
+          var callState = json.TryGetProperty("callState", out var csProp) ? csProp.GetString() ?? "" : "";
+          _logger.LogDebug("GV Trunk call state changed: {PhoneId} → {State}", phoneId, callState);
+          CallStateChanged?.Invoke(phoneId, callState);
+        }
+      });
+
+      _hubConnection.Reconnecting += ex =>
+      {
+        _logger.LogWarning(ex, "GV Trunk hub reconnecting...");
+        return Task.CompletedTask;
+      };
+
+      _hubConnection.Reconnected += connectionId =>
+      {
+        _logger.LogInformation("GV Trunk hub reconnected: {ConnectionId}", connectionId);
+        return Task.CompletedTask;
+      };
+
+      _hubConnection.Closed += ex =>
+      {
+        _logger.LogWarning(ex, "GV Trunk hub connection closed");
+        return Task.CompletedTask;
+      };
+
+      try
+      {
+        await _hubConnection.StartAsync();
+        _logger.LogInformation("Connected to GV Trunk hub at {Url}", hubUrl);
+      }
+      catch (Exception ex)
+      {
+        _logger.LogWarning(ex, "Failed to connect to GV Trunk hub at {Url} — will retry in background", hubUrl);
+        StartRetryLoop(hubUrl);
+      }
+    }
+    finally
+    {
+      _connectionLock.Release();
+    }
+  }
+
+  private void StartRetryLoop(string hubUrl)
+  {
+    _retryCts = new CancellationTokenSource();
+    _ = Task.Run(async () =>
+    {
+      var delays = new[] { 10, 30, 60 };
+      for (int attempt = 0; !_retryCts.Token.IsCancellationRequested; attempt++)
+      {
+        var delaySec = delays[Math.Min(attempt, delays.Length - 1)];
+        await Task.Delay(TimeSpan.FromSeconds(delaySec), _retryCts.Token);
+        try
+        {
+          if (_hubConnection?.State == HubConnectionState.Disconnected)
+          {
+            await _hubConnection.StartAsync(_retryCts.Token);
+            _logger.LogInformation("Connected to GV Trunk hub at {Url} (retry #{Attempt})", hubUrl, attempt + 1);
+            return;
+          }
+        }
+        catch (Exception ex)
+        {
+          _logger.LogDebug(ex, "GV Trunk hub retry #{Attempt} failed", attempt + 1);
+        }
+      }
+    }, _retryCts.Token);
+  }
+
+  public async Task StopAsync()
+  {
+    _retryCts?.Cancel();
+    _retryCts?.Dispose();
+    _retryCts = null;
+    if (_hubConnection != null)
+    {
+      await _hubConnection.DisposeAsync();
+      _hubConnection = null;
+    }
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    await StopAsync();
+    _connectionLock.Dispose();
+  }
+}

--- a/tests/Radio.Web.Tests/Components/Pages/PhonePageTests.cs
+++ b/tests/Radio.Web.Tests/Components/Pages/PhonePageTests.cs
@@ -35,16 +35,33 @@ public class PhonePageTests : TestContext
       client.BaseAddress = new Uri("http://localhost:5000");
     }).ConfigurePrimaryHttpMessageHandler(() => new EmptyResponseHandler());
 
-    // Register PhoneHubService
+    // Register GvBridgeApiService with mock handler
+    Services.AddHttpClient<GvBridgeApiService>(client =>
+    {
+      client.BaseAddress = new Uri("http://localhost:5004");
+    }).ConfigurePrimaryHttpMessageHandler(() => new EmptyResponseHandler());
+
+    // Register GvTrunkApiService with mock handler
+    Services.AddHttpClient<GvTrunkApiService>(client =>
+    {
+      client.BaseAddress = new Uri("http://localhost:5004");
+    }).ConfigurePrimaryHttpMessageHandler(() => new EmptyResponseHandler());
+
+    // Register hub services
     var config = new ConfigurationBuilder()
       .AddInMemoryCollection(new Dictionary<string, string?>
       {
-        ["RotaryPhone:HubUrl"] = "http://localhost:5004/hub"
+        ["RotaryPhone:HubUrl"] = "http://localhost:5004/hub",
+        ["RotaryPhone:ApiBaseUrl"] = "http://localhost:5004"
       })
       .Build();
     Services.AddSingleton<IConfiguration>(config);
     Services.AddSingleton(new PhoneHubService(
       NullLogger<PhoneHubService>.Instance, config));
+    Services.AddSingleton(new GvBridgeHubService(
+      NullLogger<GvBridgeHubService>.Instance, config));
+    Services.AddSingleton(new GvTrunkHubService(
+      NullLogger<GvTrunkHubService>.Instance, config));
   }
 
   [Fact]
@@ -121,6 +138,12 @@ public class PhonePageTests : TestContext
         var p when p.Contains("/api/bluetooth/pbap/contacts") => "[]",
         var p when p.Contains("/api/bluetooth/status") =>
           """{"isAvailable":true,"state":"Powered","isDiscovering":false,"pairedDevices":[],"discoveredDevices":[]}""",
+        var p when p.Contains("/api/gvbridge/status") =>
+          """{"extensionConnected":false,"extensionVersion":null,"activeMode":"BluetoothHfp"}""",
+        var p when p.Contains("/api/gvtrunk/status") =>
+          """{"isRegistered":false,"callState":"Idle","activeCallDurationSeconds":0}""",
+        var p when p.Contains("/api/gvbridge/") => "[]",
+        var p when p.Contains("/api/gvtrunk/") => "[]",
         _ => "{}"
       };
       return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)

--- a/tests/Radio.Web.Tests/Components/Pages/PhonePageTests.cs
+++ b/tests/Radio.Web.Tests/Components/Pages/PhonePageTests.cs
@@ -98,6 +98,15 @@ public class PhonePageTests : TestContext
   }
 
   [Fact]
+  public void PhonePage_Renders_CallPathSection()
+  {
+    var cut = RenderComponent<PhonePage>();
+    Assert.Contains("CALL PATH", cut.Markup);
+    Assert.Contains("CHROME EXTENSION", cut.Markup);
+    Assert.Contains("SIP TRUNK", cut.Markup);
+  }
+
+  [Fact]
   public void PhonePage_ContactsTab_Renders_SourceColumn()
   {
     // RadzenTabs only renders the active tab body; the Contacts tab item


### PR DESCRIPTION
## Summary
- Add REST API client services and SignalR hub services to consume RotaryPhone's GV Bridge (`/api/gvbridge/*`, `/hubs/gvbridge`) and GV Trunk (`/api/gvtrunk/*`, `/hubs/gvtrunk`) endpoints
- Mount connection mode selector (Bluetooth / SIP Trunk / GV Browser), Chrome extension status, and SIP trunk registration status on the Phone page Dashboard tab
- Architecture: Radio.Web is UI-only — all backend services run in the independent RotaryPhone service at `http://radio:5004`. Integration follows the existing PhoneApiService/PhoneHubService pattern (REST + SignalR)

### New files
- `GvBridgeApiService.cs` — REST client for bridge status, mode switching, SMS
- `GvTrunkApiService.cs` — REST client for trunk status, call log, dialing, re-registration
- `GvBridgeHubService.cs` — SignalR client for real-time extension connection + mode changes
- `GvTrunkHubService.cs` — SignalR client for real-time SIP registration + call state + SMS
- DTOs: `GvBridgeStatusDto`, `GvAdapterModeDto`, `GvSmsNotificationDto`, `GvTrunkStatusDto`, `GvTrunkCallLogEntryDto`

### Modified files
- `Program.cs` — service registration and hub startup
- `PhonePage.razor` — new Call Path card with mode selector, extension status, trunk status
- `PhonePage.razor.css` — cyan-themed call path card styling
- `PhonePageTests.cs` — register new services in test DI + add Call Path rendering test

## Test plan
- [x] `dotnet build --configuration Release` — 0 errors
- [x] `dotnet test tests/Radio.Web.Tests` — 130/130 pass
- [x] Code review (superpowers:code-reviewer) — critical Razor interpolation fix applied
- [x] Deployed to Ubuntu kiosk (`http://radio:5002`) — Phone page renders correctly
- [x] Audio and visualization confirmed working after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)