### PR TITLE
feat(web): formatting layer for durations, timestamps, display names, and units

### DIFF
--- a/src/Radio.Web/Components/_Imports.razor
+++ b/src/Radio.Web/Components/_Imports.razor
@@ -8,6 +8,7 @@
 @using Microsoft.JSInterop
 @using Radio.Web.Components
 @using Radio.Web.Components.Shared
+@using Radio.Web.Formatting
 @using Radzen
 @using Radzen.Blazor
 @using Radio.Web.Services

--- a/src/Radio.Web/Formatting/DisplayNames.cs
+++ b/src/Radio.Web/Formatting/DisplayNames.cs
@@ -1,0 +1,316 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using Radio.Web.Models;
+
+namespace Radio.Web.Formatting;
+
+/// <summary>
+/// Friendly display-name helpers for audio sources, devices, and now-playing tracks.
+/// Goals:
+/// <list type="bullet">
+///   <item><description>Never surface raw GUIDs or driver-name noise to the user.</description></item>
+///   <item><description>Apply alias maps first, then heuristic stripping, then length capping.</description></item>
+///   <item><description>Stateless: no DI, no configuration lookups inside the helpers.</description></item>
+/// </list>
+/// </summary>
+public static partial class DisplayNames
+{
+  /// <summary>
+  /// Em-dash placeholder for missing subtitle/artist values.
+  /// </summary>
+  private const string Dash = "—";
+
+  /// <summary>
+  /// Ellipsis (U+2026) used when capping long names. A single character so length math is simple.
+  /// </summary>
+  private const char Ellipsis = '…';
+
+  /// <summary>
+  /// Maximum length of a device display name before ellipsis-clipping.
+  /// </summary>
+  private const int DeviceNameMaxLength = 40;
+
+  /// <summary>
+  /// Trailing GUID suffix used by Source IDs (e.g. <c>radio-aabbccdd-1122-3344-5566-778899aabbcc</c>).
+  /// Matches a hyphen followed by a canonical 8-4-4-4-12 hex GUID at the end of the string.
+  /// </summary>
+  [GeneratedRegex(@"-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", RegexOptions.Compiled)]
+  private static partial Regex GuidSuffixRegex();
+
+  /// <summary>
+  /// Leading "<c>N - </c>" enumeration prefix (e.g. <c>"0 - LG TV"</c> → strip <c>"0 - "</c>).
+  /// </summary>
+  [GeneratedRegex(@"^\d+\s*-\s*", RegexOptions.Compiled)]
+  private static partial Regex EnumerationPrefixRegex();
+
+  /// <summary>
+  /// Generic filename-derived title (e.g. <c>"Track 8"</c>) — when the metadata layer
+  /// couldn't extract an actual title.
+  /// </summary>
+  [GeneratedRegex(@"^Track\s+\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+  private static partial Regex GenericTrackTitleRegex();
+
+  /// <summary>
+  /// Leading track-number tokens at the start of a filename (e.g. <c>"08 opening night"</c>,
+  /// <c>"01 - intro"</c>, <c>"03_drums"</c>).
+  /// </summary>
+  [GeneratedRegex(@"^\d+[\s\-_]+", RegexOptions.Compiled)]
+  private static partial Regex TrackNumberPrefixRegex();
+
+  /// <summary>
+  /// Trailing parenthesized hardware-driver suffixes (e.g. <c>" (AMD High Definition Audio Device)"</c>).
+  /// Capture group 1 is the head; group 2 is the parenthesized content.
+  /// </summary>
+  [GeneratedRegex(@"^(.+?)\s*\(([^)]+)\)\s*$", RegexOptions.Compiled)]
+  private static partial Regex ParenthesizedTailRegex();
+
+  /// <summary>
+  /// Known driver-name suffixes that should always be stripped.
+  /// PR 3 will extend this list as we discover more in the wild.
+  /// Match is case-insensitive against the parenthesized content.
+  /// </summary>
+  private static readonly string[] KnownDriverSuffixes =
+  [
+    "AMD High Definition Audio Device",
+    "NVIDIA High Definition Audio",
+    "Intel High Definition Audio",
+    "Realtek High Definition Audio",
+    "Realtek USB Audio",
+    "VB-Audio Virtual Cable",
+    "High Definition Audio Device",
+    "USB Audio Device",
+    "Generic USB Audio",
+  ];
+
+  /// <summary>
+  /// Pretty source name for UI rows.
+  /// <list type="bullet">
+  ///   <item><description>If <see cref="AudioSourceDto.Name"/> is non-empty, return it.</description></item>
+  ///   <item><description>Else humanize <see cref="AudioSourceDto.Type"/> (CamelCase → space-separated).</description></item>
+  ///   <item><description>Never return the raw <see cref="AudioSourceDto.Id"/>; any trailing GUID is stripped.</description></item>
+  /// </list>
+  /// </summary>
+  public static string Source(AudioSourceDto s)
+  {
+    if (s is null)
+    {
+      return Dash;
+    }
+
+    if (!string.IsNullOrWhiteSpace(s.Name))
+    {
+      return s.Name.Trim();
+    }
+
+    if (!string.IsNullOrWhiteSpace(s.Type))
+    {
+      return HumanizeCamelCase(s.Type.Trim());
+    }
+
+    // Last-resort: derive from Id with the GUID suffix stripped so we never leak raw GUIDs.
+    if (!string.IsNullOrWhiteSpace(s.Id))
+    {
+      var stripped = GuidSuffixRegex().Replace(s.Id, string.Empty);
+      return HumanizeCamelCase(stripped);
+    }
+
+    return Dash;
+  }
+
+  /// <summary>
+  /// Pretty device name for selectors and toggles.
+  /// <list type="number">
+  ///   <item><description>Apply the alias map (whole-string match against the raw <see cref="AudioDeviceDto.Name"/>).</description></item>
+  ///   <item><description>Strip a leading <c>"N - "</c> enumeration prefix.</description></item>
+  ///   <item><description>Strip a trailing parenthesized driver suffix when (a) it appears in the
+  ///     <see cref="KnownDriverSuffixes"/> allow list OR (b) the head is at least 4 characters and contains a space.</description></item>
+  ///   <item><description>Cap at <see cref="DeviceNameMaxLength"/> characters with a trailing ellipsis.</description></item>
+  /// </list>
+  /// </summary>
+  public static string Device(AudioDeviceDto d, IDictionary<string, string>? aliasMap = null)
+  {
+    if (d is null || string.IsNullOrWhiteSpace(d.Name))
+    {
+      return Dash;
+    }
+
+    var raw = d.Name.Trim();
+
+    // 1. Alias map first — whole-string match against the raw name.
+    if (aliasMap is not null && aliasMap.TryGetValue(raw, out var alias) && !string.IsNullOrWhiteSpace(alias))
+    {
+      return Cap(alias);
+    }
+
+    var working = raw;
+
+    // 2. Strip leading "N - " enumeration.
+    working = EnumerationPrefixRegex().Replace(working, string.Empty);
+
+    // 3. Strip trailing parenthesized driver suffix when allowed.
+    var parenMatch = ParenthesizedTailRegex().Match(working);
+    if (parenMatch.Success)
+    {
+      var head = parenMatch.Groups[1].Value.Trim();
+      var paren = parenMatch.Groups[2].Value.Trim();
+
+      var driverSuffixKnown = KnownDriverSuffixes.Any(
+        s => string.Equals(s, paren, StringComparison.OrdinalIgnoreCase));
+      var headDescriptive = head.Length >= 4 && head.Contains(' ');
+
+      if (driverSuffixKnown || headDescriptive)
+      {
+        working = head;
+      }
+    }
+
+    return Cap(working);
+  }
+
+  /// <summary>
+  /// Title + subtitle pair for the now-playing surface.
+  /// </summary>
+  /// <returns>
+  /// <c>Title</c>: the cleanest name available — prefers <see cref="NowPlayingDto.Title"/> unless it is empty
+  /// or looks like generic filename fallback (<c>"Track 8"</c>), in which case the file name is parsed.
+  /// <c>Subtitle</c>: <see cref="NowPlayingDto.Artist"/> if non-empty, else em-dash.
+  /// </returns>
+  public static (string Title, string Subtitle) Track(NowPlayingDto np)
+  {
+    if (np is null)
+    {
+      return (Dash, Dash);
+    }
+
+    var title = (np.Title ?? string.Empty).Trim();
+    var isGeneric = string.IsNullOrEmpty(title) || GenericTrackTitleRegex().IsMatch(title);
+
+    string finalTitle;
+    if (!isGeneric)
+    {
+      finalTitle = title;
+    }
+    else
+    {
+      var derived = DeriveTitleFromFilePath(GetFilePath(np));
+      finalTitle = !string.IsNullOrEmpty(derived)
+        ? derived
+        : (string.IsNullOrEmpty(title) ? Dash : title);
+    }
+
+    var artist = (np.Artist ?? string.Empty).Trim();
+    // Treat the existing default placeholder values as missing.
+    if (string.IsNullOrEmpty(artist) || artist == "--")
+    {
+      artist = Dash;
+    }
+
+    return (finalTitle, artist);
+  }
+
+  /// <summary>
+  /// Pulls a file path out of <see cref="NowPlayingDto.ExtendedMetadata"/> if one is present.
+  /// We look at a few common keys; callers (or PR-3+ wiring) can populate any of them.
+  /// </summary>
+  private static string? GetFilePath(NowPlayingDto np)
+  {
+    if (np.ExtendedMetadata is null)
+    {
+      return null;
+    }
+
+    foreach (var key in new[] { "FilePath", "filePath", "Path", "path", "SourcePath", "sourcePath" })
+    {
+      if (np.ExtendedMetadata.TryGetValue(key, out var raw) && raw is not null)
+      {
+        var s = raw.ToString();
+        if (!string.IsNullOrWhiteSpace(s))
+        {
+          return s;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /// <summary>
+  /// Parses a filesystem path into a human title: strips folders, extension, leading track
+  /// numbers, and title-cases the result if it looks lowercase.
+  /// </summary>
+  private static string DeriveTitleFromFilePath(string? path)
+  {
+    if (string.IsNullOrWhiteSpace(path))
+    {
+      return string.Empty;
+    }
+
+    string fileName;
+    try
+    {
+      fileName = Path.GetFileNameWithoutExtension(path) ?? string.Empty;
+    }
+    catch (ArgumentException)
+    {
+      // Path contains invalid chars — bail out gracefully.
+      fileName = string.Empty;
+    }
+
+    if (string.IsNullOrWhiteSpace(fileName))
+    {
+      return string.Empty;
+    }
+
+    var stripped = TrackNumberPrefixRegex().Replace(fileName, string.Empty).Trim();
+    if (stripped.Length == 0)
+    {
+      return string.Empty;
+    }
+
+    // Title-case if it's all lowercase (filename heuristic for case-folded music libraries).
+    if (stripped == stripped.ToLowerInvariant())
+    {
+      var culture = CultureInfo.InvariantCulture;
+      stripped = culture.TextInfo.ToTitleCase(stripped);
+    }
+
+    return stripped;
+  }
+
+  /// <summary>
+  /// Splits a CamelCase / PascalCase token into space-separated words
+  /// (<c>"FilePlayer"</c> → <c>"File Player"</c>).
+  /// </summary>
+  private static string HumanizeCamelCase(string token)
+  {
+    if (string.IsNullOrEmpty(token))
+    {
+      return string.Empty;
+    }
+
+    var sb = new StringBuilder(token.Length + 4);
+    for (var i = 0; i < token.Length; i++)
+    {
+      var c = token[i];
+      if (i > 0 && char.IsUpper(c) && !char.IsUpper(token[i - 1]))
+      {
+        sb.Append(' ');
+      }
+      sb.Append(c);
+    }
+    return sb.ToString();
+  }
+
+  /// <summary>
+  /// Truncates to <see cref="DeviceNameMaxLength"/> with a single ellipsis character.
+  /// </summary>
+  private static string Cap(string s)
+  {
+    if (s.Length <= DeviceNameMaxLength)
+    {
+      return s;
+    }
+    return s.Substring(0, DeviceNameMaxLength - 1).TrimEnd() + Ellipsis;
+  }
+}

--- a/src/Radio.Web/Formatting/Durations.cs
+++ b/src/Radio.Web/Formatting/Durations.cs
@@ -1,0 +1,64 @@
+using System.Globalization;
+
+namespace Radio.Web.Formatting;
+
+/// <summary>
+/// Track/queue duration formatting helpers.
+/// Stateless static helpers — no DI, no configuration.
+/// </summary>
+public static class Durations
+{
+  /// <summary>
+  /// Em-dash (U+2014) returned for empty / zero / unknown durations.
+  /// </summary>
+  private const string Dash = "—";
+
+  /// <summary>
+  /// Formats a track-length <see cref="TimeSpan"/> for the now-playing surface
+  /// and queue rows.
+  /// <list type="bullet">
+  ///   <item><description>Below 1 hour: <c>{m}:{ss:00}</c> (e.g. <c>3:00</c>).</description></item>
+  ///   <item><description>1 hour or more: <c>{h}:{mm:00}:{ss:00}</c> (e.g. <c>1:02:14</c>).</description></item>
+  ///   <item><description>Zero / sub-second values: em-dash.</description></item>
+  /// </list>
+  /// </summary>
+  public static string FormatTrack(TimeSpan t)
+  {
+    if (t.TotalSeconds < 1.0 || t == TimeSpan.Zero)
+    {
+      return Dash;
+    }
+
+    // Round to whole seconds first so 180.66s → 180s → 3:00 (not 3:01).
+    var totalSeconds = (long)Math.Floor(t.TotalSeconds);
+    var hours = totalSeconds / 3600;
+    var minutes = (totalSeconds % 3600) / 60;
+    var seconds = totalSeconds % 60;
+
+    return hours >= 1
+      ? string.Format(CultureInfo.InvariantCulture, "{0}:{1:00}:{2:00}", hours, minutes, seconds)
+      : string.Format(CultureInfo.InvariantCulture, "{0}:{1:00}", minutes, seconds);
+  }
+
+  /// <summary>
+  /// Overload accepting a nullable <see cref="TimeSpan"/>. Null returns the em-dash placeholder.
+  /// </summary>
+  public static string FormatTrack(TimeSpan? t) => t.HasValue ? FormatTrack(t.Value) : Dash;
+
+  /// <summary>
+  /// Always-long duration form (<c>h:mm:ss</c>) for queue/playlist totals.
+  /// Unlike <see cref="FormatTrack(TimeSpan)"/>, this never collapses to <c>m:ss</c>.
+  /// </summary>
+  public static string FormatLong(TimeSpan t)
+  {
+    var totalSeconds = (long)Math.Floor(t.TotalSeconds);
+    if (totalSeconds < 0)
+    {
+      totalSeconds = 0;
+    }
+    var hours = totalSeconds / 3600;
+    var minutes = (totalSeconds % 3600) / 60;
+    var seconds = totalSeconds % 60;
+    return string.Format(CultureInfo.InvariantCulture, "{0}:{1:00}:{2:00}", hours, minutes, seconds);
+  }
+}

--- a/src/Radio.Web/Formatting/Timestamps.cs
+++ b/src/Radio.Web/Formatting/Timestamps.cs
@@ -1,0 +1,49 @@
+using System.Globalization;
+
+namespace Radio.Web.Formatting;
+
+/// <summary>
+/// Relative-time formatting for play history, queue, and event rows.
+/// Caller is responsible for converting UTC values to local time before calling.
+/// </summary>
+public static class Timestamps
+{
+  /// <summary>
+  /// Middle dot separator (U+00B7) used between date and time in the "older" branch.
+  /// </summary>
+  private const string Separator = "·";
+
+  /// <summary>
+  /// Formats a <see cref="DateTime"/> as a short relative timestamp using <see cref="DateTime.Now"/> as the reference.
+  /// <list type="bullet">
+  ///   <item><description>Same calendar day: <c>Today HH:mm</c>.</description></item>
+  ///   <item><description>Previous calendar day: <c>Yesterday HH:mm</c>.</description></item>
+  ///   <item><description>Otherwise: <c>{MMM d} · HH:mm</c>.</description></item>
+  /// </list>
+  /// </summary>
+  /// <param name="local">A local-time <see cref="DateTime"/>. Caller must have already converted from UTC.</param>
+  public static string FormatRelative(DateTime local) => FormatRelative(local, DateTime.Now);
+
+  /// <summary>
+  /// Testable overload accepting an explicit <paramref name="now"/> reference.
+  /// </summary>
+  public static string FormatRelative(DateTime local, DateTime now)
+  {
+    var localDate = local.Date;
+    var nowDate = now.Date;
+    var time = local.ToString("HH:mm", CultureInfo.InvariantCulture);
+
+    if (localDate == nowDate)
+    {
+      return $"Today {time}";
+    }
+
+    if (localDate == nowDate.AddDays(-1))
+    {
+      return $"Yesterday {time}";
+    }
+
+    var date = local.ToString("MMM d", CultureInfo.InvariantCulture);
+    return $"{date} {Separator} {time}";
+  }
+}

--- a/src/Radio.Web/Formatting/Units.cs
+++ b/src/Radio.Web/Formatting/Units.cs
@@ -1,0 +1,71 @@
+using System.Globalization;
+using Radio.Web.Components.Shared;
+
+namespace Radio.Web.Formatting;
+
+/// <summary>
+/// Enumeration of value units the metrics/status surfaces understand.
+/// Used together with <see cref="UnitsFormatter.Format(double, Units)"/>.
+/// </summary>
+public enum Units
+{
+  /// <summary>Percentage value (0-100). Renders with a trailing <c>%</c>.</summary>
+  Percent,
+  /// <summary>Megabytes. Renders with a trailing <c> MB</c>.</summary>
+  Megabytes,
+  /// <summary>Milliseconds. Auto-promotes to seconds when ≥ 1000.</summary>
+  Milliseconds,
+  /// <summary>Unitless count. Thousands-separated.</summary>
+  Count,
+  /// <summary>Per-minute rate (events/min).</summary>
+  PerMinute,
+  /// <summary>Hertz. Delegates to <see cref="FrequencyFormatter.FormatStep(double)"/>.</summary>
+  Frequency,
+  /// <summary>Decibels (signed). Renders with a trailing <c> dB</c>.</summary>
+  Decibels,
+  /// <summary>Bare integer (no unit suffix).</summary>
+  Bare,
+}
+
+/// <summary>
+/// Static facade for <see cref="Units"/> value formatting.
+/// Named <c>UnitsFormatter</c> (not <c>Units</c>) to avoid clashing with the enum name.
+/// </summary>
+public static class UnitsFormatter
+{
+  /// <summary>
+  /// Formats a numeric value with the appropriate suffix and rounding rules.
+  /// See individual enum members for exact behaviour.
+  /// </summary>
+  public static string Format(double value, Units unit)
+  {
+    var inv = CultureInfo.InvariantCulture;
+
+    return unit switch
+    {
+      Units.Percent => value < 10
+        ? value.ToString("0.0", inv) + "%"
+        : value.ToString("0", inv) + "%",
+
+      Units.Megabytes => value.ToString("0", inv) + " MB",
+
+      Units.Milliseconds => value >= 1000
+        ? (value / 1000.0).ToString("0.0", inv) + " s"
+        : value.ToString("0", inv) + " ms",
+
+      Units.Count => value.ToString("N0", inv),
+
+      Units.PerMinute => value.ToString("0.0", inv) + "/min",
+
+      // FrequencyFormatter.FormatStep already produces a unit-suffixed display string
+      // and handles the Hz → MHz/kHz boundary.
+      Units.Frequency => FrequencyFormatter.FormatStep(value),
+
+      Units.Decibels => value.ToString("0", inv) + " dB",
+
+      Units.Bare => value.ToString("0", inv),
+
+      _ => value.ToString("0", inv),
+    };
+  }
+}

--- a/src/Radio.Web/appsettings.json
+++ b/src/Radio.Web/appsettings.json
@@ -17,5 +17,8 @@
   "RotaryPhone": {
     "HubUrl": "http://radio:5004/hub",
     "ApiBaseUrl": "http://radio:5004"
+  },
+  "Devices": {
+    "Aliases": {}
   }
 }

--- a/tests/Radio.Web.Tests/Formatting/DisplayNamesTests.cs
+++ b/tests/Radio.Web.Tests/Formatting/DisplayNamesTests.cs
@@ -1,0 +1,214 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Radio.Web.Formatting;
+using Radio.Web.Models;
+
+namespace Radio.Web.Tests.Formatting;
+
+/// <summary>
+/// Tests <see cref="DisplayNames.Source(AudioSourceDto)"/>, <see cref="DisplayNames.Device(AudioDeviceDto, IDictionary{string, string}?)"/>,
+/// and <see cref="DisplayNames.Track(NowPlayingDto)"/>.
+/// </summary>
+public class DisplayNamesTests
+{
+  // ---------- Source ----------
+
+  [Fact]
+  public void Source_NameMissing_GuidIdStripped_HumanizesType()
+  {
+    var s = new AudioSourceDto
+    {
+      Name = "",
+      Id = "radio-aabbccdd-1122-3344-5566-778899aabbcc",
+      Type = "Radio",
+    };
+    DisplayNames.Source(s).Should().Be("Radio");
+  }
+
+  [Fact]
+  public void Source_NameSet_ReturnsName()
+  {
+    var s = new AudioSourceDto
+    {
+      Name = "My Radio",
+      Id = "radio-aabbccdd-1122-3344-5566-778899aabbcc",
+      Type = "Radio",
+    };
+    DisplayNames.Source(s).Should().Be("My Radio");
+  }
+
+  [Fact]
+  public void Source_FilePlayerType_HumanizedToFilePlayerWithSpace()
+  {
+    var s = new AudioSourceDto { Name = "", Id = "", Type = "FilePlayer" };
+    DisplayNames.Source(s).Should().Be("File Player");
+  }
+
+  [Fact]
+  public void Source_NameAndTypeMissing_FallsBackToIdWithGuidStripped()
+  {
+    var s = new AudioSourceDto
+    {
+      Name = "",
+      Id = "myhandle-aabbccdd-1122-3344-5566-778899aabbcc",
+      Type = "",
+    };
+    DisplayNames.Source(s).Should().Be("myhandle");
+  }
+
+  [Fact]
+  public void Source_ResultNeverContainsGuidCharacterSpan()
+  {
+    var s = new AudioSourceDto
+    {
+      Name = "",
+      Id = "anything-aabbccdd-1122-3344-5566-778899aabbcc",
+      Type = "",
+    };
+    var result = DisplayNames.Source(s);
+    Regex.IsMatch(result, "[0-9a-f]{8}-[0-9a-f]{4}", RegexOptions.IgnoreCase)
+      .Should().BeFalse("display names must never leak GUIDs to the UI");
+  }
+
+  // ---------- Device ----------
+
+  [Fact]
+  public void Device_KnownDriverSuffixInParens_HeadKept()
+  {
+    var d = new AudioDeviceDto { Name = "LG TV SSCR2 (AMD High Definition Audio Device)" };
+    DisplayNames.Device(d, null).Should().Be("LG TV SSCR2");
+  }
+
+  [Fact]
+  public void Device_AliasMapHit_ReturnsAlias()
+  {
+    var d = new AudioDeviceDto { Name = "CABLE Input (VB-Audio Virtual Cable)" };
+    var aliases = new Dictionary<string, string>
+    {
+      ["CABLE Input (VB-Audio Virtual Cable)"] = "VB-Audio Cable In",
+    };
+    DisplayNames.Device(d, aliases).Should().Be("VB-Audio Cable In");
+  }
+
+  [Fact]
+  public void Device_EnumerationPrefix_Stripped()
+  {
+    var d = new AudioDeviceDto { Name = "0 - LG TV" };
+    DisplayNames.Device(d, null).Should().Be("LG TV");
+  }
+
+  [Fact]
+  public void Device_NameOver40Chars_TruncatedTo39CharsPlusEllipsis()
+  {
+    // Construct a 50-character name with no parens and no trailing space at position 38
+    // so the cap result is exactly 39 chars + the single-character ellipsis (U+2026) = 40.
+    // Pattern is letters + digits, no whitespace near the cut, so TrimEnd is a no-op.
+    var name = new string('A', 50);
+    var d = new AudioDeviceDto { Name = name };
+    var result = DisplayNames.Device(d, null);
+    result.Length.Should().Be(40);
+    result.EndsWith('…').Should().BeTrue();
+    result.Should().Be(new string('A', 39) + "…");
+  }
+
+  [Fact]
+  public void Device_HeuristicHeadStrip_AppliedWhenHeadHasSpaceAndIs4Plus()
+  {
+    // "BigCo Speaker" (13 chars, has a space) head → stripped, even though the paren content
+    // is not in the known-driver allow list.
+    var d = new AudioDeviceDto { Name = "BigCo Speaker (Some Obscure Codec)" };
+    DisplayNames.Device(d, null).Should().Be("BigCo Speaker");
+  }
+
+  [Fact]
+  public void Device_HeuristicHeadStrip_SkippedWhenHeadHasNoSpace()
+  {
+    // Head "Speaker" (no space) and not a known suffix → keep the original.
+    var d = new AudioDeviceDto { Name = "Speaker (Some Obscure Codec)" };
+    DisplayNames.Device(d, null).Should().Be("Speaker (Some Obscure Codec)");
+  }
+
+  [Fact]
+  public void Device_NameMissing_ReturnsEmDash()
+  {
+    var d = new AudioDeviceDto { Name = "" };
+    DisplayNames.Device(d, null).Should().Be("—");
+  }
+
+  [Fact]
+  public void Device_AliasMap_Wins_OverEnumerationPrefixStrip()
+  {
+    // Even when "0 - LG TV" would normally be cleaned to "LG TV", a whole-string alias hit wins.
+    var d = new AudioDeviceDto { Name = "0 - LG TV" };
+    var aliases = new Dictionary<string, string> { ["0 - LG TV"] = "Living Room TV" };
+    DisplayNames.Device(d, aliases).Should().Be("Living Room TV");
+  }
+
+  // ---------- Track ----------
+
+  [Fact]
+  public void Track_GenericTitle_ParsesFromFilePath()
+  {
+    var np = new NowPlayingDto
+    {
+      Title = "Track 8",
+      Artist = "Cary High Chorus",
+      ExtendedMetadata = new Dictionary<string, object>
+      {
+        ["FilePath"] = @"C:\music\Cary High Chorus\2006 Fall Concert\08 opening night.mp3",
+      },
+    };
+    var (title, subtitle) = DisplayNames.Track(np);
+    title.Should().Be("Opening Night");
+    subtitle.Should().Be("Cary High Chorus");
+  }
+
+  [Fact]
+  public void Track_NonGenericTitle_Preserved()
+  {
+    var np = new NowPlayingDto { Title = "Sweet Child O' Mine", Artist = "Guns N' Roses" };
+    var (title, _) = DisplayNames.Track(np);
+    title.Should().Be("Sweet Child O' Mine");
+  }
+
+  [Fact]
+  public void Track_EmptyArtist_ReturnsEmDash()
+  {
+    var np = new NowPlayingDto { Title = "Some Title", Artist = "" };
+    var (_, subtitle) = DisplayNames.Track(np);
+    subtitle.Should().Be("—");
+  }
+
+  [Fact]
+  public void Track_DefaultPlaceholderArtist_ReturnsEmDash()
+  {
+    // NowPlayingDto initializes Artist to "--" by default — treat as missing.
+    var np = new NowPlayingDto { Title = "Some Title" };
+    var (_, subtitle) = DisplayNames.Track(np);
+    subtitle.Should().Be("—");
+  }
+
+  [Fact]
+  public void Track_GenericTitleAndNoFilePath_KeepsOriginalTitle()
+  {
+    var np = new NowPlayingDto { Title = "Track 12", Artist = "Various" };
+    var (title, subtitle) = DisplayNames.Track(np);
+    title.Should().Be("Track 12");
+    subtitle.Should().Be("Various");
+  }
+
+  [Fact]
+  public void Track_FilePathWithMixedCase_PreservesOriginalCasing()
+  {
+    var np = new NowPlayingDto
+    {
+      Title = "",
+      ExtendedMetadata = new Dictionary<string, object>
+      {
+        ["FilePath"] = @"/music/03 - Bohemian Rhapsody.flac",
+      },
+    };
+    var (title, _) = DisplayNames.Track(np);
+    title.Should().Be("Bohemian Rhapsody");
+  }
+}

--- a/tests/Radio.Web.Tests/Formatting/DurationsTests.cs
+++ b/tests/Radio.Web.Tests/Formatting/DurationsTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using Radio.Web.Formatting;
+
+namespace Radio.Web.Tests.Formatting;
+
+/// <summary>
+/// Tests <see cref="Durations.FormatTrack(TimeSpan)"/> /
+/// <see cref="Durations.FormatTrack(TimeSpan?)"/> / <see cref="Durations.FormatLong(TimeSpan)"/>.
+/// Covers the acceptance cases from the design-tightening handoff §P0·0.
+/// </summary>
+public class DurationsTests
+{
+  [Fact]
+  public void FormatTrack_180Seconds_RendersThreeMinutesZeroSeconds()
+  {
+    Durations.FormatTrack(TimeSpan.FromSeconds(180.6628))
+      .Should().Be("3:00");
+  }
+
+  [Fact]
+  public void FormatTrack_Zero_RendersEmDash()
+  {
+    Durations.FormatTrack(TimeSpan.Zero).Should().Be("—");
+  }
+
+  [Fact]
+  public void FormatTrack_SubSecond_RendersEmDash()
+  {
+    Durations.FormatTrack(TimeSpan.FromMilliseconds(800)).Should().Be("—");
+  }
+
+  [Fact]
+  public void FormatTrack_OverOneHour_RendersHMmSs()
+  {
+    Durations.FormatTrack(TimeSpan.FromSeconds(3742))
+      .Should().Be("1:02:22");
+  }
+
+  [Fact]
+  public void FormatTrack_NullableNull_RendersEmDash()
+  {
+    Durations.FormatTrack((TimeSpan?)null).Should().Be("—");
+  }
+
+  [Fact]
+  public void FormatTrack_NullableValue_RendersAsValue()
+  {
+    Durations.FormatTrack((TimeSpan?)TimeSpan.FromSeconds(75))
+      .Should().Be("1:15");
+  }
+
+  [Fact]
+  public void FormatTrack_ExactlyOneHour_RendersHMmSs()
+  {
+    Durations.FormatTrack(TimeSpan.FromHours(1)).Should().Be("1:00:00");
+  }
+
+  [Fact]
+  public void FormatTrack_SubMinuteSeconds_PadsLeadingZero()
+  {
+    Durations.FormatTrack(TimeSpan.FromSeconds(5)).Should().Be("0:05");
+  }
+
+  [Fact]
+  public void FormatLong_OneHourThirtyMinutes_RendersHMmSs()
+  {
+    Durations.FormatLong(TimeSpan.FromMinutes(90)).Should().Be("1:30:00");
+  }
+
+  [Fact]
+  public void FormatLong_TwoAndAHalfHours_RendersHMmSs()
+  {
+    Durations.FormatLong(TimeSpan.FromHours(2.5)).Should().Be("2:30:00");
+  }
+
+  [Fact]
+  public void FormatLong_BelowOneHour_StillRendersHMmSs()
+  {
+    // Unlike FormatTrack, FormatLong never collapses to m:ss.
+    Durations.FormatLong(TimeSpan.FromSeconds(45)).Should().Be("0:00:45");
+  }
+
+  [Fact]
+  public void FormatLong_Zero_RendersZeroHMmSs()
+  {
+    Durations.FormatLong(TimeSpan.Zero).Should().Be("0:00:00");
+  }
+}

--- a/tests/Radio.Web.Tests/Formatting/TimestampsTests.cs
+++ b/tests/Radio.Web.Tests/Formatting/TimestampsTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Radio.Web.Formatting;
+
+namespace Radio.Web.Tests.Formatting;
+
+/// <summary>
+/// Tests <see cref="Timestamps.FormatRelative(DateTime, DateTime)"/> using a frozen "now"
+/// of 2026-05-17 14:00:00 local time. Exercises each branch (today / yesterday / older).
+/// </summary>
+public class TimestampsTests
+{
+  private static readonly DateTime Now = new(2026, 5, 17, 14, 0, 0, DateTimeKind.Local);
+
+  [Fact]
+  public void FormatRelative_SameDayEarlier_RendersTodayHHmm()
+  {
+    var t = new DateTime(2026, 5, 17, 9, 30, 0, DateTimeKind.Local);
+    Timestamps.FormatRelative(t, Now).Should().Be("Today 09:30");
+  }
+
+  [Fact]
+  public void FormatRelative_SameDayMidnight_RendersTodayHHmm()
+  {
+    var t = new DateTime(2026, 5, 17, 0, 0, 0, DateTimeKind.Local);
+    Timestamps.FormatRelative(t, Now).Should().Be("Today 00:00");
+  }
+
+  [Fact]
+  public void FormatRelative_Yesterday_RendersYesterdayHHmm()
+  {
+    var t = new DateTime(2026, 5, 16, 22, 15, 0, DateTimeKind.Local);
+    Timestamps.FormatRelative(t, Now).Should().Be("Yesterday 22:15");
+  }
+
+  [Fact]
+  public void FormatRelative_TwoDaysAgo_RendersMonthDayDotTime()
+  {
+    var t = new DateTime(2026, 5, 15, 8, 5, 0, DateTimeKind.Local);
+    // Middle dot U+00B7 between date and time.
+    Timestamps.FormatRelative(t, Now).Should().Be("May 15 · 08:05");
+  }
+
+  [Fact]
+  public void FormatRelative_DifferentMonth_RendersMonthDayDotTime()
+  {
+    var t = new DateTime(2026, 3, 1, 17, 45, 0, DateTimeKind.Local);
+    Timestamps.FormatRelative(t, Now).Should().Be("Mar 1 · 17:45");
+  }
+
+  [Fact]
+  public void FormatRelative_OlderBranch_ContainsMiddleDotSeparator()
+  {
+    var t = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Local);
+    var result = Timestamps.FormatRelative(t, Now);
+    result.Should().Contain("·");
+    result.Should().NotContain(" - "); // never a hyphen separator
+  }
+
+  [Fact]
+  public void FormatRelative_NoArg_DelegatesToNowOverload()
+  {
+    // Smoke test: the no-arg form should produce a non-empty string for the current moment.
+    var result = Timestamps.FormatRelative(DateTime.Now);
+    result.Should().NotBeNullOrWhiteSpace();
+    result.Should().StartWith("Today ");
+  }
+}

--- a/tests/Radio.Web.Tests/Formatting/UnitsTests.cs
+++ b/tests/Radio.Web.Tests/Formatting/UnitsTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Radio.Web.Formatting;
+
+namespace Radio.Web.Tests.Formatting;
+
+/// <summary>
+/// Tests <see cref="UnitsFormatter.Format(double, Units)"/>. One boundary case per enum member.
+/// </summary>
+public class UnitsTests
+{
+  [Fact]
+  public void Format_PercentBelow10_OneDecimal()
+  {
+    UnitsFormatter.Format(3.5, Units.Percent).Should().Be("3.5%");
+  }
+
+  [Fact]
+  public void Format_PercentAt10OrAbove_Integer()
+  {
+    UnitsFormatter.Format(65.0, Units.Percent).Should().Be("65%");
+  }
+
+  [Fact]
+  public void Format_Megabytes_Integer()
+  {
+    UnitsFormatter.Format(850.4, Units.Megabytes).Should().Be("850 MB");
+  }
+
+  [Fact]
+  public void Format_MillisecondsUnder1000_IntegerWithMsSuffix()
+  {
+    UnitsFormatter.Format(215, Units.Milliseconds).Should().Be("215 ms");
+  }
+
+  [Fact]
+  public void Format_MillisecondsAt1000OrMore_PromotesToSeconds()
+  {
+    UnitsFormatter.Format(1200, Units.Milliseconds).Should().Be("1.2 s");
+  }
+
+  [Fact]
+  public void Format_Count_ThousandsSeparated()
+  {
+    UnitsFormatter.Format(135725, Units.Count).Should().Be("135,725");
+  }
+
+  [Fact]
+  public void Format_PerMinute_OneDecimalWithSuffix()
+  {
+    UnitsFormatter.Format(12.4, Units.PerMinute).Should().Be("12.4/min");
+  }
+
+  [Fact]
+  public void Format_Frequency_DelegatesToFrequencyFormatter()
+  {
+    // FrequencyFormatter.FormatStep treats values >= 1_000_000 as MHz, otherwise kHz.
+    UnitsFormatter.Format(1_000_000, Units.Frequency).Should().Be("1 MHz");
+    UnitsFormatter.Format(500, Units.Frequency).Should().Be("0.5 kHz");
+  }
+
+  [Fact]
+  public void Format_DecibelsNegative_SignPreserved()
+  {
+    UnitsFormatter.Format(-3, Units.Decibels).Should().Be("-3 dB");
+  }
+
+  [Fact]
+  public void Format_DecibelsPositive_NoSign()
+  {
+    UnitsFormatter.Format(6, Units.Decibels).Should().Be("6 dB");
+  }
+
+  [Fact]
+  public void Format_Bare_Integer()
+  {
+    UnitsFormatter.Format(65, Units.Bare).Should().Be("65");
+  }
+}


### PR DESCRIPTION
## Summary

Lands handoff item **P0·0** — the foundation layer that PR 3 and PR 4 of the [Radio Console design-tightening arc](../blob/main/docs/superpowers/plans/2026-05-17-radio-console-design-tightening.md) will consume.

Four stateless `static class` helpers under `Radio.Web.Formatting`:

- **`Durations`** — `FormatTrack` (m:ss / h:mm:ss, em-dash for zero/null) and `FormatLong` (always h:mm:ss for queue totals).
- **`Timestamps`** — `FormatRelative(local)` plus a testable `(local, now)` overload. Renders `Today HH:mm` / `Yesterday HH:mm` / `MMM d · HH:mm` with U+00B7 middle-dot separator.
- **`DisplayNames`** — `Source`, `Device`, `Track`. Strips trailing GUID suffixes (never leaks raw IDs), applies device alias map first, then a known-driver allow list, then the head-≥-4-with-space heuristic, then a 40-char ellipsis cap. `Track` derives titles from filenames when metadata is generic (e.g. `Track 8`).
- **`Units`** enum + `UnitsFormatter.Format` — Percent / Megabytes / Milliseconds (auto-promotes to seconds ≥ 1000) / Count (thousands-separated) / PerMinute / Frequency (delegates to `FrequencyFormatter`) / Decibels / Bare.

Also:
- `Components/_Imports.razor` adds `@using Radio.Web.Formatting` so Razor files can call helpers without per-file imports.
- `appsettings.json` adds an empty `Devices:Aliases` placeholder so PR 3 can populate without touching schema.

## Pre-merge fixes

- Self-review only — single Builder cycle. No reviewer subagent dispatched (helpers are tiny, well-specified, and have full test coverage); the next cycle's reviewer can flag anything caught in real use.

## Resolved spec ambiguities (per Coordinator dispatch)

1. **`DisplayNames.Device` head-strip rule:** explicit allow list of known driver suffixes + heuristic fallback (head ≥ 4 chars AND contains a space). Allow list lives inline as `private static readonly string[] KnownDriverSuffixes` so PR 3 can extend it.
2. **`Devices:Aliases` placeholder:** added empty object to `appsettings.json`; PR 3 will populate baseline aliases and per-host overrides in `appsettings.Production.json`.
3. **`Timestamps.FormatRelative` clock testability:** added an overload `FormatRelative(DateTime local, DateTime now)` that the no-arg public form delegates to with `DateTime.Now`. Tests use a frozen `now = 2026-05-17 14:00`. No clock abstraction.

## Test plan

- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors.
- [x] `dotnet test --configuration Release --filter \"FullyQualifiedName~Radio.Web.Tests.Formatting\"` — **49 / 49 passed** (~0.66 s).
- [x] Full solution `dotnet test --configuration Release` — 1646 passed, 3 skipped, **1 pre-existing failure** in `Radio.API.Tests.Services.AudioEngineInitializationServiceTests.StartAsync_EnumeratesDevices`. Confirmed failing on `main` too; entirely unrelated to this PR (mock-counting issue in API audio engine init).
- [ ] User visual UAT — N/A for this PR. Formatters are dead code until PR 3 wires them into `NowPlayingPanel` / `QueueHistoryPanel`. The acceptance gate per plan §PR 1 is the test suite.

## Acceptance (from plan §PR 1)

- [x] All four formatter files compile under `Radio.Web.Formatting`.
- [x] `Durations.FormatTrack(TimeSpan.FromSeconds(180.6628))` → `\"3:00\"`.
- [x] `DisplayNames.Source` results never contain a GUID character span (regex test).
- [x] `dotnet build` clean, 0 warnings.
- [x] `_Imports.razor` updated so Razor files can call formatters without explicit `@using` per file.

## Operator note

No deploy-relevant changes. The empty `Devices:Aliases` block in `appsettings.json` is forward-compatible — existing deployments ignore it; PR 3 will start consuming it.

## Docs Impact

None for PR 1. The plan + handoff already describe the formatter contract; no runtime-facing docs need updates until PR 3 wires consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)