### PR TITLE
docs: commit design-tightening arc references (handoff + plan)

### DIFF
--- a/docs/handoffs/design_handoff_radio_console/Design Analysis.html
+++ b/docs/handoffs/design_handoff_radio_console/Design Analysis.html
@@ -1,0 +1,1932 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=1280" />
+<title>Radio Console — Design Analysis</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --surface-base:        #0D0D0F;
+    --surface-raised:      #141416;
+    --surface-inset:       #0A0A0C;
+    --surface-overlay:     #1A1A1D;
+    --surface-separator:   #1F1F22;
+    --surface-hairline:    #25252A;
+
+    --accent:              #5CD4E8;
+    --accent-dim:          rgba(92, 212, 232, 0.10);
+    --accent-glow:         rgba(92, 212, 232, 0.25);
+
+    --amber:               #F0A830;
+    --amber-glow:          rgba(240, 168, 48, 0.30);
+
+    --source-vinyl:        #A78BFA;
+    --source-radio:        #F0A830;
+    --source-bt:           #60A5FA;
+    --source-usb:          #4ADE80;
+    --source-file:         #5CD4E8;
+
+    --sig-red:             #F87171;
+    --sig-amber:           #FBBF24;
+    --sig-green:           #4ADE80;
+
+    --text-hi:             #F0EFF4;
+    --text-md:             #9CA3AF;
+    --text-lo:             #4B5563;
+    --text-dim:            #353841;
+
+    --font-body:           'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    --font-mono:           'JetBrains Mono', 'SF Mono', Consolas, monospace;
+    --font-led:            'Share Tech Mono', 'JetBrains Mono', monospace;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--surface-base);
+    color: var(--text-hi);
+    font-family: var(--font-body);
+    font-size: 15px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  ::selection { background: var(--accent-glow); color: var(--text-hi); }
+
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  /* ──────────── Layout shell ──────────── */
+  .shell {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 48px 120px;
+  }
+
+  /* ──────────── Top fixed nav rail (mimics product chrome) ──────────── */
+  .rail {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    height: 64px;
+    background: var(--surface-base);
+    border-bottom: 1px solid var(--surface-separator);
+    display: flex;
+    align-items: center;
+    padding: 0 48px;
+    gap: 24px;
+    backdrop-filter: blur(12px);
+  }
+  .rail-brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-md);
+  }
+  .rail-brand .dot {
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 10px var(--accent-glow);
+  }
+  .rail-clock {
+    margin-left: auto;
+    font-family: var(--font-led);
+    font-size: 18px;
+    color: var(--amber);
+    text-shadow: 0 0 8px var(--amber-glow);
+    letter-spacing: 4px;
+  }
+  .rail-toc {
+    display: flex;
+    gap: 4px;
+    font-size: 12px;
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .rail-toc a {
+    padding: 6px 10px;
+    border-radius: 6px;
+    color: var(--text-md);
+  }
+  .rail-toc a:hover {
+    background: var(--accent-dim);
+    color: var(--text-hi);
+    text-decoration: none;
+  }
+
+  /* ──────────── Hero ──────────── */
+  .hero {
+    padding: 96px 0 64px;
+    border-bottom: 1px solid var(--surface-separator);
+    margin-bottom: 56px;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 20px;
+  }
+  .eyebrow::before {
+    content: "";
+    display: inline-block;
+    width: 24px;
+    height: 1px;
+    background: var(--accent);
+    vertical-align: middle;
+    margin-right: 10px;
+  }
+  h1 {
+    font-size: 56px;
+    line-height: 1.05;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    margin: 0 0 24px;
+    max-width: 16ch;
+    text-wrap: balance;
+  }
+  h1 em {
+    font-style: normal;
+    color: var(--accent);
+  }
+  .lede {
+    font-size: 19px;
+    color: var(--text-md);
+    max-width: 68ch;
+    text-wrap: pretty;
+  }
+
+  .meta-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1px;
+    background: var(--surface-separator);
+    border: 1px solid var(--surface-separator);
+    border-radius: 10px;
+    overflow: hidden;
+    margin-top: 48px;
+  }
+  .meta-cell {
+    background: var(--surface-base);
+    padding: 18px 20px;
+  }
+  .meta-cell .k {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-lo);
+  }
+  .meta-cell .v {
+    font-size: 17px;
+    color: var(--text-hi);
+    margin-top: 6px;
+  }
+
+  /* ──────────── Section heads ──────────── */
+  section { margin-bottom: 96px; }
+  .section-head {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    margin-bottom: 36px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--surface-separator);
+  }
+  .section-num {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--accent);
+    letter-spacing: 0.1em;
+  }
+  h2 {
+    font-size: 32px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin: 0;
+  }
+  .section-sub {
+    color: var(--text-md);
+    margin-left: auto;
+    font-size: 14px;
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  h3 {
+    font-size: 20px;
+    font-weight: 600;
+    margin: 0 0 8px;
+    letter-spacing: -0.005em;
+  }
+
+  p { margin: 0 0 12px; color: var(--text-md); text-wrap: pretty; }
+  p strong { color: var(--text-hi); font-weight: 600; }
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.88em;
+    background: var(--surface-inset);
+    padding: 1px 6px;
+    border-radius: 4px;
+    color: var(--text-hi);
+    border: 1px solid var(--surface-separator);
+  }
+
+  /* ──────────── Strengths grid ──────────── */
+  .strengths {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+  .strength {
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-separator);
+    border-radius: 10px;
+    padding: 20px;
+  }
+  .strength .check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    background: rgba(74, 222, 128, 0.10);
+    color: var(--sig-green);
+    margin-bottom: 12px;
+    font-weight: 600;
+  }
+  .strength h4 {
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0 0 6px;
+    color: var(--text-hi);
+  }
+  .strength p {
+    font-size: 13px;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* ──────────── Issue cards ──────────── */
+  .issue {
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-separator);
+    border-radius: 12px;
+    padding: 28px 32px;
+    margin-bottom: 16px;
+    display: grid;
+    grid-template-columns: 1.1fr 1fr;
+    gap: 32px;
+    align-items: start;
+  }
+  .issue.no-mock { grid-template-columns: 1fr; }
+  .issue-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 14px;
+  }
+  .severity {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    padding: 4px 10px;
+    border-radius: 4px;
+    text-transform: uppercase;
+  }
+  .sev-p0 { background: rgba(248, 113, 113, 0.12); color: var(--sig-red); border: 1px solid rgba(248, 113, 113, 0.25); }
+  .sev-p1 { background: rgba(251, 191, 36, 0.10); color: var(--sig-amber); border: 1px solid rgba(251, 191, 36, 0.25); }
+  .sev-p2 { background: rgba(92, 212, 232, 0.08); color: var(--accent); border: 1px solid rgba(92, 212, 232, 0.25); }
+  .tag {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-lo);
+    text-transform: uppercase;
+    letter-spacing: 0.10em;
+    padding: 3px 8px;
+    border: 1px solid var(--surface-hairline);
+    border-radius: 4px;
+  }
+  .issue h3 { margin-bottom: 12px; }
+  .issue p { font-size: 14px; }
+  .issue .fix {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px dashed var(--surface-hairline);
+  }
+  .fix .label {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--accent);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+
+  ul.tight { margin: 0; padding-left: 18px; color: var(--text-md); font-size: 14px; }
+  ul.tight li { margin-bottom: 4px; }
+  ul.tight li::marker { color: var(--text-lo); }
+
+  /* ──────────── Mini-mocks ──────────── */
+  .mock {
+    background: var(--surface-inset);
+    border: 1px solid var(--surface-separator);
+    border-radius: 10px;
+    padding: 16px;
+    font-size: 13px;
+  }
+  .mock-label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-lo);
+    margin-bottom: 12px;
+  }
+  .mock-label .pill {
+    background: var(--surface-overlay);
+    padding: 2px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--surface-hairline);
+  }
+  .mock-row + .mock-row { margin-top: 12px; }
+
+  /* Top bar mock */
+  .tb-mock {
+    background: var(--surface-base);
+    border: 1px solid var(--surface-separator);
+    border-radius: 8px;
+    padding: 10px 14px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    height: 64px;
+  }
+  .tb-clock {
+    font-family: var(--font-led);
+    color: var(--amber);
+    text-shadow: 0 0 6px var(--amber-glow);
+    font-size: 16px;
+    letter-spacing: 3px;
+  }
+  .tb-sep {
+    width: 1px; height: 36px;
+    background: var(--surface-separator);
+  }
+  .tb-group {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    background: var(--surface-inset);
+    border: 1px solid var(--surface-separator);
+    border-radius: 28px;
+    padding: 3px 10px;
+  }
+  .tb-group-lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.10em;
+    color: var(--text-lo);
+    padding: 0 6px;
+  }
+  .tb-icon {
+    width: 38px; height: 38px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-md);
+    font-size: 16px;
+    position: relative;
+    background: transparent;
+  }
+  .tb-icon.on {
+    background: rgba(240, 168, 48, 0.12);
+    color: var(--amber);
+  }
+  .tb-icon.on::after {
+    content: "";
+    position: absolute;
+    bottom: 4px; left: 25%; right: 25%;
+    height: 2px;
+    background: currentColor;
+    border-radius: 1px;
+  }
+  .tb-nav {
+    margin-left: auto;
+    display: flex;
+    gap: 2px;
+  }
+
+  /* "After" top bar — clearer zoning */
+  .tb-after {
+    flex-direction: column;
+    align-items: stretch;
+    height: auto;
+    padding: 10px 14px;
+    gap: 8px;
+  }
+  .tb-after-row { display: flex; align-items: center; gap: 10px; }
+  .tb-cluster {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px 10px;
+    border-right: 1px solid var(--surface-separator);
+  }
+  .tb-cluster:last-child { border-right: none; }
+  .tb-cluster-lbl {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--text-lo);
+  }
+  .tb-cluster-val {
+    color: var(--text-hi);
+    font-size: 13px;
+    font-weight: 500;
+  }
+  .tb-cluster-val .swatch {
+    display: inline-block;
+    width: 8px; height: 8px;
+    border-radius: 2px;
+    margin-right: 6px;
+    vertical-align: 1px;
+  }
+
+  /* Source bubble strip */
+  .src-strip {
+    display: flex;
+    gap: 6px;
+  }
+  .src-bubble {
+    height: 44px;
+    padding: 0 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border-radius: 22px;
+    background: var(--surface-inset);
+    border: 1px solid var(--surface-separator);
+    color: var(--text-md);
+    font-size: 13px;
+    font-weight: 500;
+  }
+  .src-bubble .ic {
+    width: 22px; height: 22px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--surface-overlay);
+    font-size: 12px;
+    color: var(--text-md);
+  }
+  .src-bubble.act {
+    background: rgba(240, 168, 48, 0.10);
+    border-color: rgba(240, 168, 48, 0.35);
+    color: var(--amber);
+  }
+  .src-bubble.act .ic { background: rgba(240, 168, 48, 0.25); color: var(--amber); }
+  .src-bubble.dis { opacity: 0.4; }
+
+  /* Metrics tile mock */
+  .metric-tile {
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-separator);
+    border-radius: 8px;
+    padding: 16px;
+  }
+  .metric-tile .cat {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    color: var(--text-lo);
+    text-transform: uppercase;
+  }
+  .metric-tile .name {
+    font-size: 13px;
+    color: var(--text-md);
+    margin-top: 4px;
+  }
+  .metric-tile .val {
+    font-family: var(--font-mono);
+    font-size: 28px;
+    color: var(--accent);
+    margin-top: 6px;
+    font-weight: 500;
+  }
+  .metric-tile .val .unit {
+    font-size: 13px;
+    color: var(--text-md);
+    margin-left: 4px;
+  }
+  .metric-tile .delta {
+    font-size: 11px;
+    color: var(--sig-green);
+    margin-top: 2px;
+    font-family: var(--font-mono);
+  }
+  .metric-tile.bug .val { color: var(--sig-red); }
+  .spark {
+    height: 24px;
+    margin-top: 8px;
+  }
+
+  /* Queue row mocks */
+  .queue-mock {
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-separator);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .qrow {
+    display: grid;
+    grid-template-columns: 24px 1fr 56px 28px;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--surface-separator);
+    font-size: 13px;
+  }
+  .qrow:last-child { border-bottom: none; }
+  .qrow.now {
+    background: rgba(240, 168, 48, 0.06);
+    border-left: 3px solid var(--amber);
+    padding-left: 11px;
+  }
+  .qrow .num {
+    font-family: var(--font-mono);
+    color: var(--text-lo);
+    text-align: center;
+    font-size: 12px;
+  }
+  .qrow.now .num { color: var(--amber); }
+  .qrow .title { color: var(--text-hi); font-weight: 500; }
+  .qrow .sub { color: var(--text-md); font-size: 12px; }
+  .qrow .dur {
+    font-family: var(--font-mono);
+    color: var(--text-md);
+    font-size: 12px;
+    text-align: right;
+  }
+  .qrow .x { color: var(--text-lo); text-align: center; }
+  .qrow.bad .dur { color: var(--sig-red); font-size: 10px; }
+
+  /* File browser mock */
+  .fb-mock {
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-separator);
+    border-radius: 8px;
+    padding: 14px;
+  }
+  .fb-field {
+    background: var(--surface-inset);
+    border: 1px solid var(--surface-separator);
+    border-radius: 6px;
+    padding: 8px 12px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-md);
+    word-break: break-all;
+  }
+  .fb-field.bad { color: var(--sig-red); font-size: 10px; line-height: 1.4; }
+  .fb-field .ph { color: var(--text-lo); }
+  .fb-chips {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+  }
+  .fb-chip {
+    height: 28px;
+    padding: 0 10px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--surface-inset);
+    border: 1px solid var(--surface-separator);
+    border-radius: 14px;
+    font-size: 12px;
+    color: var(--text-md);
+    font-family: var(--font-mono);
+  }
+
+  /* Now playing dock mock */
+  .dock {
+    background: var(--surface-overlay);
+    border: 1px solid var(--surface-separator);
+    border-radius: 8px;
+    padding: 10px 14px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    backdrop-filter: blur(20px);
+  }
+  .dock .art {
+    width: 44px; height: 44px;
+    background: linear-gradient(135deg, #2a2a30, #1a1a1f);
+    border-radius: 6px;
+    flex-shrink: 0;
+    position: relative;
+    overflow: hidden;
+  }
+  .dock .art::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(
+      135deg,
+      rgba(255,255,255,0.04) 0 6px,
+      transparent 6px 12px
+    );
+  }
+  .dock .meta { flex: 1; min-width: 0; }
+  .dock .t { color: var(--text-hi); font-size: 13px; font-weight: 600; }
+  .dock .a { color: var(--text-md); font-size: 12px; }
+  .dock .eq {
+    display: flex;
+    gap: 2px;
+    align-items: flex-end;
+    height: 14px;
+    margin-right: 4px;
+  }
+  .dock .eq span {
+    width: 3px;
+    background: var(--accent);
+    border-radius: 1px;
+  }
+  .dock .eq span:nth-child(1) { height: 60%; }
+  .dock .eq span:nth-child(2) { height: 100%; }
+  .dock .eq span:nth-child(3) { height: 40%; }
+  .dock .tcontrols {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-md);
+    font-size: 18px;
+  }
+  .dock .tcontrols .pp {
+    width: 36px; height: 36px;
+    border-radius: 50%;
+    background: var(--accent);
+    color: var(--surface-base);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Two-column compare */
+  .compare {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+  .compare .mock { margin: 0; }
+
+  /* Roadmap */
+  .roadmap {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1px;
+    background: var(--surface-separator);
+    border: 1px solid var(--surface-separator);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  .phase {
+    background: var(--surface-base);
+    padding: 24px;
+  }
+  .phase .pnum {
+    font-family: var(--font-led);
+    color: var(--amber);
+    font-size: 22px;
+    letter-spacing: 4px;
+    text-shadow: 0 0 6px var(--amber-glow);
+  }
+  .phase .pname {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 6px 0 14px;
+    color: var(--text-hi);
+  }
+  .phase ul {
+    margin: 0;
+    padding-left: 18px;
+    font-size: 13px;
+    color: var(--text-md);
+  }
+  .phase ul li { margin-bottom: 6px; }
+
+  /* Page audit table */
+  .ptable {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+  }
+  .ptable th, .ptable td {
+    text-align: left;
+    padding: 14px 18px;
+    vertical-align: top;
+    border-bottom: 1px solid var(--surface-separator);
+  }
+  .ptable th {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-lo);
+    font-weight: 500;
+    background: var(--surface-raised);
+  }
+  .ptable td.name { color: var(--text-hi); font-weight: 600; width: 18%; }
+  .ptable td.is { color: var(--text-md); width: 38%; }
+  .ptable td.fix { color: var(--text-md); }
+  .ptable td.fix strong { color: var(--text-hi); }
+
+  /* Footer */
+  .endplate {
+    margin-top: 80px;
+    padding-top: 24px;
+    border-top: 1px solid var(--surface-separator);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: var(--text-lo);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+</style>
+</head>
+<body>
+
+<!-- ───────────── Top sticky rail ───────────── -->
+<header class="rail">
+  <div class="rail-brand">
+    <span class="dot"></span>
+    <span>Radio.Web · Design Review</span>
+  </div>
+  <nav class="rail-toc">
+    <a href="#context">Context</a>
+    <a href="#strengths">Strengths</a>
+    <a href="#issues">Issues</a>
+    <a href="#pages">Pages</a>
+    <a href="#system">System</a>
+    <a href="#roadmap">Roadmap</a>
+  </nav>
+  <div class="rail-clock" id="clock">--:--</div>
+</header>
+
+<div class="shell">
+
+  <!-- ───────────── Hero ───────────── -->
+  <section class="hero">
+    <div class="eyebrow">Deep design analysis · v1</div>
+    <h1>The console is <em>beautiful</em>. The product underneath it is <em>leaking</em>.</h1>
+    <p class="lede">
+      The 1920×720 broadcast-console aesthetic is genuinely strong — DSEG amber LEDs over a calm
+      dark surface, a confident cyan accent, generous touch targets, and per-source color coding all
+      do real work. But the surface is sitting on top of an interface that is still showing the
+      user its raw machinery: <code>FilePlayer-da7eb94888fa43aab0021…</code> as a "source name",
+      <code>00:03:00.6628571</code> as a track duration, <code>850.4%</code> as a memory reading,
+      escaped JSON in a filter input, and a <strong>debug-only distortion marker</strong> living in
+      production chrome. The work below is mostly about <strong>finishing the surface</strong> so
+      the design language can do its job.
+    </p>
+
+    <div class="meta-row">
+      <div class="meta-cell">
+        <div class="k">Stack</div>
+        <div class="v">Blazor Server · Radzen · SignalR</div>
+      </div>
+      <div class="meta-cell">
+        <div class="k">Viewport</div>
+        <div class="v">1920 × 720 · touch-first kiosk</div>
+      </div>
+      <div class="meta-cell">
+        <div class="k">Surfaces audited</div>
+        <div class="v">9 pages · 5 shared panels · 3 dialogs</div>
+      </div>
+      <div class="meta-cell">
+        <div class="k">Findings</div>
+        <div class="v">5 P0 · 8 P1 · 11 P2</div>
+      </div>
+    </div>
+  </section>
+
+
+  <!-- ───────────── Context ───────────── -->
+  <section id="context">
+    <div class="section-head">
+      <span class="section-num">01</span>
+      <h2>What we're looking at</h2>
+      <span class="section-sub">Setting the frame</span>
+    </div>
+
+    <div style="display: grid; grid-template-columns: 1.2fr 1fr; gap: 32px; align-items: start;">
+      <div>
+        <p>
+          Radio.Web is a Blazor Server kiosk app that runs on a fixed 1920×720 touchscreen — likely
+          a Raspberry Pi driving a wide-format panel. It controls a multi-source audio engine
+          (FM/AM radio over RTL-SDR, Bluetooth, USB, vinyl, local files, Google Cast) and surfaces
+          a single home view with three columns: <strong>Now Playing</strong>, <strong>Queue /
+          History</strong>, and <strong>Visualizer</strong>. Secondary pages — Devices, Metrics,
+          History, System, Phone, File Browser — share an 80px top bar that doubles as the global
+          source/output router.
+        </p>
+        <p>
+          The aesthetic brief is "professional broadcast console / recording-studio rack mount" —
+          DSEG segmented-LCD type in amber for time and frequency, a single electric-cyan accent
+          for active state, and a calm dark palette (<code>#0D0D0F</code> base,
+          <code>#141416</code> raised). The design system is well-articulated in
+          <code>design-system.css</code>: tokens for surfaces, accents, source colors, touch sizes,
+          animation timing.
+        </p>
+        <p>
+          <strong>The mismatch:</strong> the design system promises a calm, opinionated instrument
+          panel. The screenshots deliver something closer to a half-finished admin tool with a
+          beautiful skin on top — raw API IDs, debug controls, broken units, and pages that have
+          one component and acres of empty void below.
+        </p>
+      </div>
+
+      <!-- Real top-bar reproduction so we share a reference -->
+      <div class="mock">
+        <div class="mock-label">
+          <span>Current top bar · approximation</span>
+          <span class="pill">1920 × 80</span>
+        </div>
+        <div class="tb-mock">
+          <div class="tb-clock">11:29</div>
+          <div class="tb-sep"></div>
+          <div class="tb-group">
+            <span class="tb-group-lbl">In</span>
+            <span class="tb-icon">♪</span>
+            <span class="tb-icon on" style="color: var(--source-radio); background: rgba(240,168,48,0.12);">📻</span>
+            <span class="tb-icon">⌁</span>
+            <span class="tb-icon">▼</span>
+          </div>
+          <div class="tb-sep"></div>
+          <div class="tb-group">
+            <span class="tb-group-lbl">Out</span>
+            <span class="tb-icon on" style="color: var(--accent); background: var(--accent-dim);">▣</span>
+            <span class="tb-icon">▤</span>
+            <span class="tb-icon">⌁</span>
+          </div>
+          <span class="tb-icon" title="debug" style="color: var(--text-lo); margin-left:6px;">🐞</span>
+          <div class="tb-nav">
+            <span class="tb-icon on" style="color: var(--accent);">⌂</span>
+            <span class="tb-icon">≡</span>
+            <span class="tb-icon">▥</span>
+            <span class="tb-icon">⌥</span>
+            <span class="tb-icon">⌖</span>
+            <span class="tb-icon">⏱</span>
+            <span class="tb-icon">⚙</span>
+            <span class="tb-icon">☎</span>
+            <span class="tb-icon">⏻</span>
+          </div>
+        </div>
+        <p style="font-size: 12px; margin-top: 14px; color: var(--text-lo);">
+          Three icon groups sharing one bar, ten of them shaped identically.
+          The bar is doing routing, navigation, and a debug action at the same time —
+          users can't tell from shape alone what each pill <em>does</em>.
+        </p>
+      </div>
+    </div>
+  </section>
+
+
+  <!-- ───────────── Strengths ───────────── -->
+  <section id="strengths">
+    <div class="section-head">
+      <span class="section-num">02</span>
+      <h2>Don't break these</h2>
+      <span class="section-sub">Real strengths · keep them</span>
+    </div>
+
+    <div class="strengths">
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>Token-first design system</h4>
+        <p>One CSS file owns surfaces, accents, type, motion, and touch sizes. Already the right
+        plumbing — most of the work below is enforcement, not invention.</p>
+      </div>
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>Per-source color coding</h4>
+        <p>Vinyl violet, radio amber, Bluetooth blue, USB green, file cyan — a smart, learnable
+        mapping that pays off across the whole app once enforced.</p>
+      </div>
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>DSEG LED type as a signature</h4>
+        <p>Amber segmented display for time, frequency and ghost-segment backgrounds is the single
+        most distinctive visual move in the app. Don't dilute it by using it on regular UI.</p>
+      </div>
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>Real touch sizing</h4>
+        <p>48/56/64px tokens are defined and route toggles hit them. Better than 90% of admin-style
+        Blazor apps in the wild.</p>
+      </div>
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>SignalR-driven live state</h4>
+        <p>Now playing, queue count, sleep, source — all push-updated. The user never has to
+        refresh. Lean into this with more live state where it currently isn't.</p>
+      </div>
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>Three-column home</h4>
+        <p>Now Playing · Queue · Visualizer reading left-to-right is the right shape for a kiosk.
+        Most of the design work for the home page is already done.</p>
+      </div>
+    </div>
+  </section>
+
+
+  <!-- ───────────── Issues ───────────── -->
+  <section id="issues">
+    <div class="section-head">
+      <span class="section-num">03</span>
+      <h2>What's leaking through</h2>
+      <span class="section-sub">P0 → P2 · sorted by user pain</span>
+    </div>
+
+
+    <!-- ─── ISSUE 1: top bar overload ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p0">P0</span>
+          <span class="tag">Information architecture</span>
+          <span class="tag">MainLayout</span>
+        </div>
+        <h3>The top bar is three different toolbars stacked into one row</h3>
+        <p>
+          Eighty pixels of vertical space are doing four jobs at once: telling time, routing
+          <em>input</em>, routing <em>output</em>, exposing nine global nav targets — plus a
+          temporary debug button. Every cluster uses the same circular-pill shape, so a user can't
+          tell from form alone whether a pill <em>switches a route</em> or <em>navigates a
+          page</em>. The route toggles also conflate two actions (switch source / open detail) by
+          tap counting.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Split the bar into <strong>three visually distinct zones</strong>: a status zone
+            (clock + currently-playing pill), a routing zone (clearly labeled IN → OUT with a
+            connector glyph between them), and a nav zone (rectangular icon+label buttons, not
+            circles).</li>
+            <li>Make active source <em>and</em> active output visible as <strong>typeset names</strong>,
+            not just colored pills — operators shouldn't have to remember the color code.</li>
+            <li>Move the <strong>debug distortion marker</strong> behind a dev-tools toggle. It
+            doesn't belong in production chrome.</li>
+            <li>Replace tap-count-to-disambiguate with an explicit affordance: long-press, or a
+            chevron that opens detail.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Proposed top bar</span><span class="pill">After</span></div>
+        <div class="tb-mock tb-after">
+          <div class="tb-after-row" style="gap: 16px;">
+            <div class="tb-cluster" style="border:none; padding-left:0;">
+              <span class="tb-cluster-lbl">Time</span>
+              <span class="tb-cluster-val" style="font-family: var(--font-led); color: var(--amber); letter-spacing:2px;">11:29</span>
+            </div>
+            <div class="tb-cluster">
+              <span class="tb-cluster-lbl">In · Source</span>
+              <span class="tb-cluster-val"><span class="swatch" style="background: var(--source-radio);"></span>FM Radio · 88.5</span>
+            </div>
+            <div style="color: var(--text-lo); font-size: 18px;">→</div>
+            <div class="tb-cluster">
+              <span class="tb-cluster-lbl">Out · Destination</span>
+              <span class="tb-cluster-val"><span class="swatch" style="background: var(--accent);"></span>Living Room (Cast)</span>
+            </div>
+            <div class="tb-nav" style="gap: 4px;">
+              <span class="tb-icon" style="width:auto; padding:0 10px; border-radius:6px; background: var(--accent-dim); color: var(--accent); font-size: 11px; letter-spacing:0.1em; font-family: var(--font-mono); text-transform: uppercase;">Home</span>
+              <span class="tb-icon" style="width:auto; padding:0 10px; border-radius:6px; color: var(--text-md); font-size: 11px; letter-spacing:0.1em; font-family: var(--font-mono); text-transform: uppercase;">Queue·45</span>
+              <span class="tb-icon" style="width:auto; padding:0 10px; border-radius:6px; color: var(--text-md); font-size: 11px; letter-spacing:0.1em; font-family: var(--font-mono); text-transform: uppercase;">Radio</span>
+              <span class="tb-icon" style="width:auto; padding:0 10px; border-radius:6px; color: var(--text-md); font-size: 11px; letter-spacing:0.1em; font-family: var(--font-mono); text-transform: uppercase;">More</span>
+            </div>
+          </div>
+          <div class="tb-after-row src-strip">
+            <span class="src-bubble"><span class="ic">♪</span>File</span>
+            <span class="src-bubble act"><span class="ic">📻</span>Radio</span>
+            <span class="src-bubble"><span class="ic">⌁</span>Bluetooth</span>
+            <span class="src-bubble dis"><span class="ic">⌖</span>Vinyl · offline</span>
+            <span class="src-bubble"><span class="ic">⎘</span>USB</span>
+          </div>
+        </div>
+        <p style="font-size:12px; margin-top:10px; color: var(--text-lo);">
+          Routing reads as a sentence: <em>FM Radio → Living Room</em>. Source pills move below
+          with full labels — discoverable, learnable, and a "disabled / offline" state stops
+          looking like a faded icon.
+        </p>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 2: UUID source names ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p0">P0</span>
+          <span class="tag">Data hygiene</span>
+          <span class="tag">All pages</span>
+        </div>
+        <h3>API IDs are leaking into the UI as labels</h3>
+        <p>
+          The Audio Source dropdown in older screenshots shows
+          <code>FilePlayer-da7eb94888fa43aab0021…</code> — a UUID-suffixed internal ID being
+          rendered as a human label. Devices show
+          <code>1 - LG TV SSCR2 (AMD High Definition Audio Device)</code> straight from WASAPI.
+          Tracks fall back to <code>Track 8</code>, <code>Track 9</code>… when metadata is missing.
+          These are <em>all</em> the same problem: the app is showing internal identifiers because
+          the display-name layer is missing or thin.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>One <code>DisplayName</code> projection on every domain DTO, computed server-side.
+            Never bind a raw <code>Id</code>, <code>RawName</code>, or filename to a user-facing
+            string.</li>
+            <li>Filename fallback: parse leading <em>track-number / disc-number</em>, strip
+            extension, title-case. <code>08 - We're Ready.flac</code> → <strong>We're Ready</strong>
+            with subtitle <em>Track 8</em>.</li>
+            <li>Device names: ship a curated alias map for common adapters (VB-Audio, Realtek,
+            HDMI…), with the existing <code>FriendlyNameOverride</code> as the user-edit layer.
+            Show the alias by default, the raw name on long-press.</li>
+            <li>Sources: drop the GUID suffix entirely from the client model. The UI never needs
+            instance identity.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Source dropdown</span><span class="pill">Before · after</span></div>
+        <div class="compare">
+          <div class="mock" style="background: var(--surface-raised);">
+            <div style="font-family: var(--font-mono); font-size: 10px; color: var(--text-lo); margin-bottom:6px;">BEFORE</div>
+            <div class="fb-field" style="color: var(--text-hi);">FilePlayer-da7eb94888fa43aab0021…</div>
+            <div class="fb-field" style="color: var(--text-hi); margin-top:6px;">1 - LG TV SSCR2 (AMD High Definition Audio Device)</div>
+            <div class="fb-field" style="color: var(--text-hi); margin-top:6px;">CABLE In 16ch (VB-Audio Virtual Cable)</div>
+          </div>
+          <div class="mock" style="background: var(--surface-raised);">
+            <div style="font-family: var(--font-mono); font-size: 10px; color: var(--accent); margin-bottom:6px;">AFTER</div>
+            <div class="fb-field" style="color: var(--text-hi);">File Player <span class="ph">· local</span></div>
+            <div class="fb-field" style="color: var(--text-hi); margin-top:6px;">LG TV <span class="ph">· HDMI</span></div>
+            <div class="fb-field" style="color: var(--text-hi); margin-top:6px;">VB-Audio Cable In <span class="ph">· 16-channel</span></div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 3: durations ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p0">P0</span>
+          <span class="tag">Formatting</span>
+          <span class="tag">Queue · NowPlaying</span>
+        </div>
+        <h3>Durations are raw <code>TimeSpan.ToString()</code></h3>
+        <p>
+          The queue is showing track lengths as <code>00:03:00.6628571</code> —
+          <em>hours:minutes:seconds.ticks</em>. No one reads tracks in tick precision. It also
+          makes every column header wider than it needs to be, eating horizontal space the table
+          can't afford. Same problem on History (sub-second precision on date/time).
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>One <code>FormatDuration(TimeSpan)</code> helper used everywhere: <code>3:00</code>
+            under an hour, <code>1:02:14</code> over an hour, em-dash for unknown.</li>
+            <li>Right-align all duration columns in a tabular-figures monospaced style — already
+            in your <code>--font-mono</code> token.</li>
+            <li>History date format: <code>Today 08:40</code>, <code>Yesterday 14:22</code>,
+            <code>Feb 6 · 11:05</code> — relative within 48 hours, absolute beyond.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Queue rows</span><span class="pill">After</span></div>
+        <div class="queue-mock">
+          <div class="qrow now">
+            <span class="num">▶</span>
+            <span>
+              <div class="title">Track 8</div>
+              <div class="sub">Cary High Chorus · Fall Concert 2006</div>
+            </span>
+            <span class="dur">3:00</span>
+            <span class="x">×</span>
+          </div>
+          <div class="qrow">
+            <span class="num">2</span>
+            <span>
+              <div class="title">I'm Not in Love</div>
+              <div class="sub">10cc · Very Best Of</div>
+            </span>
+            <span class="dur">6:04</span>
+            <span class="x">×</span>
+          </div>
+          <div class="qrow">
+            <span class="num">3</span>
+            <span>
+              <div class="title">Bixby Canyon Bridge</div>
+              <div class="sub">Death Cab for Cutie · Narrow Stairs</div>
+            </span>
+            <span class="dur">5:15</span>
+            <span class="x">×</span>
+          </div>
+          <div class="qrow bad" style="opacity:0.5;">
+            <span class="num">4</span>
+            <span>
+              <div class="title">Track 9</div>
+              <div class="sub">Cary High Chorus · Fall Concert 2006</div>
+            </span>
+            <span class="dur" style="color:var(--text-md); font-size:12px;">2:20</span>
+            <span class="x">×</span>
+          </div>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 4: metrics units bug ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p0">P0</span>
+          <span class="tag">Units · trust</span>
+          <span class="tag">Metrics</span>
+        </div>
+        <h3>"Memory Usage Mb: 850.4%" — units are detached from values</h3>
+        <p>
+          The metrics dashboard is rendering every value into the same template
+          (<code>{value}{suffix}</code>) without knowing what unit the metric is in. So
+          <strong>Memory Usage Mb</strong> ends up labelled <strong>850.4%</strong>, signal
+          strength is unitless, latency reads as a bare number, and the underscored category names
+          (<code>TTS</code>, <code>RADIO</code>) look like backend leakage. The dashboard is
+          actively eroding trust in its own numbers.
+        </p>
+        <p>
+          The page is also a wall of identical tiles — 16+ scalars rendered with zero hierarchy and
+          zero time context. A metrics dashboard with no <em>trend</em> is a list with extra steps.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Metric registry has the unit baked in (<code>%</code>, <code>MB</code>,
+            <code>ms</code>, <code>count</code>, <code>req/min</code>). Tile reads it; never
+            assumes <code>%</code>.</li>
+            <li>Group tiles by <strong>category</strong> with real sub-headers (System / Audio /
+            Radio / Library / TTS) instead of a tiny grey prefix per tile.</li>
+            <li>Inline <strong>sparkline</strong> for any time-series metric over the selected
+            window — a single <code>&lt;svg&gt;</code> per tile is enough to turn "wall of
+            numbers" into a status board.</li>
+            <li>Color the value only when it's <em>actionable</em>: green for healthy, amber when
+            approaching a threshold, red when over. Don't paint every value cyan.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Metric tiles</span><span class="pill">Before · after</span></div>
+        <div class="compare">
+          <div class="metric-tile bug">
+            <div class="cat">SYSTEM</div>
+            <div class="name">Memory Usage Mb</div>
+            <div class="val">850.4<span class="unit">%</span></div>
+          </div>
+          <div class="metric-tile">
+            <div class="cat">System · Memory</div>
+            <div class="name">Heap in use</div>
+            <div class="val">850<span class="unit">MB</span></div>
+            <div class="delta">▲ 4% vs 1h ago</div>
+            <svg class="spark" viewBox="0 0 120 24" preserveAspectRatio="none">
+              <polyline fill="none" stroke="#5CD4E8" stroke-width="1.5"
+                points="0,18 10,16 20,17 30,14 40,15 50,12 60,13 70,10 80,11 90,8 100,9 110,7 120,6"/>
+              <polyline fill="rgba(92,212,232,0.10)" stroke="none"
+                points="0,18 10,16 20,17 30,14 40,15 50,12 60,13 70,10 80,11 90,8 100,9 110,7 120,6 120,24 0,24"/>
+            </svg>
+          </div>
+        </div>
+        <div class="compare" style="margin-top:10px;">
+          <div class="metric-tile bug">
+            <div class="cat">RADIO</div>
+            <div class="name">Signal Strength</div>
+            <div class="val">65.39</div>
+          </div>
+          <div class="metric-tile">
+            <div class="cat">Radio · Reception</div>
+            <div class="name">Signal strength</div>
+            <div class="val" style="color: var(--sig-green);">65<span class="unit">%</span></div>
+            <div class="delta" style="color: var(--text-md);">Stable · last 5 min</div>
+            <svg class="spark" viewBox="0 0 120 24" preserveAspectRatio="none">
+              <polyline fill="none" stroke="#4ADE80" stroke-width="1.5"
+                points="0,12 10,11 20,13 30,10 40,9 50,11 60,10 70,9 80,10 90,11 100,9 110,10 120,9"/>
+            </svg>
+          </div>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 5: file browser JSON ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p0">P0</span>
+          <span class="tag">Bug</span>
+          <span class="tag">File Browser</span>
+        </div>
+        <h3>The Filter field is showing escaped JSON</h3>
+        <p>
+          The screenshot of the File Browser shows a Filter dropdown whose value reads
+          <code>"\u0022\u0022\\\u0022\\\\\\\\\u0022\\\\\\\\…</code> — a JSON string that was
+          serialized one too many times and is now being rendered as text inside the input. This
+          is the kind of bug that <em>quietly</em> tells a user the system isn't trustworthy.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Find the binding path — likely a filter that's <code>JsonSerializer.Serialize</code>'d
+            for persistence and then bound directly back to a <code>RadzenDropDown</code> value.
+            It should deserialize before bind.</li>
+            <li>Treat the filter as <strong>chips</strong>, not a text input. Each token is one
+            extension (<code>.mp3</code>, <code>.flac</code>, <code>.wav</code>) with an × — no
+            escaping ever needs to happen.</li>
+            <li>The breadcrumb under the input (<code>Home / D:\</code>) is also wired oddly — it
+            shows <code>D:\</code> while the drive selector says <code>C:\</code>. Single source of
+            truth for "current path".</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Filter input</span><span class="pill">Before · after</span></div>
+        <div class="fb-mock">
+          <div style="font-family: var(--font-mono); font-size: 10px; color: var(--text-lo); margin-bottom:6px;">BEFORE</div>
+          <div class="fb-field bad">"\u0022\u0022\\\u0022\\\\\\\\\u0022\\\\\\\\\\\\\\\\\u0022\\\\\\\\\\\\\\\\\\\\\\\\…</div>
+        </div>
+        <div class="fb-mock" style="margin-top:12px;">
+          <div style="font-family: var(--font-mono); font-size: 10px; color: var(--accent); margin-bottom:6px;">AFTER · chips</div>
+          <div class="fb-chips">
+            <span class="fb-chip">.mp3 ×</span>
+            <span class="fb-chip">.flac ×</span>
+            <span class="fb-chip">.wav ×</span>
+            <span class="fb-chip" style="color: var(--text-lo);">+ add type</span>
+          </div>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 6: half-empty pages ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p1">P1</span>
+          <span class="tag">Density</span>
+          <span class="tag">Radio · Devices · Queue · Visualizer</span>
+        </div>
+        <h3>Most secondary pages use 30% of the screen and waste the rest</h3>
+        <p>
+          The radio page renders a small spinner in the middle of an otherwise blank 640px-tall
+          canvas. Devices shows six rows and stops. Queue lists 3 items and leaves ~480px of empty
+          dark. The kiosk has a fixed viewport — there is no fold to scroll to. Empty space below
+          content reads as "broken" or "still loading", not "minimalist".
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Treat each page as a <strong>fixed dashboard</strong>, not a scrolling list.
+            Allocate every region of the 640px content area to a real purpose.</li>
+            <li><strong>Queue</strong>: pair the list with a right-side panel — total runtime,
+            upcoming next 3 with art, "save as playlist" CTA. Already have the data.</li>
+            <li><strong>Devices</strong>: split into two columns (Outputs | Cast destinations),
+            and add a bottom strip with the actively-routed device state.</li>
+            <li><strong>Radio</strong>: while the panel loads, show a skeleton that matches its
+            actual shape (frequency well + band buttons + meter), not a centered spinner.</li>
+            <li><strong>Visualizer</strong>: the chart should fill its panel, not sit in a 60%-width
+            box with empty bands. Also make VU / WAVE / SPECTRUM a segmented control, not three
+            tiny outline buttons hugging the corner.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Queue page · split layout</span><span class="pill">After</span></div>
+        <div style="display: grid; grid-template-columns: 1.5fr 1fr; gap: 8px;">
+          <div class="queue-mock">
+            <div class="qrow now">
+              <span class="num">▶</span>
+              <span><div class="title">Track 8</div><div class="sub">Cary High Chorus</div></span>
+              <span class="dur">3:00</span>
+              <span class="x">×</span>
+            </div>
+            <div class="qrow">
+              <span class="num">2</span>
+              <span><div class="title">I'm Not in Love</div><div class="sub">10cc</div></span>
+              <span class="dur">6:04</span><span class="x">×</span>
+            </div>
+            <div class="qrow">
+              <span class="num">3</span>
+              <span><div class="title">Bixby Canyon</div><div class="sub">Death Cab</div></span>
+              <span class="dur">5:15</span><span class="x">×</span>
+            </div>
+          </div>
+          <div style="display: grid; gap:8px;">
+            <div class="metric-tile">
+              <div class="cat">Queue</div>
+              <div class="name">Total runtime</div>
+              <div class="val" style="color: var(--amber); font-family: var(--font-led); letter-spacing:2px;">2:48:15</div>
+            </div>
+            <div class="metric-tile">
+              <div class="cat">Up next</div>
+              <div class="name" style="color:var(--text-hi); margin-top:6px;">I'm Not in Love</div>
+              <div class="name" style="color:var(--text-md);">Bixby Canyon Bridge</div>
+              <div class="name" style="color:var(--text-lo);">Track 10</div>
+            </div>
+            <div class="metric-tile">
+              <div class="cat">Action</div>
+              <div class="name" style="color: var(--accent); margin-top:4px;">＋  Save as playlist</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 7: no global now playing ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p1">P1</span>
+          <span class="tag">Persistence</span>
+          <span class="tag">All non-home pages</span>
+        </div>
+        <h3>You lose Now Playing the moment you leave Home</h3>
+        <p>
+          The Now Playing panel is mounted only at <code>/</code>. As soon as you tap into
+          Devices, Metrics, History, System, or Phone, the user has <em>no visible playback
+          state</em> — no track, no transport, no progress, no source. They can see the queue
+          count on the nav icon and that's it. On a kiosk with no back-pocket phone next to it,
+          that's a real loss.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Add a <strong>persistent mini-dock</strong> at the bottom edge of every non-home
+            page: 56px tall, art thumbnail · title/artist · transport · progress · source dot.
+            Tapping the title takes you home.</li>
+            <li>SignalR is already pushing this state — no new wiring, just a shared component
+            in <code>MainLayout</code> that hides on <code>/</code> (where Now Playing already
+            owns the column).</li>
+            <li>The dock also gives sleep/wake a visible anchor — pulse it dim during sleep
+            instead of blacking the whole screen.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Persistent dock</span><span class="pill">All non-home pages</span></div>
+        <div class="dock">
+          <div class="art"></div>
+          <div class="meta">
+            <div class="t">Track 8</div>
+            <div class="a">Cary High Chorus · 3:00</div>
+          </div>
+          <div class="eq"><span></span><span></span><span></span></div>
+          <div style="flex:1; height:3px; background: var(--surface-separator); border-radius:2px; overflow:hidden;">
+            <div style="width:42%; height:100%; background: var(--accent);"></div>
+          </div>
+          <div class="tcontrols">
+            ⏮ <span class="pp">▶</span> ⏭
+          </div>
+        </div>
+        <p style="font-size:12px; margin-top:10px; color: var(--text-lo);">
+          Backdrop-blurred, sits over the page above it. Disappears on <code>/</code> where the
+          dedicated Now Playing column owns the job.
+        </p>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 8: source toggle semantics ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p1">P1</span>
+          <span class="tag">Interaction</span>
+          <span class="tag">MainLayout · HandleSourceToggleAsync</span>
+        </div>
+        <h3>The source toggle does two different things depending on tap count</h3>
+        <p>
+          Reading <code>HandleSourceToggleAsync</code>: a first tap on a non-active source switches
+          to it. A tap on the <em>already</em>-active radio source toggles the Radio Control panel
+          on the home page. A tap on the active vinyl/bluetooth source navigates to its dedicated
+          page. The user can't predict from looking at the button which of those three things
+          they're about to get.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Source pill = <strong>one action</strong>: switch to that source. Period.</li>
+            <li>"Open detail view" is a separate affordance — a chevron on the active pill, or a
+            dedicated "Source detail" tile in the home layout that's always visible when the
+            active source has one (Radio, Bluetooth).</li>
+            <li>The Radio Control panel currently <em>replaces</em> the Queue/History panel on
+            home. That's a non-obvious state change. Reserve a small persistent strip in the
+            center column for source-specific controls, and keep Queue/History below.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Source pill states</span><span class="pill">After</span></div>
+        <div class="src-strip" style="flex-wrap: wrap;">
+          <span class="src-bubble"><span class="ic">♪</span>File</span>
+          <span class="src-bubble act">
+            <span class="ic">📻</span>FM Radio · 88.5
+            <span style="margin-left:4px; color: var(--amber); opacity:0.7;">›</span>
+          </span>
+          <span class="src-bubble"><span class="ic">⌁</span>Bluetooth</span>
+          <span class="src-bubble dis"><span class="ic">⌖</span>Vinyl · offline</span>
+        </div>
+        <p style="font-size:12px; margin-top:10px; color: var(--text-lo);">
+          The active pill grows a chevron — <em>that's</em> the "open detail" affordance. Tap the
+          body to stay on the source; tap the chevron to open its dedicated panel.
+        </p>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 9: visualizer placement ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p1">P1</span>
+          <span class="tag">Hierarchy</span>
+          <span class="tag">VisualizerPanel</span>
+        </div>
+        <h3>The visualizer panel buries its own modes and shows raw debug</h3>
+        <p>
+          On the home page right column, the visualizer canvas takes ~70% of its panel, three mode
+          buttons (VU / WAVE / SPECTRUM) live in a top-right corner as small outlined chips, a
+          green <strong>Connected</strong> pill sits next to them, and the canvas itself has
+          <strong>"Updates: 22/sec"</strong> burned in as yellow Comic-Sans-y caption text at the
+          bottom-left. That's debug telemetry sitting on a primary visualization.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Mode picker should be a <strong>segmented control across the top</strong> of the
+            panel, full-width — it's the primary control of this view.</li>
+            <li>"Connected" status belongs as a small dot on the panel header, not a labeled pill.
+            And only show <em>red</em> when it's not connected; green-when-fine is noise.</li>
+            <li>"Updates: 22/sec" is dev info — gate it behind the same dev-tools toggle as the
+            distortion marker.</li>
+            <li>Make the visualization itself <strong>fill the panel</strong>. Add per-mode chrome
+            (frequency labels, dB scale) only where it materially helps reading the signal.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 10: scrollbars hidden ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p1">P1</span>
+          <span class="tag">Discoverability</span>
+          <span class="tag">design-system.css §19</span>
+        </div>
+        <h3>Hidden scrollbars + no overflow cue = invisible content</h3>
+        <p>
+          <code>* { scrollbar-width: none; } *::-webkit-scrollbar { display: none; }</code> hides
+          every scrollbar globally. The justification in the comment is "kiosk touch UI" — fine,
+          but the screenshots show several pages (Queue with 45 tracks, Devices, System tabs)
+          where there's clearly more content below the fold and <strong>nothing tells the user
+          that</strong>. The History page also crops a tall content block at ~520px with no
+          gradient or chevron.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Keep the bar hidden, but add a <strong>thin always-visible thumb</strong> (~3px
+            wide, 30% opacity) on scrollable panels so the user knows there's more.</li>
+            <li>Or: a fading mask at the bottom edge of any panel whose content is taller than its
+            box. The CSS is one declaration:
+            <code>mask-image: linear-gradient(to bottom, #000 calc(100% - 24px), transparent)</code>.</li>
+            <li>For touch lists, add a momentum-style "✨ scroll for more · N items below"
+            sentinel that fades in when more is hidden.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 11: empty/loading states ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p2">P2</span>
+          <span class="tag">States</span>
+          <span class="tag">Cross-cutting</span>
+        </div>
+        <h3>Loading and empty states are mostly centered spinners</h3>
+        <p>
+          Radio panel: centered <code>RadzenProgressBarCircular</code> in a 640×688 void. Queue
+          panel before data: blank. Devices when there are no Cast devices: nothing. The
+          design-system already defines <code>.skeleton-text</code>, <code>.skeleton-card</code>,
+          <code>.empty-state</code>, and a shimmer animation — they just aren't used.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Replace every spinner with a <strong>shape-matched skeleton</strong>: Now Playing
+            shows blurred art placeholder + 2 text bars + transport row; Radio shows freq-well +
+            band buttons + meter; Queue shows 6 ghosted rows.</li>
+            <li>Build a small <code>&lt;EmptyState Icon Title Action /&gt;</code> Razor component
+            and use it everywhere — current empty handling is ad-hoc.</li>
+            <li>For network/API failures, surface a single inline banner (not a Radzen toast that
+            pops outside the kiosk surface) with a retry button at touch size.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 12: debug button ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p2">P2</span>
+          <span class="tag">Production hygiene</span>
+          <span class="tag">MainLayout.razor:51</span>
+        </div>
+        <h3>The "distortion marker" debug button is in the production top bar</h3>
+        <p>
+          The comment in <code>MainLayout.razor</code> literally says
+          <em>"Debug: Distortion Marker (temporary — remove when done diagnosing)"</em>. It's still
+          there. It will be there in six months. It pops a 1-second color flash on every press —
+          a touch-friendly target for accidental input.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Move it behind a build-flag gate (<code>#if DEBUG</code>) or a
+            <code>config.diagnostics.enabled</code> setting that defaults false.</li>
+            <li>Better: a hidden <strong>tap-and-hold-corner gesture</strong> opens a dev panel
+            with this and any other diagnostic actions (audio frame dump, log download). The
+            corner is invisible to normal users and free in screen real estate.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 13: contrast & font weight ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p2">P2</span>
+          <span class="tag">Legibility</span>
+          <span class="tag">Type system</span>
+        </div>
+        <h3>Secondary text leans too dim for a 2-foot kiosk viewing distance</h3>
+        <p>
+          <code>--text-medium: #9CA3AF</code> on <code>--surface-base: #0D0D0F</code> hits ~6.8:1 —
+          fine on paper, fine on a desk monitor. On a glossy 12.5" touchscreen at 2-3 feet,
+          combined with smaller body text (13–14px in side panels), several places in the
+          screenshots read as "noise" rather than information. The History "Statistics" sub-labels
+          and the metric category prefixes are good examples.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Bump <code>--text-medium</code> to ~<code>#B5BCC9</code> (~9:1) for body, and reserve
+            the current value for <em>tertiary</em> metadata only.</li>
+            <li>Minimum size for any persistent UI string is 14px. Headers and metric values that
+            people glance at across the room should be 18–20px+.</li>
+            <li>Touch-screen calibration matters: ship the theme in two flavors —
+            <code>desk</code> (current) and <code>kiosk</code> (heavier base weight, ~10% larger
+            type scale, slightly elevated contrast) — and pick at startup based on a config flag.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 14: status semantics ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p2">P2</span>
+          <span class="tag">Semantics</span>
+          <span class="tag">Devices · Audio Engine</span>
+        </div>
+        <h3>Status badges all look like "Available" — including the broken ones</h3>
+        <p>
+          On the System Stats page: <strong>Audio Engine State: Active - FilePlayer (Stopped)</strong>
+          — both "Active" and "Stopped" in the same string with no visual indicator of whether
+          this is good or bad. On Devices, every row says <code>Available</code> in the same blue
+          pill that <code>Default</code> uses. Cast disconnect/connect uses transient toasts that
+          don't persist.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Reserve <strong>color</strong> for state, <strong>pills</strong> for active /
+            default markers, and <strong>plain text</strong> for "Available" (it's the steady
+            state, not a status).</li>
+            <li>Parse the Audio Engine string into a structured tuple: <em>{ active, current
+            source, current state }</em>. Render with three distinct affordances.</li>
+            <li>Persist Cast connect/disconnect to a small <strong>event ribbon</strong> below the
+            dock — last 3 events, auto-clear after 30s. Toasts that don't stick are forgotten
+            information.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+  </section>
+
+
+  <!-- ───────────── Page-by-page ───────────── -->
+  <section id="pages">
+    <div class="section-head">
+      <span class="section-num">04</span>
+      <h2>Page-by-page summary</h2>
+      <span class="section-sub">One row per surface</span>
+    </div>
+
+    <table class="ptable">
+      <thead>
+        <tr><th>Page</th><th>What's there now</th><th>What to add or change</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="name">Home <span style="color:var(--text-lo); font-weight:400;">/</span></td>
+          <td class="is">3-column: Now Playing 520 · Queue/History 688 · Visualizer 710.
+          Strong shape, but the middle column flips between Queue and Radio Control with no
+          breadcrumb back to Queue.</td>
+          <td class="fix">Add a thin <strong>mode toggle</strong> in the middle column header
+          (Queue · History · Radio) so the user knows what they're looking at and can switch back.
+          Make the Visualizer mode picker live in <em>its</em> panel header, full width.</td>
+        </tr>
+        <tr>
+          <td class="name">Radio <span style="color:var(--text-lo); font-weight:400;">/radio</span></td>
+          <td class="is">Currently shows a centered spinner over an empty 640px void on first
+          load. Real content (frequency well, band buttons, signal meter, presets) takes ~50% of
+          the page when loaded.</td>
+          <td class="fix">Shape-matched skeleton on load. Use the right half for <strong>presets
+          + RDS now-playing</strong>, currently absent. Promote frequency entry from a dialog to
+          an inline numpad on the right column.</td>
+        </tr>
+        <tr>
+          <td class="name">Queue <span style="color:var(--text-lo); font-weight:400;">/ via home</span></td>
+          <td class="is">Title-only header, ADD FILES / CLEAR ALL in opposite corner of the
+          screen from the items. Trash icon as the only row action. No reorder. Duration in
+          ticks.</td>
+          <td class="fix">Drag handle on the left (already a touch token at 56px), kebab on the
+          right with reorder/jump/save. Side panel with total runtime + up-next preview.
+          Sticky "playing now" indicator at the top of the list.</td>
+        </tr>
+        <tr>
+          <td class="name">Devices <span style="color:var(--text-lo); font-weight:400;">/devices</span></td>
+          <td class="is">Single flat table; same blue pill for "Default" and "Available" so they
+          read as related states.</td>
+          <td class="fix">Split into <strong>Outputs | Cast targets</strong>. "Available" is the
+          baseline, no badge. Add a small device card on the right showing current routing,
+          format (sample rate · channels), and a "Test tone" button.</td>
+        </tr>
+        <tr>
+          <td class="name">Metrics <span style="color:var(--text-lo); font-weight:400;">/metrics</span></td>
+          <td class="is">16+ identical scalar tiles, unit bugs (850.4%), no grouping, no trend.</td>
+          <td class="fix">Group by category with sub-headers; per-tile sparkline; semantic value
+          color (green/amber/red against threshold); fix the unit registry.</td>
+        </tr>
+        <tr>
+          <td class="name">History <span style="color:var(--text-lo); font-weight:400;">/history</span></td>
+          <td class="is">Heavy filter bar; "Plays by Source" rendered as ~equal blue chips
+          (39/66/43/2) so the eye can't read the distribution.</td>
+          <td class="fix">Replace the chip row with a <strong>horizontal bar chart</strong> (one
+          line, five segments, source-colored). Smarter date formatting. The History table is
+          fine — just give it more vertical space by collapsing the filter into a single row.</td>
+        </tr>
+        <tr>
+          <td class="name">System <span style="color:var(--text-lo); font-weight:400;">/system</span></td>
+          <td class="is">Tab strip with 7 tabs in one row, mixed icon weights. System Stats cards
+          have uneven heights. Audio Engine State card is half-empty.</td>
+          <td class="fix">Consider <strong>left-rail tabs</strong> (vertical) on this page — 7 is
+          a lot for a horizontal strip on touch. Use a 2×3 metric grid with uniform card
+          heights and a single tall "platform" card on the right.</td>
+        </tr>
+        <tr>
+          <td class="name">Phone <span style="color:var(--text-lo); font-weight:400;">/phone</span></td>
+          <td class="is">Has its own scoped CSS file — not audited from screenshots.</td>
+          <td class="fix">Make sure it uses the same dock/route-toggle vocabulary as the rest of
+          the app; phone is an output, not a separate paradigm.</td>
+        </tr>
+        <tr>
+          <td class="name">File Browser <span style="color:var(--text-lo); font-weight:400;">dialog</span></td>
+          <td class="is">JSON-escape bug in filter; breadcrumb / drive mismatch; small folder
+          icons.</td>
+          <td class="fix">Filter as chips. One source of truth for current path. Larger folder
+          icons (current ones are ~24px, should be 36–40px for touch list rows). Recent paths
+          docked to the right.</td>
+        </tr>
+        <tr>
+          <td class="name">Bluetooth <span style="color:var(--text-lo); font-weight:400;">/bluetooth</span></td>
+          <td class="is">Not in screenshots; exists in <code>Pages/</code>.</td>
+          <td class="fix">Treat as a parallel of the Radio detail surface: device list + pairing
+          status + current AVRCP metadata + volume / EQ. Same chrome.</td>
+        </tr>
+        <tr>
+          <td class="name">Diagnostic <span style="color:var(--text-lo); font-weight:400;">/diagnostic</span></td>
+          <td class="is">Internal page.</td>
+          <td class="fix">Move the distortion marker, fingerprint detail panel, and "Updates/sec"
+          telemetry here behind a gesture-unlocked entry.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+
+  <!-- ───────────── System-level ───────────── -->
+  <section id="system">
+    <div class="section-head">
+      <span class="section-num">05</span>
+      <h2>System-level recommendations</h2>
+      <span class="section-sub">Cuts across pages</span>
+    </div>
+
+    <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px;">
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">A. One formatting layer</h4>
+        <p>Create <code>Radio.Web/Formatting/</code> with <code>FormatDuration</code>,
+        <code>FormatTimestamp</code>, <code>FormatFrequency</code>, <code>FormatBytes</code>,
+        <code>FormatPercent</code>, <code>FormatDeviceName</code>, <code>FormatSourceName</code>.
+        Forbid passing raw DTOs into Razor templates. This single discipline removes ~half the P0
+        findings above.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">B. Skeleton + empty kit</h4>
+        <p>Three Razor components: <code>&lt;Skeleton Shape="now-playing | radio | list" /&gt;</code>,
+        <code>&lt;EmptyState Icon Title Body Action /&gt;</code>,
+        <code>&lt;ErrorState Title Detail Retry /&gt;</code>. Every async-bound surface uses one of
+        these in its <code>@if(_loading)</code> branch.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">C. Persistent now-playing dock</h4>
+        <p>Mount once in <code>MainLayout</code>, hide on <code>/</code>. Reads from the same
+        <code>AudioStateHubService</code> already feeding the home page. ~80 lines of Razor +
+        a slot in the layout grid.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">D. Dev-tools gate</h4>
+        <p>Triple-tap the top-right corner of the clock to unlock a dev tray containing the
+        distortion marker, fingerprint event log, updates/sec, frame dump, log download. Locks
+        again after 30s of no interaction.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">E. Motion budget</h4>
+        <p>You have 30+ <code>@keyframes</code> defined. The screenshots don't show any of them
+        in play. Pick six (page-transition, list-add, list-remove, ken-burns, eq-bounce,
+        track-change) and enforce them on the surfaces that need them. Delete or hide the rest
+        until they're used — they're vocabulary debt right now.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">F. Sleep is a screen, not a JS hack</h4>
+        <p>The current sleep flow blacks the screen via JS + a Blazor call. Treat sleep as a
+        first-class route (<code>/sleep</code>) with an ambient view — large clock, faint album
+        art, a single "tap anywhere" hint. Wake on any interaction. Makes the device feel less
+        like "off" and more like "resting".</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">G. Accessibility passes you'll want anyway</h4>
+        <p>Add <code>aria-label</code> on every icon-only button (90% of the top bar). Make
+        focus rings visible — currently
+        <code>-webkit-tap-highlight-color: transparent</code> across the board removes both touch
+        and keyboard feedback. Use Radzen's <code>Tooltip</code> on the icon nav so the labels
+        appear on long-press.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">H. Tighter "source / output" model in UI</h4>
+        <p>Currently three things hold related state: <code>SourcesApiService</code>,
+        <code>DevicesApiService</code>, <code>AudioStateHubService</code>. The UI binds to each
+        separately and races on first load (you'll see brief mismatches in the screenshots —
+        topbar shows FilePlayer source while Now Playing card says Radio). One Razor-side
+        <code>RoutingViewModel</code> that <em>derives</em> from the hub and exposes <code>{
+        source, output, route, isReady }</code> would remove a class of glitches.</p>
+      </div>
+
+    </div>
+  </section>
+
+
+  <!-- ───────────── Roadmap ───────────── -->
+  <section id="roadmap">
+    <div class="section-head">
+      <span class="section-num">06</span>
+      <h2>Suggested order of attack</h2>
+      <span class="section-sub">Three phases · ~3 sprints</span>
+    </div>
+
+    <div class="roadmap">
+      <div class="phase">
+        <div class="pnum">01</div>
+        <div class="pname">Stop the bleeding</div>
+        <ul>
+          <li>Formatting layer for durations, timestamps, sizes</li>
+          <li>Fix the metrics unit registry · kill <code>850.4%</code></li>
+          <li>Fix the File Browser filter JSON-escape bug</li>
+          <li>Strip the distortion-marker debug from production chrome</li>
+          <li>UUID-suffixed source IDs out of dropdowns</li>
+        </ul>
+      </div>
+      <div class="phase">
+        <div class="pnum">02</div>
+        <div class="pname">Finish the surface</div>
+        <ul>
+          <li>Persistent now-playing dock on non-home pages</li>
+          <li>Skeleton kit + EmptyState component, applied everywhere</li>
+          <li>Redesigned top bar — labeled route + nav zones</li>
+          <li>Single-action source pills + explicit "open detail" affordance</li>
+          <li>Metrics: groups, sparklines, semantic color</li>
+        </ul>
+      </div>
+      <div class="phase">
+        <div class="pnum">03</div>
+        <div class="pname">Polish + scale</div>
+        <ul>
+          <li>Queue split layout, history bar chart, devices two-column</li>
+          <li>Visualizer mode picker promoted to panel header</li>
+          <li>Dev-tools gesture + diagnostic page consolidation</li>
+          <li>Sleep as a first-class ambient screen</li>
+          <li>Accessibility + focus pass; <code>kiosk</code> type-scale variant</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+
+  <div class="endplate">
+    <span>Radio.Web · Design Review</span>
+    <span>· · ·</span>
+    <span>Generated · v1 · 2026</span>
+  </div>
+
+</div>
+
+<script>
+  // Light: live clock in the rail
+  function tick() {
+    const d = new Date();
+    const h = String(d.getHours()).padStart(2, '0');
+    const m = String(d.getMinutes()).padStart(2, '0');
+    document.getElementById('clock').textContent = h + ':' + m;
+  }
+  tick();
+  setInterval(tick, 30000);
+</script>
+</body>
+</html>

--- a/docs/handoffs/design_handoff_radio_console/Handoff Canvas.html
+++ b/docs/handoffs/design_handoff_radio_console/Handoff Canvas.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Radio Console — Visual Handoff</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<style>
+  html, body { margin: 0; padding: 0; background: #f0eee9; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="mocks.jsx"></script>
+<script type="text/babel" src="app.jsx"></script>
+</head>
+<body>
+<div id="root"></div>
+</body>
+</html>

--- a/docs/handoffs/design_handoff_radio_console/IMPLEMENTATION.md
+++ b/docs/handoffs/design_handoff_radio_console/IMPLEMENTATION.md
@@ -1,0 +1,570 @@
+# Implementation Script — Radio Console Design Tightening
+
+> **For the implementing agent (Claude Code or human):**
+> This script maps one canvas artboard → one set of file changes. Land changes in the order given. Do not start any section whose status is not `[APPROVED]`.
+>
+> Every section uses the same shape:
+> 1. **Reference** — which artboard / which finding
+> 2. **Files** — exact paths to touch
+> 3. **Steps** — numbered, concrete
+> 4. **Acceptance** — checkable criteria
+> 5. **Notes** — gotchas, dependencies, what NOT to change
+>
+> Tokens to use are in `src/Radio.Web/wwwroot/css/design-system.css`. Do not invent new colors, type, or spacing — extend the token block first if you genuinely need a new value.
+
+---
+
+## P0 — Fix before anything else
+
+These are bugs, data hygiene problems, and production-hygiene issues that the design system can't paper over.
+
+---
+
+### P0·0 — Formatting layer (foundation)
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Underpins P0·2, P0·3, P1·3 and the Metrics work in P0·4.
+**Files:**
+- `src/Radio.Web/Formatting/Durations.cs` (new)
+- `src/Radio.Web/Formatting/Timestamps.cs` (new)
+- `src/Radio.Web/Formatting/DisplayNames.cs` (new)
+- `src/Radio.Web/Formatting/Units.cs` (new)
+- `src/Radio.Web/_Imports.razor` (add `@using Radio.Web.Formatting`)
+
+**Steps:**
+
+1. Create the `Radio.Web.Formatting` namespace as a flat folder of `static class` helpers. No DI, no state.
+
+2. `Durations.FormatTrack(TimeSpan t)`:
+   - `t < 1 hour` → `"{m}:{ss:00}"` (e.g. `3:00`)
+   - `t >= 1 hour` → `"{h}:{mm:00}:{ss:00}"` (e.g. `1:02:14`)
+   - `t.TotalSeconds < 1 || t == TimeSpan.Zero` → `"—"`
+   - `null` → `"—"`
+
+3. `Durations.FormatLong(TimeSpan t)` for queue totals: always `h:mm:ss` form (e.g. `2:48:15`).
+
+4. `Timestamps.FormatRelative(DateTime utc)`:
+   - Same calendar day → `"Today {HH:mm}"`
+   - Yesterday → `"Yesterday {HH:mm}"`
+   - Older than 48h → `"{MMM d} · {HH:mm}"`
+   - Caller is responsible for converting from UTC to local before display.
+
+5. `DisplayNames.Source(AudioSourceDto s)`:
+   - Strip any `-{guid}` suffix from `Id` if `Name` is missing.
+   - Return `Name` if set, else humanized `Type` (`"FilePlayer"` → `"File Player"`).
+   - **Never** return the raw `Id`.
+
+6. `DisplayNames.Device(AudioDeviceDto d, IDictionary<string,string>? aliasMap = null)`:
+   - Apply `aliasMap` first (e.g. `"CABLE Input (VB-Audio Virtual Cable)" → "VB-Audio Cable"`). The map should live in `appsettings.json` under `Devices:Aliases`.
+   - Strip trailing parenthesized hardware-driver suffixes when the head is sufficiently descriptive (`"LG TV SSCR2 (AMD High Definition Audio Device)"` → `"LG TV"`).
+   - Strip leading `"N - "` enumeration prefixes.
+   - Cap at 40 chars with ellipsis.
+
+7. `DisplayNames.Track(NowPlayingDto np)`:
+   - Prefer `np.Title` if non-empty and not literally `"Track {n}"` filename-derived.
+   - When `Title` looks generic, attempt to parse the source `FilePath`: strip extension, strip leading `^\d+[\s\-_]+` (track number), title-case if all-lowercase.
+   - Subtitle is `np.Artist ?? "—"`.
+
+8. `Units` enum and `Units.Format(double value, Units unit)`:
+   ```csharp
+   public enum Units {
+     Percent,       // 35.7%
+     Megabytes,     // 850 MB
+     Milliseconds,  // 215 ms (>=1000 → "1.2 s")
+     Count,         // 135,725
+     PerMinute,     // 12.4/min
+     Frequency,     // 88.5 MHz (uses existing FrequencyFormatter)
+     Decibels,      // -3 dB
+     Bare           // 65
+   }
+   ```
+   - Always thousands-separated for `Count`.
+   - One decimal for `Percent` if value < 10, else integer.
+
+**Acceptance:**
+
+- [ ] All four files compile, exist under `Radio.Web.Formatting`, are referenced from at least one Razor file by end of P0·1.
+- [ ] `Durations.FormatTrack(TimeSpan.FromSeconds(180.6628))` → `"3:00"`.
+- [ ] `DisplayNames.Source` never returns a string containing a GUID character span (regex: `[0-9a-f]{8}-[0-9a-f]{4}`).
+- [ ] No `.ToString()` on a `TimeSpan` remains anywhere in `Components/` after P0·3 lands.
+
+**Notes:**
+
+This file is small but it is the single biggest leverage in the package — three later P0s depend on it. Land this first, even if it goes out behind a feature flag.
+
+---
+
+### P0·1 — Top bar redesign
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0 — fix before anything else` → **"Top bar redesign"**
+**Files:**
+- `src/Radio.Web/Components/Layout/MainLayout.razor`
+- `src/Radio.Web/wwwroot/css/design-system.css` (`§5 Top Bar`, `§6 Route Toggle`, `§7 Navigation Icons`)
+
+**Steps:**
+
+1. **Bump topbar height** from `80px` → `120px` in `design-system.css §2`:
+   - `--topbar-height: 120px;`
+   - `--content-height: 600px;`
+   - Verify nothing else hard-codes 720/640 split (search the project for `640px` and `80px`).
+
+2. **Restructure the topbar** in `MainLayout.razor` from one flex row into a two-row stack inside `.topbar`:
+   - Row 1 (`.topbar-primary`, 64px) — Time cluster | In cluster | `→` glyph | Out cluster | nav pill strip.
+   - Row 2 (`.topbar-sources`, 56px) — Source bubble strip, left-aligned.
+
+3. **Add `.cluster` styles** in `design-system.css §5`:
+   - `.cluster-label` — uses `var(--font-mono)`, `10px`, `0.16em` letter-spacing, `var(--text-low)`, uppercase.
+   - `.cluster-value` — `15px`, `var(--text-high)`, `font-weight: 500`. May contain an inline `--font-led` numeric span for frequency / clock time.
+   - `.cluster-swatch` — `8×8` square, `2px` radius, used to show the source / output color dot inline with the value.
+
+4. **Replace the nine circular `.nav-icon` buttons** with rectangular `.nav-pill`:
+   - `height: 56px; padding: 0 16px; border-radius: 10px;`
+   - Contains label text (Inter, `12px`, `0.10em` letter-spacing, uppercase, 500 weight) — no more icon-only navigation in the top row.
+   - Active state: `background: var(--accent-dim); color: var(--accent);`
+   - Badge variant for Queue count: `<span class="nav-badge">45</span>` styled as amber pill, 10px font.
+
+5. **Source bubbles** — extract into `Components/Shared/SourceBubble.razor`:
+   - Props: `Icon`, `Label`, `Sub`, `Accent` (CSS variable name), `IsActive`, `IsDisabled`, `HasDetail`, `OnSwitch`, `OnOpenDetail`.
+   - Render: pill shape (`height: 48px; border-radius: 24px`), 28×28 round icon chip on the left, label + optional sub.
+   - When `IsActive`, use `background: {accent}14; border: 1px solid {accent}55; color: {accent};`.
+   - When `IsActive && HasDetail`, render a trailing `›` glyph as a separate focusable element bound to `OnOpenDetail`.
+   - When `IsDisabled`, `opacity: 0.4; pointer-events: none;` and append " · offline" to the sub.
+
+6. **Remove the inline `RadzenButton` debug distortion marker** from `MainLayout.razor` (lines ~48–55). Move it to the dev tray in P2·2. Until P2·2 ships, gate it behind `#if DEBUG` so it never appears in release builds.
+
+7. **Sticky/fixed positioning:** the existing `position: fixed` on `.topbar` is fine; just verify the content offset (`margin-top` on `.content-area`) tracks `--topbar-height` not a hard 80.
+
+**Acceptance:**
+
+- [ ] Top bar matches the "After" artboard within ±2px on a 1920-wide preview.
+- [ ] No circular pill remains anywhere in the top bar.
+- [ ] Active source AND active output both show their human name, not just a colored icon.
+- [ ] Debug button is gone from release builds.
+- [ ] Content pages still vertically fit (600px content area) without scrollbars on Home/Devices/Queue.
+
+**Notes:**
+
+The current `route-toggle` CSS class is referenced from `MainLayout.razor` only. Safe to delete after the migration. The `data-source` attribute mechanism (per-source color) moves onto `SourceBubble` — keep the attribute name so any existing tests don't break.
+
+---
+
+### P0·2 — Surface clean display names
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0` → **"Source & device names"**
+**Files:**
+- `src/Radio.Web/Components/Layout/MainLayout.razor`
+- `src/Radio.Web/Components/Shared/NowPlayingPanel.razor`
+- `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor`
+- `src/Radio.Web/Components/Pages/DeviceManagementPage.razor`
+- `src/Radio.Web/Components/Dialogs/FileBrowserDialog.razor`
+- `src/Radio.Web/appsettings.json` (`Devices:Aliases` map)
+
+**Steps:**
+
+1. Add `Devices:Aliases` to `appsettings.json`:
+   ```json
+   "Devices": {
+     "Aliases": {
+       "CABLE Input (VB-Audio Virtual Cable)": "VB-Audio Cable In",
+       "CABLE In 16ch (VB-Audio Virtual Cable)":  "VB-Audio Cable 16ch",
+       "Realtek Digital Output (Realtek USB Audio)": "Realtek USB · S/PDIF"
+     }
+   }
+   ```
+   Bind into a typed `DevicesOptions` and inject where needed.
+
+2. In every place that currently binds a raw DTO field to a string template, replace with the appropriate `DisplayNames.*` call from P0·0.
+   - In MainLayout: source bubble `Label` = `DisplayNames.Source(source)`.
+   - In NowPlayingPanel: title/subtitle = `DisplayNames.Track(np)`.
+   - In Device tables: name = `DisplayNames.Device(d, aliasMap)`.
+
+3. Add a `title` attribute (HTML tooltip) on every display-name element so the **raw** name is reachable on hover — useful for debugging and accessibility.
+
+**Acceptance:**
+
+- [ ] No GUID character span (`[0-9a-f]{8}-[0-9a-f]{4}`) appears in any user-visible text on Home, Devices, Queue, History, File Browser.
+- [ ] `Track 8` / `Track 9` from `Cary High Chorus / Fall Concert 2006` displays as the parsed file name when available.
+- [ ] Long device strings are capped at 40 chars + ellipsis; full name on hover.
+
+**Notes:**
+
+Don't change the DTOs themselves — keep the raw fields available server-side. Only the *display projection* changes.
+
+---
+
+### P0·3 — Duration & timestamp formatting
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0` → **"Queue rows & duration format"**
+**Files:**
+- `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor`
+- `src/Radio.Web/Components/Shared/NowPlayingPanel.razor`
+- `src/Radio.Web/Components/Pages/PlayHistoryPage.razor`
+
+**Steps:**
+
+1. Replace every `@track.Duration.ToString()` with `@Durations.FormatTrack(track.Duration)`.
+2. Replace every progress-display `@_elapsed.ToString(@"mm\:ss")` with `@Durations.FormatTrack(_elapsed)` to handle the `>1h` long-form case.
+3. PlayHistory: replace the Date/Time column format with `@Timestamps.FormatRelative(row.PlayedAtUtc.ToLocalTime())`.
+4. Add `font-variant-numeric: tabular-nums;` to any element that displays a duration so columns line up.
+5. Right-align duration columns in tables.
+6. Add the now-playing accent treatment to the queue list:
+   - Currently-playing row gets `border-left: 3px solid var(--signal-amber);` and the number cell shows `▶` instead of its index.
+
+**Acceptance:**
+
+- [ ] No `00:03:00.6628571`-style duration appears anywhere.
+- [ ] Queue rows have a clear "this is what's playing" indicator (amber left border + ▶ glyph).
+- [ ] History "Date/Time" column reads as `Today 08:40`, `Yesterday 14:22`, or `Feb 6 · 11:05` depending on age.
+
+---
+
+### P0·4 — Metrics dashboard — units, grouping, sparklines
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0` → **"Metrics tiles"**
+**Files:**
+- `src/Radio.Web/Components/Pages/MetricsDashboardPage.razor`
+- `src/Radio.Web/Components/Shared/MetricTile.razor` (new)
+- `src/Radio.Web/Components/Shared/Sparkline.razor` (new)
+- API/model: wherever `MetricDescriptor` is declared (likely `Radio.Metrics`) — add a `Unit` field.
+
+**Steps:**
+
+1. **Add a `Unit` enum** to each metric descriptor on the server side. Defaults to `Bare` when unknown. Match the enum in `Radio.Web.Formatting.Units`.
+
+2. **`MetricTile.razor`** — parameters:
+   ```
+   Category (string, e.g. "System · Memory")
+   Name (string, e.g. "Heap in use")
+   Value (double)
+   Unit (Units)
+   Series (IReadOnlyList<double>?, last N samples) — optional
+   Thresholds (double? warn, double? critical) — optional
+   ```
+   Render:
+   - Top: category in mono, 10px, uppercase, low contrast.
+   - Middle: name in body, 13px, medium contrast.
+   - Big value: `--font-mono`, 30px, color computed from thresholds (green / amber / red), or `--text-high` when no threshold.
+   - Sparkline: if `Series` provided, render `<Sparkline />` matched to value color.
+
+3. **`Sparkline.razor`** — pure inline SVG, `viewBox="0 0 120 28" preserveAspectRatio="none"`, takes a `IReadOnlyList<double>` and a `Stroke` parameter. Filled area at 10% opacity below the line.
+
+4. **Restructure `MetricsDashboardPage.razor`**:
+   - Group tiles by category. Render each group with a sub-header (mono, 11px, uppercase, low contrast, 14px bottom margin).
+   - 2- or 4-column grid depending on density target.
+   - Remove the wall-of-tiles layout.
+
+5. **Specific fixes from the current screenshots:**
+   - `Memory Usage Mb` value is in MB not %. Unit = `Megabytes`. Tile shows `850 MB`, not `850.4%`.
+   - `Signal Strength` value is bare. Unit = `Percent`. Tile shows `65%`.
+   - `Frequency Changes` is a count — Unit = `Count`, format with thousands separator.
+   - `Latency Ms` — Unit = `Milliseconds`, formatter auto-converts to `s` above 1000.
+
+**Acceptance:**
+
+- [ ] Memory usage tile reads `850 MB` (or current value with unit `MB`) — never `%`.
+- [ ] Each tile shows a sparkline when time-series data is available for that metric in the selected window.
+- [ ] Category headers replace the per-tile category prefix.
+- [ ] Tile value color matches threshold semantics (green/amber/red) — not every tile is cyan.
+
+---
+
+### P0·5 — File Browser filter — chips, no string
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0` → **"File browser filter"**
+**Files:**
+- `src/Radio.Web/Components/Dialogs/FileBrowserDialog.razor`
+
+**Steps:**
+
+1. Locate the current filter state. It is almost certainly a `string` bound to a `RadzenDropDown` whose value is being JSON-serialized for persistence and re-bound on load without deserializing. Find the persistence boundary (look for `JsonSerializer.Serialize` calls referencing a filter or for `LocalStorage`-backed filter persistence).
+
+2. Replace with:
+   - `List<string> _filterExtensions = new();`
+   - On load, deserialize from persistence into the list directly. If the persisted blob is the double-escaped form, run a one-time repair pass (parse repeatedly until you get a `string[]`, then take it).
+
+3. Render as a row of `RadzenChip` elements, each with a remove `×`. Append a dashed `＋ add type` chip that opens a small popover with a curated set of common extensions (`.mp3 .flac .wav .m4a .aac .ogg .opus .wma`).
+
+4. Wire the filter into the file list query: case-insensitive `EndsWith` match across the list.
+
+**Acceptance:**
+
+- [ ] No escaped JSON ever appears in the filter UI.
+- [ ] Chips reorder and remove cleanly; persistence round-trips without re-escaping.
+- [ ] Adding `.mp3` filters the file list immediately, no Apply button.
+
+**Notes:**
+
+Also fix the breadcrumb / drive selector mismatch noted in the audit — the screenshot shows drive `C:\` selected while the breadcrumb reads `D:\`. They should bind to the same source of truth (`_currentPath`).
+
+---
+
+## P1 — Big quality wins
+
+These don't fix bugs, they fix the *shape* of the product.
+
+---
+
+### P1·1 — Persistent Now Playing dock
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1 — big quality wins` → **"Persistent Now Playing dock"**
+**Files:**
+- `src/Radio.Web/Components/Shared/NowPlayingDock.razor` (new)
+- `src/Radio.Web/Components/Layout/MainLayout.razor`
+- `src/Radio.Web/wwwroot/css/design-system.css` (new `§N Dock`)
+
+**Steps:**
+
+1. Build `NowPlayingDock.razor`:
+   - Height: 64px, sits at the bottom edge of the content area.
+   - Layout (left → right): art thumbnail 48×48 → title + artist → 3-bar EQ animation (existing `.now-playing-bars` keyframes) → elapsed `mm:ss` → progress bar (3px, `--accent`) → total `mm:ss` → ⏮ play/pause ⏭.
+   - Subscribes to `AudioStateHubService.NowPlayingChanged` and `.PlaybackStateChanged` only — no additional polling.
+   - On click anywhere on the title/art block, `NavigationManager.NavigateTo("/")`.
+   - Backdrop: `background: var(--surface-overlay); backdrop-filter: blur(20px); border-top: 1px solid var(--surface-separator);`.
+
+2. Mount in `MainLayout.razor`:
+   - Place inside `.content-area` as a sibling of `.page-transition`, absolute-positioned to the bottom.
+   - Render only when `NavigationManager.ToBaseRelativePath(Uri) is not "" or "/"` — i.e. not on Home (where `NowPlayingPanel` owns the column).
+   - When dock is rendered, reduce `.page-transition`'s effective height by 64px so content doesn't slide under it.
+
+3. Add the source color dot next to the artist line (8×8 square, 2px radius) using the existing `--source-*` variables.
+
+**Acceptance:**
+
+- [ ] Navigating from `/` → `/devices` reveals the dock; navigating back to `/` removes it cleanly.
+- [ ] The dock shows the same track / state as the home page within one SignalR round-trip.
+- [ ] Tapping the title takes the user home.
+- [ ] No layout shift when track changes (use `min-width: 200px` on the metadata block).
+
+---
+
+### P1·2 — Source pill semantics
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1` → **"Source pill semantics"**
+**Files:**
+- `src/Radio.Web/Components/Layout/MainLayout.razor` (method `HandleSourceToggleAsync`)
+- `src/Radio.Web/Components/Shared/SourceBubble.razor` (from P0·1)
+
+**Steps:**
+
+1. Delete the second-tap-toggles-panel and second-tap-navigates branches in `HandleSourceToggleAsync`. Tapping a source's body **always** switches to that source. Period.
+
+2. In `SourceBubble.razor`, render the active pill with a trailing `›` chevron when `HasDetail == true`. The chevron is a separate clickable element with its own `OnOpenDetail` handler. Stop the click event from bubbling to the body.
+
+3. `HasDetail` is true for source types that have a dedicated detail surface: `Radio`, `RTLSDRCore`, `RF320`, `Bluetooth`. Not for `File`, `USB`.
+
+4. When chevron is tapped:
+   - Radio family → `NavigateTo("/")` + show Radio control panel via `RadioPanelToggleService.ShowRadioPanelAsync()`.
+   - Bluetooth → `NavigateTo("/bluetooth")`.
+
+5. The current `RadioPanelToggleService` should no longer be flipped by source-tap. Only by explicit chevron tap or by an in-panel close. Audit calls to `ToggleRadioPanelAsync()` and remove the tap-driven ones.
+
+**Acceptance:**
+
+- [ ] Tapping any source pill switches to that source exactly once, never opens a panel.
+- [ ] The active source pill shows a chevron only when a detail surface exists.
+- [ ] Tapping the chevron opens that detail; the rest of the pill does not.
+
+---
+
+### P1·3 — Visualizer panel — promoted mode picker
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1` → **"Visualizer panel"**
+**Files:**
+- `src/Radio.Web/Components/Shared/VisualizerPanel.razor`
+
+**Steps:**
+
+1. Replace the corner mode chip group (VU / WAVE / SPECTRUM) with a full-width 3-segment header inside the panel:
+   - Grid layout, 3 equal columns, 44px tall.
+   - Mono font, 12px, uppercase, `0.10em` letter-spacing.
+   - Active segment: `background: var(--accent-dim); color: var(--accent);` with a 2px underline accent.
+   - Inactive segments: `color: var(--text-medium);` separated by 1px `var(--surface-separator)` borders.
+
+2. The canvas/SVG visualization fills the remaining vertical space. Remove the current padding around it.
+
+3. Move the "Connected" pill to a single 8px dot at the top-right of the panel header, color `var(--signal-green)` when connected, `var(--signal-red)` when not. No text label — the dot is enough.
+
+4. Remove the burned-in `"Updates: 22/sec"` yellow caption from the canvas. Add it to the dev tray in P2·2.
+
+5. Frequency-band axis labels (`375Hz / 750Hz / 1.1kHz / 1.5kHz`) should sit *under* the canvas in a thin (16px) strip, mono font, 10px, low contrast — not inside the canvas overlapping the bars.
+
+**Acceptance:**
+
+- [ ] Mode picker is the obvious primary control of the panel.
+- [ ] Canvas fills the available height/width with no debug telemetry overlaid.
+- [ ] Connection state is a small dot, not a pill.
+
+---
+
+### P1·4 — Queue split layout
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1` → **"Queue page — split layout"**
+**Files:**
+- `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor`
+
+**Steps:**
+
+1. Split the panel into two columns: `flex: 1.6` (list) | `flex: 1` (context). 12px gap.
+
+2. Add a tab strip at the top of the list column:
+   - Three pills: `Queue · N` / `History` / `Radio` (the third only when the active source is a radio type).
+   - Use the existing `--accent-dim` for active background, mono font, 12px uppercase 0.10em letter-spacing.
+
+3. Right context panel — three stacked tiles:
+   - **Queue Total** — `--font-led`, 30px, amber, shows `Durations.FormatLong(totalRuntime)` plus a sub-line: `{count} tracks · ends ~{nowPlus(total):HH:mm}`.
+   - **Up next** — three 32×32 album-art thumbnails with title + artist, each line dimmed progressively (text-high → text-medium → text-low).
+   - **Save as playlist** — accent-bordered CTA tile with `＋ Save as playlist` text.
+
+4. The current ADD FILES / CLEAR ALL header buttons move into a kebab menu in the list-column header. They should not occupy a whole top row.
+
+**Acceptance:**
+
+- [ ] The content area is filled when the queue has 1+ tracks (no large empty void below).
+- [ ] Tapping the History tab swaps the list contents without remounting the right column (the right column updates its content to "History stats" — total plays, top track, top artist).
+- [ ] Save-as-playlist tile triggers the existing save dialog.
+
+---
+
+### P1·5 — Skeleton loading states
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1` → **"Skeleton loading states"**
+**Files:**
+- `src/Radio.Web/Components/Shared/Skeleton.razor` (new)
+- All loading branches across `NowPlayingPanel`, `RadioControlPanel`, `QueueHistoryPanel`, `VisualizerPanel`, `DeviceManagementPage`, `PlayHistoryPage`.
+
+**Steps:**
+
+1. Build `Skeleton.razor` with one parameter:
+   ```
+   public enum Shape { NowPlaying, Radio, ListRow, DeviceRow, MetricTile, Visualizer }
+   [Parameter] public Shape Shape { get; set; }
+   ```
+   Each shape renders a shape-matched arrangement of the existing `.skeleton-*` divs from `design-system.css §17`. Sizes match the real component layout.
+
+2. Replace every `RadzenProgressBarCircular` used as a generic loading indicator with `<Skeleton Shape="..." />`.
+
+3. Keep `RadzenProgressBarCircular` only for *modal / determinate* progress (e.g. file scan progress bar).
+
+**Acceptance:**
+
+- [ ] No centered spinner in a panel-body loading branch anywhere in `Components/`.
+- [ ] First-load on Radio shows a freq-well shape + band buttons + meter outlines, then animates to real content.
+
+---
+
+## P2 — System polish
+
+Things that change how the device feels in the room.
+
+---
+
+### P2·1 — Sleep as a screen
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `System polish` → **"Sleep — ambient screen"**
+**Files:**
+- `src/Radio.Web/Components/Pages/Sleep.razor` (new — route `/sleep`)
+- `src/Radio.Web/wwwroot/js/idle-dimmer.js` (existing — modify to navigate, not overlay)
+- `src/Radio.Web/Components/Layout/MainLayout.razor` (`HandleSleepButtonAsync`)
+
+**Steps:**
+
+1. Build `/sleep` page with `@layout EmptyLayout` (no top bar):
+   - Background `#050507` with a radial amber glow at center, very subtle.
+   - 160×160 faint album art block at center, 40% opacity.
+   - Large clock below: `--font-led`, **96px**, amber, with a strong glow shadow.
+   - Track title + artist line at 18px in a very dim color.
+   - Hint text at the bottom: `tap anywhere to wake`, mono 11px, very dim, uppercase, letter-spaced.
+
+2. `HandleSleepButtonAsync` in `MainLayout`: call `SystemApi.SetSleepAsync(true)` then `NavigationManager.NavigateTo("/sleep")`.
+
+3. `Sleep.razor` has a full-screen `@onclick` handler that calls `SystemApi.SetSleepAsync(false)` then `NavigationManager.NavigateTo("/")`.
+
+4. `idle-dimmer.js` no longer overlays the page; it navigates to `/sleep` when idle.
+
+5. SignalR `SleepStateChanged` event still drives the page — if the server reports wake-from-elsewhere while we're on `/sleep`, navigate home.
+
+**Acceptance:**
+
+- [ ] Tapping the sleep button takes the user to `/sleep` with a fade-in.
+- [ ] Tapping anywhere on `/sleep` wakes and returns to last route.
+- [ ] No black overlay hack remains in JS.
+
+---
+
+### P2·2 — Dev tools gesture & tray
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `System polish` → **"Dev tools"**
+**Files:**
+- `src/Radio.Web/Components/Shared/DevTray.razor` (new)
+- `src/Radio.Web/Components/Layout/MainLayout.razor`
+- `src/Radio.Web/wwwroot/js/dev-gesture.js` (new)
+
+**Steps:**
+
+1. Add a 48×48 invisible hit area in the top-right corner of the topbar. Counts taps client-side via `dev-gesture.js`. Three taps within 1.5s call into Blazor (`DotNetObjectReference`) → toggle `_isDevTrayOpen`.
+
+2. `DevTray.razor` is positioned-fixed at top-right, slides down with a small drop shadow:
+   - Header: `● Dev Tray · unlocked · auto-lock 0:30`.
+   - 2×3 grid of action cards:
+     - **Mark distortion** — calls `AudioApi.ReportDistortionAsync()` (the action currently on the topbar button).
+     - **Updates: NN/sec** — live visualizer telemetry (moved from `VisualizerPanel`).
+     - **Dump audio frame** — last 5s buffer dump.
+     - **Download logs** — last hour, zip.
+     - **Fingerprint events** — opens the existing fingerprint detail panel.
+     - **Engine state** — readable string of the current `AudioStateHubService` state.
+   - Auto-locks after 30s of no interaction with the tray (a timer driven by `DevTray.razor`).
+
+3. Move the distortion-marker button **out** of `MainLayout.razor` entirely.
+
+**Acceptance:**
+
+- [ ] No dev-only UI is visible in production chrome without the gesture.
+- [ ] The gesture works at native 1920×720 touch resolution.
+- [ ] Tray auto-locks after 30s.
+
+---
+
+## Cross-cutting nice-to-haves
+
+These don't have their own canvas artboards but should land alongside the P0/P1 work in the same files.
+
+- **Hidden scrollbars** — `design-system.css §19` currently hides every scrollbar. Add a thin (3px) always-visible thumb just on `.panel-body` and `.queue-list-wrapper` so the "more content below" hint exists. CSS:
+  ```css
+  .panel-body { scrollbar-width: thin; scrollbar-color: var(--text-low) transparent; }
+  .panel-body::-webkit-scrollbar { display: block; width: 3px; }
+  .panel-body::-webkit-scrollbar-thumb { background: var(--text-low); border-radius: 2px; }
+  ```
+- **Bump `--text-medium`** from `#9CA3AF` to `#B5BCC9` in `design-system.css §2` for better legibility at touchscreen viewing distance.
+- **`aria-label` on every icon-only button** in `MainLayout` (Sleep, Queue badge, debug if it stays).
+- **Visible focus rings**: keep `-webkit-tap-highlight-color: transparent` for touch, but add `:focus-visible` outlines with `outline: 2px solid var(--accent); outline-offset: 2px;`.
+
+## What NOT to change
+
+- The DSEG amber LED treatment for time / frequency. It is the strongest visual element in the app — keep it on `.display-frequency`, `.topbar-clock`, sleep screen, queue total. Do not extend it to regular UI text.
+- The per-source color mapping (`--source-vinyl / -file / -radio / -bluetooth / -usb`). Already correct.
+- The three-column home page split (520 / fill / 710). The proportions work.
+- SignalR push patterns. They are the right architecture for this app.
+
+---
+
+## Build / verify checklist
+
+After landing each section:
+
+- [ ] `dotnet build` clean.
+- [ ] `dotnet test` green (`tests/Radio.Web.Tests`).
+- [ ] Run E2E suite (`scripts/run-e2e-tests.ps1` or `.sh`).
+- [ ] Eyeball the affected page in the dev build at native 1920×720 — content fits, no scrollbars except where intended, no debug UI visible.
+- [ ] Take a fresh screenshot into `screenshots/{page}.png` (overwrite the current one) so the next design pass starts from a current baseline.

--- a/docs/handoffs/design_handoff_radio_console/README.md
+++ b/docs/handoffs/design_handoff_radio_console/README.md
@@ -1,0 +1,52 @@
+# Handoff: Radio Console — Design Tightening Pass
+
+## Overview
+
+This package contains a curated set of design improvements for the **Radio.Web** Blazor Server kiosk app (the 1920×720 multi-source audio console at `src/Radio.Web/`). It is the deliverable from a design-review pass that audited the current screens (`screenshots/*.png`) against `design-system.css` and the shared panel components.
+
+The goal is not a rebuild. The aesthetic — broadcast-console dark + DSEG amber LED + electric cyan accent + per-source color coding — is intact and good. The package fixes **what's leaking through the surface** (raw IDs, raw `TimeSpan`s, unit bugs, debug controls in production chrome, half-empty pages) and **promotes a few components** that were sitting in the corner doing real work (Visualizer mode picker, source-pill detail affordance).
+
+## About the design files
+
+The HTML files in this folder are **design references**, not code to copy into the app:
+
+- `Design Analysis.html` — long-form audit identifying 5 P0, 8 P1, and 11 P2 findings, with severity ratings and rationale.
+- `Handoff Canvas.html` (+ `design-canvas.jsx`, `mocks.jsx`, `app.jsx`) — a pan/zoom canvas of **12 focused before/after artboards**, one per proposed change. This is what the developer should treat as the visual spec.
+
+Both files are styled in the project's own design language (same tokens, same fonts where shippable). The real implementation happens **in the existing Blazor codebase** using its existing components (Radzen, the design-system tokens, the SignalR hub) — not by porting HTML into the app.
+
+## Fidelity
+
+**High-fidelity for visuals, behaviour-spec for interactions.**
+
+- Spacing, colors, typography, and component shapes shown in the canvas mocks should be matched within ±2px and exact token values (mocks use the same hex values as `design-system.css`).
+- Interaction details (gestures, state machines, route changes) are written out in `IMPLEMENTATION.md`. The mocks are static — they cannot show motion or transitions, so the script is the source of truth there.
+
+## How to use this package
+
+1. **Review `Handoff Canvas.html`** first. The user has labeled which artboards are approved, parked, or need iteration via the inline edit / drag-reorder controls.
+2. **Read `IMPLEMENTATION.md`**. Each section maps one canvas artboard → one or more files in `src/Radio.Web/` with concrete steps, code references, and acceptance criteria.
+3. **Skip any section marked `[PARKED]` or `[NEEDS ITERATION]`** at the top — those are not approved yet.
+4. **Land changes in the order given** (P0 → P1 → P2). P0 includes one new file (`Formatting/DisplayNames.cs`) that several later changes depend on.
+
+## Status legend
+
+Each change in `IMPLEMENTATION.md` carries one of:
+
+| Status | Meaning |
+|---|---|
+| `[APPROVED]` | Ship as specified. |
+| `[PENDING REVIEW]` | Drafted but not yet locked. Don't start. |
+| `[NEEDS ITERATION]` | User has comments; see the inline note for what to change. |
+| `[PARKED]` | Out of scope for this pass. |
+
+## Files in this folder
+
+- `README.md` — this file.
+- `IMPLEMENTATION.md` — the developer script, one section per change.
+- `Design Analysis.html` — long-form audit with rationale and severity ratings.
+- `Handoff Canvas.html` + `design-canvas.jsx` + `mocks.jsx` + `app.jsx` — visual specs.
+
+## Design tokens
+
+All values referenced in the implementation script already exist in `src/Radio.Web/wwwroot/css/design-system.css`. Do **not** introduce new tokens; if a value is needed that isn't tokenized, add it to design-system.css first under the appropriate section (`§2 CSS Custom Properties`) and reference it from there.

--- a/docs/handoffs/design_handoff_radio_console/app.jsx
+++ b/docs/handoffs/design_handoff_radio_console/app.jsx
@@ -1,0 +1,83 @@
+// handoff-app.jsx — assemble the design canvas
+
+const { useEffect } = React;
+
+function App() {
+  useEffect(() => { document.title = 'Radio Console — Visual Handoff'; }, []);
+
+  return (
+    <DesignCanvas>
+
+      <DCSection
+        id="p0"
+        title="P0 — fix before anything else"
+        subtitle="Bugs and IDs leaking through the surface. Each of these makes the product look unfinished or untrustworthy."
+      >
+        <DCArtboard id="topbar" label="Top bar redesign" width={1920} height={420}>
+          <Mock_TopBar />
+        </DCArtboard>
+
+        <DCArtboard id="naming" label="Source &amp; device names" width={880} height={460}>
+          <Mock_Naming />
+        </DCArtboard>
+
+        <DCArtboard id="queue" label="Queue rows &amp; duration format" width={1280} height={540}>
+          <Mock_Queue />
+        </DCArtboard>
+
+        <DCArtboard id="metrics" label="Metrics tiles — units, groups, trends" width={1280} height={580}>
+          <Mock_Metrics />
+        </DCArtboard>
+
+        <DCArtboard id="fbfilter" label="File browser filter — chips" width={880} height={360}>
+          <Mock_FbFilter />
+        </DCArtboard>
+      </DCSection>
+
+
+      <DCSection
+        id="p1"
+        title="P1 — big quality wins"
+        subtitle="Behavioural / structural fixes. The product feels twice as finished after these land."
+      >
+        <DCArtboard id="dock" label="Persistent Now Playing dock" width={1920} height={760}>
+          <Mock_Dock />
+        </DCArtboard>
+
+        <DCArtboard id="pill" label="Source pill semantics — one action + chevron" width={1100} height={320}>
+          <Mock_PillSemantics />
+        </DCArtboard>
+
+        <DCArtboard id="viz" label="Visualizer panel — promoted mode picker" width={1480} height={620}>
+          <Mock_Visualizer />
+        </DCArtboard>
+
+        <DCArtboard id="qsplit" label="Queue page — split layout" width={1200} height={660}>
+          <Mock_QueueSplit />
+        </DCArtboard>
+
+        <DCArtboard id="skel" label="Skeleton loading states" width={1280} height={660}>
+          <Mock_Skeleton />
+        </DCArtboard>
+      </DCSection>
+
+
+      <DCSection
+        id="system"
+        title="System polish"
+        subtitle="Things that change how the product feels in the room, not just how it looks on a screenshot."
+      >
+        <DCArtboard id="sleep" label="Sleep — ambient screen" width={1920} height={760}>
+          <Mock_Sleep />
+        </DCArtboard>
+
+        <DCArtboard id="dev" label="Dev tools — gesture-gated tray" width={880} height={620}>
+          <Mock_DevTools />
+        </DCArtboard>
+      </DCSection>
+
+    </DesignCanvas>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/docs/handoffs/design_handoff_radio_console/design-canvas.jsx
+++ b/docs/handoffs/design_handoff_radio_console/design-canvas.jsx
@@ -1,0 +1,966 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), deletable, labels/titles are
+// inline-editable, and any artboard can be opened in a fullscreen focus
+// overlay (←/→/Esc). State persists to a .design-canvas.state.json sidecar
+// via the host bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    // isolation:isolate contains artboard content's z-indexes so a
+    // z-indexed child (sticky navbar etc.) can't paint over .dc-header or
+    // the .dc-menu popover that drops into the top of the card.
+    '.dc-card{isolation:isolate;transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    // Per-artboard header: grip + label on the left, delete/expand on the
+    // right. Single flex row; when the artboard's on-screen width is too
+    // narrow for both the label yields (ellipsis, then hidden entirely below
+    // ~4ch via the container query) and the buttons stay on the row.
+    '.dc-header{position:absolute;bottom:100%;left:-4px;margin-bottom:calc(4px * var(--dc-inv-zoom,1));z-index:2;',
+    '  display:flex;align-items:center;container-type:inline-size}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px;flex:1 1 auto;min-width:0}',
+    '.dc-grip{flex:0 0 auto;cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s,opacity .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{flex:1 1 auto;min-width:0;cursor:pointer;border-radius:4px;padding:3px 6px;',
+    '  display:flex;align-items:center;transition:background .12s;overflow:hidden}',
+    // Below ~4ch of label room: hide the label entirely, and drop the grip to
+    // hover-only (same reveal rule as .dc-btns) so a narrow header is clean
+    // until the card is moused.
+    '@container (max-width: 110px){',
+    '  .dc-labeltext{display:none}',
+    '  .dc-grip{opacity:0}',
+    '  [data-dc-slot]:hover .dc-grip{opacity:1}',
+    '}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-labeltext .dc-editable{overflow:hidden;text-overflow:ellipsis;max-width:100%}',
+    '.dc-labeltext .dc-editable:focus{overflow:visible;text-overflow:clip}',
+    '.dc-btns{flex:0 0 auto;margin-left:auto;display:flex;gap:2px;opacity:0;transition:opacity .12s}',
+    '[data-dc-slot]:hover .dc-btns,.dc-btns:has(.dc-menu){opacity:1}',
+    '.dc-expand,.dc-kebab{width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center;',
+    '  font:inherit;transition:background .12s,color .12s}',
+    '.dc-expand:hover,.dc-kebab:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    // Slot hosting an open menu floats above later siblings (which otherwise
+    // paint on top — same z-index:auto, later DOM order) so the popup isn't
+    // clipped by the next card.
+    '[data-dc-slot]:has(.dc-menu){z-index:10}',
+    '.dc-menu{position:absolute;top:100%;right:0;margin-top:4px;background:#fff;border-radius:8px;',
+    '  box-shadow:0 8px 28px rgba(0,0,0,.18),0 0 0 1px rgba(0,0,0,.05);padding:4px;min-width:160px;z-index:10}',
+    '.dc-menu button{display:block;width:100%;padding:7px 10px;border:0;background:transparent;',
+    '  border-radius:5px;font-family:inherit;font-size:13px;font-weight:500;line-height:1.2;',
+    '  color:#29261b;cursor:pointer;text-align:left;transition:background .12s;white-space:nowrap}',
+    '.dc-menu button:hover{background:rgba(0,0,0,.05)}',
+    '.dc-menu hr{border:0;border-top:1px solid rgba(0,0,0,.08);margin:4px 2px}',
+    '.dc-menu .dc-danger{color:#c96442}',
+    '.dc-menu .dc-danger:hover{background:rgba(201,100,66,.1)}',
+    // Chrome (titles / labels / buttons) counter-scales against the viewport
+    // zoom so it stays a constant on-screen size. --dc-inv-zoom is set by
+    // DCViewport on every transform update and inherits to all descendants —
+    // any overlay inside the world (e.g. a TweaksPanel on an artboard) can use
+    // it the same way.
+    //
+    // The header uses transform:scale (out-of-flow, so layout impact doesn't
+    // matter) with its world-space width set to card-width / inv-zoom so that
+    // after counter-scaling its on-screen width exactly matches the card's —
+    // that's what lets the container query + text-overflow behave against the
+    // card's visible edge at every zoom level.
+    //
+    // The section head uses CSS zoom instead of transform so its layout box
+    // grows with the counter-scale, pushing the card row down — otherwise the
+    // constant-screen-size title would overflow into the (shrinking) world-
+    // space gap and overlap the artboard headers at low zoom.
+    '.dc-header{width:calc((100% + 4px) / var(--dc-inv-zoom,1));',
+    '  transform:scale(var(--dc-inv-zoom,1));transform-origin:bottom left}',
+    '.dc-sectionhead{zoom:var(--dc-inv-zoom,1)}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// Recursively unwrap React.Fragment so <>…</> grouping doesn't hide
+// DCSection/DCArtboard children from the type-based walks below.
+function dcFlatten(children) {
+  const out = [];
+  React.Children.forEach(children, (c) => {
+    if (c && c.type === React.Fragment) out.push(...dcFlatten(c.props.children));
+    else out.push(c);
+  });
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, hidden
+// artboards, focused artboard). Order/titles/labels/hidden persist to a
+// .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Fragments are flattened; wrapping in other
+  // elements still opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  dcFlatten(children).forEach((sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const abs = [];
+    dcFlatten(sec.props.children).forEach((ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (aid) abs.push([aid, ab]);
+    });
+    // hidden is scoped to one source revision — when the agent regenerates
+    // (artboard-ID set changes), prior deletes don't apply to new content.
+    const srcKey = abs.map(([k]) => k).join('\x1f');
+    const hidden = persisted.srcKey === srcKey ? (persisted.hidden || []) : [];
+    const srcIds = [];
+    abs.forEach(([aid, ab]) => {
+      if (hidden.includes(aid)) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+  // Persist viewport across reloads so the user lands back where they were
+  // after an agent edit or browser refresh. The sandbox origin is already
+  // per-project; pathname keeps multiple canvas files in one project apart.
+  const tfKey = 'dc-viewport:' + location.pathname;
+  const saveT = React.useRef(0);
+
+  const lastPostedScale = React.useRef();
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (!el) return;
+    el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+    // Exposed for zoom-invariant chrome (labels, buttons, TweaksPanel).
+    el.style.setProperty('--dc-inv-zoom', String(1 / scale));
+    // Keep the host toolbar's % readout in sync with the canvas scale. Pan
+    // ticks leave scale unchanged — skip the cross-frame post for those.
+    if (lastPostedScale.current !== scale) {
+      lastPostedScale.current = scale;
+      window.parent.postMessage({ type: '__dc_zoom', scale }, '*');
+    }
+    clearTimeout(saveT.current);
+    saveT.current = setTimeout(() => {
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    }, 200);
+  }, [tfKey]);
+
+  React.useLayoutEffect(() => {
+    const flush = () => {
+      clearTimeout(saveT.current);
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    };
+    try {
+      const s = JSON.parse(localStorage.getItem(tfKey) || 'null');
+      if (s && Number.isFinite(s.x) && Number.isFinite(s.y) && Number.isFinite(s.scale)) {
+        tf.current = { x: s.x, y: s.y, scale: Math.min(maxScale, Math.max(minScale, s.scale)) };
+        apply();
+      }
+    } catch {}
+    // Flush on pagehide and unmount so a reload within the 200ms debounce
+    // window doesn't drop the last pan/zoom.
+    window.addEventListener('pagehide', flush);
+    return () => { window.removeEventListener('pagehide', flush); flush(); };
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // --dc-inv-zoom consumers (.dc-sectionhead's CSS zoom, each section's
+      // marginBottom) reflow on every scale change, vertically shifting the
+      // world layout — so a world point mathematically pinned under the cursor
+      // drifts as you zoom (content creeps up on zoom-in, down on zoom-out).
+      // Anchor the DOM element under the cursor instead: record its screen Y,
+      // apply the transform + --dc-inv-zoom, then cancel whatever vertical
+      // drift the reflow introduced so it stays put on screen.
+      let marker = null, markerY0 = 0;
+      if (k !== 1) {
+        const hit = document.elementFromPoint(cx, cy);
+        marker = hit && hit.closest ? hit.closest('[data-dc-slot],[data-dc-section]') : null;
+        if (marker) markerY0 = marker.getBoundingClientRect().top;
+      }
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+      if (marker) {
+        // A pure zoom around (cx, cy) maps screen Y → cy + (Y - cy) * k. Any
+        // departure after the --dc-inv-zoom reflow is the layout drift.
+        const drift = marker.getBoundingClientRect().top - (cy + (markerY0 - cy) * k);
+        if (Math.abs(drift) > 0.1) { t.y -= drift; apply(); }
+      }
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if ((e.ctrlKey || e.metaKey) && !isMouseWheel(e)) {
+        // trackpad pinch, or ctrl/cmd + smooth-scroll mouse. Notched
+        // wheels fall through to the fixed-step branch below.
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    // Host-driven zoom (toolbar % menu). Zooms around viewport centre so the
+    // visible midpoint stays fixed — matching the host's iframe-zoom feel.
+    const onHostMsg = (e) => {
+      const d = e.data;
+      if (d && d.type === '__dc_set_zoom' && typeof d.scale === 'number') {
+        const r = vp.getBoundingClientRect();
+        zoomAt(r.left + r.width / 2, r.top + r.height / 2, d.scale / tf.current.scale);
+      } else if (d && d.type === '__dc_probe') {
+        // Host's [readyGen] reset asks whether a canvas is present; it
+        // fires on the iframe's native 'load', which for canvases with
+        // images/fonts is after our mount-time announce, so re-announce.
+        // Clear the pan-tick guard so apply() re-posts the current scale
+        // even if it's unchanged — the host just reset dcScale to 1.
+        window.parent.postMessage({ type: '__dc_present' }, '*');
+        lastPostedScale.current = undefined;
+        apply();
+      }
+    };
+    window.addEventListener('message', onHostMsg);
+    // Announce canvas mode so the host toolbar proxies its % control here
+    // instead of scaling the iframe element (which would just shrink the
+    // viewport window of an infinite canvas). The apply() that follows emits
+    // the initial __dc_zoom so the toolbar % is correct before first pinch.
+    // lastPostedScale reset mirrors the __dc_probe handler: the layout
+    // effect's restore-path apply() may already have posted the restored
+    // scale (before __dc_present), so clear the guard to re-post it in order.
+    window.parent.postMessage({ type: '__dc_present' }, '*');
+    lastPostedScale.current = undefined;
+    apply();
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      window.removeEventListener('message', onHostMsg);
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(dcFlatten(children));
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+  // Must match DesignCanvas's srcKey computation exactly (it filters falsy
+  // IDs), or onDelete persists a srcKey that DesignCanvas never recognizes.
+  const allIds = artboards.map((a) => a.props.id ?? a.props.label).filter(Boolean);
+  const srcKey = allIds.join('\x1f');
+  const hidden = sec.srcKey === srcKey ? (sec.hidden || []) : [];
+  const srcOrder = allIds.filter((k) => !hidden.includes(k));
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  // marginBottom counter-scales so the on-screen gap between sections stays
+  // constant — otherwise at low zoom the (world-space) gap collapses while
+  // the screen-constant sectionhead below it doesn't, and the title reads as
+  // belonging to the section above. paddingBottom below is just enough for
+  // the 24px artboard-header (abs-positioned above each card) plus ~8px, so
+  // the title sits tight against its own row at every zoom.
+  return (
+    <div data-dc-section={sid}
+      style={{ marginBottom: 'calc(80px * var(--dc-inv-zoom, 1))', position: 'relative' }}>
+      <div style={{ padding: '0 60px' }}>
+        <div className="dc-sectionhead" style={{ paddingBottom: 36 }}>
+          <DCEditable tag="div" value={sec.title ?? title}
+            onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+            style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+          {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onDelete={() => ctx && ctx.patchSection(sid, (x) => ({
+              hidden: [...(x.srcKey === srcKey ? (x.hidden || []) : []), k],
+              srcKey,
+            }))}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+// Per-artboard export (kind: 'png' | 'html'). Both paths share the same
+// self-contained clone: computed styles baked in, @font-face / <img> /
+// inline-style background-image urls inlined as data URIs. PNG wraps the
+// clone in foreignObject→canvas at 3× the artboard's natural width×height
+// (same pipeline the host uses for page captures); HTML wraps it in a
+// minimal standalone document. Both are independent of viewport zoom.
+async function dcExport(node, w, h, name, kind) {
+  try { await document.fonts.ready; } catch {}
+  const toDataURL = (url) => fetch(url).then((r) => r.blob()).then((b) => new Promise((res) => {
+    const fr = new FileReader(); fr.onload = () => res(fr.result); fr.onerror = () => res(url); fr.readAsDataURL(b);
+  })).catch(() => url);
+
+  // Collect @font-face rules. ss.cssRules throws SecurityError on
+  // cross-origin sheets (e.g. fonts.googleapis.com) — in that case fetch
+  // the CSS text directly (those endpoints send ACAO:*) and regex-extract
+  // the blocks. @import and @media/@supports are walked so nested
+  // @font-face rules aren't missed.
+  const fontRules = [], pending = [], seen = new Set();
+  const scrapeCss = (href) => {
+    if (seen.has(href)) return; seen.add(href);
+    pending.push(fetch(href).then((r) => r.text()).then((css) => {
+      for (const m of css.match(/@font-face\s*{[^}]*}/g) || []) fontRules.push({ css: m, base: href });
+      for (const m of css.matchAll(/@import\s+(?:url\()?['"]?([^'")\s;]+)/g))
+        scrapeCss(new URL(m[1], href).href);
+    }).catch(() => {}));
+  };
+  const walk = (rules, base) => {
+    for (const r of rules) {
+      if (r.type === CSSRule.FONT_FACE_RULE) fontRules.push({ css: r.cssText, base });
+      else if (r.type === CSSRule.IMPORT_RULE && r.styleSheet) {
+        const ibase = r.styleSheet.href || base;
+        try { walk(r.styleSheet.cssRules, ibase); } catch { scrapeCss(ibase); }
+      } else if (r.cssRules) walk(r.cssRules, base);
+    }
+  };
+  for (const ss of document.styleSheets) {
+    const base = ss.href || location.href;
+    try { walk(ss.cssRules, base); } catch { if (ss.href) scrapeCss(ss.href); }
+  }
+  while (pending.length) await pending.shift();
+  const fontCss = (await Promise.all(fontRules.map(async (rule) => {
+    let out = rule.css, m; const re = /url\((['"]?)([^'")]+)\1\)/g;
+    while ((m = re.exec(rule.css))) {
+      if (m[2].indexOf('data:') === 0) continue;
+      let abs; try { abs = new URL(m[2], rule.base).href; } catch { continue; }
+      out = out.split(m[0]).join('url("' + await toDataURL(abs) + '")');
+    }
+    return out;
+  }))).join('\n');
+
+  const cloneStyled = (src) => {
+    if (src.nodeType === 8 || (src.nodeType === 1 && src.tagName === 'SCRIPT')) return document.createTextNode('');
+    const dst = src.cloneNode(false);
+    if (src.nodeType === 1) {
+      const cs = getComputedStyle(src); let txt = '';
+      for (let i = 0; i < cs.length; i++) txt += cs[i] + ':' + cs.getPropertyValue(cs[i]) + ';';
+      dst.setAttribute('style', txt + 'animation:none;transition:none;');
+      if (src.tagName === 'CANVAS') try { const im = document.createElement('img'); im.src = src.toDataURL(); im.setAttribute('style', txt); return im; } catch {}
+    }
+    for (let c = src.firstChild; c; c = c.nextSibling) dst.appendChild(cloneStyled(c));
+    return dst;
+  };
+  const clone = cloneStyled(node);
+  clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+  // Drop the card's own shadow/radius so the export is a flush w×h rect;
+  // the artboard's own background (if any) is already in the computed style.
+  clone.style.boxShadow = 'none'; clone.style.borderRadius = '0';
+
+  const jobs = [];
+  clone.querySelectorAll('img').forEach((el) => {
+    const s = el.getAttribute('src');
+    if (s && s.indexOf('data:') !== 0) jobs.push(toDataURL(el.src).then((d) => el.setAttribute('src', d)));
+  });
+  [clone, ...clone.querySelectorAll('*')].forEach((el) => {
+    const bg = el.style.backgroundImage; if (!bg) return;
+    let m; const re = /url\(["']?([^"')]+)["']?\)/g;
+    while ((m = re.exec(bg))) {
+      const tok = m[0], url = m[1];
+      if (url.indexOf('data:') === 0) continue;
+      jobs.push(toDataURL(url).then((d) => { el.style.backgroundImage = el.style.backgroundImage.split(tok).join('url("' + d + '")'); }));
+    }
+  });
+  await Promise.all(jobs);
+
+  const xml = new XMLSerializer().serializeToString(clone);
+  const save = (blob, ext) => {
+    if (!blob) return;
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob); a.download = name + '.' + ext; a.click();
+    setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+  };
+
+  if (kind === 'html') {
+    const html = '<!doctype html><html><head><meta charset="utf-8"><title>' + name + '</title>' +
+      (fontCss ? '<style>' + fontCss + '</style>' : '') +
+      '</head><body style="margin:0">' + xml + '</body></html>';
+    return save(new Blob([html], { type: 'text/html' }), 'html');
+  }
+
+  // PNG: the SVG's own width/height must be the output resolution — an
+  // <img>-loaded SVG rasterizes at its intrinsic size, so sizing it at 1×
+  // and ctx.scale()-ing up would just upscale a 1× bitmap. viewBox maps the
+  // w×h foreignObject onto the px·w × px·h SVG canvas so the browser renders
+  // the HTML at full resolution.
+  const px = 3;
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + w * px + '" height="' + h * px +
+    '" viewBox="0 0 ' + w + ' ' + h + '"><foreignObject width="' + w + '" height="' + h + '">' +
+    (fontCss ? '<style><![CDATA[' + fontCss + ']]></style>' : '') + xml + '</foreignObject></svg>';
+  const img = new Image();
+  await new Promise((res, rej) => {
+    img.onload = res; img.onerror = () => rej(new Error('svg load failed'));
+    img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+  });
+  const cv = document.createElement('canvas');
+  cv.width = w * px; cv.height = h * px;
+  cv.getContext('2d').drawImage(img, 0, 0);
+  cv.toBlob((blob) => save(blob, 'png'), 'image/png');
+}
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus, onDelete }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+  const cardRef = React.useRef(null);
+  const menuRef = React.useRef(null);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [confirming, setConfirming] = React.useState(false);
+
+  // ⋯ menu: close on any outside pointerdown. Two-click delete lives inside
+  // the menu — first click arms the row, second commits; closing disarms.
+  React.useEffect(() => {
+    if (!menuOpen) { setConfirming(false); return; }
+    const off = (e) => { if (!menuRef.current || !menuRef.current.contains(e.target)) setMenuOpen(false); };
+    document.addEventListener('pointerdown', off, true);
+    return () => document.removeEventListener('pointerdown', off, true);
+  }, [menuOpen]);
+
+  const doExport = (kind) => {
+    setMenuOpen(false);
+    if (!cardRef.current) return;
+    const name = String(label || id || 'artboard').replace(/[^\w\s.-]+/g, '_');
+    dcExport(cardRef.current, width, height, name, kind)
+      .catch((e) => console.error('[design-canvas] export failed:', e));
+  };
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-header" data-noncommentable="" style={{ color: DC.label }} onPointerDown={(e) => e.stopPropagation()}>
+        <div className="dc-labelrow">
+          <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+            <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+          </div>
+          <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+            <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+              style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+          </div>
+        </div>
+        <div className="dc-btns">
+          <div ref={menuRef} style={{ position: 'relative' }}>
+            <button className="dc-kebab" title="More" onClick={() => setMenuOpen((o) => !o)}>
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><circle cx="2.5" cy="6" r="1.1"/><circle cx="6" cy="6" r="1.1"/><circle cx="9.5" cy="6" r="1.1"/></svg>
+            </button>
+            {menuOpen && (
+              <div className="dc-menu" onPointerDown={(e) => e.stopPropagation()}>
+                <button onClick={() => doExport('png')}>Download PNG</button>
+                <button onClick={() => doExport('html')}>Download HTML</button>
+                <hr />
+                <button className="dc-danger"
+                  onClick={() => { if (confirming) { setMenuOpen(false); onDelete(); } else setConfirming(true); }}>
+                  {confirming ? 'Click again to delete' : 'Delete'}
+                </button>
+              </div>
+            )}
+          </div>
+          <button className="dc-expand" onClick={onFocus} title="Focus">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+          </button>
+        </div>
+      </div>
+      <div ref={cardRef} className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    // Sections whose artboards are all deleted have slotIds:[] — step past
+    // them to the next non-empty section so ↑/↓ doesn't dead-end.
+    const n = sectionOrder.length;
+    for (let i = 1; i < n; i++) {
+      const ns = sectionOrder[(((secIdx + d * i) % n) + n) % n];
+      const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+      if (first) { ctx.setFocus(`${ns}/${first}`); return; }
+    }
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.filter((sid) => sectionMeta[sid].slotIds.length).map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/docs/handoffs/design_handoff_radio_console/mocks.jsx
+++ b/docs/handoffs/design_handoff_radio_console/mocks.jsx
@@ -1,0 +1,1065 @@
+// handoff-mocks.jsx — Mock components for each proposed change in the
+// Radio.Web design analysis. Each component renders at a specific fixed
+// size meant to be wrapped in a <DCArtboard>. Styling is intentionally
+// inline so this file is self-contained and doesn't compete with the
+// design-canvas chrome's CSS.
+
+const T = {
+  base:       '#0D0D0F',
+  raised:     '#141416',
+  inset:      '#0A0A0C',
+  overlay:    '#1A1A1D',
+  sep:        '#1F1F22',
+  hair:       '#25252A',
+
+  accent:     '#5CD4E8',
+  accentDim:  'rgba(92,212,232,0.10)',
+  accentGlow: 'rgba(92,212,232,0.25)',
+  amber:      '#F0A830',
+  amberGlow:  'rgba(240,168,48,0.30)',
+
+  sVinyl:     '#A78BFA',
+  sRadio:     '#F0A830',
+  sBT:        '#60A5FA',
+  sUSB:       '#4ADE80',
+  sFile:      '#5CD4E8',
+
+  red:        '#F87171',
+  yellow:     '#FBBF24',
+  green:      '#4ADE80',
+
+  hi:         '#F0EFF4',
+  md:         '#9CA3AF',
+  lo:         '#4B5563',
+  dim:        '#353841',
+
+  body:       "'Inter', -apple-system, BlinkMacSystemFont, sans-serif",
+  mono:       "'JetBrains Mono', 'SF Mono', Consolas, monospace",
+  led:        "'Share Tech Mono', 'JetBrains Mono', monospace",
+};
+
+/* ─────────── shared atoms ─────────── */
+const Stage = ({ w, h, pad = 0, children, style }) => (
+  <div style={{
+    width: w, height: h, background: T.base, color: T.hi,
+    fontFamily: T.body, fontSize: 14, lineHeight: 1.45,
+    overflow: 'hidden', boxSizing: 'border-box', padding: pad,
+    ...style,
+  }}>{children}</div>
+);
+
+const SectionLabel = ({ kicker, title, after }) => (
+  <div style={{
+    display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+    padding: '14px 20px 10px', borderBottom: `1px solid ${T.sep}`,
+  }}>
+    <div>
+      <div style={{
+        fontFamily: T.mono, fontSize: 10, letterSpacing: '0.16em',
+        textTransform: 'uppercase', color: after ? T.accent : T.red,
+      }}>{kicker}</div>
+      <div style={{ fontSize: 13, color: T.hi, marginTop: 2 }}>{title}</div>
+    </div>
+    <div style={{
+      fontFamily: T.mono, fontSize: 10, letterSpacing: '0.14em',
+      textTransform: 'uppercase', color: T.lo,
+    }}>{after ? 'After' : 'Before'}</div>
+  </div>
+);
+
+const Divider = () => (
+  <div style={{ width: 1, background: T.sep, alignSelf: 'stretch' }} />
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   1. P0 — Top bar redesign
+   ════════════════════════════════════════════════════════════ */
+
+const Icon = ({ ch, color = T.md, size = 18 }) => (
+  <span style={{ fontSize: size, color, lineHeight: 1, display: 'inline-block' }}>{ch}</span>
+);
+
+const TbCircle = ({ children, on, accent, w = 64 }) => (
+  <div style={{
+    width: w, height: 64, borderRadius: 32,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    background: on ? (accent ? `${accent}1F` : T.accentDim) : 'transparent',
+    color: on ? (accent || T.accent) : T.md,
+    position: 'relative',
+  }}>
+    {children}
+    {on && <span style={{
+      position: 'absolute', bottom: 2, left: '25%', right: '25%',
+      height: 2, background: accent || T.accent, borderRadius: 1,
+    }} />}
+  </div>
+);
+
+const TopBarBefore = () => (
+  <div style={{
+    width: '100%', height: 80, background: T.base,
+    borderBottom: `1px solid ${T.sep}`,
+    display: 'flex', alignItems: 'center', padding: '0 16px', gap: 16,
+  }}>
+    <div style={{
+      fontFamily: T.led, fontSize: 24, color: T.amber,
+      textShadow: `0 0 8px ${T.amberGlow}`, letterSpacing: 4, minWidth: 100,
+    }}>11:29</div>
+    <div style={{ width: 1, height: 48, background: T.sep }} />
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 2,
+      background: T.inset, border: `1px solid ${T.sep}`,
+      borderRadius: 36, padding: '4px 12px',
+    }}>
+      <span style={{
+        fontFamily: T.mono, fontSize: 12, textTransform: 'uppercase',
+        letterSpacing: '0.10em', color: T.lo, padding: '0 6px',
+      }}>In</span>
+      <TbCircle><Icon ch="♪" /></TbCircle>
+      <TbCircle on accent={T.sRadio}><Icon ch="📻" size={20} /></TbCircle>
+      <TbCircle><Icon ch="⌁" /></TbCircle>
+      <TbCircle><Icon ch="▼" /></TbCircle>
+      <TbCircle><Icon ch="⎘" /></TbCircle>
+    </div>
+    <div style={{ width: 1, height: 48, background: T.sep }} />
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 2,
+      background: T.inset, border: `1px solid ${T.sep}`,
+      borderRadius: 36, padding: '4px 12px',
+    }}>
+      <span style={{
+        fontFamily: T.mono, fontSize: 12, textTransform: 'uppercase',
+        letterSpacing: '0.10em', color: T.lo, padding: '0 6px',
+      }}>Out</span>
+      <TbCircle on><Icon ch="🔊" size={18} /></TbCircle>
+      <TbCircle><Icon ch="🔈" size={18} /></TbCircle>
+      <TbCircle><Icon ch="📺" size={18} /></TbCircle>
+      <TbCircle w={120}>
+        <Icon ch="📡" /><span style={{ fontSize: 11, color: T.md, marginLeft: 4 }}>Cast</span>
+      </TbCircle>
+    </div>
+    <TbCircle><Icon ch="🐞" size={20} color={T.lo} /></TbCircle>
+    <div style={{ marginLeft: 'auto', display: 'flex', gap: 2 }}>
+      <TbCircle on w={56}><Icon ch="⌂" size={22} color={T.accent} /></TbCircle>
+      <TbCircle w={56}><Icon ch="≡" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="▥" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="⌥" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="⌖" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="⏱" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="⚙" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="☎" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="⏻" size={22} /></TbCircle>
+    </div>
+  </div>
+);
+
+const NavPill = ({ label, badge, on }) => (
+  <div style={{
+    height: 56, padding: '0 16px',
+    display: 'inline-flex', alignItems: 'center', gap: 8,
+    borderRadius: 10,
+    background: on ? T.accentDim : 'transparent',
+    color: on ? T.accent : T.md,
+    fontFamily: T.mono, fontSize: 12, letterSpacing: '0.10em',
+    textTransform: 'uppercase', fontWeight: 500,
+    position: 'relative',
+  }}>
+    {label}
+    {badge && <span style={{
+      background: T.amber, color: T.base, fontSize: 10, fontWeight: 700,
+      borderRadius: 8, padding: '2px 6px', fontFamily: T.mono,
+    }}>{badge}</span>}
+  </div>
+);
+
+const SourceBubble = ({ ch, label, sub, color = T.md, accent, disabled, chev }) => (
+  <div style={{
+    height: 48, padding: '0 16px',
+    display: 'inline-flex', alignItems: 'center', gap: 10,
+    borderRadius: 24,
+    background: accent ? `${accent}14` : T.inset,
+    border: `1px solid ${accent ? `${accent}55` : T.sep}`,
+    color: accent || color,
+    opacity: disabled ? 0.4 : 1,
+    fontSize: 14, fontWeight: 500,
+  }}>
+    <span style={{
+      width: 28, height: 28, borderRadius: 14,
+      background: accent ? `${accent}33` : T.overlay,
+      display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+      fontSize: 14, color: accent || T.md,
+    }}>{ch}</span>
+    <span>{label}{sub && <span style={{
+      color: accent ? `${accent}cc` : T.lo, fontSize: 12, marginLeft: 6,
+    }}>· {sub}</span>}</span>
+    {chev && <span style={{
+      marginLeft: 4, color: accent || T.md, opacity: 0.7, fontSize: 16,
+    }}>›</span>}
+  </div>
+);
+
+const TopBarAfter = () => (
+  <div style={{
+    width: '100%', background: T.base,
+    borderBottom: `1px solid ${T.sep}`,
+    padding: '12px 24px',
+    display: 'flex', flexDirection: 'column', gap: 10,
+  }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 28 }}>
+      <div>
+        <div style={{
+          fontFamily: T.mono, fontSize: 10, letterSpacing: '0.16em',
+          textTransform: 'uppercase', color: T.lo,
+        }}>Time</div>
+        <div style={{
+          fontFamily: T.led, fontSize: 22, color: T.amber,
+          textShadow: `0 0 8px ${T.amberGlow}`, letterSpacing: 4,
+        }}>11:29</div>
+      </div>
+      <div style={{ width: 1, height: 40, background: T.sep }} />
+      <div>
+        <div style={{
+          fontFamily: T.mono, fontSize: 10, letterSpacing: '0.16em',
+          textTransform: 'uppercase', color: T.lo,
+        }}>In · Source</div>
+        <div style={{ fontSize: 15, color: T.hi, marginTop: 4, fontWeight: 500 }}>
+          <span style={{
+            display: 'inline-block', width: 8, height: 8, borderRadius: 2,
+            background: T.sRadio, marginRight: 8, verticalAlign: 1,
+          }} />
+          FM Radio · <span style={{ fontFamily: T.led, color: T.amber, letterSpacing: 2 }}>88.5</span>
+        </div>
+      </div>
+      <div style={{ color: T.lo, fontSize: 18, alignSelf: 'flex-end', marginBottom: 4 }}>→</div>
+      <div>
+        <div style={{
+          fontFamily: T.mono, fontSize: 10, letterSpacing: '0.16em',
+          textTransform: 'uppercase', color: T.lo,
+        }}>Out · Destination</div>
+        <div style={{ fontSize: 15, color: T.hi, marginTop: 4, fontWeight: 500 }}>
+          <span style={{
+            display: 'inline-block', width: 8, height: 8, borderRadius: 2,
+            background: T.accent, marginRight: 8, verticalAlign: 1,
+          }} />
+          Living Room <span style={{ color: T.md, fontWeight: 400 }}>· Cast</span>
+        </div>
+      </div>
+      <div style={{ marginLeft: 'auto', display: 'flex', gap: 4 }}>
+        <NavPill label="Home" on />
+        <NavPill label="Queue" badge="45" />
+        <NavPill label="Radio" />
+        <NavPill label="History" />
+        <NavPill label="Devices" />
+        <NavPill label="System" />
+      </div>
+    </div>
+    <div style={{ display: 'flex', gap: 8 }}>
+      <SourceBubble ch="♪" label="File" />
+      <SourceBubble ch="📻" label="Radio" sub="88.5" accent={T.sRadio} chev />
+      <SourceBubble ch="⌁" label="Bluetooth" />
+      <SourceBubble ch="⌖" label="Vinyl" sub="offline" disabled />
+      <SourceBubble ch="⎘" label="USB" />
+    </div>
+  </div>
+);
+
+const Mock_TopBar = () => (
+  <Stage w={1920} h={420}>
+    <SectionLabel kicker="Current" title="Three clusters of identical circular pills · debug button live · IDs unlabeled" />
+    <TopBarBefore />
+    <div style={{ height: 28 }} />
+    <SectionLabel kicker="Proposed" title="Labeled routing reads as a sentence · pill sources strip · rectangular nav · debug gated"
+      after />
+    <TopBarAfter />
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   2. P0 — Source / device naming
+   ════════════════════════════════════════════════════════════ */
+
+const NameRow = ({ raw, sub, danger }) => (
+  <div style={{
+    padding: '12px 16px', borderBottom: `1px solid ${T.sep}`,
+    display: 'flex', flexDirection: 'column', gap: 2,
+    fontFamily: danger ? T.mono : T.body,
+    fontSize: danger ? 12 : 14,
+    color: danger ? T.red : T.hi,
+  }}>
+    <span style={danger ? { wordBreak: 'break-all' } : null}>{raw}</span>
+    {sub && <span style={{ fontSize: 12, color: T.md, fontFamily: T.body }}>{sub}</span>}
+  </div>
+);
+
+const Mock_Naming = () => (
+  <Stage w={880} h={460} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{ display: 'flex', flex: 1 }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Raw API leakage" title="Audio Source · Devices · Tracks" />
+        <div style={{ flex: 1, background: T.raised, margin: '12px 16px', borderRadius: 8, border: `1px solid ${T.sep}` }}>
+          <NameRow raw="FilePlayer-da7eb94888fa43aab0021b8c0a4c2e1f7" danger />
+          <NameRow raw="1 - LG TV SSCR2 (AMD High Definition Audio Device)" danger />
+          <NameRow raw="CABLE In 16ch (VB-Audio Virtual Cable)" danger />
+          <NameRow raw="Track 8" sub="00:03:00.6628571" />
+        </div>
+      </div>
+      <Divider />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Display layer" title="DisplayName projection on every DTO" after />
+        <div style={{ flex: 1, background: T.raised, margin: '12px 16px', borderRadius: 8, border: `1px solid ${T.sep}` }}>
+          <NameRow raw="File Player" sub="Local · 45 tracks queued" />
+          <NameRow raw="LG TV" sub="HDMI · 5.1 surround capable" />
+          <NameRow raw="VB-Audio Cable" sub="16-channel virtual" />
+          <NameRow raw="We're Ready" sub="3:00 · from file name «08 - We're Ready.flac»" />
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   3. P0 — Queue formatting
+   ════════════════════════════════════════════════════════════ */
+
+const QRowBefore = ({ n, title, art, dur, active }) => (
+  <div style={{
+    display: 'grid', gridTemplateColumns: '24px 1fr 140px 24px',
+    alignItems: 'center', gap: 12, padding: '14px 16px',
+    borderBottom: `1px solid ${T.sep}`,
+    background: active ? 'rgba(92,212,232,0.06)' : 'transparent',
+  }}>
+    <span style={{ fontFamily: T.mono, color: T.lo, fontSize: 12 }}>{n}</span>
+    <div>
+      <div style={{ color: active ? T.accent : T.hi, fontSize: 14, fontWeight: 500 }}>{title}</div>
+      <div style={{ color: T.md, fontSize: 12 }}>{art}</div>
+    </div>
+    <span style={{ fontFamily: T.mono, color: T.md, fontSize: 11 }}>{dur}</span>
+    <span style={{ color: T.lo, textAlign: 'center' }}>×</span>
+  </div>
+);
+
+const QRowAfter = ({ n, title, art, alb, dur, active }) => (
+  <div style={{
+    display: 'grid', gridTemplateColumns: '28px 1fr 56px 24px',
+    alignItems: 'center', gap: 14, padding: '12px 16px',
+    borderBottom: `1px solid ${T.sep}`,
+    background: active ? 'rgba(240,168,48,0.06)' : 'transparent',
+    borderLeft: active ? `3px solid ${T.amber}` : '3px solid transparent',
+    paddingLeft: 13,
+  }}>
+    <span style={{
+      fontFamily: T.mono, color: active ? T.amber : T.lo, fontSize: 13, textAlign: 'center',
+    }}>{active ? '▶' : n}</span>
+    <div>
+      <div style={{ color: T.hi, fontSize: 15, fontWeight: 500 }}>{title}</div>
+      <div style={{ color: T.md, fontSize: 13 }}>{art} · {alb}</div>
+    </div>
+    <span style={{
+      fontFamily: T.mono, color: T.md, fontSize: 13, textAlign: 'right',
+      fontVariantNumeric: 'tabular-nums',
+    }}>{dur}</span>
+    <span style={{ color: T.lo, textAlign: 'center', fontSize: 16 }}>×</span>
+  </div>
+);
+
+const Mock_Queue = () => (
+  <Stage w={1280} h={540} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{ display: 'flex', flex: 1 }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Raw TimeSpan in column" title="Sub-tick precision · column eats space · no playing indicator" />
+        <div style={{ flex: 1, padding: 16 }}>
+          <div style={{
+            background: T.raised, borderRadius: 8, border: `1px solid ${T.sep}`,
+          }}>
+            <QRowBefore n="0" title="Track 8" art="Cary High Chorus" dur="00:03:00.6628571" active />
+            <QRowBefore n="1" title="I'm Not in Love" art="10cc" dur="00:06:04.9044897" />
+            <QRowBefore n="2" title="Track 9" art="Cary High Chorus" dur="00:02:19.9640816" />
+            <QRowBefore n="3" title="Bixby Canyon Bridge" art="Death Cab for Cutie" dur="00:05:15.4546938" />
+            <QRowBefore n="4" title="Track 10" art="Cary High Chorus" dur="00:01:17.1395918" />
+            <QRowBefore n="5" title="Track 11" art="Cary High Chorus" dur="00:02:00.5551020" />
+          </div>
+        </div>
+      </div>
+      <Divider />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Formatted · amber accent for now-playing" title="FormatDuration() · accent border · tabular numerals" after />
+        <div style={{ flex: 1, padding: 16 }}>
+          <div style={{
+            background: T.raised, borderRadius: 8, border: `1px solid ${T.sep}`,
+          }}>
+            <QRowAfter n="1" title="We're Ready" art="Boston" alb="Third Stage" dur="3:00" active />
+            <QRowAfter n="2" title="I'm Not in Love" art="10cc" alb="The Original Soundtrack" dur="6:04" />
+            <QRowAfter n="3" title="Track 9" art="Cary High Chorus" alb="Fall Concert 2006" dur="2:20" />
+            <QRowAfter n="4" title="Bixby Canyon Bridge" art="Death Cab for Cutie" alb="Narrow Stairs" dur="5:15" />
+            <QRowAfter n="5" title="Hot for Teacher" art="Van Halen" alb="1984" dur="4:42" />
+            <QRowAfter n="6" title="Don't Look Back" art="Boston" alb="Don't Look Back" dur="5:58" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   4. P0 — Metrics tiles
+   ════════════════════════════════════════════════════════════ */
+
+const TileBefore = ({ cat, name, val, suffix }) => (
+  <div style={{
+    background: T.raised, borderRadius: 8, padding: 16,
+    border: `1px solid ${T.sep}`,
+  }}>
+    <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.12em' }}>{cat}</div>
+    <div style={{ fontSize: 13, color: T.md, marginTop: 4 }}>{name}</div>
+    <div style={{ fontFamily: T.mono, fontSize: 28, color: T.accent, marginTop: 6, fontWeight: 500 }}>
+      {val}<span style={{ fontSize: 13, color: T.md }}>{suffix}</span>
+    </div>
+  </div>
+);
+
+const Sparkline = ({ stroke = T.accent, pts }) => (
+  <svg viewBox="0 0 120 28" preserveAspectRatio="none" style={{ width: '100%', height: 28, marginTop: 8, display: 'block' }}>
+    <polyline fill={`${stroke}1A`} stroke="none" points={`${pts} 120,28 0,28`} />
+    <polyline fill="none" stroke={stroke} strokeWidth="1.5" points={pts} />
+  </svg>
+);
+
+const TileAfter = ({ cat, name, val, suffix, delta, deltaColor = T.green, valColor, spark }) => (
+  <div style={{
+    background: T.raised, borderRadius: 8, padding: 16,
+    border: `1px solid ${T.sep}`,
+  }}>
+    <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.10em', textTransform: 'uppercase' }}>{cat}</div>
+    <div style={{ fontSize: 13, color: T.md, marginTop: 4 }}>{name}</div>
+    <div style={{ fontFamily: T.mono, fontSize: 30, color: valColor || T.hi, marginTop: 6, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>
+      {val}<span style={{ fontSize: 13, color: T.md, marginLeft: 4 }}>{suffix}</span>
+    </div>
+    {delta && <div style={{ fontSize: 11, color: deltaColor, marginTop: 2, fontFamily: T.mono }}>{delta}</div>}
+    {spark && <Sparkline {...spark} />}
+  </div>
+);
+
+const Mock_Metrics = () => (
+  <Stage w={1280} h={580} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{ display: 'flex', flex: 1 }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Unit & hierarchy bugs" title="850.4% memory · raw category prefixes · no trend" />
+        <div style={{ flex: 1, padding: 16, display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 12, gridAutoRows: 'min-content' }}>
+          <TileBefore cat="SYSTEM" name="Memory Usage Mb" val="850.4" suffix="%" />
+          <TileBefore cat="RADIO"  name="Signal Strength" val="65.39" />
+          <TileBefore cat="SYSTEM" name="Disk Usage Percent" val="35.7" suffix="%" />
+          <TileBefore cat="TTS"    name="Latency Ms" val="215" />
+          <TileBefore cat="RADIO"  name="Frequency Changes" val="261" />
+          <TileBefore cat="API"    name="Requests Total" val="135725" />
+        </div>
+      </div>
+      <Divider />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Grouped · sparklines · semantic color" title="One registry knows the unit · trend is part of the value" after />
+        <div style={{ flex: 1, padding: 16, overflow: 'hidden' }}>
+          <div style={{ fontFamily: T.mono, fontSize: 11, color: T.lo, letterSpacing: '0.14em', textTransform: 'uppercase', marginBottom: 8 }}>System</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 10, marginBottom: 14 }}>
+            <TileAfter cat="Memory" name="Heap in use" val="850" suffix="MB" delta="▲ 4% vs 1h ago"
+              spark={{ pts: '0,20 10,18 20,19 30,16 40,17 50,14 60,15 70,12 80,13 90,10 100,11 110,9 120,7', stroke: T.accent }} />
+            <TileAfter cat="Disk" name="Usage" val="35.7" suffix="%" valColor={T.green} delta="Stable"
+              spark={{ pts: '0,16 30,16 60,16 90,15 120,16', stroke: T.green }} />
+          </div>
+          <div style={{ fontFamily: T.mono, fontSize: 11, color: T.lo, letterSpacing: '0.14em', textTransform: 'uppercase', marginBottom: 8 }}>Radio</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 10 }}>
+            <TileAfter cat="Reception" name="Signal strength" val="65" suffix="%" valColor={T.green} delta="Stable · last 5 min"
+              spark={{ pts: '0,14 10,12 20,14 30,11 40,10 50,12 60,11 70,10 80,11 90,12 100,10 110,11 120,10', stroke: T.green }} />
+            <TileAfter cat="Tuning" name="Frequency changes · 24h" val="261" delta="▲ 12 today · last at 11:14" deltaColor={T.md} />
+          </div>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   5. P0 — File browser filter chips
+   ════════════════════════════════════════════════════════════ */
+
+const Mock_FbFilter = () => (
+  <Stage w={880} h={360} pad={20} style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+    <div>
+      <div style={{ fontFamily: T.mono, fontSize: 10, color: T.red, letterSpacing: '0.16em', textTransform: 'uppercase' }}>
+        Current — JSON re-serialization leaks
+      </div>
+      <div style={{
+        marginTop: 8, background: T.raised, border: `1px solid ${T.sep}`,
+        borderRadius: 8, padding: 14,
+      }}>
+        <div style={{ fontFamily: T.mono, fontSize: 11, color: T.lo, letterSpacing: '0.10em', textTransform: 'uppercase', marginBottom: 6 }}>Filter</div>
+        <div style={{
+          background: T.inset, border: `1px solid ${T.sep}`, borderRadius: 6,
+          padding: '10px 12px', fontFamily: T.mono, fontSize: 10, color: T.red,
+          wordBreak: 'break-all', lineHeight: 1.5,
+        }}>
+          "\u0022\u0022\\\u0022\\\\\\\\\u0022\\\\\\\\\\\\\\\\\u0022\\\\\\\\\\\\\\\\\\\\\\\\\u0022…
+        </div>
+      </div>
+    </div>
+    <div>
+      <div style={{ fontFamily: T.mono, fontSize: 10, color: T.accent, letterSpacing: '0.16em', textTransform: 'uppercase' }}>
+        Proposed — chips · one extension per chip · nothing to escape
+      </div>
+      <div style={{
+        marginTop: 8, background: T.raised, border: `1px solid ${T.sep}`,
+        borderRadius: 8, padding: 14,
+      }}>
+        <div style={{ fontFamily: T.mono, fontSize: 11, color: T.lo, letterSpacing: '0.10em', textTransform: 'uppercase', marginBottom: 8 }}>Show only</div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {['.mp3', '.flac', '.wav', '.m4a'].map((x) => (
+            <span key={x} style={{
+              height: 32, padding: '0 12px',
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              background: T.accentDim, border: `1px solid ${T.accent}55`,
+              borderRadius: 16, fontSize: 13, color: T.accent,
+              fontFamily: T.mono,
+            }}>{x} <span style={{ opacity: 0.6, fontSize: 14 }}>×</span></span>
+          ))}
+          <span style={{
+            height: 32, padding: '0 12px',
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+            background: 'transparent', border: `1px dashed ${T.sep}`,
+            borderRadius: 16, fontSize: 13, color: T.lo, fontFamily: T.mono,
+          }}>＋ add type</span>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   6. P1 — Persistent Now Playing dock
+   ════════════════════════════════════════════════════════════ */
+
+const FakePage = ({ title, children }) => (
+  <div style={{ flex: 1, padding: 24, display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <div style={{ fontSize: 22, fontWeight: 600, color: T.hi }}>{title}</div>
+    {children}
+  </div>
+);
+
+const SkelRow = ({ w = '100%', h = 12 }) => (
+  <div style={{ width: w, height: h, background: T.raised, borderRadius: 4 }} />
+);
+
+const Dock = () => (
+  <div style={{
+    height: 64, background: T.overlay, borderTop: `1px solid ${T.sep}`,
+    padding: '0 24px',
+    display: 'flex', alignItems: 'center', gap: 14,
+    backdropFilter: 'blur(20px)',
+  }}>
+    <div style={{
+      width: 48, height: 48, borderRadius: 6, flexShrink: 0,
+      background: 'linear-gradient(135deg, #2a2a30, #1a1a1f)',
+      position: 'relative', overflow: 'hidden',
+    }}>
+      <div style={{
+        position: 'absolute', inset: 0,
+        backgroundImage: `repeating-linear-gradient(135deg, rgba(255,255,255,0.05) 0 6px, transparent 6px 12px)`,
+      }} />
+    </div>
+    <div style={{ minWidth: 200 }}>
+      <div style={{ color: T.hi, fontSize: 14, fontWeight: 600 }}>We're Ready</div>
+      <div style={{ color: T.md, fontSize: 12 }}>
+        <span style={{
+          display: 'inline-block', width: 8, height: 8, borderRadius: 2,
+          background: T.sFile, marginRight: 6, verticalAlign: 1,
+        }} />
+        Boston · Third Stage
+      </div>
+    </div>
+    <div style={{ display: 'flex', gap: 2, alignItems: 'flex-end', height: 16, marginRight: 4 }}>
+      <span style={{ width: 3, height: 9, background: T.accent, borderRadius: 1 }} />
+      <span style={{ width: 3, height: 16, background: T.accent, borderRadius: 1 }} />
+      <span style={{ width: 3, height: 6, background: T.accent, borderRadius: 1 }} />
+    </div>
+    <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 10 }}>
+      <span style={{ fontFamily: T.mono, fontSize: 11, color: T.md, fontVariantNumeric: 'tabular-nums' }}>1:18</span>
+      <div style={{ flex: 1, height: 3, background: T.sep, borderRadius: 2, overflow: 'hidden' }}>
+        <div style={{ width: '44%', height: '100%', background: T.accent }} />
+      </div>
+      <span style={{ fontFamily: T.mono, fontSize: 11, color: T.md, fontVariantNumeric: 'tabular-nums' }}>3:00</span>
+    </div>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: T.md, fontSize: 20 }}>
+      <span>⏮</span>
+      <span style={{
+        width: 40, height: 40, borderRadius: 20, background: T.accent, color: T.base,
+        display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 16,
+      }}>▶</span>
+      <span>⏭</span>
+    </div>
+  </div>
+);
+
+const Mock_Dock = () => (
+  <Stage w={1920} h={760} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{
+      height: 64, background: T.base, borderBottom: `1px solid ${T.sep}`,
+      display: 'flex', alignItems: 'center', padding: '0 24px', gap: 20,
+    }}>
+      <div style={{ fontFamily: T.led, fontSize: 18, color: T.amber, letterSpacing: 3, textShadow: `0 0 6px ${T.amberGlow}` }}>11:29</div>
+      <div style={{ width: 1, height: 32, background: T.sep }} />
+      <div style={{ color: T.md, fontSize: 13 }}>FM Radio · 88.5 → Living Room</div>
+      <div style={{ marginLeft: 'auto', display: 'flex', gap: 4 }}>
+        <NavPill label="Home" />
+        <NavPill label="Devices" on />
+        <NavPill label="Metrics" />
+        <NavPill label="System" />
+      </div>
+    </div>
+    <FakePage title="Device Management">
+      <div style={{
+        background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8,
+        padding: 0, overflow: 'hidden',
+      }}>
+        {['VB-Audio Cable', 'Arctis Pro Wireless', 'LG TV · HDMI', 'Realtek USB', 'HTTP Audio Stream'].map((d, i) => (
+          <div key={d} style={{
+            padding: '14px 18px', display: 'flex', alignItems: 'center', gap: 14,
+            borderBottom: i < 4 ? `1px solid ${T.sep}` : 'none',
+            background: i === 0 ? 'rgba(92,212,232,0.04)' : 'transparent',
+          }}>
+            <span style={{ color: i === 0 ? T.accent : T.md, fontSize: 18 }}>{i === 0 ? '★' : '○'}</span>
+            <span style={{ color: T.hi, fontSize: 15, fontWeight: 500, flex: 1 }}>{d}</span>
+            {i === 0 && <span style={{
+              fontFamily: T.mono, fontSize: 11, color: T.accent,
+              background: T.accentDim, padding: '2px 8px', borderRadius: 4, letterSpacing: '0.1em', textTransform: 'uppercase',
+            }}>Default</span>}
+            <span style={{ color: T.md, fontSize: 13 }}>Output</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ flex: 1 }} />
+    </FakePage>
+    <Dock />
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   7. P1 — Source pill semantics
+   ════════════════════════════════════════════════════════════ */
+
+const Mock_PillSemantics = () => (
+  <Stage w={1100} h={320} pad={24} style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+    <div>
+      <div style={{ fontFamily: T.mono, fontSize: 10, color: T.red, letterSpacing: '0.16em', textTransform: 'uppercase' }}>
+        Current — one button, three different actions, no chevron
+      </div>
+      <div style={{ marginTop: 12, display: 'flex', gap: 8, fontSize: 12, color: T.lo, fontFamily: T.mono }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="📻" label="Radio" accent={T.sRadio} />
+          <span>tap → switch source</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="📻" label="Radio" accent={T.sRadio} />
+          <span style={{ color: T.amber }}>tap again → toggle home panel</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="⌁" label="Bluetooth" accent={T.sBT} />
+          <span style={{ color: T.amber }}>tap again → navigate /bluetooth</span>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div style={{ fontFamily: T.mono, fontSize: 10, color: T.accent, letterSpacing: '0.16em', textTransform: 'uppercase' }}>
+        Proposed — body switches source · chevron opens detail
+      </div>
+      <div style={{ marginTop: 12, display: 'flex', gap: 8, fontSize: 12, color: T.lo, fontFamily: T.mono }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="📻" label="Radio" sub="88.5" accent={T.sRadio} chev />
+          <span>body → switch  ·  ›  → detail</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="⌁" label="Bluetooth" sub="JBL Charge" accent={T.sBT} chev />
+          <span>body → switch  ·  ›  → device list</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="♪" label="File" />
+          <span>no detail · just switches</span>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   8. P1 — Visualizer panel
+   ════════════════════════════════════════════════════════════ */
+
+const VizSpectrum = ({ bars = 32, w = '100%', h = 380, color = T.accent }) => {
+  const data = Array.from({ length: bars }, (_, i) => {
+    const x = i / bars;
+    return 0.35 + 0.6 * Math.abs(Math.sin(x * 6 + 1)) * (1 - x * 0.4);
+  });
+  return (
+    <svg viewBox={`0 0 ${bars * 10} 100`} preserveAspectRatio="none" style={{ width: w, height: h, display: 'block' }}>
+      {data.map((v, i) => (
+        <rect key={i} x={i * 10 + 1.5} y={100 - v * 90} width={7} height={v * 90}
+              fill={color} opacity={0.75 + 0.25 * v} />
+      ))}
+    </svg>
+  );
+};
+
+const Mock_Visualizer = () => (
+  <Stage w={1480} h={620} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{ display: 'flex', flex: 1 }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Current" title="Mode picker in corner · debug telemetry overlaid · canvas inset from edges" />
+        <div style={{ flex: 1, padding: 16 }}>
+          <div style={{ height: '100%', background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, padding: 16, position: 'relative' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+              <div style={{ color: T.hi, fontSize: 14 }}>Visualizer</div>
+              <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+                <span style={{ background: T.green, color: T.base, padding: '2px 8px', borderRadius: 10, fontSize: 10, fontWeight: 600 }}>Connected</span>
+                <span style={{ border: `1px solid ${T.accent}`, color: T.accent, padding: '2px 8px', borderRadius: 4, fontSize: 11 }}>VU</span>
+                <span style={{ border: `1px solid ${T.sep}`, color: T.md, padding: '2px 8px', borderRadius: 4, fontSize: 11 }}>WAVE</span>
+                <span style={{ border: `1px solid ${T.sep}`, color: T.md, padding: '2px 8px', borderRadius: 4, fontSize: 11 }}>SPEC</span>
+              </div>
+            </div>
+            <div style={{ position: 'relative', background: T.inset, borderRadius: 4, height: 360, overflow: 'hidden' }}>
+              <VizSpectrum h={360} bars={28} />
+              <div style={{
+                position: 'absolute', bottom: 8, left: 8,
+                color: T.yellow, fontFamily: T.mono, fontSize: 11, fontWeight: 600,
+              }}>Updates: 22/sec</div>
+              <div style={{
+                position: 'absolute', bottom: 8, left: '50%', transform: 'translateX(-50%)',
+                color: T.lo, fontFamily: T.mono, fontSize: 9, display: 'flex', gap: 60,
+              }}>
+                <span>375Hz</span><span>750Hz</span><span>1.1kHz</span><span>1.5kHz</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Divider />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Promoted" title="Mode picker = top segmented control · canvas fills · dev telemetry gated" after />
+        <div style={{ flex: 1, padding: 16 }}>
+          <div style={{ height: '100%', background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+            <div style={{
+              display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)',
+              borderBottom: `1px solid ${T.sep}`,
+            }}>
+              {['VU Meter', 'Waveform', 'Spectrum'].map((m, i) => (
+                <div key={m} style={{
+                  padding: '14px 0', textAlign: 'center',
+                  background: i === 2 ? T.accentDim : 'transparent',
+                  color: i === 2 ? T.accent : T.md,
+                  fontFamily: T.mono, fontSize: 12, letterSpacing: '0.10em',
+                  textTransform: 'uppercase', fontWeight: 600,
+                  borderRight: i < 2 ? `1px solid ${T.sep}` : 'none',
+                  position: 'relative',
+                }}>
+                  {m}
+                  {i === 2 && <span style={{
+                    position: 'absolute', bottom: 0, left: '20%', right: '20%',
+                    height: 2, background: T.accent,
+                  }} />}
+                </div>
+              ))}
+            </div>
+            <div style={{ flex: 1, position: 'relative', background: T.inset }}>
+              <VizSpectrum h="100%" bars={48} />
+              <div style={{
+                position: 'absolute', top: 12, right: 12,
+                width: 8, height: 8, borderRadius: 4, background: T.green,
+                boxShadow: `0 0 8px ${T.green}`,
+              }} />
+              <div style={{
+                position: 'absolute', bottom: 8, left: 0, right: 0,
+                color: T.lo, fontFamily: T.mono, fontSize: 10, display: 'flex',
+                justifyContent: 'space-around',
+              }}>
+                <span>250Hz</span><span>500Hz</span><span>1kHz</span><span>2kHz</span><span>4kHz</span><span>8kHz</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   9. P1 — Queue split layout
+   ════════════════════════════════════════════════════════════ */
+
+const Mock_QueueSplit = () => (
+  <Stage w={1200} h={660} style={{ display: 'flex', flexDirection: 'column' }}>
+    <SectionLabel kicker="Center column of Home" title="Queue list + context panel · uses the whole 640px of vertical content area"
+      after />
+    <div style={{ flex: 1, padding: 16, display: 'flex', gap: 12 }}>
+      <div style={{ flex: 1.6, display: 'flex', flexDirection: 'column' }}>
+        <div style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          padding: '6px 10px 12px',
+        }}>
+          <div style={{ display: 'flex', gap: 4 }}>
+            <span style={{
+              padding: '6px 14px', background: T.accentDim, color: T.accent,
+              borderRadius: 6, fontFamily: T.mono, fontSize: 12,
+              letterSpacing: '0.10em', textTransform: 'uppercase', fontWeight: 600,
+            }}>Queue · 45</span>
+            <span style={{
+              padding: '6px 14px', color: T.md,
+              borderRadius: 6, fontFamily: T.mono, fontSize: 12,
+              letterSpacing: '0.10em', textTransform: 'uppercase', fontWeight: 600,
+            }}>History</span>
+            <span style={{
+              padding: '6px 14px', color: T.md,
+              borderRadius: 6, fontFamily: T.mono, fontSize: 12,
+              letterSpacing: '0.10em', textTransform: 'uppercase', fontWeight: 600,
+            }}>Radio</span>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <span style={{ color: T.accent, fontSize: 16 }}>＋</span>
+            <span style={{ color: T.md, fontSize: 16 }}>⋮</span>
+          </div>
+        </div>
+        <div style={{
+          flex: 1, background: T.raised, borderRadius: 8, border: `1px solid ${T.sep}`,
+          overflow: 'hidden',
+        }}>
+          <QRowAfter n="1" title="We're Ready" art="Boston" alb="Third Stage" dur="3:00" active />
+          <QRowAfter n="2" title="I'm Not in Love" art="10cc" alb="Original Soundtrack" dur="6:04" />
+          <QRowAfter n="3" title="Bixby Canyon Bridge" art="Death Cab" alb="Narrow Stairs" dur="5:15" />
+          <QRowAfter n="4" title="Hot for Teacher" art="Van Halen" alb="1984" dur="4:42" />
+          <QRowAfter n="5" title="Don't Look Back" art="Boston" alb="Don't Look Back" dur="5:58" />
+          <QRowAfter n="6" title="Foreplay / Long Time" art="Boston" alb="Boston" dur="7:48" />
+          <QRowAfter n="7" title="More Than a Feeling" art="Boston" alb="Boston" dur="4:44" />
+        </div>
+      </div>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 12, marginTop: 50 }}>
+        <div style={{ background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, padding: 16 }}>
+          <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.14em', textTransform: 'uppercase' }}>Queue Total</div>
+          <div style={{ fontFamily: T.led, fontSize: 30, color: T.amber, marginTop: 6, letterSpacing: 4, textShadow: `0 0 8px ${T.amberGlow}` }}>
+            2:48:15
+          </div>
+          <div style={{ color: T.md, fontSize: 12, marginTop: 4 }}>45 tracks · ends ~14:17</div>
+        </div>
+        <div style={{ background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, padding: 16 }}>
+          <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.14em', textTransform: 'uppercase', marginBottom: 8 }}>Up next</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {[
+              ['I\'m Not in Love', '10cc', T.hi],
+              ['Bixby Canyon Bridge', 'Death Cab', T.md],
+              ['Hot for Teacher', 'Van Halen', T.lo],
+            ].map(([t, a, c]) => (
+              <div key={t} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                <div style={{ width: 32, height: 32, background: T.overlay, borderRadius: 4, flexShrink: 0 }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ color: c, fontSize: 13, fontWeight: 500, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{t}</div>
+                  <div style={{ color: T.lo, fontSize: 11 }}>{a}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div style={{ background: T.raised, border: `1px solid ${T.accent}55`, borderRadius: 8, padding: 14, display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ color: T.accent, fontSize: 18 }}>＋</span>
+          <span style={{ color: T.accent, fontSize: 14, fontWeight: 500 }}>Save as playlist</span>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   10. P1 — Skeleton loading
+   ════════════════════════════════════════════════════════════ */
+
+const Skel = ({ w, h, br = 4 }) => (
+  <div style={{ width: w, height: h, background: `linear-gradient(90deg, ${T.raised} 0%, ${T.overlay} 50%, ${T.raised} 100%)`, backgroundSize: '200% 100%', borderRadius: br, animation: 'shimmer 1.4s infinite' }} />
+);
+
+const Mock_Skeleton = () => (
+  <Stage w={1280} h={660} style={{ display: 'flex', flexDirection: 'column' }}>
+    <SectionLabel kicker="Loading states" title="Shape-matched skeletons replace centered spinners on every primary panel"
+      after />
+    <style>{`@keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }`}</style>
+    <div style={{ flex: 1, padding: 16, display: 'flex', gap: 12 }}>
+      <div style={{ width: 360, background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, padding: 16, display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.12em', textTransform: 'uppercase' }}>Now Playing · loading</div>
+        <Skel w={280} h={280} br={8} />
+        <Skel w="80%" h={18} />
+        <Skel w="60%" h={14} />
+        <div style={{ flex: 1 }} />
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
+          <Skel w={40} h={40} br={20} />
+          <Skel w={56} h={56} br={28} />
+          <Skel w={40} h={40} br={20} />
+        </div>
+      </div>
+      <div style={{ flex: 1, background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, padding: 20, display: 'flex', flexDirection: 'column', gap: 18 }}>
+        <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.12em', textTransform: 'uppercase' }}>Radio control · loading</div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <Skel w={64} h={36} br={6} />
+          <Skel w={64} h={36} br={6} />
+          <Skel w={64} h={36} br={6} />
+        </div>
+        <div style={{ background: T.inset, borderRadius: 8, padding: 24, textAlign: 'center', border: `1px solid ${T.sep}` }}>
+          <Skel w={300} h={56} br={4} />
+        </div>
+        <div>
+          <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 6 }}>Signal</div>
+          <div style={{ display: 'flex', gap: 2 }}>
+            {Array.from({ length: 20 }).map((_, i) => (
+              <Skel key={i} w={20} h={20} br={2} />
+            ))}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 8, marginTop: 'auto' }}>
+          <Skel w={48} h={48} br={24} />
+          <Skel w={48} h={48} br={24} />
+          <Skel w={64} h={48} br={24} />
+          <Skel w={48} h={48} br={24} />
+          <Skel w={48} h={48} br={24} />
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   11. P2 — Sleep screen ambient
+   ════════════════════════════════════════════════════════════ */
+
+const Mock_Sleep = () => (
+  <Stage w={1920} h={760} style={{ background: '#050507', position: 'relative' }}>
+    <div style={{
+      position: 'absolute', inset: 0,
+      background: 'radial-gradient(ellipse at center, rgba(240,168,48,0.06) 0%, transparent 60%)',
+    }} />
+    <div style={{
+      position: 'absolute', inset: 0, display: 'flex',
+      alignItems: 'center', justifyContent: 'center', flexDirection: 'column', gap: 28,
+    }}>
+      <div style={{
+        width: 160, height: 160, borderRadius: 16,
+        background: 'linear-gradient(135deg, #1a1517 0%, #0d0a0c 100%)',
+        position: 'relative', overflow: 'hidden',
+        boxShadow: '0 20px 80px rgba(240,168,48,0.08)',
+        opacity: 0.4,
+      }}>
+        <div style={{ position: 'absolute', inset: 0, backgroundImage: `repeating-linear-gradient(135deg, rgba(240,168,48,0.05) 0 10px, transparent 10px 20px)` }} />
+      </div>
+      <div style={{
+        fontFamily: T.led, fontSize: 96, color: T.amber,
+        textShadow: `0 0 24px ${T.amberGlow}, 0 0 60px rgba(240,168,48,0.15)`,
+        letterSpacing: 14,
+      }}>11:29</div>
+      <div style={{
+        fontFamily: T.body, fontSize: 18, color: T.dim,
+        letterSpacing: '0.08em',
+      }}>We're Ready · Boston</div>
+      <div style={{
+        fontFamily: T.mono, fontSize: 11, color: '#1f1a1d',
+        letterSpacing: '0.18em', textTransform: 'uppercase',
+        marginTop: 60,
+      }}>tap anywhere to wake</div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   12. P2 — Dev tools gesture & tray
+   ════════════════════════════════════════════════════════════ */
+
+const Mock_DevTools = () => (
+  <Stage w={880} h={620} style={{ display: 'flex', flexDirection: 'column' }}>
+    <SectionLabel kicker="Production hygiene" title="Distortion marker + telemetry hidden behind a corner gesture"
+      after />
+    <div style={{ flex: 1, padding: 20, display: 'flex', flexDirection: 'column', gap: 16, overflow: 'hidden' }}>
+      <div style={{
+        position: 'relative', height: 64, background: T.base,
+        border: `1px solid ${T.sep}`, borderRadius: 6,
+        display: 'flex', alignItems: 'center', padding: '0 16px', gap: 16,
+      }}>
+        <div style={{ fontFamily: T.led, fontSize: 18, color: T.amber, letterSpacing: 3, textShadow: `0 0 6px ${T.amberGlow}` }}>11:29</div>
+        <span style={{ color: T.md, fontSize: 13 }}>FM Radio · 88.5 → Living Room</span>
+        <div style={{
+          position: 'absolute', top: 0, right: 0, width: 48, height: 48,
+          border: `1px dashed ${T.accent}55`,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <span style={{ fontSize: 10, color: T.accent, fontFamily: T.mono, letterSpacing: '0.10em' }}>3×TAP</span>
+        </div>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+        <div style={{ fontSize: 20, color: T.accent, marginTop: 4 }}>↓</div>
+        <div style={{ color: T.md, fontSize: 13 }}>
+          Triple-tap the clock corner to unlock the dev tray. Re-locks after 30s idle.
+        </div>
+      </div>
+      <div style={{
+        background: T.raised, border: `1px solid ${T.accent}55`,
+        borderRadius: 8, padding: 14,
+        boxShadow: `0 8px 32px rgba(0,0,0,0.4)`,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+          <div style={{ fontFamily: T.mono, fontSize: 10, color: T.accent, letterSpacing: '0.14em', textTransform: 'uppercase' }}>
+            ● Dev Tray  ·  unlocked
+          </div>
+          <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo }}>auto-lock 0:27</div>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+          {[
+            ['🐞', 'Mark distortion', 'reports a flag at current playback offset'],
+            ['📊', 'Updates: 22/sec', 'live visualizer telemetry'],
+            ['💾', 'Dump audio frame', 'last 5s buffered'],
+            ['📜', 'Download logs', 'last hour · zip'],
+            ['🔧', 'Fingerprint events', '12 events · last 5 min'],
+            ['🧪', 'Engine state', 'Active · FilePlayer · Stopped'],
+          ].map(([ic, t, sub]) => (
+            <div key={t} style={{
+              padding: 12, background: T.inset, borderRadius: 6,
+              border: `1px solid ${T.sep}`,
+              display: 'flex', gap: 10, alignItems: 'flex-start',
+            }}>
+              <span style={{ fontSize: 16 }}>{ic}</span>
+              <div>
+                <div style={{ color: T.hi, fontSize: 13, fontWeight: 500 }}>{t}</div>
+                <div style={{ color: T.lo, fontSize: 11 }}>{sub}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ─────────── publish ─────────── */
+Object.assign(window, {
+  Mock_TopBar,
+  Mock_Naming,
+  Mock_Queue,
+  Mock_Metrics,
+  Mock_FbFilter,
+  Mock_Dock,
+  Mock_PillSemantics,
+  Mock_Visualizer,
+  Mock_QueueSplit,
+  Mock_Skeleton,
+  Mock_Sleep,
+  Mock_DevTools,
+});

--- a/docs/superpowers/plans/2026-05-17-radio-console-design-tightening.md
+++ b/docs/superpowers/plans/2026-05-17-radio-console-design-tightening.md
@@ -1,0 +1,728 @@
+# Radio Console — Design Tightening Arc
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement each PR task-by-task. Each PR in this arc is a standalone unit — pick one PR section and ship it end-to-end. Do NOT bundle multiple PRs into a single branch.
+
+## Arc overview
+
+This arc converts the approved Radio Console design-tightening handoff (`docs/handoffs/design_handoff_radio_console/`) into shippable work. The handoff defines 12 change items (P0·0–P2·2) plus a cross-cutting nice-to-haves section. The visual + behaviour spec lives in `Handoff Canvas.html` and `IMPLEMENTATION.md` inside that folder — this plan does NOT redesign anything; it slices the approved script into reviewable PR-sized units.
+
+The arc is multi-PR because:
+
+1. **P0·0 (Formatting layer)** is a foundation that P0·2, P0·3, and P0·4 all consume. It must land first.
+2. **The topbar redesign (P0·1)** touches `MainLayout.razor` heavily and is large enough to deserve its own review window, especially with the new `SourceBubble.razor` extraction.
+3. **Display-name and timestamp fixes (P0·2 + P0·3)** touch the same panels (`NowPlayingPanel`, `QueueHistoryPanel`) and naturally group.
+4. **Metrics, File Browser, Now Playing dock, source-pill semantics, Visualizer, Queue split, Skeletons, Sleep, Dev tray** each touch distinct surfaces and are best landed as small focused PRs.
+
+We collapse the 12 items into **6 sequenced PRs**:
+
+| PR | Items landed | Theme |
+|---|---|---|
+| PR 1 | P0·0 | Formatting layer foundation |
+| PR 2 | P0·1 + cross-cutting nice-to-haves | Topbar redesign + a11y/legibility polish |
+| PR 3 | P0·2 + P0·3 + P0·5 | Display names, durations/timestamps, File Browser chips |
+| PR 4 | P0·4 + P1·3 + P1·5 | Metrics tiles + Visualizer mode picker + Skeleton states |
+| PR 5 | P1·1 + P1·2 + P1·4 | Now Playing dock + source-pill semantics + Queue split |
+| PR 6 | P2·1 + P2·2 | Sleep screen + Dev tray gesture |
+
+**Branch lineage rules (apply to every PR):**
+
+- Branch from `main`, NOT from `feature/rotaryphone-sip-integration` (that branch has unrelated SIP/PhonePage WIP that must not ride along).
+- Name pattern: `feat/web-design-<short-theme>` (e.g. `feat/web-design-formatting-layer`).
+- Each PR opens against `main` and is squash-merged after review.
+- Do NOT chain PRs off each other unless a hard code dependency requires it — when PR N's files only *consume* PR N-1's new APIs, rebase onto main after the prior PR merges rather than stacking.
+
+**Tech stack:** .NET 10, Blazor Server (Radzen + MudBlazor), `src/Radio.Web/`, design tokens in `src/Radio.Web/wwwroot/css/design-system.css`. Tests in `tests/Radio.Web.Tests/`. Target viewport: **1920×720 kiosk**.
+
+**Build/test cadence (every PR):**
+
+```bash
+dotnet build --configuration Release        # 0 warnings expected
+dotnet test  --configuration Release        # ~1,697 tests across 10 projects
+```
+
+UAT happens on the Ubuntu kiosk:
+
+```powershell
+.\deploy\Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64
+```
+
+Then browse `http://radio:5002/` at 1920×720.
+
+---
+
+## PR 1 — `feat(web): formatting layer for durations, timestamps, display names, and units`
+
+**Handoff items landed:** P0·0
+
+**Why standalone:** This is the foundation that PRs 3 and 4 consume. Landing it alone keeps the diff tiny and reviewable (~250 LOC including tests), and lets reviewers focus on the formatting contract rather than its consumers.
+
+**Branch:** `feat/web-design-formatting-layer` off `main`.
+
+### Files
+
+**New:**
+- `src/Radio.Web/Formatting/Durations.cs`
+- `src/Radio.Web/Formatting/Timestamps.cs`
+- `src/Radio.Web/Formatting/DisplayNames.cs`
+- `src/Radio.Web/Formatting/Units.cs`
+- `tests/Radio.Web.Tests/Formatting/DurationsTests.cs`
+- `tests/Radio.Web.Tests/Formatting/TimestampsTests.cs`
+- `tests/Radio.Web.Tests/Formatting/DisplayNamesTests.cs`
+- `tests/Radio.Web.Tests/Formatting/UnitsTests.cs`
+
+**Modified:**
+- `src/Radio.Web/Components/_Imports.razor` — add `@using Radio.Web.Formatting`
+- `src/Radio.Web/appsettings.json` — add an empty `Devices:Aliases` object so PR 3 can populate without touching schema (optional; PR 3 can add it too — surface as open question below).
+
+### Implementation notes (verbatim from handoff §P0·0, condensed)
+
+1. Flat `static class` helpers under `Radio.Web.Formatting`. No DI, no state.
+
+2. `Durations.FormatTrack(TimeSpan t)`:
+   - `t < 1h` → `"{m}:{ss:00}"` (e.g. `3:00`)
+   - `t >= 1h` → `"{h}:{mm:00}:{ss:00}"` (e.g. `1:02:14`)
+   - `t.TotalSeconds < 1 || t == TimeSpan.Zero` → `"—"`
+   - `TimeSpan?` overload returns `"—"` on null.
+
+3. `Durations.FormatLong(TimeSpan t)` for queue totals: always `h:mm:ss`.
+
+4. `Timestamps.FormatRelative(DateTime local)`:
+   - Same calendar day → `"Today {HH:mm}"`
+   - Yesterday → `"Yesterday {HH:mm}"`
+   - Older → `"{MMM d} · {HH:mm}"`
+   - Caller converts UTC → local before calling.
+
+5. `DisplayNames.Source(AudioSourceDto s)`:
+   - Strip `-{guid}` suffix from `Id` when `Name` is missing.
+   - Return `Name` if set, else humanize `Type` (`"FilePlayer"` → `"File Player"`).
+   - **Never** return raw `Id`.
+
+6. `DisplayNames.Device(AudioDeviceDto d, IDictionary<string,string>? aliasMap = null)`:
+   - Apply `aliasMap` first.
+   - Strip trailing parenthesized hardware-driver suffixes when head is sufficiently descriptive (define threshold: head length ≥ 4 chars AND contains a space, OR explicit allow list — Builder decides during impl, document in code).
+   - Strip leading `"N - "` enumeration prefixes.
+   - Cap at 40 chars + ellipsis.
+
+7. `DisplayNames.Track(NowPlayingDto np)`:
+   - Prefer `np.Title` if non-empty and not literally `"Track {n}"` filename-derived.
+   - When generic, parse `np.FilePath`: strip extension, strip `^\d+[\s\-_]+`, title-case if all-lowercase.
+   - Subtitle: `np.Artist ?? "—"`.
+
+8. `Units` enum + `Units.Format(double value, Units unit)`:
+   ```csharp
+   public enum Units {
+     Percent, Megabytes, Milliseconds, Count, PerMinute, Frequency, Decibels, Bare
+   }
+   ```
+   - Thousands-separated for `Count`.
+   - One decimal for `Percent` if value < 10, else integer.
+   - `Milliseconds` auto-converts to `"{value/1000:0.0} s"` when ≥ 1000.
+   - `Frequency` delegates to existing `FrequencyFormatter`.
+
+### Tests (xUnit)
+
+- `DurationsTests` — round-trip the acceptance cases: 180.66s → `3:00`; 0s → `—`; 3742s → `1:02:22`; `null` → `—`. ~10 cases.
+- `TimestampsTests` — freeze `now`, exercise same-day / yesterday / older branches. Use a `Func<DateTime>` clock hook or pass `now` as a second arg for testability (Builder picks one approach; document choice).
+- `DisplayNamesTests`:
+  - GUID-suffix stripping cases.
+  - `Track 8` + `FilePath = ".../01 - opening.mp3"` → `"Opening"`.
+  - Device alias map applied; long names ellipsised; `N - ` prefix stripped.
+  - Regex assertion: result never matches `[0-9a-f]{8}-[0-9a-f]{4}`.
+- `UnitsTests` — one assertion per enum variant for boundary values.
+
+### Acceptance
+
+- [ ] All four formatter files compile under `Radio.Web.Formatting`.
+- [ ] `Durations.FormatTrack(TimeSpan.FromSeconds(180.6628))` → `"3:00"`.
+- [ ] `DisplayNames.Source` results never contain a GUID character span (regex test in unit tests).
+- [ ] Unit test coverage ≥ 90% on each formatter class (verify with `dotnet test --collect:"XPlat Code Coverage"` — soft target, don't block PR on it).
+- [ ] `dotnet build` clean, 0 warnings.
+- [ ] `_Imports.razor` updated so Razor files can call formatters without explicit `@using` per file.
+
+### UAT
+
+No UI surface yet — formatter library is dead code until PR 2/3 consume it. The acceptance gate is the test suite.
+
+### Dependencies
+
+None. This is the foundation PR.
+
+### LOC estimate
+
+~250–350 (production) + ~250 (tests). Single PR, easily reviewable.
+
+---
+
+## PR 2 — `feat(web): topbar redesign with source bubbles and a11y polish`
+
+**Handoff items landed:** P0·1 + cross-cutting nice-to-haves (scrollbars, `--text-medium` bump, `aria-label`, focus rings)
+
+**Why standalone:** P0·1 is the single largest change in the package — it restructures `MainLayout.razor`, extracts a new `SourceBubble.razor` component, and reworks four CSS sections. Folding it together with display-name fixes (P0·2) would create a monster PR. The cross-cutting nice-to-haves naturally belong here because they primarily touch `design-system.css` and `MainLayout.razor` chrome.
+
+**Branch:** `feat/web-design-topbar` off `main`. Rebase onto main after PR 1 merges (no code dependency on PR 1 — topbar wiring to display names happens in PR 3).
+
+### Files
+
+**New:**
+- `src/Radio.Web/Components/Shared/SourceBubble.razor`
+- `src/Radio.Web/Components/Shared/SourceBubble.razor.css` (scoped CSS optional — Builder may inline into design-system.css §N Source bubble)
+- `tests/Radio.Web.Tests/Components/Shared/SourceBubbleTests.cs`
+
+**Modified:**
+- `src/Radio.Web/Components/Layout/MainLayout.razor` — restructure topbar; remove `route-toggle` markup; remove debug button (gate behind `#if DEBUG` until P2·2 lands).
+- `src/Radio.Web/wwwroot/css/design-system.css`:
+  - `§2 CSS Custom Properties` — `--topbar-height: 120px`, `--content-height: 600px`, bump `--text-medium` from `#9CA3AF` to `#B5BCC9`.
+  - `§5 Top Bar` — `.topbar-primary` (64px), `.topbar-sources` (56px), `.cluster`, `.cluster-label`, `.cluster-value`, `.cluster-swatch`.
+  - `§6 Route Toggle` — delete `.route-toggle`/`.route-active` after migration confirms no other references.
+  - `§7 Navigation Icons` → rename to `§7 Navigation Pills`, replace `.nav-icon` with `.nav-pill` (56px tall, 16px h-padding, 10px radius), `.nav-pill.active`, `.nav-badge`.
+  - `§19 Scrollbars` — replace blanket-hide with thin (3px) visible thumb on `.panel-body` and `.queue-list-wrapper`.
+  - New `§N Focus rings` — `:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }` while preserving `-webkit-tap-highlight-color: transparent` for touch.
+
+### Implementation notes (verbatim from handoff §P0·1, condensed)
+
+1. Bump topbar from 80px → 120px; verify nothing else hard-codes `640px`/`80px` (grep both).
+2. Two-row topbar inside `.topbar`:
+   - **Row 1 `.topbar-primary` (64px):** Time cluster | In cluster | `→` glyph | Out cluster | nav pill strip.
+   - **Row 2 `.topbar-sources` (56px):** Left-aligned source bubble strip.
+3. Cluster atoms: `.cluster-label` (mono 10px, 0.16em letter-spacing, uppercase, `--text-low`), `.cluster-value` (15px, `--text-high`, 500 weight, may contain inline `--font-led` span), `.cluster-swatch` (8×8, 2px radius).
+4. Replace nine `.nav-icon` circles with `.nav-pill` rectangles (56px tall, 16px padding, 10px radius, Inter 12px uppercase 0.10em letter-spacing). Active: `background: var(--accent-dim); color: var(--accent);`. Queue badge variant: amber pill, 10px font.
+5. `SourceBubble.razor` props:
+   ```
+   [Parameter] public string Icon
+   [Parameter] public string Label
+   [Parameter] public string? Sub
+   [Parameter] public string Accent       // CSS variable name, e.g. "--source-radio"
+   [Parameter] public bool IsActive
+   [Parameter] public bool IsDisabled
+   [Parameter] public bool HasDetail
+   [Parameter] public EventCallback OnSwitch
+   [Parameter] public EventCallback OnOpenDetail
+   ```
+   - Pill shape `height: 48px; border-radius: 24px`, 28×28 round icon chip on left, label + optional sub.
+   - Active: `background: {accent}14; border: 1px solid {accent}55; color: {accent};`.
+   - `HasDetail && IsActive` → trailing `›` glyph as separate focusable element bound to `OnOpenDetail`, with `@onclick:stopPropagation`.
+   - `IsDisabled` → `opacity: 0.4; pointer-events: none;` and append ` · offline` to `Sub`.
+   - **Keep the `data-source` attribute** on the root element so existing tests / CSS hooks don't break.
+6. Remove the inline `RadzenButton` debug distortion marker at lines ~76–83 of `MainLayout.razor`. Gate behind `#if DEBUG` (lower priority — full removal happens in P2·2 / PR 6).
+7. Verify `.content-area` margin tracks `--topbar-height` and not a hard `80`.
+8. **Cross-cutting:**
+   - Add `aria-label` to every icon-only button in `MainLayout` (Sleep, Queue badge, debug button if it stays for DEBUG builds).
+   - Scrollbar CSS as in handoff:
+     ```css
+     .panel-body { scrollbar-width: thin; scrollbar-color: var(--text-low) transparent; }
+     .panel-body::-webkit-scrollbar { display: block; width: 3px; }
+     .panel-body::-webkit-scrollbar-thumb { background: var(--text-low); border-radius: 2px; }
+     ```
+   - Same rules for `.queue-list-wrapper`.
+
+### Tests
+
+- `SourceBubbleTests` (bUnit, MudBlazor + Radzen with `JSInterop.Mode = JSRuntimeMode.Loose`):
+  - Renders label + sub.
+  - `IsActive` applies the accent class and shows the chevron only when `HasDetail`.
+  - Clicking the body fires `OnSwitch`; clicking the chevron fires `OnOpenDetail` but NOT `OnSwitch`.
+  - `IsDisabled` suppresses click and appends "offline" sub text.
+- Update or smoke-check `MainLayout` rendering tests if any exist that assert `.route-toggle`. Add a smoke test that renders `MainLayout` and asserts: zero `.route-toggle` elements; one `.topbar-primary`; one `.topbar-sources`; nav pills present.
+
+### Acceptance (from handoff)
+
+- [ ] Top bar matches the "After" artboard within ±2px on a 1920-wide preview.
+- [ ] No circular pill remains anywhere in the top bar.
+- [ ] Active source AND active output both show their human name (not just a colored icon).
+- [ ] Debug button is gone from release builds.
+- [ ] Content pages still vertically fit in 600px without scrollbars on Home/Devices/Queue.
+- [ ] Thin scrollbar thumb appears on overflowing `.panel-body`.
+- [ ] `--text-medium` is `#B5BCC9`.
+- [ ] Tabbing through the topbar shows visible focus rings on every focusable element.
+
+### UAT (1920×720 kiosk)
+
+- [ ] Deploy and open Home — topbar is 120px, two rows, sources show as labelled pills.
+- [ ] Active source pill has correct per-source accent color.
+- [ ] Queue badge appears as an amber pill on the Queue nav button.
+- [ ] Tab key cycles focus rings cleanly across topbar elements.
+- [ ] No black or shifted layout on Home/Devices/Queue/Metrics — all pages still fit 600px content area.
+- [ ] Screenshot diff against `screenshots/home.png` matches handoff "After" artboard.
+
+### Dependencies
+
+None hard. Cosmetic only — PR 1 not strictly required, but rebase onto main after PR 1 merges to avoid conflicts in `_Imports.razor`.
+
+### LOC estimate
+
+~500–700 (MainLayout + SourceBubble + CSS + tests).
+
+---
+
+## PR 3 — `feat(web): clean display names, duration/timestamp formatting, and File Browser chips`
+
+**Handoff items landed:** P0·2 + P0·3 + P0·5
+
+**Why grouped:** P0·2 (display names) and P0·3 (durations) both touch `NowPlayingPanel.razor`, `QueueHistoryPanel.razor`, and `DeviceManagementPage.razor` — natural co-edit. P0·5 (File Browser chip filter) is isolated to `FileBrowserDialog.razor` but is a small P0 fix that fits the "data-hygiene polish" theme and keeps PR 4 focused on dashboards/visualizer.
+
+**Branch:** `feat/web-design-display-hygiene` off `main`. **Hard dependency on PR 1** (consumes the formatters). Rebase onto main after PR 1 merges.
+
+### Files
+
+**Modified:**
+- `src/Radio.Web/Components/Layout/MainLayout.razor` — source bubble labels via `DisplayNames.Source`.
+- `src/Radio.Web/Components/Shared/NowPlayingPanel.razor` — `DisplayNames.Track`, `Durations.FormatTrack`.
+- `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor` — `Durations.FormatTrack`, `Durations.FormatLong`, currently-playing row treatment.
+- `src/Radio.Web/Components/Pages/DeviceManagementPage.razor` — `DisplayNames.Device` with alias map.
+- `src/Radio.Web/Components/Dialogs/FileBrowserDialog.razor` — chip-based filter; fix breadcrumb/drive selector binding.
+- `src/Radio.Web/Components/Pages/PlayHistoryPage.razor` — `Timestamps.FormatRelative` for Date/Time column.
+- `src/Radio.Web/appsettings.json` — populate `Devices:Aliases` map.
+- `src/Radio.Web/Models/DevicesOptions.cs` (new, or wherever options types live — check `src/Radio.Web/Models/`) — typed binding for `Devices:Aliases`.
+- `src/Radio.Web/Program.cs` — bind `DevicesOptions` to configuration.
+
+**Tests (modified or added):**
+- `tests/Radio.Web.Tests/Components/Shared/QueueHistoryPanelTests.cs` — assert currently-playing row has amber border + `▶`.
+- `tests/Radio.Web.Tests/Components/Shared/NowPlayingPanelTests.cs` — assert no `TimeSpan.ToString` artefacts.
+- `tests/Radio.Web.Tests/Components/Dialogs/FileBrowserDialogTests.cs` — chip add/remove, persistence round-trip without double-escaping.
+
+### Implementation notes (verbatim from handoff §P0·2, §P0·3, §P0·5, condensed)
+
+**P0·2 (display names):**
+1. Add `Devices:Aliases` to `appsettings.json`:
+   ```json
+   "Devices": {
+     "Aliases": {
+       "CABLE Input (VB-Audio Virtual Cable)": "VB-Audio Cable In",
+       "CABLE In 16ch (VB-Audio Virtual Cable)": "VB-Audio Cable 16ch",
+       "Realtek Digital Output (Realtek USB Audio)": "Realtek USB · S/PDIF"
+     }
+   }
+   ```
+2. Bind a typed `DevicesOptions` in `Program.cs` and inject `IOptions<DevicesOptions>` where needed.
+3. Replace every raw-DTO-field binding with the appropriate `DisplayNames.*` call.
+4. Add `title="@rawName"` HTML tooltip on every display-name element for debug/a11y reach to the raw value.
+5. **Do NOT change DTOs server-side** — only display projection changes.
+
+**P0·3 (durations + timestamps):**
+1. Replace every `@track.Duration.ToString()` with `@Durations.FormatTrack(track.Duration)`.
+2. Replace progress display `@_elapsed.ToString(@"mm\:ss")` with `@Durations.FormatTrack(_elapsed)` to handle >1h case.
+3. PlayHistory: `@Timestamps.FormatRelative(row.PlayedAtUtc.ToLocalTime())` for Date/Time column.
+4. Add `font-variant-numeric: tabular-nums;` to every duration element so columns align.
+5. Right-align duration columns.
+6. Currently-playing row in queue: `border-left: 3px solid var(--signal-amber);` + replace index cell with `▶`.
+
+**P0·5 (File Browser chips):**
+1. Find filter persistence boundary — likely `JsonSerializer.Serialize` calls referencing a filter string or `LocalStorage`-backed filter.
+2. Replace persisted `string` with `List<string> _filterExtensions`. Add one-time repair pass for double-escaped legacy values: parse repeatedly until you get a `string[]`, then take it.
+3. Render row of `RadzenChip` with remove `×`. Append dashed `＋ add type` chip → popover with `.mp3 .flac .wav .m4a .aac .ogg .opus .wma`.
+4. Wire filter into file list query as case-insensitive `EndsWith` match.
+5. Fix breadcrumb/drive selector mismatch — both bind to `_currentPath`.
+
+### Acceptance (from handoff)
+
+P0·2:
+- [ ] No GUID character span (`[0-9a-f]{8}-[0-9a-f]{4}`) appears in any user-visible text on Home, Devices, Queue, History, File Browser.
+- [ ] `Track 8` / `Track 9` cases display parsed file names.
+- [ ] Long device strings ≤ 40 chars + ellipsis; full name in `title` tooltip.
+
+P0·3:
+- [ ] No `00:03:00.6628571`-style duration appears anywhere.
+- [ ] Queue rows show amber-left-border + `▶` indicator for currently-playing.
+- [ ] History Date/Time column reads `Today 08:40`, `Yesterday 14:22`, or `Feb 6 · 11:05` per age.
+
+P0·5:
+- [ ] No escaped JSON appears in filter UI.
+- [ ] Chips reorder/remove cleanly; persistence round-trips without re-escaping.
+- [ ] Adding `.mp3` filters file list immediately (no Apply button).
+- [ ] Breadcrumb and drive selector stay in sync.
+
+### UAT (1920×720 kiosk)
+
+- [ ] Switch between Bluetooth / File Player / Radio sources — topbar source bubble label is human-readable in every case, no GUIDs.
+- [ ] Devices page — paired BT device shows clean name; hover reveals raw name.
+- [ ] Queue with a file playing — currently-playing row has amber-left + `▶` glyph; duration column reads `3:42`, not `00:03:42.000…`.
+- [ ] Queue total tile reads `2:48:15`, not `02:48:15.4567890`.
+- [ ] Play history shows `Today 14:22`, `Yesterday 09:15`, `Mar 6 · 11:05` mix.
+- [ ] File Browser: open, see chips for current filter, remove `.flac` and watch list update without Apply; persistence survives dialog close/reopen.
+- [ ] File Browser: breadcrumb and drive selector show the same drive after navigation.
+
+### Dependencies
+
+**PR 1 must be merged first** (consumes all four formatters).
+
+### LOC estimate
+
+~400–600 across 7 files + tests.
+
+---
+
+## PR 4 — `feat(web): metrics dashboard, visualizer mode picker, and skeleton loading states`
+
+**Handoff items landed:** P0·4 + P1·3 + P1·5
+
+**Why grouped:** All three are about how *information surfaces inside panels* — metric tiles, visualizer mode segments, and skeleton placeholders. Skeleton is naturally introduced alongside the metric tile redesign (which has visible loading states) and the visualizer rework (same). Grouping keeps the new `Skeleton.razor` and `Sparkline.razor` components reviewed together and prevents two PRs both touching the loading-state branches across the same files.
+
+**Branch:** `feat/web-design-data-surfaces` off `main`. Hard dependency on PR 1 (for `Units` enum).
+
+### Files
+
+**New:**
+- `src/Radio.Web/Components/Shared/MetricTile.razor`
+- `src/Radio.Web/Components/Shared/Sparkline.razor`
+- `src/Radio.Web/Components/Shared/Skeleton.razor`
+- `tests/Radio.Web.Tests/Components/Shared/MetricTileTests.cs`
+- `tests/Radio.Web.Tests/Components/Shared/SparklineTests.cs`
+- `tests/Radio.Web.Tests/Components/Shared/SkeletonTests.cs`
+
+**Modified:**
+- `src/Radio.Web/Components/Pages/MetricsDashboardPage.razor` — group by category, swap layout, use `MetricTile`.
+- `src/Radio.Web/Components/Shared/VisualizerPanel.razor` — 3-segment header, full-bleed canvas, connection dot, remove burned-in telemetry.
+- Loading branches across:
+  - `src/Radio.Web/Components/Shared/NowPlayingPanel.razor`
+  - `src/Radio.Web/Components/Shared/RadioControlPanel.razor`
+  - `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor`
+  - `src/Radio.Web/Components/Shared/VisualizerPanel.razor`
+  - `src/Radio.Web/Components/Pages/DeviceManagementPage.razor`
+  - `src/Radio.Web/Components/Pages/PlayHistoryPage.razor`
+- Server-side metric descriptor — add `Unit` field. Located in `src/Radio.Metrics/` (standalone NuGet package). **Check whether this requires the package to be re-versioned + re-published locally.** Surface as open question.
+
+### Implementation notes (handoff §P0·4, §P1·3, §P1·5, condensed)
+
+**P0·4 (metrics):**
+1. Add `Unit` enum to each metric descriptor on server side. Defaults to `Bare`. Mirrors `Radio.Web.Formatting.Units`.
+2. `MetricTile.razor` parameters: `Category`, `Name`, `Value (double)`, `Unit`, `Series (IReadOnlyList<double>?)`, `Thresholds (double? warn, double? critical)`.
+   - Top: category in mono, 10px, uppercase, low contrast.
+   - Middle: name in body, 13px, medium contrast.
+   - Value: `--font-mono`, 30px, color from thresholds (green/amber/red) or `--text-high`.
+   - Sparkline: if `Series` provided, render `<Sparkline />` matched to value color.
+3. `Sparkline.razor` — pure inline SVG, `viewBox="0 0 120 28" preserveAspectRatio="none"`, takes `IReadOnlyList<double>` + `Stroke` parameter. Filled area 10% opacity below line.
+4. Group tiles by category with sub-header (mono 11px uppercase low contrast, 14px bottom margin). 2- or 4-column grid.
+5. Specific fixes from screenshots:
+   - `Memory Usage Mb` → Unit `Megabytes` → "850 MB" (NOT "850.4%").
+   - `Signal Strength` → Unit `Percent` → "65%".
+   - `Frequency Changes` → Unit `Count` → thousands-separated.
+   - `Latency Ms` → Unit `Milliseconds` → auto-converts to `s` above 1000.
+
+**P1·3 (visualizer):**
+1. Replace corner chip group with full-width 3-segment header (VU / WAVE / SPECTRUM), grid 3-col, 44px tall, mono 12px uppercase 0.10em letter-spacing.
+   - Active: `background: var(--accent-dim); color: var(--accent);` with 2px accent underline.
+   - Inactive: `color: var(--text-medium);` separated by 1px `var(--surface-separator)` borders.
+2. Canvas fills remaining vertical space. Remove current padding.
+3. Move "Connected" pill to single 8px dot at top-right of header — `var(--signal-green)` when connected, `var(--signal-red)` when not. No text.
+4. Remove burned-in `"Updates: 22/sec"` overlay from the canvas — moves to dev tray in PR 6.
+5. Frequency-band axis labels (`375Hz / 750Hz / 1.1kHz / 1.5kHz`) under canvas in 16px strip, mono 10px, low contrast.
+
+**P1·5 (skeletons):**
+1. `Skeleton.razor`:
+   ```csharp
+   public enum Shape { NowPlaying, Radio, ListRow, DeviceRow, MetricTile, Visualizer }
+   [Parameter] public Shape Shape { get; set; }
+   ```
+   Each shape arranges existing `.skeleton-*` divs from `design-system.css §17` to match real component layout.
+2. Replace every `RadzenProgressBarCircular` used as generic loading indicator with `<Skeleton Shape="..." />`.
+3. Keep `RadzenProgressBarCircular` only for modal/determinate progress (e.g. file scan bar).
+
+### Tests
+
+- `MetricTileTests` — value color matches threshold band; sparkline rendered only when `Series` provided.
+- `SparklineTests` — SVG path d-attribute computed correctly for known input; min/max normalization.
+- `SkeletonTests` — each `Shape` value produces a distinct DOM arrangement (basic structural assertions).
+- Update `MetricsDashboardPageTests` (if it exists) — assertion that "Memory Usage" tile shows MB not %.
+- Update `VisualizerPanelTests` (if it exists) — 3-segment header present, no burned-in "Updates" text.
+
+### Acceptance (from handoff)
+
+P0·4:
+- [ ] Memory tile reads `850 MB`, never `%`.
+- [ ] Each tile shows a sparkline when time-series data exists in the selected window.
+- [ ] Category sub-headers replace per-tile category prefix.
+- [ ] Tile value color matches threshold semantics (green/amber/red) — not all cyan.
+
+P1·3:
+- [ ] Mode picker is obvious primary control of panel.
+- [ ] Canvas fills available height/width, no debug telemetry overlaid.
+- [ ] Connection state is small dot, not pill.
+
+P1·5:
+- [ ] No centered spinner in any panel-body loading branch in `Components/`.
+- [ ] First-load on Radio shows freq-well + band-button + meter outlines, then animates to real content.
+
+### UAT (1920×720 kiosk)
+
+- [ ] Metrics page — category sub-headers visible; Memory tile reads "850 MB"; sparklines render under tiles with time-series data; color matches threshold.
+- [ ] Home → Visualizer panel — VU/WAVE/SPECTRUM 3-segment header at top, canvas fills below; no "Updates: NN/sec" overlay; connection dot top-right.
+- [ ] Hard-refresh Home — skeleton outlines flash before real content, no spinner.
+- [ ] Hard-refresh Devices page — device-row skeletons flash, then real rows.
+- [ ] Cold-load Radio page — band-button + freq-well skeletons appear.
+
+### Dependencies
+
+**PR 1 must be merged** (`Units` enum). If `Radio.Metrics` package needs a version bump for the new `Unit` field, surface that as an open question — Builder may need to coordinate with the local NuGet feed (`pack-local.ps1`).
+
+### LOC estimate
+
+~600–800 (three new components + dashboard refactor + visualizer rework + skeleton swaps).
+
+---
+
+## PR 5 — `feat(web): persistent Now Playing dock, source-pill semantics, and queue split layout`
+
+**Handoff items landed:** P1·1 + P1·2 + P1·4
+
+**Why grouped:** All three are P1 "shape of the product" changes that interact:
+- P1·1 (dock) needs the source bubble + accent treatment from PR 2.
+- P1·2 (source-pill semantics) directly modifies the `SourceBubble.razor` and `MainLayout.HandleSourceToggleAsync` from PR 2.
+- P1·4 (queue split) re-shapes `QueueHistoryPanel.razor` which PR 3 already touched for duration formatting — landing them together avoids a double-edit churn on that file.
+
+**Branch:** `feat/web-design-queue-and-dock` off `main`. Hard dependencies on PR 2 (SourceBubble) and PR 3 (duration formatters in QueueHistoryPanel).
+
+### Files
+
+**New:**
+- `src/Radio.Web/Components/Shared/NowPlayingDock.razor`
+- `tests/Radio.Web.Tests/Components/Shared/NowPlayingDockTests.cs`
+
+**Modified:**
+- `src/Radio.Web/Components/Layout/MainLayout.razor`:
+  - Mount `NowPlayingDock` inside `.content-area`, conditional on non-Home routes.
+  - Rewrite `HandleSourceToggleAsync` — tap always switches source, never opens/closes panel.
+  - Audit & remove tap-driven `RadioPanelToggleService.ToggleRadioPanelAsync()` calls.
+- `src/Radio.Web/Components/Shared/SourceBubble.razor` — wire `HasDetail` chevron's `OnOpenDetail` to route or panel-show call sites.
+- `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor` — split into list (flex 1.6) + context (flex 1); tab strip; right-column tiles (Queue Total, Up Next, Save as playlist); move ADD FILES / CLEAR ALL into kebab.
+- `src/Radio.Web/wwwroot/css/design-system.css` — new `§N Dock` section.
+- `src/Radio.Web/Services/RadioPanelToggleService.cs` — verify `ShowRadioPanelAsync` exists (add if only `ToggleRadioPanelAsync` does).
+
+### Implementation notes (handoff §P1·1, §P1·2, §P1·4, condensed)
+
+**P1·1 (Now Playing dock):**
+1. `NowPlayingDock.razor`:
+   - 64px tall, bottom edge of content area.
+   - Left→right: art thumb 48×48 → title + artist → 3-bar EQ animation (`.now-playing-bars`) → elapsed `mm:ss` → progress bar (3px, `--accent`) → total `mm:ss` → ⏮ play/pause ⏭.
+   - Subscribes to `AudioStateHubService.NowPlayingChanged` + `PlaybackStateChanged` only — no extra polling.
+   - Click on title/art → `NavigationManager.NavigateTo("/")`.
+   - Backdrop: `background: var(--surface-overlay); backdrop-filter: blur(20px); border-top: 1px solid var(--surface-separator);`.
+2. Mount in `MainLayout.razor` inside `.content-area` as sibling of `.page-transition`, absolute-positioned to bottom. Render only when route is NOT `/` or empty.
+3. When dock is rendered, reduce `.page-transition` effective height by 64px.
+4. 8×8 source color dot next to artist line using `--source-*` variables.
+
+**P1·2 (source-pill semantics):**
+1. Delete second-tap-toggles-panel and second-tap-navigates branches from `HandleSourceToggleAsync`. Tap body **always** switches source.
+2. `SourceBubble.razor` already renders chevron when `HasDetail && IsActive` (from PR 2). Confirm it's a separate focusable element with `stopPropagation`.
+3. `HasDetail = true` for `Radio`, `RTLSDRCore`, `RF320`, `Bluetooth`. Not for `File`, `USB`.
+4. Chevron-tap dispatch:
+   - Radio family → `NavigateTo("/")` + `RadioPanelToggleService.ShowRadioPanelAsync()`.
+   - Bluetooth → `NavigateTo("/bluetooth")`.
+5. Audit `RadioPanelToggleService` callers — `ToggleRadioPanelAsync()` is only invoked by explicit chevron tap or in-panel close, never tap-driven.
+
+**P1·4 (queue split):**
+1. Split `QueueHistoryPanel.razor` columns: `flex: 1.6` (list) | `flex: 1` (context). 12px gap.
+2. Tab strip at top of list column: `Queue · N` / `History` / `Radio` (third only when active source is a radio type). Active uses `--accent-dim` background, mono 12px uppercase 0.10em letter-spacing.
+3. Right context — three stacked tiles:
+   - **Queue Total** — `--font-led`, 30px amber, `Durations.FormatLong(totalRuntime)` + sub `{count} tracks · ends ~{nowPlus(total):HH:mm}`.
+   - **Up next** — three 32×32 album thumbs + title/artist, dimmed progressively (text-high → text-medium → text-low).
+   - **Save as playlist** — accent-bordered CTA `＋ Save as playlist`.
+4. ADD FILES / CLEAR ALL header buttons move into kebab menu in list-column header.
+
+### Tests
+
+- `NowPlayingDockTests` — renders given a `NowPlayingDto`; click on title triggers navigation to `/`; respects `PlaybackState`.
+- `QueueHistoryPanelTests`:
+  - Tab strip switches list contents without remounting right column.
+  - Right column shows Queue Total LED, Up Next thumbs, Save CTA.
+  - Kebab opens menu containing ADD FILES + CLEAR ALL.
+- Update `MainLayoutTests` (if exists) — assert `NowPlayingDock` mounts on `/devices` but not on `/`.
+- `SourceBubbleTests` (from PR 2) — second tap on already-active body does NOT fire `OnOpenDetail`; chevron tap fires only `OnOpenDetail`.
+
+### Acceptance (from handoff)
+
+P1·1:
+- [ ] Navigating `/` → `/devices` reveals dock; back to `/` removes it.
+- [ ] Dock shows same track/state as home within one SignalR round-trip.
+- [ ] Tapping title navigates home.
+- [ ] No layout shift on track change (`min-width: 200px` on metadata block).
+
+P1·2:
+- [ ] Tapping a source pill body switches source exactly once, never opens a panel.
+- [ ] Active source pill shows chevron only when detail surface exists.
+- [ ] Tapping chevron opens detail; pill body does not.
+
+P1·4:
+- [ ] Content area fills when queue has ≥1 track (no large empty void below).
+- [ ] Tapping History tab swaps list without remounting right column; right column shows history stats (total plays, top track, top artist).
+- [ ] Save-as-playlist tile triggers existing save dialog.
+
+### UAT (1920×720 kiosk)
+
+- [ ] Open `/` — no dock; switch to `/devices` — dock appears at bottom with current track; click title — returns to `/`.
+- [ ] Cycle through sources via topbar — every tap switches source, never toggles panel.
+- [ ] Active Radio source — chevron visible on pill; tap chevron → Radio panel opens.
+- [ ] Active File source — no chevron (no detail surface).
+- [ ] Open Queue page with files queued — list on left, right column shows Queue Total LED, Up Next thumbs, Save CTA. No empty void.
+- [ ] Tap History tab — right column transitions to history stats; list reloads.
+- [ ] Kebab in list header shows ADD FILES and CLEAR ALL options.
+
+### Dependencies
+
+**PR 2 (SourceBubble + topbar) + PR 3 (Durations.FormatLong) must be merged.**
+
+### LOC estimate
+
+~700–900 (dock + queue split + source-pill semantics + tests).
+
+---
+
+## PR 6 — `feat(web): sleep screen and dev tray gesture`
+
+**Handoff items landed:** P2·1 + P2·2
+
+**Why grouped:** Both are P2 system-polish items, both introduce new routes/components, and P2·2 is the natural home for the dev artefacts removed in PRs 2 and 4 (distortion marker, visualizer "Updates: NN/sec"). Landing them together ties off the dev-UI loose ends in one place.
+
+**Branch:** `feat/web-design-sleep-and-dev-tray` off `main`. Soft dependency on PR 2 (distortion button removal) and PR 4 (visualizer telemetry removal). If those have merged, this PR has clean places to wire them in; if not, surface a conflict warning.
+
+### Files
+
+**New:**
+- `src/Radio.Web/Components/Pages/Sleep.razor` (route `/sleep`, `@layout EmptyLayout`)
+- `src/Radio.Web/Components/Shared/DevTray.razor`
+- `src/Radio.Web/wwwroot/js/dev-gesture.js`
+- `tests/Radio.Web.Tests/Components/Pages/SleepTests.cs`
+- `tests/Radio.Web.Tests/Components/Shared/DevTrayTests.cs`
+
+**Modified:**
+- `src/Radio.Web/Components/Layout/MainLayout.razor`:
+  - `HandleSleepButtonAsync` → `SystemApi.SetSleepAsync(true)` + `NavigationManager.NavigateTo("/sleep")`.
+  - Add 48×48 invisible hit area top-right of topbar for dev gesture (`DotNetObjectReference`).
+  - Mount `<DevTray>` conditionally on `_isDevTrayOpen`.
+  - **Final removal** of distortion-marker button (was DEBUG-gated in PR 2).
+- `src/Radio.Web/wwwroot/js/idle-dimmer.js` — navigate to `/sleep` on idle instead of overlaying.
+- `src/Radio.Web/Components/Shared/VisualizerPanel.razor` — expose visualizer "Updates: NN/sec" as a service-level reading consumed by `DevTray` (the burned-in label was removed in PR 4; this PR wires the data through).
+
+### Implementation notes (handoff §P2·1, §P2·2, condensed)
+
+**P2·1 (Sleep as a screen):**
+1. `/sleep` page with `@layout EmptyLayout`:
+   - Background `#050507`, subtle radial amber glow at center.
+   - 160×160 faint album art block (40% opacity).
+   - Clock: `--font-led`, **96px**, amber with strong glow shadow.
+   - Track title + artist at 18px in very dim color.
+   - Hint at bottom: `tap anywhere to wake`, mono 11px, very dim, uppercase, letter-spaced.
+2. `HandleSleepButtonAsync` calls `SystemApi.SetSleepAsync(true)` then navigates.
+3. `Sleep.razor` full-screen `@onclick` → `SystemApi.SetSleepAsync(false)` + `NavigationManager.NavigateTo("/")`.
+4. `idle-dimmer.js` navigates instead of overlaying.
+5. Server-pushed `SleepStateChanged` event: if server reports wake while on `/sleep`, navigate home.
+
+**P2·2 (Dev tray):**
+1. 48×48 invisible hit area top-right of topbar. `dev-gesture.js` counts taps client-side; 3 taps within 1.5s call into Blazor via `DotNetObjectReference` → toggle `_isDevTrayOpen`.
+2. `DevTray.razor` positioned-fixed top-right, slides down with drop shadow:
+   - Header: `● Dev Tray · unlocked · auto-lock 0:30`.
+   - 2×3 grid of action cards:
+     - **Mark distortion** — `AudioApi.ReportDistortionAsync()`.
+     - **Updates: NN/sec** — live visualizer telemetry.
+     - **Dump audio frame** — last 5s buffer dump.
+     - **Download logs** — last hour, zip.
+     - **Fingerprint events** — opens existing fingerprint detail panel.
+     - **Engine state** — readable `AudioStateHubService` state string.
+   - Auto-locks after 30s no interaction (timer in `DevTray.razor`).
+3. Final removal of distortion-marker button from `MainLayout.razor`.
+
+### Tests
+
+- `SleepTests` — renders clock + title + hint; click anywhere fires wake handler.
+- `DevTrayTests` — opens via JS interop bridge (mock `DotNetObjectReference`); auto-locks after timer; "Mark distortion" wires to API.
+- E2E: idle-timer triggers `/sleep` navigation (manual UAT only — hard to automate at 1920×720 kiosk).
+
+### Acceptance (from handoff)
+
+P2·1:
+- [ ] Sleep button takes user to `/sleep` with fade-in.
+- [ ] Tap anywhere on `/sleep` wakes and returns to last route.
+- [ ] No black overlay hack remains in JS.
+
+P2·2:
+- [ ] No dev-only UI is visible in production chrome without the gesture.
+- [ ] Gesture works at native 1920×720 touch resolution.
+- [ ] Tray auto-locks after 30s.
+
+### UAT (1920×720 kiosk)
+
+- [ ] Tap sleep button — `/sleep` page fades in with 96px amber clock + faint art.
+- [ ] Wait 5s, tap screen — returns to last route with current playback intact.
+- [ ] Idle for configured idle period — auto-navigates to `/sleep` (no overlay).
+- [ ] 3-tap top-right invisible hit area within 1.5s — DevTray slides down.
+- [ ] All 6 dev cards present; "Mark distortion" actually marks; visualizer telemetry updates live.
+- [ ] Wait 30s without interacting — tray auto-locks.
+- [ ] No distortion-marker button anywhere in topbar.
+
+### Dependencies
+
+**Soft on PR 2 (distortion-marker DEBUG gating) and PR 4 (visualizer telemetry decoupling).** Land last in the arc.
+
+### LOC estimate
+
+~500–700 (Sleep page + DevTray + JS gesture + MainLayout wiring + tests).
+
+---
+
+## Open questions for the user (surface before Builder starts)
+
+These are spec ambiguities or coordination items that should be answered before Builder picks up the corresponding PR. None block PR 1 — they affect PR 3 and onward.
+
+1. **`Devices:Aliases` location.** The handoff puts the alias map in `appsettings.json`, but the project's existing pattern (per project memory) is to use `appsettings.Production.json` for per-machine overrides because deploy overwrites `appsettings.json`. **Question:** put the default aliases (the VB-Audio + Realtek entries) in `appsettings.json` baseline OR in `appsettings.Production.json` only? Recommend: baseline goes in `appsettings.json`, per-host extensions go in `appsettings.Production.json`.
+
+2. **`Radio.Metrics` package versioning (PR 4).** Adding a `Unit` field to `MetricDescriptor` is a breaking API change for the standalone NuGet package. **Question:** bump the package minor version + republish to local feed via `pack-local.ps1` as part of the PR, OR keep the field internal to the consuming side until the package is re-released? Recommend: bump minor version, run `pack-local.ps1`, commit updated `nuget.config` references.
+
+3. **Device-name head-length threshold (PR 1 / `DisplayNames.Device`).** The handoff says "strip trailing parenthesized hardware-driver suffixes when the head is sufficiently descriptive." That's a judgement call. **Question:** define "sufficient" as (a) head length ≥ 4 chars AND contains a space, (b) explicit allow list of known driver suffixes, or (c) both? Recommend: (c) — start with explicit allow list (`AMD High Definition Audio Device`, `Realtek USB Audio`, `VB-Audio Virtual Cable`, …) and fall back to heuristic only when no match.
+
+4. **Skeleton replacement scope (PR 4 / P1·5).** The handoff says "No centered spinner in any panel-body loading branch in `Components/`." There may be deliberate spinners in modal/determinate contexts that are NOT panel-body loading. **Question:** Builder will distinguish "panel-body initial-load" (replace with Skeleton) from "modal/determinate progress" (keep `RadzenProgressBarCircular`). Confirm this is the user's read of the intent — there's no risk of removing legitimate spinners.
+
+5. **Visualizer telemetry data path (PR 6).** The "Updates: NN/sec" reading needs to move from a burned-in canvas label to a service-level value consumed by `DevTray`. **Question:** add a new `VisualizerTelemetryService` singleton, OR push it through an existing service like `AudioStateHubService`? Recommend: a small new singleton — keeps the visualizer self-contained.
+
+6. **`HasDetail` matrix (PR 5 / P1·2).** Handoff lists `Radio`, `RTLSDRCore`, `RF320`, `Bluetooth` as having details, and `File`, `USB` as not. **Question:** what about future sources (Vinyl, Phono, TTS, Spotify)? Builder will mark only the four enumerated source types as `HasDetail=true` and leave others false; new sources must be explicitly added. Confirm.
+
+7. **PR 6 timing vs. PR 2/4 conflicts.** PR 6 finalizes removal of the distortion-marker button (DEBUG-gated in PR 2) and consumes the visualizer telemetry value (decoupled in PR 4). If for any reason PR 6 ships before PR 2 or PR 4 merge, the conflicts will need a manual rebase. Builder should land 1 → 2 → 3 → 4 → 5 → 6 strictly in order; if any PR slips, sequence the remainder accordingly.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Topbar height bump from 80→120 breaks an unrelated page that hard-codes 640 content area. | PR 2 includes a `grep` for `640px` and `80px` across the project (handoff explicitly calls this out). Add a 600px content-area assertion test to `MainLayoutTests` if feasible. |
+| Display-name regex matches a legitimate non-GUID hex sequence. | Test set in PR 1 includes both positive (GUID present) and negative (hex but not GUID-shaped) cases. |
+| Skeleton swap inadvertently removes a determinate progress bar (e.g. file scan). | PR 4 keeps `RadzenProgressBarCircular` for modal/determinate cases. UAT explicitly exercises file scan to confirm progress still shows. |
+| `Radio.Metrics` package version bump conflicts with another in-flight PR consuming the old shape. | Check `git log` for other branches touching `Radio.Metrics`; coordinate sequencing. |
+| Dev gesture (3-tap top-right) overlaps with an existing gesture or button hit area. | The 48×48 hit area sits in unused topbar corner; PR 6 UAT checks no overlap. If overlap found, narrow the area or pick a different gesture (e.g. four-finger touch). |
+| Queue split layout changes break drag-reorder behaviour. | PR 5 must preserve `RadzenDataList` drag-reorder events; UAT exercises reorder + verify persistence. |
+
+---
+
+## What this arc explicitly does NOT change
+
+(Copied from handoff "What NOT to change" — keep these locked.)
+
+- DSEG amber LED treatment for time/frequency on `.display-frequency`, `.topbar-clock`, sleep screen, queue total. Do not extend to regular UI text.
+- Per-source color mapping (`--source-vinyl/-file/-radio/-bluetooth/-usb`). Already correct.
+- Three-column home page split (520 / fill / 710). Proportions work.
+- SignalR push patterns. They are the right architecture for this app.
+
+Also:
+
+- **`feature/rotaryphone-sip-integration` WIP does not ride along.** Every PR branches from `main`, not from that branch.
+- **No new design tokens** unless a value is genuinely missing — extend `design-system.css §2` only when forced.
+- **DTOs server-side stay as-is** — only display projection changes (P0·2).
+
+---
+
+## Build / verify checklist (per PR)
+
+- [ ] `dotnet build --configuration Release` — 0 warnings.
+- [ ] `dotnet test --configuration Release --verbosity normal` — green.
+- [ ] Eyeball affected pages in dev build at native 1920×720 — content fits, no scrollbars except intended, no debug UI visible.
+- [ ] Take fresh screenshot into `screenshots/{page}.png` (overwrite current) so next design pass starts from current baseline.
+- [ ] Open PR against `main` with body that lists handoff items landed and pastes acceptance checkbox list.
+- [ ] Run automated code review agent + address any high-priority feedback before merge.
+
+---
+
+## Out of scope
+
+- Anything marked `[PARKED]` in `IMPLEMENTATION.md` (none in the current package — all 12 items are in scope per Coordinator's instruction).
+- Server-side audio engine changes.
+- New design tokens beyond `--text-medium` bump.
+- Re-platforming SignalR or hub patterns.
+- Folding in the `feature/rotaryphone-sip-integration` WIP.


### PR DESCRIPTION
## Summary

Commits the design-tightening handoff package and the implementation plan to `main`. These were created on a different branch and stashed during arc kickoff, leaving them unreachable from any committed history.

This is a docs-only PR with no code impact — adding it to `main` lets the rest of the arc's Builder/Tester/Polisher dispatches read the spec directly instead of every prompt re-pasting the relevant sections.

## Contents

- `docs/handoffs/design_handoff_radio_console/` — 7 files (README, IMPLEMENTATION script, Design Analysis + Handoff Canvas HTML, mock JSX)
- `docs/superpowers/plans/2026-05-17-radio-console-design-tightening.md` — Planner output covering all 6 PRs in the arc

## Why now

PRs #359 and #360 are already in flight against this plan. Subsequent PRs (#3-#6 of the arc) will reference these docs by path — committing them avoids spec-drift and lets agents work from a single source of truth.

## Test plan

- [ ] Visual review of the two markdown files renders correctly in GitHub
- [ ] No code, no tests, no CI impact beyond documentation linting

🤖 Generated with [Claude Code](https://claude.com/claude-code)