### PR TITLE
PR 4: metrics dashboard, visualizer mode picker, and skeleton loading states

### DIFF
--- a/src/Radio.Metrics/MetricDescriptor.cs
+++ b/src/Radio.Metrics/MetricDescriptor.cs
@@ -1,0 +1,53 @@
+namespace Radio.Metrics;
+
+/// <summary>
+/// Optional metadata describing a metric — its display unit, category,
+/// and threshold band — used by dashboards to render unit-aware tiles.
+/// <para>
+/// Descriptors are purely declarative; the collector pipeline does not
+/// require them. When absent, dashboards fall back to key-pattern
+/// heuristics for unit selection. The descriptor surface exists so
+/// that producers can opt in to authoritative units (e.g. fixing the
+/// "Memory Usage Mb" tile that previously rendered as a percentage).
+/// </para>
+/// </summary>
+public sealed record MetricDescriptor
+{
+  /// <summary>
+  /// The metric key (e.g. <c>"system.memory_usage_mb"</c>).
+  /// </summary>
+  public required string Key { get; init; }
+
+  /// <summary>
+  /// Display unit used by dashboards to pick a formatter. Defaults to
+  /// <see cref="MetricUnit.Bare"/> for unknown values.
+  /// </summary>
+  public MetricUnit Unit { get; init; } = MetricUnit.Bare;
+
+  /// <summary>
+  /// Optional category label used to group tiles in the dashboard
+  /// (e.g. <c>"System | Memory"</c>). When null, the dashboard
+  /// derives a category from the leading dot-segment of the key.
+  /// </summary>
+  public string? Category { get; init; }
+
+  /// <summary>
+  /// Optional warn threshold. Values at or above this render the tile
+  /// in the amber signal color. Interpretation is unit-specific; see
+  /// dashboard rules for inverted-above metrics (e.g. buffer fill).
+  /// </summary>
+  public double? Warn { get; init; }
+
+  /// <summary>
+  /// Optional critical threshold. Values at or above this render the
+  /// tile in the red signal color. See <see cref="Warn"/> for
+  /// inversion rules.
+  /// </summary>
+  public double? Critical { get; init; }
+
+  /// <summary>
+  /// Human-readable short name for the metric. Optional; dashboards
+  /// fall back to a title-cased form of the trailing key segment.
+  /// </summary>
+  public string? DisplayName { get; init; }
+}

--- a/src/Radio.Metrics/MetricUnit.cs
+++ b/src/Radio.Metrics/MetricUnit.cs
@@ -1,0 +1,42 @@
+namespace Radio.Metrics;
+
+/// <summary>
+/// Server-side mirror of the consumer-facing display unit enum.
+/// <para>
+/// Read by dashboards and UI surfaces to pick a unit-aware formatter
+/// for each metric. The default for any metric that has not been
+/// described is <see cref="Bare"/>.
+/// </para>
+/// <para>
+/// Values are deliberately aligned (name + intent) with the
+/// <c>Radio.Web.Formatting.Units</c> enum so that the wire format and
+/// the dashboard formatter stay in lockstep. If a new entry is added
+/// here, mirror it in the Web formatting layer.
+/// </para>
+/// </summary>
+public enum MetricUnit
+{
+  /// <summary>Percentage value (0-100). Renders with a trailing <c>%</c>.</summary>
+  Percent = 0,
+
+  /// <summary>Megabytes. Renders with a trailing <c> MB</c>.</summary>
+  Megabytes = 1,
+
+  /// <summary>Milliseconds. Auto-promotes to seconds when at or above 1000.</summary>
+  Milliseconds = 2,
+
+  /// <summary>Unitless count. Thousands-separated.</summary>
+  Count = 3,
+
+  /// <summary>Per-minute rate (events/min).</summary>
+  PerMinute = 4,
+
+  /// <summary>Hertz (Hz / kHz / MHz auto-scaling).</summary>
+  Frequency = 5,
+
+  /// <summary>Decibels (signed). Renders with a trailing <c> dB</c>.</summary>
+  Decibels = 6,
+
+  /// <summary>Bare integer — no unit suffix.</summary>
+  Bare = 7,
+}

--- a/src/Radio.Metrics/Radio.Metrics.csproj
+++ b/src/Radio.Metrics/Radio.Metrics.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <!-- NuGet package metadata -->
     <PackageId>Radio.Metrics</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Description>Lightweight metrics collection and time-series storage library with SQLite backend. Supports counters and gauges, buffered writes, multi-resolution rollup (minute/hour/day), configurable retention, and system monitoring. Zero external service dependencies.</Description>
     <PackageTags>metrics;telemetry;time-series;sqlite;counters;gauges;monitoring;rollup</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Radio.Web/Components/Pages/DeviceManagementPage.razor
+++ b/src/Radio.Web/Components/Pages/DeviceManagementPage.razor
@@ -29,7 +29,9 @@
 
           @if (isLoadingDisplay)
           {
-            <RadzenProgressBar Mode="ProgressBarMode.Indeterminate" ProgressBarStyle="ProgressBarStyle.Primary" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
           }
           else if (displaySettings == null || !displaySettings.Any())
           {
@@ -97,7 +99,9 @@
 
           @if (isLoadingOutput)
           {
-            <RadzenProgressBar Mode="ProgressBarMode.Indeterminate" ProgressBarStyle="ProgressBarStyle.Primary" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
           }
           else if (outputDevices == null || !outputDevices.Any())
           {
@@ -174,7 +178,9 @@
 
           @if (isLoadingCast)
           {
-            <RadzenProgressBar Mode="ProgressBarMode.Indeterminate" ProgressBarStyle="ProgressBarStyle.Primary" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
           }
           else if (castDevices == null || !castDevices.Any())
           {
@@ -250,7 +256,9 @@
 
           @if (isLoadingInput)
           {
-            <RadzenProgressBar Mode="ProgressBarMode.Indeterminate" ProgressBarStyle="ProgressBarStyle.Primary" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
           }
           else if (inputDevices == null || !inputDevices.Any())
           {
@@ -310,7 +318,9 @@
 
           @if (isLoadingUsb)
           {
-            <RadzenProgressBar Mode="ProgressBarMode.Indeterminate" ProgressBarStyle="ProgressBarStyle.Primary" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.DeviceRow" />
           }
           else if (usbPorts == null || !usbPorts.Any())
           {

--- a/src/Radio.Web/Components/Pages/MetricsDashboardPage.razor
+++ b/src/Radio.Web/Components/Pages/MetricsDashboardPage.razor
@@ -6,10 +6,27 @@
 @inject NotificationService NotificationService
 @implements IAsyncDisposable
 
+@*
+  MetricsDashboardPage — categorized metric tile grid (PR 4 §P0·4).
+
+  Layout:
+    Header: title + time-range pills + refresh.
+    Optional time-series chart panel for the selected metric.
+    Body: one block per category, each block has a mono uppercase
+          sub-header and a CSS-grid of MetricTile cards.
+
+  The unit fixes called out in the handoff (Memory Usage Mb → MB,
+  Signal Strength → %, Frequency Changes → thousands-separated count,
+  Latency Ms → ms/s auto-promotion) are driven by MapKeyToUnit, which
+  classifies the metric key into a Units value. A Radio.Metrics
+  MetricDescriptor.Unit field (added in PR 4) is the eventual
+  authoritative source; until producers register descriptors the
+  key-pattern mapping is the source of truth.
+*@
+
 <PageTitle>Metrics Dashboard</PageTitle>
 
 <div class="metrics-page">
-  <!-- Header bar -->
   <div class="metrics-header">
     <span class="metrics-title">Metrics</span>
     <div class="route-group" style="padding: 4px 8px; flex-wrap: wrap;">
@@ -26,42 +43,17 @@
     </div>
   </div>
 
-  @if (_loading)
+  @if (_loading && (_snapshots == null || _snapshots.Count == 0))
   {
     <RadzenProgressBar Mode="ProgressBarMode.Indeterminate" ProgressBarStyle="ProgressBarStyle.Primary" Style="height: 2px;" />
   }
 
   <div class="metrics-body">
-    <!-- Hero stat cards row -->
-    <div class="metrics-hero-row">
-      @foreach (var hero in GetHeroMetrics())
-      {
-        var thresholdColor = GetThresholdColor(hero.Key, hero.Value);
-        var isSelected = _selectedMetric == hero.Key;
-        var heroKey = hero.Key;
-        <div class="metrics-hero-card @(isSelected ? "selected" : "")"
-             style="border-left-color: @thresholdColor;"
-             @onclick="@(async () => await SelectMetricAsync(heroKey))">
-          <button class="metrics-hero-dismiss"
-                  title="Remove from hero cards"
-                  @onclick="@(async () => await RemoveHeroCardAsync(heroKey))"
-                  @onclick:stopPropagation="true">&times;</button>
-          <div class="metrics-hero-label">@GetMetricLabel(heroKey)</div>
-          <div class="metrics-hero-value" style="color: @thresholdColor;">
-            @FormatMetricValue(hero.Value, heroKey)
-          </div>
-          @if (_sparklineData.TryGetValue(heroKey, out var points) && points.Count > 1)
-          {
-            <div style="margin-top: 4px; height: 50px;">
-              @((MarkupString)RenderSparkline(points, 200, 50, thresholdColor))
-            </div>
-          }
-        </div>
-      }
-    </div>
-
-    <!-- Time-series chart panel -->
-    <div class="metrics-chart-panel">
+    <!-- Time-series chart panel — rendered always so the canvas is in the
+         DOM for metricsChart.init even before the user picks a metric.
+         Collapses to zero height when no metric is selected. -->
+    <div class="metrics-chart-panel"
+         style="@(string.IsNullOrEmpty(_selectedMetric) ? "display: none;" : "")">
       <div style="flex: 1; min-height: 0; position: relative;">
         <canvas id="metricsChartCanvas" style="width: 100%; height: 100%; display: block;"></canvas>
       </div>
@@ -78,60 +70,46 @@
       }
     </div>
 
-    <!-- Collapsible category sections -->
-    <div class="metrics-categories">
-      @if (_snapshots != null && _snapshots.Count > 0)
-      {
+    <!-- Categorized tile grid -->
+    @if (_snapshots != null && _snapshots.Count > 0)
+    {
+      <div class="metrics-categories-grid">
         @foreach (var category in _categories)
         {
-          var isExpanded = _expandedCategories.Contains(category);
           var catMetrics = GetMetricsForCategory(category).ToList();
-          <div class="metrics-category">
-            <div class="metrics-category-header" @onclick="@(() => ToggleCategory(category))">
-              <span class="metrics-category-arrow">@(isExpanded ? "\u25BE" : "\u25B8")</span>
-              <span class="metrics-category-name">@category</span>
-              <span class="metrics-category-count">(@catMetrics.Count)</span>
+          if (catMetrics.Count == 0) continue;
+          <div class="metrics-category-block">
+            <h3 class="metrics-category-subheader">@category</h3>
+            <div class="metrics-tile-grid">
+              @foreach (var metric in catMetrics)
+              {
+                var key = metric.Key;
+                var unit = MapKeyToUnit(key);
+                var (warn, critical, invert) = GetThresholds(key);
+                _sparklineData.TryGetValue(key, out var series);
+                <div @onclick="@(async () => await SelectMetricAsync(key))" style="cursor: pointer;">
+                  <MetricTile Key="@key"
+                              Category="@FormatCategoryLabel(category, key)"
+                              Name="@GetMetricLabel(key)"
+                              Value="@metric.Value"
+                              Unit="@unit"
+                              Series="@series"
+                              Warn="@warn"
+                              Critical="@critical"
+                              InvertThresholds="@invert" />
+                </div>
+              }
             </div>
-            @if (isExpanded)
-            {
-              <div class="metrics-category-body">
-                @foreach (var metric in catMetrics)
-                {
-                  var isRowSelected = _selectedMetric == metric.Key;
-                  var trend = GetTrendIndicator(metric.Key);
-                  var metricKey = metric.Key;
-                  var isPinned = _pinnedHeroKeys?.Contains(metricKey) == true;
-                  <div class="metrics-row @(isRowSelected ? "selected" : "")"
-                       @onclick="@(async () => await SelectMetricAsync(metricKey))">
-                    <button class="metrics-row-pin @(isPinned ? "pinned" : "")"
-                            title="@(isPinned ? "Remove from hero cards" : "Pin to hero cards")"
-                            @onclick="@(async () => await ToggleHeroCardAsync(metricKey))"
-                            @onclick:stopPropagation="true">
-                      @(isPinned ? "\u2605" : "\u2606")
-                    </button>
-                    <span class="metrics-row-label">@GetMetricLabel(metricKey)</span>
-                    <span class="metrics-row-value">@FormatMetricValue(metric.Value, metricKey)</span>
-                    @if (_sparklineData.TryGetValue(metricKey, out var rowPoints) && rowPoints.Count > 1)
-                    {
-                      <span class="metrics-row-sparkline">
-                        @((MarkupString)RenderSparkline(rowPoints, 150, 20))
-                      </span>
-                    }
-                    <span class="metrics-row-trend @(trend.css)">@trend.symbol</span>
-                  </div>
-                }
-              </div>
-            }
           </div>
         }
-      }
-      else if (!_loading)
-      {
-        <div style="padding: 24px; text-align: center; color: var(--text-low);">
-          No metrics available. The backend may not be collecting metrics yet.
-        </div>
-      }
-    </div>
+      </div>
+    }
+    else if (!_loading)
+    {
+      <div style="padding: 24px; text-align: center; color: var(--text-low);">
+        No metrics available. The backend may not be collecting metrics yet.
+      </div>
+    }
   </div>
 </div>
 
@@ -149,27 +127,18 @@
   private string? _selectedMetric;
   private MetricAggregateDto? _selectedMetricAggregate;
   private List<string> _categories = new();
-  private HashSet<string> _expandedCategories = new();
   private Dictionary<string, List<double>> _sparklineData = new();
   private Dictionary<string, List<MetricHistoryDto>> _sparklineHistory = new();
 
-  // Hero metrics: user-pinned metric keys (persisted to config)
-  // null = never configured (use pattern defaults), empty = user dismissed all
-  private List<string>? _pinnedHeroKeys;
-
-  // Default patterns used when no pinned keys are configured
-  private static readonly string[] _defaultHeroPatterns =
-    ["cpu", "memory", "buffer", "underrun", "error", "active"];
-
-  private const int MaxHeroCards = 10;
-
-  // Threshold definitions: (warning, critical) by metric name fragment
+  // Threshold definitions: (warning, critical) by metric name fragment.
+  // invertAbove == true → high is bad (cpu, memory).
+  // invertAbove == false → low is bad (buffer fill).
   private static readonly Dictionary<string, (double warn, double crit, bool invertAbove)> _thresholds = new()
   {
     ["cpu_temp"] = (70, 85, true),
     ["cpu_usage"] = (80, 95, true),
     ["memory_percent"] = (80, 95, true),
-    ["buffer_fill"] = (50, 20, false),     // below warn=amber, below crit=red
+    ["buffer_fill"] = (50, 20, false),
     ["buffer_percent"] = (50, 20, false),
     ["underrun"] = (1, 10, true),
     ["error"] = (1, 10, true),
@@ -193,16 +162,16 @@
 
   protected override async Task OnAfterRenderAsync(bool firstRender)
   {
-    if (firstRender)
+    // The chart canvas only exists when a metric is selected. Init lazily
+    // the first time a metric is picked.
+    if (!_chartInitialized && !string.IsNullOrEmpty(_selectedMetric))
     {
       try
       {
-        _jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/metricsChart.js");
+        _jsModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/metricsChart.js");
         var success = await _jsModule.InvokeAsync<bool>("metricsChart.init", "metricsChartCanvas");
         _chartInitialized = success;
-
-        // If we already have a selected metric, render it
-        if (_chartInitialized && !string.IsNullOrEmpty(_selectedMetric))
+        if (_chartInitialized)
           await RenderChartForSelectedMetricAsync();
       }
       catch (Exception ex)
@@ -217,21 +186,8 @@
     try
     {
       var prefs = await ConfigApi.GetConfigurationAsync<Dictionary<string, System.Text.Json.JsonElement>>("ui.metrics");
-      if (prefs != null)
-      {
-        if (prefs.TryGetValue("timeRange", out var trObj))
-          _timeRange = trObj.GetString() ?? "1h";
-
-        if (prefs.TryGetValue("heroCards", out var heroObj) &&
-            heroObj.ValueKind == System.Text.Json.JsonValueKind.Array)
-        {
-          _pinnedHeroKeys = heroObj.EnumerateArray()
-            .Select(e => e.GetString())
-            .Where(s => !string.IsNullOrEmpty(s))
-            .Select(s => s!)
-            .ToList();
-        }
-      }
+      if (prefs != null && prefs.TryGetValue("timeRange", out var trObj))
+        _timeRange = trObj.GetString() ?? "1h";
     }
     catch (Exception ex) { Logger.LogWarning(ex, "Failed to load metrics preferences"); }
   }
@@ -262,14 +218,6 @@
       UpdateCategories();
       await LoadSparklineDataAsync();
       UpdateCardValuesFromSparklines();
-
-      // Auto-select first hero metric
-      if (string.IsNullOrEmpty(_selectedMetric))
-      {
-        var heroes = GetHeroMetrics().ToList();
-        if (heroes.Count > 0)
-          _selectedMetric = heroes[0].Key;
-      }
     }
     finally { _loading = false; }
   }
@@ -297,8 +245,9 @@
     var (start, end) = GetTimeRangeFromSelection();
     var resolution = GetResolution();
 
-    // Load sparkline data in parallel for visible metrics (max 20)
-    var metricsToLoad = _snapshots.Keys.Take(20).ToList();
+    // Load sparkline data in parallel for visible metrics (cap to avoid
+    // hammering the API on dashboards with hundreds of metrics).
+    var metricsToLoad = _snapshots.Keys.Take(40).ToList();
     var tasks = metricsToLoad.Select(async key =>
     {
       try
@@ -363,7 +312,6 @@
     _loading = true;
     try
     {
-      // Ensure we have history for this metric
       if (!_sparklineHistory.ContainsKey(metricKey))
       {
         var (start, end) = GetTimeRangeFromSelection();
@@ -376,9 +324,7 @@
         }
       }
 
-      // Compute aggregate stats from history data
       _selectedMetricAggregate = ComputeAggregateFromHistory(metricKey);
-
       await RenderChartForSelectedMetricAsync();
     }
     catch (Exception ex)
@@ -421,13 +367,13 @@
       var max = history.Select(h => h.Max ?? h.Value).ToArray();
 
       var chartData = new { labels, values, min, max };
-      var thresholdColor = GetThresholdColor(_selectedMetric!, _snapshots?.GetValueOrDefault(_selectedMetric!, 0) ?? 0);
+      var thresholdColor = GetThresholdColorRaw(_selectedMetric!, _snapshots?.GetValueOrDefault(_selectedMetric!, 0) ?? 0);
       var chartOptions = new
       {
         color = thresholdColor == "var(--signal-red)" ? "#F87171" :
                 thresholdColor == "var(--signal-amber)" ? "#F0A830" : "#5CD4E8",
         fillOpacity = 0.15,
-        unit = GetMetricUnit(_selectedMetric!),
+        unit = GetMetricUnitForChart(_selectedMetric!),
         thresholds = GetChartThresholds(_selectedMetric!)
       };
 
@@ -446,91 +392,6 @@
       .Distinct()
       .OrderBy(c => c)
       .ToList();
-
-    // Expand all categories by default
-    if (_expandedCategories.Count == 0)
-      _expandedCategories = new HashSet<string>(_categories);
-  }
-
-  private void ToggleCategory(string category)
-  {
-    if (!_expandedCategories.Remove(category))
-      _expandedCategories.Add(category);
-  }
-
-  private IEnumerable<KeyValuePair<string, double>> GetHeroMetrics()
-  {
-    if (_snapshots == null) return Enumerable.Empty<KeyValuePair<string, double>>();
-
-    // null = never configured → use pattern defaults
-    // non-null (even empty) = user has customized → respect their choice
-    if (_pinnedHeroKeys != null)
-    {
-      return _pinnedHeroKeys
-        .Where(key => _snapshots.ContainsKey(key))
-        .Select(key => new KeyValuePair<string, double>(key, _snapshots[key]))
-        .Take(MaxHeroCards);
-    }
-
-    return _snapshots
-      .Where(m => _defaultHeroPatterns.Any(p => m.Key.ToLowerInvariant().Contains(p)))
-      .OrderBy(m => Array.FindIndex(_defaultHeroPatterns, p => m.Key.ToLowerInvariant().Contains(p)))
-      .Take(6);
-  }
-
-  private async Task RemoveHeroCardAsync(string metricKey)
-  {
-    // If never configured, initialize from defaults so user can selectively remove
-    if (_pinnedHeroKeys == null)
-      InitializePinnedFromDefaults();
-
-    _pinnedHeroKeys!.Remove(metricKey);
-    await SaveHeroCardsAsync();
-    StateHasChanged();
-  }
-
-  private async Task ToggleHeroCardAsync(string metricKey)
-  {
-    // If never configured, initialize from defaults so user can selectively modify
-    if (_pinnedHeroKeys == null)
-      InitializePinnedFromDefaults();
-
-    if (_pinnedHeroKeys!.Contains(metricKey))
-    {
-      _pinnedHeroKeys.Remove(metricKey);
-    }
-    else if (_pinnedHeroKeys.Count < MaxHeroCards)
-    {
-      _pinnedHeroKeys.Add(metricKey);
-    }
-    else
-    {
-      NotificationService.Notify(NotificationSeverity.Warning, "Warning", $"Maximum {MaxHeroCards} hero cards allowed");
-      return;
-    }
-
-    await SaveHeroCardsAsync();
-    StateHasChanged();
-  }
-
-  private void InitializePinnedFromDefaults()
-  {
-    if (_snapshots == null)
-    {
-      _pinnedHeroKeys = new List<string>();
-      return;
-    }
-
-    _pinnedHeroKeys = _snapshots.Keys
-      .Where(key => _defaultHeroPatterns.Any(p => key.ToLowerInvariant().Contains(p)))
-      .OrderBy(key => Array.FindIndex(_defaultHeroPatterns, p => key.ToLowerInvariant().Contains(p)))
-      .Take(6)
-      .ToList();
-  }
-
-  private async Task SaveHeroCardsAsync()
-  {
-    await SavePreferenceAsync("heroCards", _pinnedHeroKeys ?? new List<string>());
   }
 
   private IEnumerable<KeyValuePair<string, double>> GetMetricsForCategory(string category)
@@ -539,7 +400,58 @@
     return _snapshots.Where(m => GetMetricCategory(m.Key) == category).OrderBy(m => m.Key);
   }
 
-  private string GetThresholdColor(string metricKey, double value)
+  /// <summary>
+  /// Maps a metric key to a display Unit by pattern matching the suffix
+  /// and well-known fragments. This is what fixes the "Memory Usage Mb
+  /// = 850.4%" bug — the key ends in <c>_mb</c> and ought to render
+  /// with the MB suffix.
+  /// </summary>
+  internal static Units MapKeyToUnit(string metricKey)
+  {
+    if (string.IsNullOrEmpty(metricKey)) return Units.Bare;
+    var k = metricKey.ToLowerInvariant();
+
+    // Order matters — match more-specific suffixes first.
+    if (k.EndsWith("_mb") || k.Contains("memory_usage_mb") || k.Contains("_memory_mb")) return Units.Megabytes;
+    if (k.EndsWith("_ms") || k.Contains("latency_ms") || k.Contains("duration_ms")) return Units.Milliseconds;
+    if (k.Contains("percent") || k.Contains("_pct") || k.EndsWith("_ratio") ||
+        (k.Contains("cpu") && k.Contains("usage")) ||
+        (k.Contains("memory") && k.Contains("usage") && !k.EndsWith("_mb"))) return Units.Percent;
+    if (k.Contains("strength") || k.Contains("signal_quality")) return Units.Percent;
+    if (k.EndsWith("_per_min") || k.Contains("rate_per_min") || k.Contains("_per_minute")) return Units.PerMinute;
+    if (k.Contains("frequency_changes") || k.Contains("changes_count") || k.EndsWith("_count")) return Units.Count;
+    if (k.Contains("decibel") || k.EndsWith("_db") || k.Contains("_dbfs")) return Units.Decibels;
+    if (k.Contains("_hz") || k.Contains("frequency_hz") || k.Contains("_freq_hz")) return Units.Frequency;
+    if (k.Contains("count") || k.Contains("total") || k.Contains("errors") ||
+        k.Contains("underruns") || k.Contains("dropped") || k.Contains("requests") ||
+        k.Contains("failures") || k.Contains("connected") || k.Contains("disconnected") ||
+        k.Contains("reconnect") || k.Contains("played") || k.Contains("queued")) return Units.Count;
+
+    return Units.Bare;
+  }
+
+  /// <summary>
+  /// Returns the threshold band for a key (warn, critical, invert), or
+  /// (null, null, false) if no threshold is configured.
+  /// </summary>
+  private static (double? warn, double? critical, bool invert) GetThresholds(string metricKey)
+  {
+    var keyLower = metricKey.ToLowerInvariant();
+    foreach (var (pattern, (warn, crit, invertAbove)) in _thresholds)
+    {
+      if (!keyLower.Contains(pattern)) continue;
+      // invertAbove==true → high is bad (default MetricTile semantics).
+      // invertAbove==false → low is bad → flip via InvertThresholds=true.
+      return invertAbove ? (warn, crit, false) : (warn, crit, true);
+    }
+    return (null, null, false);
+  }
+
+  /// <summary>
+  /// Mirrors GetThresholds for the legacy chart pipeline which expects a
+  /// CSS color string rather than the MetricTile-style threshold band.
+  /// </summary>
+  private string GetThresholdColorRaw(string metricKey, double value)
   {
     var keyLower = metricKey.ToLowerInvariant();
     foreach (var (pattern, (warn, crit, invertAbove)) in _thresholds)
@@ -573,21 +485,6 @@
       };
     }
     return null;
-  }
-
-  private (string symbol, string css) GetTrendIndicator(string metricKey)
-  {
-    if (!_sparklineData.TryGetValue(metricKey, out var points) || points.Count < 3)
-      return ("\u2014", "trend-flat");
-
-    var recent = points.Skip(points.Count - 3).Average();
-    var older = points.Take(3).Average();
-    if (older == 0) return ("\u2014", "trend-flat");
-
-    var change = (recent - older) / Math.Abs(older);
-    if (change > 0.05) return ("\u25B2", "trend-up");
-    if (change < -0.05) return ("\u25BC", "trend-down");
-    return ("\u2014", "trend-flat");
   }
 
   private (DateTime start, DateTime end) GetTimeRangeFromSelection()
@@ -631,58 +528,50 @@
     return parts.Length > 0 ? parts[0] : "Other";
   }
 
-  private static string GetMetricLabel(string metricKey)
+  /// <summary>
+  /// Forms the per-tile category text. Where a metric key has the form
+  /// <c>system.memory.usage_mb</c>, we surface <c>"System · Memory"</c>
+  /// in the tile so the category line carries the sub-component as well.
+  /// </summary>
+  private static string FormatCategoryLabel(string topCategory, string metricKey)
+  {
+    var parts = metricKey.Split('.');
+    if (parts.Length < 3) return TitleCase(topCategory);
+    var sub = parts[1];
+    return TitleCase(topCategory) + " · " + TitleCase(sub);
+  }
+
+  private static string TitleCase(string s)
+  {
+    if (string.IsNullOrEmpty(s)) return s;
+    return System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(s.Replace('_', ' '));
+  }
+
+  internal static string GetMetricLabel(string metricKey)
   {
     if (string.IsNullOrEmpty(metricKey)) return metricKey;
     var parts = metricKey.Split('.');
     if (parts.Length > 1)
     {
       var label = string.Join(" ", parts.Skip(1));
-      return System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(label.Replace('_', ' '));
+      return TitleCase(label);
     }
     return metricKey;
   }
 
-  private static string GetMetricUnit(string metricKey)
+  private static string GetMetricUnitForChart(string metricKey)
   {
-    var key = metricKey.ToLowerInvariant();
-    if (key.Contains("percent") || key.Contains("_ratio") || (key.Contains("cpu") && key.Contains("usage")))
-      return "%";
-    if (key.Contains("temp")) return "\u00B0C";
-    if (key.Contains("_ms") || key.Contains("latency_ms")) return "ms";
-    if (key.Contains("seconds") || key.Contains("duration")) return "s";
-    if (key.Contains("memory") || key.Contains("bytes")) return "MB";
-    return "";
-  }
-
-  private static string FormatMetricValue(double value, string metricKey)
-  {
-    var key = metricKey.ToLowerInvariant();
-
-    if (key.Contains("memory") || key.Contains("bytes") || key.Contains("_mb") || key.Contains("file_size"))
-      return FormatBytes(value * 1024 * 1024);
-
-    if (key.Contains("percent") || key.Contains("_ratio"))
-      return $"{value:F1}%";
-
-    if (key.Contains("cpu") && key.Contains("usage"))
-      return $"{value:F1}%";
-
-    if (key.Contains("seconds") || key.Contains("duration") || key.Contains("latency") || key.Contains("_time"))
-      return FormatDuration(value, key);
-
-    return FormatScaled(value);
-  }
-
-  private static string FormatBytes(double bytes)
-  {
-    var abs = Math.Abs(bytes);
-    if (abs < 1024) return $"{bytes:F3} B";
-    if (abs < 1024 * 1024) return $"{bytes / 1024:F3} KB";
-    if (abs < 1024L * 1024 * 1024) return $"{bytes / (1024 * 1024):F3} MB";
-    if (abs < 1024L * 1024 * 1024 * 1024) return $"{bytes / (1024L * 1024 * 1024):F3} GB";
-    if (abs < 1024L * 1024 * 1024 * 1024 * 1024) return $"{bytes / (1024L * 1024 * 1024 * 1024):F3} TB";
-    return $"{bytes / (1024L * 1024 * 1024 * 1024 * 1024):F3} PB";
+    var unit = MapKeyToUnit(metricKey);
+    return unit switch
+    {
+      Units.Percent => "%",
+      Units.Megabytes => "MB",
+      Units.Milliseconds => "ms",
+      Units.Decibels => "dB",
+      Units.Frequency => "Hz",
+      Units.PerMinute => "/min",
+      _ => ""
+    };
   }
 
   private static string FormatScaled(double value)
@@ -700,45 +589,9 @@
     return $"{value / 1_000_000_000_000_000:F3} P";
   }
 
-  private static string FormatDuration(double value, string key)
-  {
-    if (key.Contains("_ms") || key.Contains("latency_ms") || key.Contains("duration_ms"))
-      return $"{value:F1} ms";
-    return $"{value:F1} s";
-  }
-
-  private static string RenderSparkline(List<double> points, int width, int height, string? color = null)
-  {
-    if (points.Count < 2) return "";
-
-    var min = points.Min();
-    var max = points.Max();
-    var range = max - min;
-    if (range == 0) range = 1;
-
-    var stepX = (double)width / (points.Count - 1);
-    var padding = 1;
-    var usableHeight = height - padding * 2;
-
-    var pathPoints = new System.Text.StringBuilder();
-    var areaPath = new System.Text.StringBuilder();
-    for (int i = 0; i < points.Count; i++)
-    {
-      var x = i * stepX;
-      var y = padding + usableHeight - ((points[i] - min) / range) * usableHeight;
-      pathPoints.Append(i == 0 ? $"M{x:F1},{y:F1}" : $" L{x:F1},{y:F1}");
-      areaPath.Append(i == 0 ? $"M{x:F1},{y:F1}" : $" L{x:F1},{y:F1}");
-    }
-    // Close area path
-    areaPath.Append($" L{(points.Count - 1) * stepX:F1},{height} L0,{height} Z");
-
-    var strokeColor = color ?? "#5CD4E8";
-
-    return $"<svg viewBox=\"0 0 {width} {height}\" preserveAspectRatio=\"none\" style=\"width:100%;height:100%;\">" +
-           $"<path d=\"{areaPath}\" fill=\"{strokeColor}\" fill-opacity=\"0.1\"/>" +
-           $"<path d=\"{pathPoints}\" fill=\"none\" stroke=\"{strokeColor}\" stroke-width=\"1.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/>" +
-           "</svg>";
-  }
+  // Used by the chart stats footer. Mirrors MetricTile's unit-aware formatting.
+  private static string FormatMetricValue(double value, string metricKey)
+    => UnitsFormatter.Format(value, MapKeyToUnit(metricKey));
 
   public async ValueTask DisposeAsync()
   {

--- a/src/Radio.Web/Components/Pages/PlayHistoryPage.razor
+++ b/src/Radio.Web/Components/Pages/PlayHistoryPage.razor
@@ -106,8 +106,14 @@
 
     @if (_isLoading)
     {
-      <div style="display:flex; justify-content:center; padding:16px;">
-        <RadzenProgressBarCircular Mode="ProgressBarMode.Indeterminate" />
+      @* PR 4: panel-body initial-load shows skeleton rows so the
+         placeholder reads as the grid that's about to appear. *@
+      <div style="padding: 8px 0;">
+        <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
+        <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
+        <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
+        <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
+        <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
       </div>
     }
     else if (_historyData?.Items.Any() == true)

--- a/src/Radio.Web/Components/Pages/RadioPage.razor
+++ b/src/Radio.Web/Components/Pages/RadioPage.razor
@@ -11,9 +11,9 @@
 <div style="height: 100%; display: flex; gap: 2px; overflow: hidden;">
   @if (_radioState == null)
   {
-    <div style="flex: 1; display: flex; justify-content: center; align-items: center;">
-      <RadzenProgressBarCircular Mode="ProgressBarMode.Indeterminate" ProgressBarStyle="ProgressBarStyle.Primary" />
-    </div>
+    @* Initial-load skeleton — shape mirrors the band buttons + freq well +
+       meter strip that take its place once _radioState is hydrated. *@
+    <Skeleton Shape="Skeleton.SkeletonShape.Radio" />
   }
   else
   {

--- a/src/Radio.Web/Components/Shared/MetricTile.razor
+++ b/src/Radio.Web/Components/Shared/MetricTile.razor
@@ -1,0 +1,116 @@
+@*
+  MetricTile — unit-aware metric card used by the metrics dashboard
+  redesign introduced in PR 4 (handoff §P0·4).
+
+  Renders a single metric in three stacked bands:
+    Category — mono 10px uppercase, low contrast
+    Name     — body 13px, medium contrast
+    Value    — mono 30px, threshold-tinted
+
+  When a time-series is supplied the matching <Sparkline /> is rendered
+  underneath, colored to match the value band so the sparkline reads
+  as the same metric at a glance.
+*@
+
+<div class="metric-tile" data-metric-key="@Key">
+  <div class="metric-tile-category">@Category</div>
+  <div class="metric-tile-name">@Name</div>
+  <div class="metric-tile-value" style="color: @_valueColor;">
+    @_formattedValue
+  </div>
+
+  @if (Series is { Count: > 0 })
+  {
+    <div class="metric-tile-spark">
+      <Sparkline Values="@Series" Stroke="@_valueColor" />
+    </div>
+  }
+</div>
+
+@code {
+  /// <summary>
+  /// Category label, e.g. <c>"System · Memory"</c>. Rendered above the metric name.
+  /// </summary>
+  [Parameter, EditorRequired]
+  public string Category { get; set; } = string.Empty;
+
+  /// <summary>
+  /// Human-readable metric name, e.g. <c>"Heap in use"</c>.
+  /// </summary>
+  [Parameter, EditorRequired]
+  public string Name { get; set; } = string.Empty;
+
+  /// <summary>The current value to display.</summary>
+  [Parameter, EditorRequired]
+  public double Value { get; set; }
+
+  /// <summary>
+  /// Display unit used to pick a formatter. Defaults to
+  /// <see cref="Units.Bare"/> when unset.
+  /// </summary>
+  [Parameter, EditorRequired]
+  public Units Unit { get; set; } = Units.Bare;
+
+  /// <summary>
+  /// Optional sparkline series. When provided (and non-empty) a 28px
+  /// sparkline renders under the value, colored to match.
+  /// </summary>
+  [Parameter] public IReadOnlyList<double>? Series { get; set; }
+
+  /// <summary>
+  /// Optional underlying metric key (e.g. <c>"system.memory_usage_mb"</c>).
+  /// Surfaced as a <c>data-metric-key</c> attribute so tests and CSS
+  /// selectors can target a specific tile without depending on label text.
+  /// </summary>
+  [Parameter] public string? Key { get; set; }
+
+  /// <summary>
+  /// Optional warn threshold. Values at or above warn render the value
+  /// in amber. For inverted-above metrics (e.g. buffer fill), set
+  /// <see cref="InvertThresholds"/>.
+  /// </summary>
+  [Parameter] public double? Warn { get; set; }
+
+  /// <summary>
+  /// Optional critical threshold. Values at or above critical render
+  /// the value in red. See <see cref="InvertThresholds"/> for inverted
+  /// semantics.
+  /// </summary>
+  [Parameter] public double? Critical { get; set; }
+
+  /// <summary>
+  /// When true, treat low values as bad (e.g. buffer fill, free disk):
+  /// values at or below <see cref="Critical"/> render red; at or below
+  /// <see cref="Warn"/> render amber. Otherwise high values are bad.
+  /// </summary>
+  [Parameter] public bool InvertThresholds { get; set; }
+
+  private string _formattedValue = string.Empty;
+  private string _valueColor = "var(--text-high)";
+
+  protected override void OnParametersSet()
+  {
+    _formattedValue = UnitsFormatter.Format(Value, Unit);
+    _valueColor = ComputeValueColor();
+  }
+
+  private string ComputeValueColor()
+  {
+    // No thresholds → neutral high-contrast text.
+    if (!Warn.HasValue && !Critical.HasValue)
+      return "var(--text-high)";
+
+    if (InvertThresholds)
+    {
+      // Low values are bad. Order matters: critical wins over warn.
+      if (Critical.HasValue && Value <= Critical.Value) return "var(--signal-red)";
+      if (Warn.HasValue && Value <= Warn.Value) return "var(--signal-amber)";
+      return "var(--signal-green)";
+    }
+
+    // Normal-above semantics: high values are bad.
+    if (Critical.HasValue && Value >= Critical.Value) return "var(--signal-red)";
+    if (Warn.HasValue && Value >= Warn.Value) return "var(--signal-amber)";
+    return "var(--signal-green)";
+  }
+}

--- a/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
@@ -7,6 +7,12 @@
 @implements IAsyncDisposable
 
 <div style="height: 100%; display: flex; flex-direction: column; position: relative; overflow: hidden;">
+  @* PR 4 note: NowPlayingPanel already had no centered-spinner initial-load
+     branch — it renders an empty/"No Track Playing" state immediately, then
+     swaps to real content via SignalR updates. The handoff §P1·5 skeleton
+     swap is therefore a no-op here. Acceptance criterion ("no centered
+     spinner in any panel-body loading branch") is met without a Skeleton. *@
+
   <!-- Full-bleed album art background -->
   @if (_hasValidAlbumArt)
   {

--- a/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
+++ b/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
@@ -183,10 +183,13 @@
           <!-- History List -->
           @if (_isLoadingHistory)
           {
-            <div style="flex: 1; display: flex; align-items: center; justify-content: center;">
-              <RadzenProgressBarCircular Mode="ProgressBarMode.Indeterminate"
-                                         ProgressBarStyle="ProgressBarStyle.Primary"
-                                         Size="ProgressBarCircularSize.Small" />
+            @* PR 4: skeleton row stack instead of a centered spinner —
+               panel-body initial-load reads as "list rows about to appear". *@
+            <div style="flex: 1; min-height: 0; padding: 8px;">
+              <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
+              <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
+              <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
+              <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
             </div>
           }
           else if (_historyItems.Any())

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -9,9 +9,9 @@
 <div class="rcp-root">
   @if (_radioState == null)
   {
-    <div style="flex: 1; display: flex; justify-content: center; align-items: center;">
-      <RadzenProgressBarCircular Mode="ProgressBarMode.Indeterminate" ProgressBarStyle="ProgressBarStyle.Primary" />
-    </div>
+    @* Initial-load skeleton — shape mirrors the band buttons + freq well +
+       meter strip that take its place once _radioState is hydrated. *@
+    <Skeleton Shape="Skeleton.SkeletonShape.Radio" />
   }
   else
   {

--- a/src/Radio.Web/Components/Shared/Skeleton.razor
+++ b/src/Radio.Web/Components/Shared/Skeleton.razor
@@ -1,0 +1,116 @@
+@*
+  Skeleton — shape-aware loading placeholder introduced by PR 4 (handoff §P1·5).
+
+  Replaces the centered <RadzenProgressBarCircular /> spinners that
+  used to dominate panel-body initial-load branches. Each Shape value
+  arranges the shimmer-animated .skeleton-* primitives from
+  design-system.css §17 into a layout that roughly matches the real
+  component's silhouette, so the loading state reads as the content
+  about to appear rather than a generic spinner.
+
+  Shape rationale:
+    NowPlaying — album-art block + title/artist lines + progress bar.
+    Radio      — band-button row + freq-well outline + meter band.
+    ListRow    — single 56px row with leading thumb + two text lines.
+    DeviceRow  — list row with trailing action-pill placeholder.
+    MetricTile — category + name + value bar + sparkline strip.
+    Visualizer — full-bleed shimmer block with an axis strip below.
+*@
+
+<div class="skeleton skeleton-@(_shapeClass)" role="status" aria-live="polite" aria-busy="true">
+  @switch (Shape)
+  {
+    case SkeletonShape.NowPlaying:
+      <div class="skeleton-loading skeleton-art"></div>
+      <div class="skeleton-loading skeleton-heading"></div>
+      <div class="skeleton-loading skeleton-text" style="width: 60%;"></div>
+      <div class="skeleton-loading skeleton-progress"></div>
+      break;
+
+    case SkeletonShape.Radio:
+      <div class="skeleton-radio-bands">
+        <div class="skeleton-loading skeleton-band"></div>
+        <div class="skeleton-loading skeleton-band"></div>
+        <div class="skeleton-loading skeleton-band"></div>
+        <div class="skeleton-loading skeleton-band"></div>
+      </div>
+      <div class="skeleton-loading skeleton-freq-well"></div>
+      <div class="skeleton-loading skeleton-meter"></div>
+      break;
+
+    case SkeletonShape.ListRow:
+      <div class="skeleton-list-row">
+        <div class="skeleton-loading skeleton-thumb"></div>
+        <div class="skeleton-list-row-text">
+          <div class="skeleton-loading skeleton-text" style="width: 75%;"></div>
+          <div class="skeleton-loading skeleton-text" style="width: 45%;"></div>
+        </div>
+      </div>
+      break;
+
+    case SkeletonShape.DeviceRow:
+      <div class="skeleton-list-row">
+        <div class="skeleton-loading skeleton-circle"></div>
+        <div class="skeleton-list-row-text">
+          <div class="skeleton-loading skeleton-text" style="width: 60%;"></div>
+          <div class="skeleton-loading skeleton-text" style="width: 35%;"></div>
+        </div>
+        <div class="skeleton-loading skeleton-action-pill"></div>
+      </div>
+      break;
+
+    case SkeletonShape.MetricTile:
+      <div class="skeleton-loading skeleton-text" style="width: 30%; height: 10px;"></div>
+      <div class="skeleton-loading skeleton-text" style="width: 55%;"></div>
+      <div class="skeleton-loading skeleton-text" style="width: 80%; height: 28px;"></div>
+      <div class="skeleton-loading skeleton-spark"></div>
+      break;
+
+    case SkeletonShape.Visualizer:
+      <div class="skeleton-loading skeleton-viz-canvas"></div>
+      <div class="skeleton-viz-axis">
+        <div class="skeleton-loading skeleton-axis-tick"></div>
+        <div class="skeleton-loading skeleton-axis-tick"></div>
+        <div class="skeleton-loading skeleton-axis-tick"></div>
+        <div class="skeleton-loading skeleton-axis-tick"></div>
+      </div>
+      break;
+  }
+  <span class="visually-hidden">Loading…</span>
+</div>
+
+@code {
+  /// <summary>
+  /// Distinct layouts the skeleton can render. Each shape arranges the
+  /// shimmer primitives to match the corresponding real component.
+  /// </summary>
+  public enum SkeletonShape
+  {
+    NowPlaying,
+    Radio,
+    ListRow,
+    DeviceRow,
+    MetricTile,
+    Visualizer,
+  }
+
+  /// <summary>The shape arrangement to render. Required.</summary>
+  [Parameter, EditorRequired]
+  public SkeletonShape Shape { get; set; } = SkeletonShape.ListRow;
+
+  private string _shapeClass = "list-row";
+
+  protected override void OnParametersSet()
+  {
+    _shapeClass = Shape switch
+    {
+      SkeletonShape.NowPlaying => "now-playing",
+      SkeletonShape.Radio => "radio",
+      SkeletonShape.ListRow => "list-row",
+      SkeletonShape.DeviceRow => "device-row",
+      SkeletonShape.MetricTile => "metric-tile",
+      SkeletonShape.Visualizer => "visualizer",
+      _ => "list-row",
+    };
+  }
+}

--- a/src/Radio.Web/Components/Shared/Sparkline.razor
+++ b/src/Radio.Web/Components/Shared/Sparkline.razor
@@ -1,0 +1,143 @@
+@*
+  Sparkline — pure inline-SVG mini line chart introduced by PR 4 of the
+  design tightening arc (handoff §P0·4).
+
+  Renders the supplied series into a fixed 120×28 SVG viewBox with
+  preserveAspectRatio="none" so it stretches to fill its parent
+  horizontally while staying crisp vertically. The line is drawn at the
+  Stroke color; a 10%-opacity fill of the same color sits under the
+  curve to imply magnitude.
+
+  Edge cases:
+    Values null or empty  → empty SVG (no path).
+    Single value          → flat line at mid-height.
+    All equal values      → flat line at mid-height (avoids div-by-zero).
+*@
+
+@using System.Globalization
+@using System.Text
+
+<svg viewBox="0 0 120 28"
+     preserveAspectRatio="none"
+     style="@RootStyle"
+     aria-hidden="true"
+     focusable="false">
+  @if (_hasPath)
+  {
+    <path d="@_areaPath" fill="@Stroke" fill-opacity="0.1" />
+    <path d="@_linePath" fill="none" stroke="@Stroke" stroke-width="1.5"
+          stroke-linecap="round" stroke-linejoin="round" />
+  }
+</svg>
+
+@code {
+  /// <summary>The time series to plot. Null or empty renders an empty SVG.</summary>
+  [Parameter, EditorRequired]
+  public IReadOnlyList<double> Values { get; set; } = Array.Empty<double>();
+
+  /// <summary>
+  /// Stroke and fill color (any CSS color, including <c>var(--…)</c>
+  /// or <c>currentColor</c>). Defaults to <c>currentColor</c> so the
+  /// sparkline inherits its parent's text color when unset.
+  /// </summary>
+  [Parameter]
+  public string Stroke { get; set; } = "currentColor";
+
+  /// <summary>
+  /// Inline style applied to the root SVG. Defaults to filling the
+  /// parent's width and a tile-friendly 28px height.
+  /// </summary>
+  [Parameter]
+  public string RootStyle { get; set; } = "width: 100%; height: 28px; display: block;";
+
+  private bool _hasPath;
+  private string _linePath = string.Empty;
+  private string _areaPath = string.Empty;
+
+  // SVG canvas dimensions — must match the viewBox above.
+  private const double ViewWidth = 120.0;
+  private const double ViewHeight = 28.0;
+
+  protected override void OnParametersSet()
+  {
+    BuildPaths();
+  }
+
+  private void BuildPaths()
+  {
+    _hasPath = false;
+    _linePath = string.Empty;
+    _areaPath = string.Empty;
+
+    if (Values == null || Values.Count == 0)
+      return;
+
+    var inv = CultureInfo.InvariantCulture;
+    var n = Values.Count;
+    var midY = ViewHeight / 2.0;
+
+    // Single-value sparklines render as a flat line at mid-height.
+    if (n == 1)
+    {
+      _linePath = $"M0,{midY.ToString("0.##", inv)} L{ViewWidth.ToString("0.##", inv)},{midY.ToString("0.##", inv)}";
+      _areaPath = $"M0,{midY.ToString("0.##", inv)} L{ViewWidth.ToString("0.##", inv)},{midY.ToString("0.##", inv)} L{ViewWidth.ToString("0.##", inv)},{ViewHeight.ToString("0.##", inv)} L0,{ViewHeight.ToString("0.##", inv)} Z";
+      _hasPath = true;
+      return;
+    }
+
+    double min = Values[0];
+    double max = Values[0];
+    for (var i = 1; i < n; i++)
+    {
+      var v = Values[i];
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+
+    var range = max - min;
+    var stepX = ViewWidth / (n - 1);
+
+    var line = new StringBuilder(n * 12);
+    var area = new StringBuilder(n * 12);
+
+    for (var i = 0; i < n; i++)
+    {
+      var x = i * stepX;
+      double y;
+      if (range == 0)
+      {
+        // All values equal — paint a flat line through the middle so
+        // the tile still reads as "present but unchanging".
+        y = midY;
+      }
+      else
+      {
+        // Normalize into [0, ViewHeight], invert (SVG y grows downward).
+        y = ViewHeight - ((Values[i] - min) / range) * ViewHeight;
+      }
+
+      var xs = x.ToString("0.##", inv);
+      var ys = y.ToString("0.##", inv);
+      if (i == 0)
+      {
+        line.Append('M').Append(xs).Append(',').Append(ys);
+        area.Append('M').Append(xs).Append(',').Append(ys);
+      }
+      else
+      {
+        line.Append(" L").Append(xs).Append(',').Append(ys);
+        area.Append(" L").Append(xs).Append(',').Append(ys);
+      }
+    }
+
+    // Close the area path back along the baseline to form a filled region.
+    var lastX = ((n - 1) * stepX).ToString("0.##", inv);
+    var baseY = ViewHeight.ToString("0.##", inv);
+    area.Append(" L").Append(lastX).Append(',').Append(baseY)
+        .Append(" L0,").Append(baseY).Append(" Z");
+
+    _linePath = line.ToString();
+    _areaPath = area.ToString();
+    _hasPath = true;
+  }
+}

--- a/src/Radio.Web/Components/Shared/VisualizerPanel.razor
+++ b/src/Radio.Web/Components/Shared/VisualizerPanel.razor
@@ -1,59 +1,86 @@
 @rendermode InteractiveServer
 @inject AudioVisualizationHubService VisualizationHub
+@inject VisualizerTelemetryService Telemetry
 @inject IJSRuntime JS
 @inject ILogger<VisualizerPanel> Logger
 @inject ConfigurationApiService ConfigApi
 @implements IAsyncDisposable
 
-<div style="height: 100%; position: relative; background: var(--surface-inset); overflow: hidden;">
-  <!-- Floating mode selector pill -->
-  <div style="position: absolute; top: 8px; right: 8px; z-index: 2; display: flex; align-items: center; gap: 6px;">
-    @if (!VisualizationHub.IsConnected)
-    {
-      <RadzenBadge BadgeStyle="BadgeStyle.Warning" IsPill="true" Text="Disconnected" Style="font-size: 12px;" />
-    }
-    <div class="route-group" style="background: rgba(0,0,0,0.6); backdrop-filter: blur(8px);">
-      <div class="route-toggle @(_currentMode == VisualizationMode.VUMeter ? "route-active" : "")"
-           style="width: 40px; height: 36px; border-radius: 16px; font-size: 13px; font-weight: 600;"
-           @onclick="@(() => SelectMode(VisualizationMode.VUMeter))">
-        VU
-      </div>
-      <div class="route-toggle @(_currentMode == VisualizationMode.Waveform ? "route-active" : "")"
-           style="width: 50px; height: 36px; border-radius: 16px; font-size: 13px; font-weight: 600;"
-           @onclick="@(() => SelectMode(VisualizationMode.Waveform))">
-        Wave
-      </div>
-      <div class="route-toggle @(_currentMode == VisualizationMode.Spectrum ? "route-active" : "")"
-           style="width: 70px; height: 36px; border-radius: 16px; font-size: 13px; font-weight: 600;"
-           @onclick="@(() => SelectMode(VisualizationMode.Spectrum))">
-        Spectrum
-      </div>
-      <div class="route-toggle @(_currentMode == VisualizationMode.Spectrogram ? "route-active" : "")"
-           style="width: 50px; height: 36px; border-radius: 16px; font-size: 13px; font-weight: 600;"
-           @onclick="@(() => SelectMode(VisualizationMode.Spectrogram))">
-        Fall
-      </div>
-      <div class="route-toggle @(_currentMode == VisualizationMode.Circular ? "route-active" : "")"
-           style="width: 50px; height: 36px; border-radius: 16px; font-size: 13px; font-weight: 600;"
-           @onclick="@(() => SelectMode(VisualizationMode.Circular))">
-        Ring
-      </div>
-      <div class="route-toggle @(_currentMode == VisualizationMode.PhaseScope ? "route-active" : "")"
-           style="width: 60px; height: 36px; border-radius: 16px; font-size: 13px; font-weight: 600;"
-           @onclick="@(() => SelectMode(VisualizationMode.PhaseScope))">
-        Phase
-      </div>
+@*
+  VisualizerPanel — full-bleed visualizer with promoted 3-segment mode picker.
+
+  PR 4 rework (handoff §P1·3):
+    • Replaced the floating chip group with a full-width 3-segment header
+      (VU / WAVE / SPECTRUM) — 44px tall, mono 12px uppercase 0.10em
+      letter-spacing, active segment tinted with --accent-dim + accent
+      underline.
+    • Canvas now fills the remaining vertical space — no inset padding.
+    • "Connected" pill collapsed to an 8px dot at top-right.
+    • The "Updates: NN/sec" overlay moves out of the canvas into
+      VisualizerTelemetryService so the dev tray (PR 6) can subscribe.
+    • Frequency-band axis labels live in a 16px strip under the canvas
+      (mono 10px, low-contrast).
+
+  The underlying VisualizationMode enum still has six entries because the
+  visualizer.js module supports waveform/phase/spectrogram/circular. The
+  promoted header only exposes the three primary modes; the secondary
+  modes remain reachable from the dev tray (PR 6) and from saved
+  preferences.
+*@
+
+<div class="viz-panel">
+  <!-- 3-segment mode picker header -->
+  <div class="visualizer-header">
+    <div class="visualizer-mode-picker" role="tablist" aria-label="Visualizer mode">
+      <button class="visualizer-mode @(IsVuMode ? "is-active" : "")"
+              type="button"
+              @onclick="@(() => SelectMode(VisualizationMode.VUMeter))"
+              role="tab"
+              aria-selected="@(IsVuMode ? "true" : "false")"
+              aria-label="VU meter mode">VU</button>
+      <button class="visualizer-mode @(IsWaveMode ? "is-active" : "")"
+              type="button"
+              @onclick="@(() => SelectMode(VisualizationMode.Waveform))"
+              role="tab"
+              aria-selected="@(IsWaveMode ? "true" : "false")"
+              aria-label="Waveform mode">Wave</button>
+      <button class="visualizer-mode @(IsSpectrumMode ? "is-active" : "")"
+              type="button"
+              @onclick="@(() => SelectMode(VisualizationMode.Spectrum))"
+              role="tab"
+              aria-selected="@(IsSpectrumMode ? "true" : "false")"
+              aria-label="Spectrum mode">Spectrum</button>
     </div>
+    <span class="visualizer-conn-dot @(VisualizationHub.IsConnected ? "is-connected" : "")"
+          aria-label="@(VisualizationHub.IsConnected ? "Connected" : "Disconnected")"
+          title="@(VisualizationHub.IsConnected ? "Connected" : "Disconnected")"></span>
   </div>
 
-  <!-- Edge-to-edge canvas -->
-  <canvas id="@WebConstants.ElementIds.VisualizerCanvas" style="width: 100%; height: 100%; display: block;"></canvas>
+  <!-- Full-bleed canvas -->
+  <div class="visualizer-canvas-wrap">
+    <canvas id="@WebConstants.ElementIds.VisualizerCanvas" class="visualizer-canvas"></canvas>
 
-  @if (_isInitialized && !_hasReceivedData)
+    @if (_isInitialized && !_hasReceivedData)
+    {
+      <div class="visualizer-waiting" aria-live="polite">
+        <RadzenIcon Icon="graphic_eq" Style="font-size: 64px; color: var(--text-low); margin-bottom: 8px;" />
+        <div style="font-size: 16px; color: var(--text-low);">Waiting for audio data...</div>
+      </div>
+    }
+    else if (!_isInitialized)
+    {
+      <Skeleton Shape="Skeleton.SkeletonShape.Visualizer" />
+    }
+  </div>
+
+  <!-- Frequency-band axis strip (visible in spectrum-family modes) -->
+  @if (IsSpectrumMode)
   {
-    <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; animation: ambientPulse 3s ease-in-out infinite;">
-      <RadzenIcon Icon="graphic_eq" Style="font-size: 64px; color: var(--text-low); margin-bottom: 8px;" />
-      <div style="font-size: 16px; color: var(--text-low);">Waiting for audio data...</div>
+    <div class="visualizer-axis" aria-hidden="true">
+      <span>375 Hz</span>
+      <span>750 Hz</span>
+      <span>1.1 kHz</span>
+      <span>1.5 kHz</span>
     </div>
   }
 </div>
@@ -75,6 +102,21 @@
   private bool _hasReceivedData;
   private IJSObjectReference? _jsModule;
 
+  // Updates/sec telemetry — counted in HandleLevelData/HandleWaveformData/
+  // HandleSpectrumData and sampled every second by _telemetryTimer.
+  private int _frameCountSinceLastSample;
+  private System.Threading.Timer? _telemetryTimer;
+
+  // Map the six-mode enum to the three primary buckets the header exposes.
+  private bool IsVuMode => _currentMode == VisualizationMode.VUMeter;
+  private bool IsWaveMode =>
+    _currentMode == VisualizationMode.Waveform ||
+    _currentMode == VisualizationMode.PhaseScope;
+  private bool IsSpectrumMode =>
+    _currentMode == VisualizationMode.Spectrum ||
+    _currentMode == VisualizationMode.Spectrogram ||
+    _currentMode == VisualizationMode.Circular;
+
   protected override async Task OnInitializedAsync()
   {
     try
@@ -87,6 +129,15 @@
       VisualizationHub.OnLevelData += HandleLevelData;
       VisualizationHub.OnWaveformData += HandleWaveformData;
       VisualizationHub.OnSpectrumData += HandleSpectrumData;
+
+      // Publish an "updates/sec" sample once per second by snapshotting
+      // the frame counter and resetting it. The dev tray (PR 6) reads
+      // the value via VisualizerTelemetryService.
+      _telemetryTimer = new System.Threading.Timer(_ =>
+      {
+        var n = System.Threading.Interlocked.Exchange(ref _frameCountSinceLastSample, 0);
+        Telemetry.SetUpdatesPerSecond(n);
+      }, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
     }
     catch (Exception ex)
     {
@@ -208,6 +259,7 @@
   private async Task HandleLevelData(LevelDataDto data)
   {
     if (_isDisposed || !_isInitialized || _jsModule == null || _currentMode != VisualizationMode.VUMeter) return;
+    System.Threading.Interlocked.Increment(ref _frameCountSinceLastSample);
     var wasFirst = !_hasReceivedData;
     _hasReceivedData = true;
     try
@@ -225,6 +277,7 @@
   {
     if (_isDisposed || !_isInitialized || _jsModule == null) return;
     if (_currentMode != VisualizationMode.Waveform && _currentMode != VisualizationMode.PhaseScope) return;
+    System.Threading.Interlocked.Increment(ref _frameCountSinceLastSample);
     var wasFirst = !_hasReceivedData;
     _hasReceivedData = true;
     try
@@ -248,6 +301,7 @@
     if (_currentMode != VisualizationMode.Spectrum &&
         _currentMode != VisualizationMode.Spectrogram &&
         _currentMode != VisualizationMode.Circular) return;
+    System.Threading.Interlocked.Increment(ref _frameCountSinceLastSample);
     var wasFirst = !_hasReceivedData;
     _hasReceivedData = true;
     try
@@ -290,6 +344,10 @@
   public async ValueTask DisposeAsync()
   {
     _isDisposed = true;
+
+    _telemetryTimer?.Dispose();
+    // Publish a final zero so subscribers don't see a stale value after dispose.
+    try { Telemetry.SetUpdatesPerSecond(0); } catch { /* ignore */ }
 
     VisualizationHub.OnLevelData -= HandleLevelData;
     VisualizationHub.OnWaveformData -= HandleWaveformData;

--- a/src/Radio.Web/Program.cs
+++ b/src/Radio.Web/Program.cs
@@ -348,6 +348,10 @@ builder.Services.AddScoped<Radio.Web.Services.QueuePersistenceService>();
 builder.Services.AddScoped<Radio.Web.Services.DeviceDisplayStateService>();
 builder.Services.AddScoped<Radio.Web.Services.RadioPanelToggleService>();
 
+// Visualizer "updates/sec" telemetry. Singleton because the value is shared
+// across all visualizer panels and consumed by the dev tray (PR 6).
+builder.Services.AddSingleton<Radio.Web.Services.VisualizerTelemetryService>();
+
 // Bind Devices:Aliases → DevicesOptions so MainLayout and DeviceManagementPage can
 // inject IOptionsMonitor<DevicesOptions> to clean up raw driver names at render time.
 // Defaults to an empty alias map when the section is absent or empty.

--- a/src/Radio.Web/Services/VisualizerTelemetryService.cs
+++ b/src/Radio.Web/Services/VisualizerTelemetryService.cs
@@ -1,0 +1,57 @@
+namespace Radio.Web.Services;
+
+/// <summary>
+/// Singleton holding the most recent visualizer "updates per second"
+/// telemetry value (the rate at which the visualizer's <c>OnLevel</c> /
+/// <c>OnSpectrum</c> / <c>OnWaveform</c> callbacks are firing).
+///
+/// <para>
+/// Introduced in PR 4 of the design tightening arc (handoff §P1·3) to
+/// remove the burned-in <c>"Updates: NN/sec"</c> overlay from the
+/// visualizer canvas while keeping the value available for the dev
+/// tray, which is built in PR 6 (handoff §P2·2).
+/// </para>
+///
+/// <para>
+/// Consumers should subscribe to <see cref="UpdatesPerSecondChanged"/>
+/// for push notifications, or read <see cref="UpdatesPerSecond"/>
+/// directly for the latest snapshot. The service stays in-process —
+/// no SignalR, no persistence.
+/// </para>
+/// </summary>
+public sealed class VisualizerTelemetryService
+{
+  private int _updatesPerSecond;
+
+  /// <summary>
+  /// The most recently published "updates per second" measurement.
+  /// Defaults to zero until the visualizer publishes a value.
+  /// </summary>
+  public int UpdatesPerSecond => _updatesPerSecond;
+
+  /// <summary>
+  /// Fired when <see cref="UpdatesPerSecond"/> changes. The handler is
+  /// invoked synchronously from the publishing thread; subscribers
+  /// should marshal to their own UI dispatcher as required.
+  /// </summary>
+  public event Action<int>? UpdatesPerSecondChanged;
+
+  /// <summary>
+  /// Publishes a new "updates per second" value. No-op when the value
+  /// matches the current value (saves UI churn for stable rates).
+  /// </summary>
+  /// <param name="updatesPerSecond">
+  /// Non-negative rate. Negative inputs are clamped to zero.
+  /// </param>
+  public void SetUpdatesPerSecond(int updatesPerSecond)
+  {
+    var v = updatesPerSecond < 0 ? 0 : updatesPerSecond;
+    if (_updatesPerSecond == v)
+    {
+      return;
+    }
+
+    _updatesPerSecond = v;
+    UpdatesPerSecondChanged?.Invoke(v);
+  }
+}

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -2009,14 +2009,14 @@ body {
 }
 
 .visualizer-mode:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--accent-primary);
   outline-offset: -2px;
 }
 
 .visualizer-mode.is-active {
   background: var(--accent-dim);
-  color: var(--accent);
-  box-shadow: inset 0 -2px 0 var(--accent);
+  color: var(--accent-primary);
+  box-shadow: inset 0 -2px 0 var(--accent-primary);
 }
 
 /* 8×8 connection dot, top-right of the header. No text label. */

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -1949,3 +1949,335 @@ body {
 .source-bubble-chevron:active {
   transform: scale(0.92);
 }
+
+/* ─── §28  Visualizer Panel (PR 4) ────────────────────────────────────────── */
+
+/* Replaces the floating chip-group + canvas-overlap layout. The panel is
+   a flex column: 44px header, full-bleed canvas wrap, and an optional
+   16px frequency-band axis strip below for spectrum modes. */
+
+.viz-panel {
+  position: relative;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-inset);
+  overflow: hidden;
+}
+
+.visualizer-header {
+  position: relative;
+  flex: 0 0 44px;
+  display: flex;
+  align-items: stretch;
+  border-bottom: 1px solid var(--surface-separator);
+  background: var(--surface-base);
+}
+
+.visualizer-mode-picker {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  height: 44px;
+}
+
+.visualizer-mode {
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--surface-separator);
+  color: var(--text-medium);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--anim-duration-fast) var(--anim-ease-standard),
+              color var(--anim-duration-fast) var(--anim-ease-standard);
+}
+
+.visualizer-mode:last-child {
+  border-right: none;
+}
+
+.visualizer-mode:hover:not(.is-active) {
+  color: var(--text-high);
+  background: var(--surface-hover);
+}
+
+.visualizer-mode:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.visualizer-mode.is-active {
+  background: var(--accent-dim);
+  color: var(--accent);
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
+/* 8×8 connection dot, top-right of the header. No text label. */
+.visualizer-conn-dot {
+  position: absolute;
+  top: 18px;
+  right: 12px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--signal-red);
+  box-shadow: 0 0 0 2px var(--surface-base);
+  pointer-events: none;
+}
+
+.visualizer-conn-dot.is-connected {
+  background: var(--signal-green);
+}
+
+.visualizer-canvas-wrap {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.visualizer-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.visualizer-waiting {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  animation: ambientPulse 3s ease-in-out infinite;
+  pointer-events: none;
+}
+
+/* Frequency-band axis strip — 16px tall, mono 10px, low contrast.
+   Spectrum-family modes only. */
+.visualizer-axis {
+  flex: 0 0 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  padding: 0 8px;
+  border-top: 1px solid var(--surface-separator);
+  background: var(--surface-base);
+  color: var(--text-low);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+}
+
+/* ─── §29  Metric Tile + Sparkline (PR 4) ─────────────────────────────────── */
+
+/* Replaces the dense MetricsDashboardPage hero/row layout with a grid
+   of category-grouped tiles. Each tile shows: category line, name line,
+   big value (color from threshold band), and an optional inline
+   sparkline matched to the value color. */
+
+.metric-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  background: var(--surface-raised);
+  border: 1px solid var(--surface-separator);
+  border-radius: 8px;
+  min-height: 110px;
+}
+
+.metric-tile-category {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-low);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.metric-tile-name {
+  font-size: 13px;
+  color: var(--text-medium);
+  line-height: 1.25;
+  /* Allow two lines for long metric names without distorting tile height. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 32px;
+}
+
+.metric-tile-value {
+  font-family: var(--font-mono);
+  font-size: 30px;
+  font-weight: 600;
+  line-height: 1.1;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.metric-tile-spark {
+  margin-top: 4px;
+  height: 28px;
+  /* Sparkline takes its parent's color for stroke when Stroke="currentColor". */
+}
+
+/* ─── §30  Metrics Dashboard — categorized grid (PR 4) ────────────────────── */
+
+.metrics-categories-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 16px 20px 24px;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.metrics-category-block {
+  display: flex;
+  flex-direction: column;
+}
+
+.metrics-category-subheader {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+  color: var(--text-low);
+  margin: 0 0 14px;
+}
+
+.metrics-tile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+/* ─── §31  Skeleton Shapes (PR 4) ─────────────────────────────────────────── */
+
+/* Replaces the generic centered <RadzenProgressBarCircular /> spinners
+   in panel-body initial-load branches. Each shape arranges the existing
+   .skeleton-* shimmer primitives from §17 (animation: shimmer) into a
+   layout that mirrors the real component about to take its place. */
+
+.skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.skeleton .visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skeleton-art {
+  flex: 1 1 auto;
+  min-height: 180px;
+  border-radius: 8px;
+}
+
+.skeleton-progress {
+  height: 4px;
+  border-radius: 2px;
+  width: 100%;
+}
+
+.skeleton-radio-bands {
+  display: flex;
+  gap: 8px;
+}
+
+.skeleton-band {
+  flex: 1;
+  height: 36px;
+  border-radius: 18px;
+}
+
+.skeleton-freq-well {
+  height: 100px;
+  border-radius: 8px;
+}
+
+.skeleton-meter {
+  height: 24px;
+  border-radius: 4px;
+}
+
+.skeleton-list-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 4px;
+  border-bottom: 1px solid var(--surface-separator);
+}
+
+.skeleton-list-row:last-child {
+  border-bottom: none;
+}
+
+.skeleton-thumb {
+  width: 48px;
+  height: 48px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.skeleton-list-row-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.skeleton-action-pill {
+  width: 96px;
+  height: 28px;
+  border-radius: 14px;
+  flex-shrink: 0;
+}
+
+.skeleton-spark {
+  height: 28px;
+  border-radius: 2px;
+}
+
+.skeleton-viz-canvas {
+  flex: 1 1 auto;
+  border-radius: 4px;
+  min-height: 120px;
+}
+
+.skeleton-viz-axis {
+  display: flex;
+  gap: 12px;
+  padding: 0 8px;
+}
+
+.skeleton-axis-tick {
+  flex: 1;
+  height: 10px;
+  border-radius: 2px;
+}

--- a/tests/Radio.Web.Tests/Components/Pages/HomePageTests.cs
+++ b/tests/Radio.Web.Tests/Components/Pages/HomePageTests.cs
@@ -72,6 +72,9 @@ public class HomePageTests : TestContext
 
     // RadioApiService (used by RadioControlPanel child component)
     Services.AddHttpClient<RadioApiService>();
+
+    // VisualizerTelemetryService (PR 4 — consumed by VisualizerPanel).
+    Services.AddSingleton<VisualizerTelemetryService>();
   }
 
   protected override void Dispose(bool disposing)

--- a/tests/Radio.Web.Tests/Components/Shared/MetricTileTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/MetricTileTests.cs
@@ -1,0 +1,222 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Radzen;
+using Radio.Web.Components.Shared;
+using Radio.Web.Formatting;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for the <see cref="MetricTile"/> card introduced by PR 4
+/// of the design tightening arc (handoff §P0·4).
+///
+/// Covers:
+///   * Category / Name / unit-aware Value rendering.
+///   * Threshold-band color logic (warn / critical, normal + inverted).
+///   * Sparkline rendered only when Series is provided.
+///   * The fixed-bug cases from the screenshot audit (Memory Usage Mb
+///     reads as MB, Signal Strength as %, Latency Ms as ms/s, etc.).
+/// </summary>
+public class MetricTileTests : TestContext
+{
+  public MetricTileTests()
+  {
+    Services.AddRadzenComponents();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+  }
+
+  [Fact]
+  public void MetricTile_RendersCategory_Name_AndUnitFormattedValue()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "System · Memory")
+      .Add(x => x.Name, "Heap in use")
+      .Add(x => x.Value, 850)
+      .Add(x => x.Unit, Units.Megabytes));
+
+    cut.Find(".metric-tile-category").TextContent.Trim().Should().Be("System · Memory");
+    cut.Find(".metric-tile-name").TextContent.Trim().Should().Be("Heap in use");
+    cut.Find(".metric-tile-value").TextContent.Trim().Should().Be("850 MB");
+  }
+
+  [Fact]
+  public void MetricTile_MemoryBugRegression_ShowsMBNotPercent()
+  {
+    // Regression for handoff §P0·4: Memory Usage Mb tile previously
+    // rendered as "850.4%". Must read "850 MB".
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "System · Memory")
+      .Add(x => x.Name, "Memory Usage Mb")
+      .Add(x => x.Value, 850)
+      .Add(x => x.Unit, Units.Megabytes));
+
+    var value = cut.Find(".metric-tile-value").TextContent.Trim();
+    value.Should().Be("850 MB");
+    value.Should().NotContain("%");
+  }
+
+  [Fact]
+  public void MetricTile_SignalStrength_RendersAsPercent()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "Radio · Signal")
+      .Add(x => x.Name, "Signal Strength")
+      .Add(x => x.Value, 65)
+      .Add(x => x.Unit, Units.Percent));
+
+    cut.Find(".metric-tile-value").TextContent.Trim().Should().Be("65%");
+  }
+
+  [Fact]
+  public void MetricTile_LatencyMs_BelowOneSecond_RendersMs()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "Radio · Latency")
+      .Add(x => x.Name, "Latency Ms")
+      .Add(x => x.Value, 250)
+      .Add(x => x.Unit, Units.Milliseconds));
+
+    cut.Find(".metric-tile-value").TextContent.Trim().Should().Be("250 ms");
+  }
+
+  [Fact]
+  public void MetricTile_LatencyMs_AboveOneSecond_AutoPromotesToSeconds()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "Radio · Latency")
+      .Add(x => x.Name, "Latency Ms")
+      .Add(x => x.Value, 1200)
+      .Add(x => x.Unit, Units.Milliseconds));
+
+    cut.Find(".metric-tile-value").TextContent.Trim().Should().Be("1.2 s");
+  }
+
+  [Fact]
+  public void MetricTile_FrequencyChanges_AsCount_IsThousandsSeparated()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "Radio · Tuner")
+      .Add(x => x.Name, "Frequency Changes")
+      .Add(x => x.Value, 12345)
+      .Add(x => x.Unit, Units.Count));
+
+    var value = cut.Find(".metric-tile-value").TextContent.Trim();
+    value.Should().BeOneOf("12,345", "12.345"); // tolerate culture difference
+  }
+
+  [Fact]
+  public void MetricTile_NoThresholds_UsesTextHighColor()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "X")
+      .Add(x => x.Name, "Y")
+      .Add(x => x.Value, 50)
+      .Add(x => x.Unit, Units.Bare));
+
+    var style = cut.Find(".metric-tile-value").GetAttribute("style") ?? string.Empty;
+    style.Should().Contain("--text-high");
+  }
+
+  [Fact]
+  public void MetricTile_BelowWarn_UsesSignalGreenColor()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "X")
+      .Add(x => x.Name, "Y")
+      .Add(x => x.Value, 30)
+      .Add(x => x.Unit, Units.Percent)
+      .Add(x => x.Warn, 80.0)
+      .Add(x => x.Critical, 95.0));
+
+    var style = cut.Find(".metric-tile-value").GetAttribute("style") ?? string.Empty;
+    style.Should().Contain("--signal-green");
+  }
+
+  [Fact]
+  public void MetricTile_AtOrAboveWarn_BelowCritical_UsesSignalAmberColor()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "X")
+      .Add(x => x.Name, "Y")
+      .Add(x => x.Value, 85)
+      .Add(x => x.Unit, Units.Percent)
+      .Add(x => x.Warn, 80.0)
+      .Add(x => x.Critical, 95.0));
+
+    var style = cut.Find(".metric-tile-value").GetAttribute("style") ?? string.Empty;
+    style.Should().Contain("--signal-amber");
+  }
+
+  [Fact]
+  public void MetricTile_AtOrAboveCritical_UsesSignalRedColor()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "X")
+      .Add(x => x.Name, "Y")
+      .Add(x => x.Value, 96)
+      .Add(x => x.Unit, Units.Percent)
+      .Add(x => x.Warn, 80.0)
+      .Add(x => x.Critical, 95.0));
+
+    var style = cut.Find(".metric-tile-value").GetAttribute("style") ?? string.Empty;
+    style.Should().Contain("--signal-red");
+  }
+
+  [Fact]
+  public void MetricTile_InvertedThresholds_LowValuesRenderRed()
+  {
+    // Buffer-fill style: low values are bad. value=10, critical=20 → red.
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "Audio · Buffer")
+      .Add(x => x.Name, "Buffer Fill")
+      .Add(x => x.Value, 10)
+      .Add(x => x.Unit, Units.Percent)
+      .Add(x => x.Warn, 50.0)
+      .Add(x => x.Critical, 20.0)
+      .Add(x => x.InvertThresholds, true));
+
+    var style = cut.Find(".metric-tile-value").GetAttribute("style") ?? string.Empty;
+    style.Should().Contain("--signal-red");
+  }
+
+  [Fact]
+  public void MetricTile_NoSeries_DoesNotRenderSparkline()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "X")
+      .Add(x => x.Name, "Y")
+      .Add(x => x.Value, 50)
+      .Add(x => x.Unit, Units.Bare));
+
+    cut.FindAll(".metric-tile-spark").Should().BeEmpty();
+    cut.FindAll("svg").Should().BeEmpty();
+  }
+
+  [Fact]
+  public void MetricTile_WithSeries_RendersSparkline()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "X")
+      .Add(x => x.Name, "Y")
+      .Add(x => x.Value, 50)
+      .Add(x => x.Unit, Units.Bare)
+      .Add(x => x.Series, new double[] { 10, 20, 30, 40, 50 }));
+
+    cut.FindAll(".metric-tile-spark").Count.Should().Be(1);
+    cut.FindAll("svg").Count.Should().Be(1);
+  }
+
+  [Fact]
+  public void MetricTile_KeyAttribute_PropagatesAsDataAttribute()
+  {
+    var cut = RenderComponent<MetricTile>(p => p
+      .Add(x => x.Category, "X")
+      .Add(x => x.Name, "Y")
+      .Add(x => x.Value, 1)
+      .Add(x => x.Unit, Units.Bare)
+      .Add(x => x.Key, "system.memory_usage_mb"));
+
+    cut.Find(".metric-tile").GetAttribute("data-metric-key").Should().Be("system.memory_usage_mb");
+  }
+}

--- a/tests/Radio.Web.Tests/Components/Shared/SkeletonTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/SkeletonTests.cs
@@ -1,0 +1,125 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Radzen;
+using Radio.Web.Components.Shared;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for the <see cref="Skeleton"/> shape-aware placeholder
+/// introduced by PR 4 of the design tightening arc (handoff §P1·5).
+///
+/// Each test asserts the structural fingerprint of one Shape value so a
+/// future refactor that accidentally collapses two shapes into one would
+/// trip the test. We do not assert exact CSS or pixel sizing here — the
+/// design-system stylesheet owns the visual concerns; the component only
+/// owns the markup arrangement.
+/// </summary>
+public class SkeletonTests : TestContext
+{
+  public SkeletonTests()
+  {
+    Services.AddRadzenComponents();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+  }
+
+  [Fact]
+  public void Skeleton_NowPlaying_RendersArt_Heading_Text_Progress()
+  {
+    var cut = RenderComponent<Skeleton>(p => p
+      .Add(x => x.Shape, Skeleton.SkeletonShape.NowPlaying));
+
+    var root = cut.Find(".skeleton");
+    root.GetAttribute("class").Should().Contain("skeleton-now-playing");
+    cut.FindAll(".skeleton-art").Count.Should().Be(1);
+    cut.FindAll(".skeleton-heading").Count.Should().Be(1);
+    cut.FindAll(".skeleton-text").Count.Should().BeGreaterThanOrEqualTo(1);
+    cut.FindAll(".skeleton-progress").Count.Should().Be(1);
+  }
+
+  [Fact]
+  public void Skeleton_Radio_RendersBands_FreqWell_Meter()
+  {
+    var cut = RenderComponent<Skeleton>(p => p
+      .Add(x => x.Shape, Skeleton.SkeletonShape.Radio));
+
+    cut.Find(".skeleton").GetAttribute("class").Should().Contain("skeleton-radio");
+    cut.FindAll(".skeleton-band").Count.Should().Be(4);
+    cut.FindAll(".skeleton-freq-well").Count.Should().Be(1);
+    cut.FindAll(".skeleton-meter").Count.Should().Be(1);
+  }
+
+  [Fact]
+  public void Skeleton_ListRow_RendersThumb_TwoTextLines()
+  {
+    var cut = RenderComponent<Skeleton>(p => p
+      .Add(x => x.Shape, Skeleton.SkeletonShape.ListRow));
+
+    cut.Find(".skeleton").GetAttribute("class").Should().Contain("skeleton-list-row");
+    cut.FindAll(".skeleton-thumb").Count.Should().Be(1);
+    cut.FindAll(".skeleton-text").Count.Should().Be(2);
+    cut.FindAll(".skeleton-circle").Should().BeEmpty(); // distinct from DeviceRow
+  }
+
+  [Fact]
+  public void Skeleton_DeviceRow_RendersCircle_TextLines_ActionPill()
+  {
+    var cut = RenderComponent<Skeleton>(p => p
+      .Add(x => x.Shape, Skeleton.SkeletonShape.DeviceRow));
+
+    cut.Find(".skeleton").GetAttribute("class").Should().Contain("skeleton-device-row");
+    cut.FindAll(".skeleton-circle").Count.Should().Be(1);
+    cut.FindAll(".skeleton-text").Count.Should().Be(2);
+    cut.FindAll(".skeleton-action-pill").Count.Should().Be(1);
+    cut.FindAll(".skeleton-thumb").Should().BeEmpty(); // distinct from ListRow
+  }
+
+  [Fact]
+  public void Skeleton_MetricTile_RendersCategoryNameValueAndSpark()
+  {
+    var cut = RenderComponent<Skeleton>(p => p
+      .Add(x => x.Shape, Skeleton.SkeletonShape.MetricTile));
+
+    cut.Find(".skeleton").GetAttribute("class").Should().Contain("skeleton-metric-tile");
+    cut.FindAll(".skeleton-text").Count.Should().BeGreaterThanOrEqualTo(3);
+    cut.FindAll(".skeleton-spark").Count.Should().Be(1);
+  }
+
+  [Fact]
+  public void Skeleton_Visualizer_RendersCanvasAndAxisTicks()
+  {
+    var cut = RenderComponent<Skeleton>(p => p
+      .Add(x => x.Shape, Skeleton.SkeletonShape.Visualizer));
+
+    cut.Find(".skeleton").GetAttribute("class").Should().Contain("skeleton-visualizer");
+    cut.FindAll(".skeleton-viz-canvas").Count.Should().Be(1);
+    cut.FindAll(".skeleton-viz-axis").Count.Should().Be(1);
+    cut.FindAll(".skeleton-axis-tick").Count.Should().Be(4);
+  }
+
+  [Fact]
+  public void Skeleton_AllShapes_ProduceDistinctRootClasses()
+  {
+    // Cheap structural smoke test — render every shape and assert their
+    // root class differs. Catches accidental enum→class collapses.
+    var classes = new HashSet<string>();
+    foreach (Skeleton.SkeletonShape shape in Enum.GetValues(typeof(Skeleton.SkeletonShape)))
+    {
+      var cut = RenderComponent<Skeleton>(p => p.Add(x => x.Shape, shape));
+      var c = cut.Find(".skeleton").GetAttribute("class") ?? string.Empty;
+      classes.Add(c).Should().BeTrue($"shape {shape} must have a distinct root class");
+    }
+  }
+
+  [Fact]
+  public void Skeleton_AriaBusyAndRole_IsSetForAccessibility()
+  {
+    var cut = RenderComponent<Skeleton>(p => p
+      .Add(x => x.Shape, Skeleton.SkeletonShape.ListRow));
+
+    var root = cut.Find(".skeleton");
+    root.GetAttribute("role").Should().Be("status");
+    root.GetAttribute("aria-busy").Should().Be("true");
+  }
+}

--- a/tests/Radio.Web.Tests/Components/Shared/SparklineTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/SparklineTests.cs
@@ -1,0 +1,154 @@
+using System.Globalization;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Radzen;
+using Radio.Web.Components.Shared;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for the <see cref="Sparkline"/> SVG mini-chart introduced
+/// by PR 4 of the design tightening arc (handoff §P0·4).
+///
+/// Asserts the SVG shell renders, path generation rules for the empty
+/// / single-value / multi-value cases, and that the Stroke parameter
+/// is propagated to both the line and the filled-area paths.
+/// </summary>
+public class SparklineTests : TestContext
+{
+  public SparklineTests()
+  {
+    Services.AddRadzenComponents();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+  }
+
+  [Fact]
+  public void Sparkline_RendersRootSvg_WithCorrectViewBox()
+  {
+    var cut = RenderComponent<Sparkline>(p => p
+      .Add(x => x.Values, new double[] { 1, 2, 3 }));
+
+    var svg = cut.Find("svg");
+    svg.GetAttribute("viewBox").Should().Be("0 0 120 28");
+    svg.GetAttribute("preserveAspectRatio").Should().Be("none");
+  }
+
+  [Fact]
+  public void Sparkline_EmptyValues_RenderEmptySvg()
+  {
+    var cut = RenderComponent<Sparkline>(p => p
+      .Add(x => x.Values, Array.Empty<double>()));
+
+    cut.FindAll("path").Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Sparkline_NullValues_RenderEmptySvg()
+  {
+    var cut = RenderComponent<Sparkline>(p => p
+      .Add(x => x.Values, null!));
+
+    cut.FindAll("path").Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Sparkline_SingleValue_RendersFlatLineAtMidHeight()
+  {
+    var cut = RenderComponent<Sparkline>(p => p
+      .Add(x => x.Values, new double[] { 42 }));
+
+    var paths = cut.FindAll("path");
+    paths.Count.Should().Be(2); // area + line
+
+    // The line path should be a flat segment at y == ViewHeight/2 == 14.
+    var line = paths[1].GetAttribute("d") ?? string.Empty;
+    line.Should().Contain("14");
+    line.Should().StartWith("M0,14");
+  }
+
+  [Fact]
+  public void Sparkline_FivePointSeries_GeneratesFivePointPath()
+  {
+    var values = new double[] { 0, 25, 50, 75, 100 };
+    var cut = RenderComponent<Sparkline>(p => p
+      .Add(x => x.Values, values));
+
+    var paths = cut.FindAll("path");
+    paths.Count.Should().Be(2);
+
+    var line = paths[1].GetAttribute("d") ?? string.Empty;
+    // Five points → "M" + four " L" segments.
+    line.Should().StartWith("M");
+    var lCount = line.Split(" L", StringSplitOptions.None).Length - 1;
+    lCount.Should().Be(4);
+  }
+
+  [Fact]
+  public void Sparkline_FivePointSeries_FirstPointAtLeftEdge_LastAtRightEdge()
+  {
+    var values = new double[] { 0, 25, 50, 75, 100 };
+    var cut = RenderComponent<Sparkline>(p => p
+      .Add(x => x.Values, values));
+
+    var line = cut.FindAll("path")[1].GetAttribute("d") ?? string.Empty;
+
+    // First moveTo should be at x = 0; last point should be near x = 120 (ViewWidth).
+    line.Should().StartWith("M0,");
+    // The last L segment should include "120,"
+    line.Should().Contain("120,");
+  }
+
+  [Fact]
+  public void Sparkline_NormalizesValues_TopAndBottomOfRange()
+  {
+    // With a five-point ramp the minimum (0) should map to ViewHeight (28)
+    // and the maximum (100) to 0 (SVG y is inverted relative to data).
+    var values = new double[] { 0, 25, 50, 75, 100 };
+    var cut = RenderComponent<Sparkline>(p => p
+      .Add(x => x.Values, values));
+
+    var line = cut.FindAll("path")[1].GetAttribute("d") ?? string.Empty;
+    // First point (value 0) → y = 28; rendered as "M0,28".
+    line.Should().StartWith("M0,28");
+    // Last point (value 100) → y = 0; expect ",0" anywhere after the last L.
+    var lastL = line.LastIndexOf(" L", StringComparison.Ordinal);
+    var lastSegment = line[(lastL + 2)..];
+    lastSegment.Should().EndWith(",0");
+  }
+
+  [Fact]
+  public void Sparkline_AllEqualValues_RenderFlatLineAtMidHeight()
+  {
+    // Range == 0 case — the path generator falls back to mid-height.
+    var values = new double[] { 5, 5, 5, 5 };
+    var cut = RenderComponent<Sparkline>(p => p
+      .Add(x => x.Values, values));
+
+    var line = cut.FindAll("path")[1].GetAttribute("d") ?? string.Empty;
+    line.Should().Contain(",14");
+    // All four points should land at y = 14.
+    line.Split(',').Where(s => s.StartsWith("14")).Count().Should().BeGreaterThanOrEqualTo(2);
+  }
+
+  [Fact]
+  public void Sparkline_PropagatesStrokeToBothPaths()
+  {
+    var cut = RenderComponent<Sparkline>(p => p
+      .Add(x => x.Values, new double[] { 1, 2, 3 })
+      .Add(x => x.Stroke, "var(--signal-red)"));
+
+    var paths = cut.FindAll("path");
+    paths[0].GetAttribute("fill").Should().Be("var(--signal-red)"); // area
+    paths[1].GetAttribute("stroke").Should().Be("var(--signal-red)"); // line
+  }
+
+  [Fact]
+  public void Sparkline_DefaultStroke_IsCurrentColor()
+  {
+    var cut = RenderComponent<Sparkline>(p => p
+      .Add(x => x.Values, new double[] { 1, 2 }));
+
+    cut.FindAll("path")[1].GetAttribute("stroke").Should().Be("currentColor");
+  }
+}

--- a/tests/Radio.Web.Tests/Services/VisualizerTelemetryServiceTests.cs
+++ b/tests/Radio.Web.Tests/Services/VisualizerTelemetryServiceTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Radio.Web.Services;
+
+namespace Radio.Web.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="VisualizerTelemetryService"/> — the
+/// singleton that holds the visualizer's "updates/sec" value after
+/// PR 4 moved it off the canvas (handoff §P1·3).
+///
+/// Verifies the read/write contract the dev tray (PR 6) will rely on:
+///   * SetUpdatesPerSecond clamps negative values to zero.
+///   * UpdatesPerSecond reflects the most recent value.
+///   * UpdatesPerSecondChanged fires on changes and is debounced for
+///     no-op writes (same value twice).
+/// </summary>
+public class VisualizerTelemetryServiceTests
+{
+  [Fact]
+  public void UpdatesPerSecond_DefaultsToZero()
+  {
+    var svc = new VisualizerTelemetryService();
+    svc.UpdatesPerSecond.Should().Be(0);
+  }
+
+  [Fact]
+  public void SetUpdatesPerSecond_StoresValue()
+  {
+    var svc = new VisualizerTelemetryService();
+    svc.SetUpdatesPerSecond(42);
+    svc.UpdatesPerSecond.Should().Be(42);
+  }
+
+  [Fact]
+  public void SetUpdatesPerSecond_NegativeValue_ClampsToZero()
+  {
+    var svc = new VisualizerTelemetryService();
+    svc.SetUpdatesPerSecond(-5);
+    svc.UpdatesPerSecond.Should().Be(0);
+  }
+
+  [Fact]
+  public void SetUpdatesPerSecond_FiresChangedEvent_OnNewValue()
+  {
+    var svc = new VisualizerTelemetryService();
+    var received = new List<int>();
+    svc.UpdatesPerSecondChanged += v => received.Add(v);
+
+    svc.SetUpdatesPerSecond(10);
+    svc.SetUpdatesPerSecond(20);
+
+    received.Should().Equal(new[] { 10, 20 });
+  }
+
+  [Fact]
+  public void SetUpdatesPerSecond_SameValue_DoesNotFireEventTwice()
+  {
+    // Stable rates should not spam subscribers — write the same value
+    // back-to-back and only the first should be observed.
+    var svc = new VisualizerTelemetryService();
+    var received = new List<int>();
+    svc.UpdatesPerSecondChanged += v => received.Add(v);
+
+    svc.SetUpdatesPerSecond(30);
+    svc.SetUpdatesPerSecond(30);
+    svc.SetUpdatesPerSecond(30);
+
+    received.Should().Equal(new[] { 30 });
+  }
+
+  [Fact]
+  public void SetUpdatesPerSecond_NoSubscribers_DoesNotThrow()
+  {
+    var svc = new VisualizerTelemetryService();
+    var act = () => svc.SetUpdatesPerSecond(7);
+    act.Should().NotThrow();
+  }
+}


### PR DESCRIPTION
PR 4 of the Radio Console design tightening arc — handoff §P0·4 (metrics dashboard), §P1·3 (visualizer mode picker), §P1·5 (skeleton loading states).

## Summary

Three grouped surface changes: how information surfaces inside panels.

**Metrics dashboard (§P0·4)** — Wall-of-tiles replaced with a category-grouped grid of unit-aware `MetricTile` cards (category + name + threshold-tinted value + optional Sparkline). The screenshot bugs are fixed: *Memory Usage Mb* now reads `850 MB` instead of `850.4%`; *Signal Strength* renders as `65%`; *Frequency Changes* is thousands-separated; *Latency Ms* auto-promotes to seconds at/above 1000. `Radio.Metrics` gains a `MetricDescriptor` + `MetricUnit` surface (bumped to 1.1.0) so producers can opt into authoritative units; the Web falls back to key-pattern heuristics until descriptors are registered.

**Visualizer mode picker (§P1·3)** — Floating chip group replaced with a full-width 3-segment `VU / WAVE / SPECTRUM` header (44px tall, mono 12px uppercase 0.10em letter-spacing). Active segment uses `--accent-dim` background + 2px accent underline. The canvas now fills the remaining vertical space; the *Connected* pill collapses to an 8px dot at top-right. The burned-in `Updates: NN/sec` overlay moves off the canvas into a new singleton `VisualizerTelemetryService` that the dev tray (PR 6) will consume. Spectrum modes also render a 16px frequency-band axis strip (mono 10px, low-contrast) under the canvas.

**Skeleton loading states (§P1·5)** — New `Skeleton.razor` with `NowPlaying / Radio / ListRow / DeviceRow / MetricTile / Visualizer` shapes; each arranges the existing `.skeleton-*` shimmer primitives from `design-system.css §17` to match the real component's silhouette. Panel-body initial-load spinners swapped in `RadioControlPanel`, `QueueHistoryPanel` (history tab), `PlayHistoryPage`, `DeviceManagementPage`, and `VisualizerPanel`. `NowPlayingPanel` kept as-is — it already rendered an empty state immediately, with no centered spinner to swap.

## Pre-merge fixes
- Threshold logic for inverted-above metrics (buffer fill) goes through `MetricTile.InvertThresholds` to keep tile color semantics consistent.
- Visualizer canvas is rendered unconditionally so `metricsChart.init` and `visualizer.init` can find their target ids; skeleton/waiting states sit on top.
- Visualizer telemetry timer disposed in `DisposeAsync` and publishes a final zero on tear-down so subscribers don't observe a stale rate.

## Acceptance (from plan §PR 4)

P0·4:
- [x] Memory tile reads `850 MB`, never `%` (regression test in `MetricTileTests`).
- [x] Each tile shows a sparkline when time-series data exists in the selected window.
- [x] Category sub-headers replace per-tile category prefix.
- [x] Tile value color matches threshold semantics (green/amber/red) — not all cyan.

P1·3:
- [x] Mode picker is obvious primary control of panel.
- [x] Canvas fills available height/width, no debug telemetry overlaid.
- [x] Connection state is small dot, not pill.

P1·5:
- [x] No centered spinner in any panel-body initial-load branch in `Components/` (NowPlayingPanel had none originally; flagged in comment).
- [x] First-load on Radio shows freq-well + band-button + meter outlines.

## Test Plan

Local gates (run before merge):
- [x] `dotnet build --configuration Release -p:NuGetAudit=false` — 0 errors, 25 IDE0011 warnings (all pre-existing).
- [x] `dotnet test tests/Radio.Web.Tests --configuration Release` — 251/251 pass (was 224; +27 new).
- [x] `dotnet test tests/Radio.Metrics.Tests --configuration Release` — 17/17 pass.

User UAT (browser, 1920×720 kiosk — known gap, Tester will run):
- [ ] Metrics page — category sub-headers visible; Memory tile reads `850 MB`; sparklines render under tiles with time-series data; color matches threshold.
- [ ] Home → Visualizer panel — VU/WAVE/SPECTRUM 3-segment header at top, canvas fills below, no `Updates: NN/sec` overlay, connection dot top-right.
- [ ] Hard-refresh Home — skeleton outlines flash before real content, no spinner.
- [ ] Hard-refresh Devices page — device-row skeletons flash, then real rows.
- [ ] Cold-load Radio page — band-button + freq-well skeletons appear.

## Operator note

`Radio.Metrics` package bumped to 1.1.0. `pack-local.ps1` produces `packages/Radio.Metrics.1.1.0.nupkg`. Internal projects reference `Radio.Metrics` by `ProjectReference`, so the version bump is forward-looking only (no consumer updates required).

## Docs Impact

None landed in this PR — handoff IMPLEMENTATION.md §P0·4 / §P1·3 / §P1·5 status flips are left for the Polisher cycle.

## Known limitations / Pre-existing CI red

- `Radio.API.Tests.Services.AudioEngineInitializationServiceTests.StartAsync_EnumeratesDevices` still fails (Moq mock expected once, observed twice). Pre-existing — tracked as Builder queue task #10. Unchanged by this PR.
- CI's `NuGetAudit` step still flags four CVE warnings-as-errors in `Microsoft.AspNetCore.DataProtection 10.0.0` / `System.Security.Cryptography.Xml 10.0.0` / `Tmds.DBus 0.90.2`. Identical to main; tracked as queue task #6. Local builds pass with `-p:NuGetAudit=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)