### PR TITLE
PR 5: Now Playing dock, source-pill semantics, queue split layout

### DIFF
--- a/src/Radio.Web/Components/Layout/MainLayout.razor
+++ b/src/Radio.Web/Components/Layout/MainLayout.razor
@@ -781,7 +781,7 @@
   }
 
   private static bool IsRadioSource(string sourceType) =>
-    sourceType is "Radio" or "RTLSDRCore" or "RF320";
+    SourceTypeHelper.IsRadioFamily(sourceType);
 
   private async Task HandleDistortionMarkerAsync()
   {

--- a/src/Radio.Web/Components/Layout/MainLayout.razor
+++ b/src/Radio.Web/Components/Layout/MainLayout.razor
@@ -168,16 +168,23 @@
                       HasDetail="@HasSourceDetail(source.Type)"
                       DataSourceAttr="@dataAttr"
                       OnSwitch="@(EventCallback.Factory.Create(this, () => HandleSourceToggleAsync(source)))"
-                      OnOpenDetail="@(EventCallback.Factory.Create(this, () => NavigateToSourcePage(source.Type)))" />
+                      OnOpenDetail="@(EventCallback.Factory.Create(this, () => HandleSourceDetailAsync(source)))" />
       }
     </div>
   </div>
 
-  <!-- Main Content Area (height = viewport - topbar = 720 - var(--topbar-height)) -->
-  <div class="content-area">
+  @* Main Content Area (height = viewport - topbar = 720 - var(--topbar-height)).
+     The .has-dock modifier engages on every route except Home so .page-transition
+     reserves the bottom 64px for <NowPlayingDock> and routed content never slides
+     under it (handoff §P1·1). *@
+  <div class="content-area @(IsDockVisible ? "has-dock" : "")">
     <div class="page-transition">
       @Body
     </div>
+    @if (IsDockVisible)
+    {
+      <NowPlayingDock />
+    }
   </div>
 </div>
 
@@ -200,6 +207,9 @@
   private string _ramUsage = "0";
   private string _threadCount = "0";
   private System.Timers.Timer? _timer;
+  // Cached on every LocationChanged so the render condition is a cheap field
+  // read instead of re-parsing the URI inside the template (handoff §P1·1).
+  private bool _isOnHome = true;
   private List<AudioSourceDto> _availableSources = new();
   private List<AudioDeviceDto> _availableOutputs = new();
   private string? _selectedSourceId = null;
@@ -244,6 +254,11 @@
       HubService.SourceChanged += OnSourceChanged;
       HubService.SleepStateChanged += OnSleepStateChanged;
       DeviceDisplayState.DisplaySettingsChanged += OnDeviceDisplaySettingsChanged;
+
+      // Dock visibility is route-dependent (handoff §P1·1: dock only on
+      // non-Home routes). Seed from the current URI and update on every nav.
+      _isOnHome = IsCurrentlyOnHome();
+      NavigationManager.LocationChanged += OnLocationChanged;
       Logger.LogDebug("MainLayout - Subscribed to audio state events");
 
       // Load initial state
@@ -626,17 +641,12 @@
 
   /// <summary>
   /// Map a source type to the CSS custom-property name for its accent colour.
-  /// Used by SourceBubble (Accent parameter) and the IN cluster swatch.
+  /// Used by SourceBubble (Accent parameter), the IN cluster swatch, and the
+  /// NowPlayingDock source-color dot. Delegates to <see cref="SourceTypeHelper"/>
+  /// so every consumer reads from the same matrix.
   /// </summary>
-  private static string GetAccentVarForSource(string sourceType) => sourceType switch
-  {
-    "Vinyl" => "--source-vinyl",
-    "FilePlayer" or "File" => "--source-file",
-    "Radio" or "RTLSDRCore" or "RF320" => "--source-radio",
-    "Bluetooth" => "--source-bluetooth",
-    "GenericUSB" or "USB" => "--source-usb",
-    _ => "--accent-primary"
-  };
+  private static string GetAccentVarForSource(string sourceType) =>
+    SourceTypeHelper.GetAccentVar(sourceType);
 
   private string GetActiveSourceAccentVar() =>
     ActiveSource is null ? "--text-low" : GetAccentVarForSource(ActiveSource.Type);
@@ -665,10 +675,13 @@
 
   /// <summary>
   /// True if a source has a dedicated detail surface (Radio control panel,
-  /// Bluetooth pairing page) that the chevron can open.
+  /// Bluetooth pairing page) that the chevron can open. Delegates to
+  /// <see cref="SourceTypeHelper.HasDetail(string)"/> so the matrix is defined
+  /// in exactly one place — adding a new source with a detail surface only
+  /// requires updating <c>SourcesWithDetail</c> there.
   /// </summary>
   private static bool HasSourceDetail(string sourceType) =>
-    IsRadioSource(sourceType) || sourceType == "Bluetooth";
+    SourceTypeHelper.HasDetail(sourceType);
 
   // Source availability check
   private static bool IsSourceAvailable(AudioSourceDto source) =>
@@ -682,34 +695,51 @@
     return $"/{uri}".StartsWith(path, StringComparison.OrdinalIgnoreCase);
   }
 
-  // Combined source toggle: switch source AND navigate for Radio/Bluetooth
+  /// <summary>
+  /// True when the routed page is anywhere other than Home — the NowPlayingPanel
+  /// already owns the player surface on <c>/</c>, so the dock is suppressed there
+  /// (handoff §P1·1).
+  /// </summary>
+  private bool IsDockVisible => !_isOnHome;
+
+  private bool IsCurrentlyOnHome()
+  {
+    var rel = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+    // Strip query/fragment so "/?foo=bar" still counts as home.
+    var slash = rel.IndexOfAny(new[] { '?', '#' });
+    if (slash >= 0) rel = rel[..slash];
+    return string.IsNullOrEmpty(rel) || rel == "/";
+  }
+
+  private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+  {
+    var wasOnHome = _isOnHome;
+    _isOnHome = IsCurrentlyOnHome();
+    if (wasOnHome != _isOnHome)
+    {
+      // Dock visibility flipped — trigger a re-render so the <NowPlayingDock>
+      // appears/disappears and .has-dock toggles on .content-area.
+      _ = InvokeAsync(StateHasChanged);
+    }
+  }
+
+  /// <summary>
+  /// Source pill body tap (handoff §P1·2). Tapping a source pill ALWAYS switches
+  /// to that source — nothing else. The pill no longer toggles the radio panel
+  /// on second-tap and no longer navigates between detail surfaces; those
+  /// affordances live on the chevron (<see cref="HandleSourceDetailAsync"/>).
+  ///
+  /// We still maintain the side-effect that switching TO Radio shows the radio
+  /// control panel on Home and switching AWAY hides it — the panel-visibility
+  /// state is a function of the active source, not of user-tap intent.
+  /// </summary>
   private async Task HandleSourceToggleAsync(AudioSourceDto source)
   {
     if (!IsSourceAvailable(source)) return;
-    if (source.Id == _selectedSourceId)
-    {
-      // Already selected — toggle inline panel or navigate
-      if (IsRadioSource(source.Type))
-      {
-        // Toggle radio control panel in the Home page center area
-        var currentPath = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
-        if (!string.IsNullOrEmpty(currentPath))
-        {
-          // Not on Home page — navigate there first, panel will auto-show
-          RadioPanelToggle.IsRadioPanelVisible = true;
-          NavigationManager.NavigateTo("/");
-        }
-        else
-        {
-          await RadioPanelToggle.ToggleRadioPanelAsync();
-        }
-        return;
-      }
-      NavigateToSourcePage(source.Type);
-      return;
-    }
+    // Idempotent: tapping the currently-active pill is a no-op for source
+    // switching. The body never opens panels or navigates — that's the chevron.
+    if (source.Id == _selectedSourceId) return;
 
-    // Show radio panel when switching TO Radio, hide when switching away
     if (IsRadioSource(source.Type))
     {
       await HandleSourceChangeAsync(source.Id);
@@ -719,6 +749,34 @@
     {
       await RadioPanelToggle.HideRadioPanelAsync();
       await HandleSourceChangeAsync(source.Id);
+    }
+  }
+
+  /// <summary>
+  /// Chevron tap on a source bubble (handoff §P1·2). The chevron is only rendered
+  /// when the source is active AND has a detail surface (see
+  /// <see cref="SourceTypeHelper.HasDetail(string)"/>). Dispatch:
+  ///
+  /// <list type="bullet">
+  ///   <item>Radio family (Radio / RTLSDRCore / RF320) → navigate Home and show
+  ///         the radio control panel (idempotent).</item>
+  ///   <item>Bluetooth → navigate to the BT pairing page.</item>
+  /// </list>
+  ///
+  /// Unknown / unmapped types fall through silently; the chevron wouldn't have
+  /// rendered for them.
+  /// </summary>
+  private async Task HandleSourceDetailAsync(AudioSourceDto source)
+  {
+    if (IsRadioSource(source.Type))
+    {
+      NavigationManager.NavigateTo("/");
+      await RadioPanelToggle.ShowRadioPanelAsync();
+      return;
+    }
+    if (source.Type == "Bluetooth")
+    {
+      NavigationManager.NavigateTo("/bluetooth");
     }
   }
 
@@ -739,24 +797,6 @@
   {
     await RadioPanelToggle.HideRadioPanelAsync();
     NavigationManager.NavigateTo("/");
-  }
-
-  private void NavigateToSourcePage(string sourceType)
-  {
-    switch (sourceType)
-    {
-      case "Radio":
-      case "RTLSDRCore":
-      case "RF320":
-        NavigationManager.NavigateTo("/radio");
-        break;
-      case "Bluetooth":
-        NavigationManager.NavigateTo("/bluetooth");
-        break;
-      default:
-        NavigationManager.NavigateTo("/");
-        break;
-    }
   }
 
   private async Task OnCastDeviceSelected(CastDeviceDto selectedDevice)
@@ -896,6 +936,7 @@
     HubService.SourceChanged -= OnSourceChanged;
     HubService.SleepStateChanged -= OnSleepStateChanged;
     DeviceDisplayState.DisplaySettingsChanged -= OnDeviceDisplaySettingsChanged;
+    NavigationManager.LocationChanged -= OnLocationChanged;
 
     _timer?.Stop();
     _timer?.Dispose();

--- a/src/Radio.Web/Components/Shared/NowPlayingDock.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingDock.razor
@@ -147,11 +147,37 @@
 
   private async Task OnNowPlayingChanged(NowPlayingDto? dto)
   {
-    if (dto != null)
+    if (dto is null)
     {
-      ApplyNowPlayingDto(dto);
+      // Source went silent (hub pushed a null payload). Reset to the empty-state
+      // shape so we don't leave the previous track lingering in the dock. Mirrors
+      // the initial render — placeholder title, em-dash subtitle, no album art,
+      // 0:00 / — durations, progress at 0.
+      ClearDockState();
+      await InvokeAsync(StateHasChanged);
+      return;
     }
+    ApplyNowPlayingDto(dto);
     await InvokeAsync(StateHasChanged);
+  }
+
+  /// <summary>
+  /// Reset every field touched by <see cref="ApplyNowPlayingDto"/> back to the
+  /// initial empty-state values declared at the top of <c>@code</c>. Called when
+  /// the hub pushes a null payload (source went silent / nothing playing).
+  /// </summary>
+  private void ClearDockState()
+  {
+    _displayTitle = "No Track Playing";
+    _displaySubtitle = "—";
+    _rawTitle = string.Empty;
+    _albumArtUrl = null;
+    _albumArtFailed = false;
+    _sourceAccent = "--text-low";
+    _isPlaying = false;
+    _elapsedSeconds = 0;
+    _totalSeconds = 0;
+    RecomputeProgress();
   }
 
   private async Task OnPlaybackStateChanged()
@@ -195,8 +221,11 @@
     _isPlaying = dto.IsPlaying;
     _sourceAccent = SourceTypeHelper.GetAccentVar(dto.SourceType ?? string.Empty);
 
-    if (dto.Position.HasValue) _elapsedSeconds = dto.Position.Value.TotalSeconds;
-    if (dto.Duration.HasValue) _totalSeconds = dto.Duration.Value.TotalSeconds;
+    // Always zero out elapsed/total when the DTO omits them, otherwise stale
+    // numbers from the previous source persist (e.g. File → Radio leaves the
+    // last file's elapsed time on screen until the next PlaybackStateChanged).
+    _elapsedSeconds = dto.Position?.TotalSeconds ?? 0;
+    _totalSeconds = dto.Duration?.TotalSeconds ?? 0;
     RecomputeProgress();
   }
 

--- a/src/Radio.Web/Components/Shared/NowPlayingDock.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingDock.razor
@@ -1,0 +1,306 @@
+@*
+  NowPlayingDock — 64px persistent player strip mounted at the bottom edge
+  of the .content-area on every route except Home (handoff §P1·1, plan PR 5).
+
+  Renders: 48×48 art → title + artist (with 8×8 source colour dot) →
+  3-bar EQ animation when playing → elapsed → progress bar (3px) → total →
+  ⏮ play/pause ⏭ controls.
+
+  Click the title/art block to navigate Home; the controls @onclick:stopPropagation
+  so they don't trigger the home-nav handler. Subscribes to
+  AudioStateHubService.NowPlayingChanged + PlaybackStateChanged only — no polling
+  beyond what NowPlayingPanel already does (the dock shares the same hub events).
+*@
+
+@rendermode InteractiveServer
+@inject NavigationManager NavigationManager
+@inject AudioApiService AudioApi
+@inject AudioStateHubService HubService
+@inject ILogger<NowPlayingDock> Logger
+@implements IAsyncDisposable
+
+<div class="now-playing-dock"
+     role="region"
+     aria-label="Now playing dock"
+     @onclick="HandleNavigateHome">
+  <div class="now-playing-dock-art" aria-hidden="true">
+    @if (_hasValidAlbumArt)
+    {
+      <img src="@_albumArtUrl"
+           alt=""
+           referrerpolicy="no-referrer"
+           @onerror="OnAlbumArtError" />
+    }
+    else
+    {
+      <RadzenIcon Icon="music_note" />
+    }
+  </div>
+  <div class="now-playing-dock-text">
+    <div class="now-playing-dock-title" title="@_rawTitle">@_displayTitle</div>
+    <div class="now-playing-dock-artist">
+      <span class="source-color-dot"
+            style="@($"background: var({_sourceAccent});")"
+            aria-hidden="true"></span>
+      <span class="now-playing-dock-artist-text">@_displaySubtitle</span>
+    </div>
+  </div>
+  @if (_isPlaying)
+  {
+    <div class="now-playing-bars now-playing-dock-bars" aria-hidden="true">
+      <span></span><span></span><span></span>
+    </div>
+  }
+  else
+  {
+    @* Stable placeholder so the grid column doesn't collapse when paused —
+       avoids the elapsed/total cells jumping horizontally on play/pause. *@
+    <div class="now-playing-dock-bars-placeholder" aria-hidden="true"></div>
+  }
+  <div class="now-playing-dock-elapsed">@_elapsedDisplay</div>
+  <div class="now-playing-dock-progress"
+       role="progressbar"
+       aria-valuemin="0"
+       aria-valuemax="@(_totalSeconds > 0 ? _totalSeconds : 100)"
+       aria-valuenow="@_elapsedSeconds"
+       aria-label="Playback progress">
+    <div class="now-playing-dock-progress-bar"
+         style="@($"width: {_progressPercent.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)}%;")"></div>
+  </div>
+  <div class="now-playing-dock-total">@_totalDisplay</div>
+  <div class="now-playing-dock-controls" @onclick:stopPropagation="true">
+    <button type="button"
+            class="now-playing-dock-btn"
+            @onclick="HandlePrevAsync"
+            aria-label="Previous track">
+      <RadzenIcon Icon="skip_previous" />
+    </button>
+    <button type="button"
+            class="now-playing-dock-btn now-playing-dock-btn-primary"
+            @onclick="HandlePlayPauseAsync"
+            aria-label="@(_isPlaying ? "Pause" : "Play")">
+      <RadzenIcon Icon="@(_isPlaying ? "pause" : "play_arrow")" />
+    </button>
+    <button type="button"
+            class="now-playing-dock-btn"
+            @onclick="HandleNextAsync"
+            aria-label="Next track">
+      <RadzenIcon Icon="skip_next" />
+    </button>
+  </div>
+</div>
+
+@code {
+  private string _displayTitle = "No Track Playing";
+  private string _displaySubtitle = "—";
+  private string _rawTitle = string.Empty;
+  private string? _albumArtUrl;
+  private bool _albumArtFailed;
+  private string _sourceAccent = "--text-low";
+  private bool _isPlaying;
+
+  // Elapsed / total — tracked in seconds (double) so the progress percent stays
+  // smooth. The display strings are formatted once per update via Durations.FormatTrack.
+  private double _elapsedSeconds;
+  private double _totalSeconds;
+  private string _elapsedDisplay = "0:00";
+  private string _totalDisplay = "—";
+  private double _progressPercent;
+
+  private bool _hasValidAlbumArt =>
+    !_albumArtFailed
+    && !string.IsNullOrEmpty(_albumArtUrl)
+    && _albumArtUrl != "/images/default-album-art.png";
+
+  protected override async Task OnInitializedAsync()
+  {
+    HubService.NowPlayingChanged += OnNowPlayingChanged;
+    HubService.PlaybackStateChanged += OnPlaybackStateChanged;
+    await RefreshAsync();
+  }
+
+  private async Task RefreshAsync()
+  {
+    try
+    {
+      var nowPlayingTask = AudioApi.GetNowPlayingAsync();
+      var stateTask = AudioApi.GetPlaybackStateAsync();
+      await Task.WhenAll(nowPlayingTask, stateTask);
+
+      var nowPlaying = await nowPlayingTask;
+      var state = await stateTask;
+
+      if (nowPlaying != null)
+      {
+        ApplyNowPlayingDto(nowPlaying);
+      }
+      if (state != null)
+      {
+        ApplyPlaybackState(state);
+      }
+    }
+    catch (Exception ex)
+    {
+      Logger.LogDebug(ex, "NowPlayingDock initial refresh failed (API offline?)");
+    }
+  }
+
+  private async Task OnNowPlayingChanged(NowPlayingDto? dto)
+  {
+    if (dto != null)
+    {
+      ApplyNowPlayingDto(dto);
+    }
+    await InvokeAsync(StateHasChanged);
+  }
+
+  private async Task OnPlaybackStateChanged()
+  {
+    try
+    {
+      var state = await AudioApi.GetPlaybackStateAsync();
+      if (state != null)
+      {
+        ApplyPlaybackState(state);
+      }
+    }
+    catch (Exception ex)
+    {
+      Logger.LogDebug(ex, "Failed to refresh playback state");
+    }
+    await InvokeAsync(StateHasChanged);
+  }
+
+  /// <summary>
+  /// Pull display title / subtitle through <see cref="DisplayNames.Track"/> so the
+  /// dock matches whatever the home page is showing — even when the metadata reader
+  /// only produced "Track N" we get the cleaned-up filename, and the placeholder
+  /// "--" artist surfaces as the canonical em-dash.
+  /// </summary>
+  private void ApplyNowPlayingDto(NowPlayingDto dto)
+  {
+    var (title, subtitle) = DisplayNames.Track(dto);
+    _rawTitle = dto.Title ?? string.Empty;
+    _displayTitle = string.Equals(title, "No Track", StringComparison.Ordinal)
+      ? "No Track Playing"
+      : title;
+    _displaySubtitle = subtitle;
+
+    if (_albumArtUrl != dto.AlbumArtUrl)
+    {
+      _albumArtFailed = false;
+    }
+    _albumArtUrl = dto.AlbumArtUrl;
+
+    _isPlaying = dto.IsPlaying;
+    _sourceAccent = SourceTypeHelper.GetAccentVar(dto.SourceType ?? string.Empty);
+
+    if (dto.Position.HasValue) _elapsedSeconds = dto.Position.Value.TotalSeconds;
+    if (dto.Duration.HasValue) _totalSeconds = dto.Duration.Value.TotalSeconds;
+    RecomputeProgress();
+  }
+
+  /// <summary>
+  /// Apply the elapsed/total/playing fields from a <see cref="PlaybackStateDto"/>.
+  /// Mirrors NowPlayingPanel's parsing logic so the two views stay in lock-step:
+  /// sub-second positions floor to <c>0:00</c>; null/zero durations leave the
+  /// progress bar at 0 and surface the total as an em-dash.
+  /// </summary>
+  private void ApplyPlaybackState(PlaybackStateDto state)
+  {
+    _isPlaying = state.IsPlaying;
+
+    if (!string.IsNullOrEmpty(state.Position)
+        && TimeSpan.TryParse(state.Position, System.Globalization.CultureInfo.InvariantCulture, out var pos))
+    {
+      _elapsedSeconds = pos.TotalSeconds;
+    }
+    else
+    {
+      _elapsedSeconds = 0;
+    }
+
+    if (!string.IsNullOrEmpty(state.Duration)
+        && TimeSpan.TryParse(state.Duration, System.Globalization.CultureInfo.InvariantCulture, out var dur)
+        && dur.TotalSeconds > 0)
+    {
+      _totalSeconds = dur.TotalSeconds;
+    }
+    else
+    {
+      _totalSeconds = 0;
+    }
+
+    RecomputeProgress();
+  }
+
+  private void RecomputeProgress()
+  {
+    _elapsedDisplay = _elapsedSeconds >= 1.0
+      ? Durations.FormatTrack(TimeSpan.FromSeconds(_elapsedSeconds))
+      : "0:00";
+
+    _totalDisplay = _totalSeconds > 0
+      ? Durations.FormatTrack(TimeSpan.FromSeconds(_totalSeconds))
+      : "—";
+
+    _progressPercent = _totalSeconds > 0
+      ? Math.Clamp((_elapsedSeconds / _totalSeconds) * 100.0, 0, 100)
+      : 0;
+  }
+
+  private void HandleNavigateHome()
+  {
+    NavigationManager.NavigateTo("/");
+  }
+
+  private async Task HandlePlayPauseAsync()
+  {
+    try
+    {
+      var action = _isPlaying ? "Pause" : "Play";
+      await AudioApi.UpdatePlaybackStateAsync(new UpdatePlaybackRequest(action, null, null, null));
+    }
+    catch (Exception ex)
+    {
+      Logger.LogWarning(ex, "Dock play/pause failed");
+    }
+  }
+
+  private async Task HandleNextAsync()
+  {
+    try
+    {
+      await AudioApi.NextAsync();
+    }
+    catch (Exception ex)
+    {
+      Logger.LogWarning(ex, "Dock next-track failed");
+    }
+  }
+
+  private async Task HandlePrevAsync()
+  {
+    try
+    {
+      await AudioApi.PreviousAsync();
+    }
+    catch (Exception ex)
+    {
+      Logger.LogWarning(ex, "Dock previous-track failed");
+    }
+  }
+
+  private void OnAlbumArtError()
+  {
+    _albumArtFailed = true;
+    StateHasChanged();
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    HubService.NowPlayingChanged -= OnNowPlayingChanged;
+    HubService.PlaybackStateChanged -= OnPlaybackStateChanged;
+    await Task.CompletedTask;
+  }
+}

--- a/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
+++ b/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
@@ -755,7 +755,7 @@
     {
       var primary = await SourcesApi.GetPrimarySourceAsync();
       var primaryType = primary?.Type;
-      _isRadioActive = primaryType is "Radio" or "RTLSDRCore" or "RF320";
+      _isRadioActive = SourceTypeHelper.IsRadioFamily(primaryType);
       // Queue tab for FilePlayer, History tab for all others — preserves the
       // pre-PR-5 default-tab behaviour now that we've renamed the indexes.
       _activeTab = primaryType == "FilePlayer" ? TabQueue : TabHistory;

--- a/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
+++ b/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
@@ -13,260 +13,388 @@
 @inject SourcesApiService SourcesApi
 @implements IAsyncDisposable
 
-<div style="height: 100%; display: flex; flex-direction: column; padding: 0;">
-  <RadzenTabs RenderMode="TabRenderMode.Client"
-              SelectedIndex="_activeTab"
-              Change="@(args => OnTabChanged(args))"
-              Style="height: 100%; display: flex; flex-direction: column; min-height: 0;">
-    <Tabs>
-      <RadzenTabsItem Text="@(_queueItems.Count > 0 ? $"Queue ({_queueItems.Count})" : "Queue")"
-                      Icon="queue_music"
-                      Style="flex: 1; overflow: hidden; display: flex; flex-direction: column; min-height: 0;">
-        <div style="height: 100%; display: flex; flex-direction: column; min-height: 0;">
-          <!-- Queue Header. Total runtime rendered with Durations.FormatLong so a queue
-               like "2h 48m 15s" shows as "2:48:15" rather than the raw TimeSpan tail. -->
-          <div class="panel-header">
-            <span style="display: inline-flex; align-items: center; gap: 8px;">
-              @if (_playedCount > 0)
-              {
-                @($"{_playedCount}/{_queueItems.Count} played")
-              }
-              else
-              {
-                @($"{_queueItems.Count} tracks")
-              }
-              @if (_totalRuntime > TimeSpan.Zero)
-              {
-                <span style="font-family: var(--font-mono); font-variant-numeric: tabular-nums; color: var(--text-medium);"
-                      title="Total queue runtime">
-                  · @Durations.FormatLong(_totalRuntime)
-                </span>
-              }
-            </span>
-            <div style="display: flex; gap: 4px;">
-              <RadzenButton Variant="Variant.Text"
-                            Icon="add"
-                            ButtonStyle="ButtonStyle.Primary"
-                            Size="ButtonSize.Small"
-                            Click="OpenFileSelectionDialogAsync"
-                            title="Add Files" />
-              <RadzenButton Variant="Variant.Text"
-                            Icon="playlist_play"
-                            ButtonStyle="ButtonStyle.Primary"
-                            Size="ButtonSize.Small"
-                            Click="OpenLoadPlaylistDialogAsync"
-                            title="Load Playlist" />
-              <RadzenButton Variant="Variant.Text"
-                            Icon="save"
-                            ButtonStyle="ButtonStyle.Primary"
-                            Size="ButtonSize.Small"
-                            Disabled="@(!_queueItems.Any())"
-                            Click="OpenSavePlaylistDialogAsync"
-                            title="Save as Playlist" />
-              <RadzenButton Variant="Variant.Text"
-                            Icon="delete_sweep"
-                            ButtonStyle="ButtonStyle.Danger"
-                            Size="ButtonSize.Small"
-                            Disabled="@(!_queueItems.Any())"
-                            Click="HandleClearQueueAsync"
-                            title="Clear All" />
-            </div>
-          </div>
+@*
+  Queue + History panel — restructured by PR 5 (handoff §P1·4) into a two-column
+  split: a list column on the left (flex 1.6) and a context column on the right
+  (flex 1, fixed-width tiles). Tabs swap the LIST contents only; the right column
+  re-renders its tiles based on _activeTab but is never remounted — so the LED
+  total, Up Next thumbs, and Save CTA persist visual state between switches.
 
-          <!-- Queue List -->
-          @if (!_queueItems.Any())
-          {
-            <div style="flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-low);">
-              <RadzenIcon Icon="queue_music" Style="font-size: 80px; opacity: 0.4; margin-bottom: 12px;" />
-              <span style="font-size: 16px;">No tracks in queue</span>
-            </div>
-          }
-          else
-          {
-            <div id="queue-scroll-container" class="scrollable" style="flex: 1; overflow-y: auto; min-height: 0;">
-              <Virtualize Items="@_queueItems" ItemSize="56" OverscanCount="5" Context="item">
-                @{
-                  var state = item.State ?? "Upcoming";
-                  var isCurrent = state == "Current";
-                  // queue-row-current paints an amber left-border (var(--signal-amber)),
-                  // overriding the .list-item-active accent-primary treatment for the
-                  // currently-playing track. The class is appended only on the current row.
-                  var rowClasses = "list-item-touch"
-                    + (isCurrent ? " list-item-active queue-row-current" : "");
+  Layout map:
+    .queue-split
+      .queue-split-list-col
+        .queue-split-tabstrip   ← Queue · N / History / Radio? + kebab menu
+        .queue-split-list-body  ← virtualized queue rows OR history rows
+      .queue-split-context-col
+        if _activeTab == queue:    Queue Total LED + Up Next + Save CTA
+        if _activeTab == history:  History stats (total plays, top track, top artist)
+        if _activeTab == radio:    (Radio context block — placeholder until P1·3
+                                    promotes the radio detail surface)
+*@
+
+<div class="queue-split">
+  <!-- ── Left column: tab strip + list body ── -->
+  <div class="queue-split-list-col">
+    <div class="queue-split-tabstrip" role="tablist" aria-label="Queue, History, Radio tabs">
+      <button type="button"
+              class="queue-split-tab @(_activeTab == TabQueue ? "is-active" : "")"
+              role="tab"
+              aria-selected="@(_activeTab == TabQueue ? "true" : "false")"
+              @onclick="@(() => SetTab(TabQueue))">
+        Queue · @_queueItems.Count
+      </button>
+      <button type="button"
+              class="queue-split-tab @(_activeTab == TabHistory ? "is-active" : "")"
+              role="tab"
+              aria-selected="@(_activeTab == TabHistory ? "true" : "false")"
+              @onclick="@(() => SetTab(TabHistory))">
+        History
+      </button>
+      @if (_isRadioActive)
+      {
+        <button type="button"
+                class="queue-split-tab @(_activeTab == TabRadio ? "is-active" : "")"
+                role="tab"
+                aria-selected="@(_activeTab == TabRadio ? "true" : "false")"
+                @onclick="@(() => SetTab(TabRadio))">
+          Radio
+        </button>
+      }
+      <div class="queue-split-tab-spacer"></div>
+      <div style="position: relative;">
+        <button type="button"
+                class="queue-split-kebab"
+                @onclick="ToggleKebab"
+                aria-label="Queue actions">⋮</button>
+        @if (_isKebabOpen)
+        {
+          <div @onclick="CloseKebab" @onclick:stopPropagation="true"
+               style="position: fixed; inset: 0; z-index: 99;"></div>
+          <div @onclick:stopPropagation="true"
+               style="position: absolute; top: 100%; right: 0; z-index: 100; min-width: 180px;
+                      background: rgba(30,30,30,0.95); backdrop-filter: blur(12px);
+                      border: 1px solid rgba(255,255,255,0.15); border-radius: 6px;
+                      box-shadow: 0 8px 24px rgba(0,0,0,0.5); overflow: hidden;
+                      margin-top: 4px;">
+            <button type="button" class="queue-split-kebab-item"
+                    @onclick="@(async () => { CloseKebab(); await OpenFileSelectionDialogAsync(); })"
+                    style="display: flex; align-items: center; gap: 8px; width: 100%; padding: 10px 14px;
+                           background: transparent; border: none; color: var(--text-high);
+                           font-size: 13px; cursor: pointer; text-align: left;">
+              <RadzenIcon Icon="add" /> Add Files
+            </button>
+            <button type="button" class="queue-split-kebab-item"
+                    @onclick="@(async () => { CloseKebab(); await OpenLoadPlaylistDialogAsync(); })"
+                    style="display: flex; align-items: center; gap: 8px; width: 100%; padding: 10px 14px;
+                           background: transparent; border: none; color: var(--text-high);
+                           font-size: 13px; cursor: pointer; text-align: left;">
+              <RadzenIcon Icon="playlist_play" /> Load Playlist
+            </button>
+            <button type="button" class="queue-split-kebab-item"
+                    disabled="@(!_queueItems.Any())"
+                    @onclick="@(async () => { CloseKebab(); await HandleClearQueueAsync(); })"
+                    style="display: flex; align-items: center; gap: 8px; width: 100%; padding: 10px 14px;
+                           background: transparent; border: none;
+                           color: @(_queueItems.Any() ? "var(--rz-danger)" : "var(--text-low)");
+                           font-size: 13px; cursor: @(_queueItems.Any() ? "pointer" : "not-allowed"); text-align: left;">
+              <RadzenIcon Icon="delete_sweep" /> Clear All
+            </button>
+          </div>
+        }
+      </div>
+    </div>
+
+    <div class="queue-split-list-body">
+      @if (_activeTab == TabQueue)
+      {
+        @if (!_queueItems.Any())
+        {
+          <div style="flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-low);">
+            <RadzenIcon Icon="queue_music" Style="font-size: 80px; opacity: 0.4; margin-bottom: 12px;" />
+            <span style="font-size: 16px;">No tracks in queue</span>
+          </div>
+        }
+        else
+        {
+          <div id="queue-scroll-container" class="scrollable" style="flex: 1; overflow-y: auto; min-height: 0;">
+            <Virtualize Items="@_queueItems" ItemSize="56" OverscanCount="5" Context="item">
+              @{
+                var state = item.State ?? "Upcoming";
+                var isCurrent = state == "Current";
+                var rowClasses = "list-item-touch"
+                  + (isCurrent ? " list-item-active queue-row-current" : "");
+              }
+              <div class="@rowClasses"
+                   style="cursor: @(state == "Error" ? "not-allowed" : "pointer");
+                          opacity: @(state == "Error" ? "0.4" : state == "Played" ? "0.6" : "1");"
+                   @onclick="@(() => HandleItemClickAsync(item))">
+                <div style="width: 24px; text-align: center; flex-shrink: 0;">
+                  @if (isCurrent)
+                  {
+                    <span class="queue-row-glyph"
+                          style="font-size: 16px; color: var(--signal-amber); font-family: var(--font-mono); line-height: 1;"
+                          aria-label="Now playing">▶</span>
+                  }
+                  else if (state == "Played")
+                  {
+                    <RadzenIcon Icon="check" Style="font-size: 20px; color: var(--text-low);" />
+                  }
+                  else if (state == "Error")
+                  {
+                    <RadzenIcon Icon="error" Style="font-size: 20px; color: var(--rz-danger);" />
+                  }
+                  else
+                  {
+                    <span style="font-size: 13px; color: var(--text-low); font-family: var(--font-mono); font-variant-numeric: tabular-nums;">@(item.FullPlaylistIndex + 1)</span>
+                  }
+                </div>
+                <div style="flex: 1; min-width: 0;">
+                  <div style="font-size: 16px;
+                              font-weight: @(isCurrent ? "600" : "400");
+                              color: @(isCurrent ? "var(--signal-amber)" : state == "Error" ? "var(--signal-red)" : "var(--text-high)");
+                              white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+                              @(state == "Error" ? "text-decoration: line-through;" : "")">
+                    @item.Title
+                  </div>
+                  <div style="font-size: 14px; color: var(--text-medium); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                    @item.Artist
+                  </div>
+                </div>
+                @if (!string.IsNullOrEmpty(item.Duration))
+                {
+                  <div style="font-size: 13px; color: var(--text-medium); font-family: var(--font-mono); font-variant-numeric: tabular-nums; text-align: right; min-width: 56px; flex-shrink: 0;">
+                    @item.Duration
+                  </div>
                 }
-                <div class="@rowClasses"
-                     style="cursor: @(state == "Error" ? "not-allowed" : "pointer");
-                            opacity: @(state == "Error" ? "0.4" : state == "Played" ? "0.6" : "1");"
-                     @onclick="@(() => HandleItemClickAsync(item))">
-                  <!-- State icon. Currently-playing row replaces the numeric index with a ▶
-                       glyph (per the design tightening spec) so the visual hierarchy
-                       reinforces "this is what's playing" without relying on bar animation
-                       being visible on low-contrast displays. -->
-                  <div style="width: 24px; text-align: center; flex-shrink: 0;">
-                    @if (isCurrent)
-                    {
-                      <span class="queue-row-glyph"
-                            style="font-size: 16px; color: var(--signal-amber); font-family: var(--font-mono); line-height: 1;"
-                            aria-label="Now playing">▶</span>
-                    }
-                    else if (state == "Played")
-                    {
-                      <RadzenIcon Icon="check" Style="font-size: 20px; color: var(--text-low);" />
-                    }
-                    else if (state == "Error")
-                    {
-                      <RadzenIcon Icon="error" Style="font-size: 20px; color: var(--rz-danger);" />
-                    }
-                    else
-                    {
-                      <span style="font-size: 13px; color: var(--text-low); font-family: var(--font-mono); font-variant-numeric: tabular-nums;">@(item.FullPlaylistIndex + 1)</span>
-                    }
+                @if (state == "Upcoming")
+                {
+                  <div @onclick:stopPropagation="true">
+                    <RadzenButton Variant="Variant.Text"
+                                  Icon="close"
+                                  Size="ButtonSize.Small"
+                                  ButtonStyle="ButtonStyle.Light"
+                                  Click="@(() => HandleRemoveAsync(item.Index))"
+                                  title="Remove" />
                   </div>
-
-                  <!-- Track info (title + artist) -->
-                  <div style="flex: 1; min-width: 0;">
-                    <div style="font-size: 16px;
-                                font-weight: @(isCurrent ? "600" : "400");
-                                color: @(isCurrent ? "var(--signal-amber)" : state == "Error" ? "var(--signal-red)" : "var(--text-high)");
-                                white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-                                @(state == "Error" ? "text-decoration: line-through;" : "")">
-                      @item.Title
-                    </div>
-                    <div style="font-size: 14px; color: var(--text-medium); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                      @item.Artist
-                    </div>
-                  </div>
-
-                  <!-- Duration column — right-aligned, mono, tabular-nums.
-                       Already a clean "m:ss" / "h:mm:ss" string from the server (formatted
-                       via Durations equivalents), so we render as-is without re-parsing. -->
-                  @if (!string.IsNullOrEmpty(item.Duration))
-                  {
-                    <div style="font-size: 13px; color: var(--text-medium); font-family: var(--font-mono); font-variant-numeric: tabular-nums; text-align: right; min-width: 56px; flex-shrink: 0;">
-                      @item.Duration
-                    </div>
-                  }
-
-                  <!-- Remove button (only for upcoming items) -->
-                  @if (state == "Upcoming")
-                  {
-                    <div @onclick:stopPropagation="true">
-                      <RadzenButton Variant="Variant.Text"
-                                    Icon="close"
-                                    Size="ButtonSize.Small"
-                                    ButtonStyle="ButtonStyle.Light"
-                                    Click="@(() => HandleRemoveAsync(item.Index))"
-                                    title="Remove" />
-                    </div>
-                  }
-                </div>
-              </Virtualize>
-            </div>
-          }
-        </div>
-      </RadzenTabsItem>
-
-      <RadzenTabsItem Text="History" Icon="history"
-                      Style="flex: 1; overflow: hidden; display: flex; flex-direction: column; min-height: 0;">
-        <div style="height: 100%; display: flex; flex-direction: column; min-height: 0;">
-          <!-- History Header -->
-          <div class="panel-header">
-            <span>Recent Plays</span>
-            <RadzenButton Variant="Variant.Text"
-                          Icon="refresh"
-                          ButtonStyle="ButtonStyle.Light"
-                          Size="ButtonSize.Small"
-                          Click="RefreshHistoryAsync"
-                          title="Refresh" />
+                }
+              </div>
+            </Virtualize>
           </div>
-
-          <!-- History List -->
-          @if (_isLoadingHistory)
-          {
-            @* PR 4: skeleton row stack instead of a centered spinner —
-               panel-body initial-load reads as "list rows about to appear". *@
-            <div style="flex: 1; min-height: 0; padding: 8px;">
-              <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
-              <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
-              <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
-              <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
-            </div>
-          }
-          else if (_historyItems.Any())
-          {
-            <div class="scrollable" style="flex: 1; overflow-y: auto; min-height: 0;">
-              @foreach (var item in _historyItems)
-              {
-                <div class="list-item-touch">
-                  <!-- Album art or source icon -->
-                  <div style="width: 36px; height: 36px; flex-shrink: 0; border-radius: 4px; overflow: hidden; display: flex; align-items: center; justify-content: center;">
-                    @if (!string.IsNullOrEmpty(item.Track?.CoverArtUrl)
-                      && item.Track.CoverArtUrl != "/images/default-album-art.png")
-                    {
-                      <img src="@item.Track.CoverArtUrl"
-                           style="width: 36px; height: 36px; object-fit: cover;"
-                           loading="lazy" />
-                    }
-                    else
-                    {
-                      <RadzenIcon Icon="@SourceTypeHelper.GetIcon(item.Source)"
-                                  Style="font-size: 20px; color: var(--text-low);" />
-                    }
-                  </div>
-                  <!-- Track info -->
-                  <div style="flex: 1; min-width: 0;">
-                    <div style="font-size: 16px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--text-high);">
-                      @(item.Title ?? "Unknown")
-                    </div>
-                    <div style="font-size: 14px; color: var(--text-medium); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                      @(item.Artist ?? "—")
-                      @if (item.DurationSeconds.HasValue && item.DurationSeconds.Value > 0)
-                      {
-                        <text> · </text>
-                        <span style="font-family: var(--font-mono); font-variant-numeric: tabular-nums;">@Durations.FormatTrack(TimeSpan.FromSeconds(item.DurationSeconds.Value))</span>
-                      }
-                      <text> · </text>
-                      <span style="font-family: var(--font-mono); font-variant-numeric: tabular-nums; color: var(--text-low);">@Timestamps.FormatRelative(item.PlayedAt.ToLocalTime())</span>
-                    </div>
-                    @if (!string.IsNullOrEmpty(item.SourceDetails) && item.SourceDetails != $"{item.Title} - {item.Artist}")
-                    {
-                      <div style="font-size: 12px; color: var(--text-low); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                        @item.SourceDetails
-                      </div>
-                    }
-                  </div>
-                  <RadzenBadge BadgeStyle="@GetSourceBadgeStyle(item.Source)"
-                               IsPill="true"
-                               Text="@item.Source"
-                               Style="font-size: 13px;" />
+        }
+      }
+      else if (_activeTab == TabHistory)
+      {
+        @if (_isLoadingHistory)
+        {
+          <div style="flex: 1; min-height: 0; padding: 8px;">
+            <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
+            <Skeleton Shape="Skeleton.SkeletonShape.ListRow" />
+          </div>
+        }
+        else if (_historyItems.Any())
+        {
+          <div class="scrollable" style="flex: 1; overflow-y: auto; min-height: 0;">
+            @foreach (var item in _historyItems)
+            {
+              <div class="list-item-touch">
+                <div style="width: 36px; height: 36px; flex-shrink: 0; border-radius: 4px; overflow: hidden; display: flex; align-items: center; justify-content: center;">
+                  @if (!string.IsNullOrEmpty(item.Track?.CoverArtUrl)
+                    && item.Track.CoverArtUrl != "/images/default-album-art.png")
+                  {
+                    <img src="@item.Track.CoverArtUrl"
+                         style="width: 36px; height: 36px; object-fit: cover;"
+                         loading="lazy" />
+                  }
+                  else
+                  {
+                    <RadzenIcon Icon="@SourceTypeHelper.GetIcon(item.Source)"
+                                Style="font-size: 20px; color: var(--text-low);" />
+                  }
                 </div>
-              }
-            </div>
-          }
-          else
+                <div style="flex: 1; min-width: 0;">
+                  <div style="font-size: 16px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--text-high);">
+                    @(item.Title ?? "Unknown")
+                  </div>
+                  <div style="font-size: 14px; color: var(--text-medium); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                    @(item.Artist ?? "—")
+                    @if (item.DurationSeconds.HasValue && item.DurationSeconds.Value > 0)
+                    {
+                      <text> · </text>
+                      <span style="font-family: var(--font-mono); font-variant-numeric: tabular-nums;">@Durations.FormatTrack(TimeSpan.FromSeconds(item.DurationSeconds.Value))</span>
+                    }
+                    <text> · </text>
+                    <span style="font-family: var(--font-mono); font-variant-numeric: tabular-nums; color: var(--text-low);">@Timestamps.FormatRelative(item.PlayedAt.ToLocalTime())</span>
+                  </div>
+                  @if (!string.IsNullOrEmpty(item.SourceDetails) && item.SourceDetails != $"{item.Title} - {item.Artist}")
+                  {
+                    <div style="font-size: 12px; color: var(--text-low); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                      @item.SourceDetails
+                    </div>
+                  }
+                </div>
+                <RadzenBadge BadgeStyle="@GetSourceBadgeStyle(item.Source)"
+                             IsPill="true"
+                             Text="@item.Source"
+                             Style="font-size: 13px;" />
+              </div>
+            }
+          </div>
+        }
+        else
+        {
+          <div style="flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-low);">
+            <RadzenIcon Icon="history" Style="font-size: 80px; opacity: 0.4; margin-bottom: 12px;" />
+            <span style="font-size: 16px;">No history yet</span>
+          </div>
+        }
+      }
+      else if (_activeTab == TabRadio)
+      {
+        @* Radio tab is a thin placeholder until P1·3 promotes the radio detail
+           surface here. The chevron on the Source Bubble still opens the
+           RadioControlPanel inline on Home — this is just the secondary entry
+           point for kiosk users on the Queue page. *@
+        <div style="flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-low); padding: 16px; text-align: center;">
+          <RadzenIcon Icon="radio" Style="font-size: 80px; opacity: 0.4; margin-bottom: 12px;" />
+          <span style="font-size: 16px;">Radio context</span>
+          <span style="font-size: 13px; color: var(--text-low); margin-top: 4px;">Tap the chevron on the Radio pill to open the control panel.</span>
+        </div>
+      }
+    </div>
+  </div>
+
+  <!-- ── Right column: persistent context tiles ── -->
+  <div class="queue-split-context-col">
+    @if (_activeTab == TabHistory)
+    {
+      <!-- History stats: total plays, top track, top artist. Re-renders inside
+           the same column container so the surrounding flex layout doesn't
+           remount the right side when tabs swap. -->
+      <div class="history-stats-tile">
+        <div class="history-stats-row">
+          <span class="history-stats-label">Total Plays</span>
+          <span class="history-stats-value history-stats-value-led">@(_historyStats?.TotalPlays.ToString() ?? "—")</span>
+        </div>
+        <div class="history-stats-row">
+          <span class="history-stats-label">Top Track</span>
+          <span class="history-stats-value" title="@_topTrackTooltip">@_topTrackDisplay</span>
+        </div>
+        <div class="history-stats-row">
+          <span class="history-stats-label">Top Artist</span>
+          <span class="history-stats-value" title="@_topArtistTooltip">@_topArtistDisplay</span>
+        </div>
+      </div>
+    }
+    else if (_activeTab == TabRadio)
+    {
+      <div class="history-stats-tile">
+        <div class="history-stats-row">
+          <span class="history-stats-label">Source</span>
+          <span class="history-stats-value">Radio</span>
+        </div>
+      </div>
+    }
+    else
+    {
+      <!-- Queue Total LED tile. Reads the same _totalRuntime as the older inline
+           header (preserves the PR 3 contract) and formats via Durations.FormatLong. -->
+      <div class="queue-total-tile">
+        <div class="queue-total-tile-value">@(_totalRuntime > TimeSpan.Zero ? Durations.FormatLong(_totalRuntime) : "0:00:00")</div>
+        <div class="queue-total-tile-sub">
+          @_queueItems.Count track@(_queueItems.Count == 1 ? "" : "s")
+          @if (_totalRuntime > TimeSpan.Zero)
           {
-            <div style="flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-low);">
-              <RadzenIcon Icon="history" Style="font-size: 80px; opacity: 0.4; margin-bottom: 12px;" />
-              <span style="font-size: 16px;">No history yet</span>
-            </div>
+            <text> · ends ~@(DateTime.Now.Add(_totalRuntime).ToString("HH:mm"))</text>
           }
         </div>
-      </RadzenTabsItem>
-    </Tabs>
-  </RadzenTabs>
+      </div>
+
+      <!-- Up Next: three rows of next-upcoming tracks (Played + Current excluded).
+           Album art is best-effort via ExtendedMetadata.CoverArtUrl if the server
+           supplied one; otherwise a music_note icon stands in. -->
+      <div class="up-next-tile">
+        <div class="up-next-tile-header">Up Next</div>
+        @{
+          var upNext = GetUpNext(3);
+        }
+        @if (upNext.Count == 0)
+        {
+          <div class="up-next-empty">Nothing queued.</div>
+        }
+        else
+        {
+          @for (var i = 0; i < upNext.Count; i++)
+          {
+            var dimClass = $"dim-{i + 1}";
+            var entry = upNext[i];
+            <div class="up-next-row @dimClass">
+              <div class="up-next-row-thumb">
+                @if (!string.IsNullOrEmpty(entry.CoverArtUrl)
+                  && entry.CoverArtUrl != "/images/default-album-art.png")
+                {
+                  <img src="@entry.CoverArtUrl" alt="" loading="lazy" />
+                }
+                else
+                {
+                  <RadzenIcon Icon="music_note" />
+                }
+              </div>
+              <div class="up-next-row-text">
+                <div class="up-next-row-title">@entry.Title</div>
+                <div class="up-next-row-artist">@entry.Artist</div>
+              </div>
+            </div>
+          }
+        }
+      </div>
+
+      <!-- Save-as-playlist CTA. Disabled when the queue is empty — saving nothing
+           would create an empty playlist (no current dialog flow handles that). -->
+      <button type="button"
+              class="save-playlist-tile"
+              disabled="@(!_queueItems.Any())"
+              @onclick="OpenSavePlaylistDialogAsync"
+              aria-label="Save current queue as playlist">
+        ＋ Save as playlist
+      </button>
+    }
+  </div>
 </div>
 
 @code {
-  private int _activeTab;
+  // ── Tab constants — define once so markup and code-behind agree. ──
+  private const int TabQueue = 0;
+  private const int TabHistory = 1;
+  private const int TabRadio = 2;
+
+  private int _activeTab = TabQueue;
   private bool _userOverrodeTab;
   private List<QueueItemDto> _queueItems = new();
   private List<PlayHistoryEntryDto> _historyItems = new();
+  private PlayHistoryStatsDto? _historyStats;
   private bool _isLoadingHistory;
   private int _playedCount;
   // Aggregate of every queue item's parsed Duration string. Surfaced as "h:mm:ss" in the
   // header via Durations.FormatLong. Zero when no rows have durations yet.
   private TimeSpan _totalRuntime = TimeSpan.Zero;
   private CancellationTokenSource? _refreshCts;
+
+  // Is the current primary source a radio family member? Drives the optional
+  // Radio tab in the tab strip — only shown when relevant so we don't clutter
+  // the strip for FilePlayer-only kiosk modes.
+  private bool _isRadioActive;
+
+  // Kebab menu open state (Add Files / Load Playlist / Clear All actions).
+  private bool _isKebabOpen;
+
+  // Cached display strings for the history-stats tile so the right column can
+  // render synchronously without re-querying TopTracks/TopArtists each render.
+  private string _topTrackDisplay = "—";
+  private string _topTrackTooltip = string.Empty;
+  private string _topArtistDisplay = "—";
+  private string _topArtistTooltip = string.Empty;
 
   protected override async Task OnInitializedAsync()
   {
@@ -293,10 +421,11 @@
       try
       {
         // Only refresh when History tab is active
-        if (_activeTab == 1)
+        if (_activeTab == TabHistory)
         {
           var result = await HistoryApi.GetHistoryAsync(limit: 50);
           _historyItems = result?.Items ?? new();
+          await RefreshHistoryStatsAsync();
           await InvokeAsync(StateHasChanged);
         }
       }
@@ -366,6 +495,30 @@
     return total;
   }
 
+  /// <summary>
+  /// Picks the next <paramref name="count"/> queue rows whose state is "Upcoming",
+  /// projected into a small UI record so the markup doesn't reach into <see cref="QueueItemDto"/>.
+  /// CoverArtUrl is best-effort — most QueueItemDto rows don't carry album art today,
+  /// so the tile falls back to a music_note icon if the URL is missing.
+  /// </summary>
+  private List<UpNextEntry> GetUpNext(int count)
+  {
+    var result = new List<UpNextEntry>(count);
+    foreach (var item in _queueItems)
+    {
+      if (item.State != "Upcoming") continue;
+      result.Add(new UpNextEntry(
+        item.Title ?? "Unknown",
+        item.Artist ?? "—",
+        // QueueItemDto doesn't currently carry CoverArtUrl; placeholder for future wiring.
+        null));
+      if (result.Count >= count) break;
+    }
+    return result;
+  }
+
+  private record UpNextEntry(string Title, string Artist, string? CoverArtUrl);
+
   private async Task RefreshHistoryAsync()
   {
     try
@@ -373,8 +526,13 @@
       _isLoadingHistory = true;
       StateHasChanged();
 
-      var result = await HistoryApi.GetHistoryAsync(limit: 50);
-      _historyItems = result?.Items ?? new();
+      var listTask = HistoryApi.GetHistoryAsync(limit: 50);
+      var statsTask = HistoryApi.GetStatsAsync();
+      await Task.WhenAll(listTask, statsTask);
+
+      _historyItems = (await listTask)?.Items ?? new();
+      _historyStats = await statsTask;
+      ApplyHistoryStatsProjections();
     }
     catch (Exception ex)
     {
@@ -384,6 +542,60 @@
     {
       _isLoadingHistory = false;
       StateHasChanged();
+    }
+  }
+
+  /// <summary>
+  /// Refreshes only the history stats payload, without disturbing the list-loading
+  /// flag. Called from the periodic refresh loop so a stale stats tile doesn't
+  /// linger while the list itself updates.
+  /// </summary>
+  private async Task RefreshHistoryStatsAsync()
+  {
+    try
+    {
+      _historyStats = await HistoryApi.GetStatsAsync();
+      ApplyHistoryStatsProjections();
+    }
+    catch (Exception ex)
+    {
+      Logger.LogDebug(ex, "Failed to refresh history stats");
+    }
+  }
+
+  private void ApplyHistoryStatsProjections()
+  {
+    if (_historyStats == null)
+    {
+      _topTrackDisplay = "—";
+      _topTrackTooltip = string.Empty;
+      _topArtistDisplay = "—";
+      _topArtistTooltip = string.Empty;
+      return;
+    }
+
+    var topTrack = _historyStats.TopTracks?.FirstOrDefault();
+    if (topTrack != null)
+    {
+      _topTrackDisplay = $"{topTrack.Title} · {topTrack.PlayCount}×";
+      _topTrackTooltip = $"{topTrack.Title} by {topTrack.Artist} ({topTrack.PlayCount} plays)";
+    }
+    else
+    {
+      _topTrackDisplay = "—";
+      _topTrackTooltip = string.Empty;
+    }
+
+    var topArtist = _historyStats.TopArtists?.FirstOrDefault();
+    if (topArtist != null)
+    {
+      _topArtistDisplay = $"{topArtist.Artist} · {topArtist.PlayCount}×";
+      _topArtistTooltip = $"{topArtist.Artist} ({topArtist.PlayCount} plays)";
+    }
+    else
+    {
+      _topArtistDisplay = "—";
+      _topArtistTooltip = string.Empty;
     }
   }
 
@@ -513,11 +725,20 @@
     };
   }
 
-  private void OnTabChanged(int newTab)
+  private async Task SetTab(int newTab)
   {
+    if (newTab == _activeTab) return;
     _activeTab = newTab;
     _userOverrodeTab = true;
+    if (newTab == TabHistory && _historyStats == null)
+    {
+      // First switch to History — ensure the stats tile has data.
+      await RefreshHistoryStatsAsync();
+    }
   }
+
+  private void ToggleKebab() => _isKebabOpen = !_isKebabOpen;
+  private void CloseKebab() => _isKebabOpen = false;
 
   private async Task OnSourceChanged()
   {
@@ -533,13 +754,17 @@
     try
     {
       var primary = await SourcesApi.GetPrimarySourceAsync();
-      // Queue tab (0) for FilePlayer, History tab (1) for all others
-      _activeTab = primary?.Type == "FilePlayer" ? 0 : 1;
+      var primaryType = primary?.Type;
+      _isRadioActive = primaryType is "Radio" or "RTLSDRCore" or "RF320";
+      // Queue tab for FilePlayer, History tab for all others — preserves the
+      // pre-PR-5 default-tab behaviour now that we've renamed the indexes.
+      _activeTab = primaryType == "FilePlayer" ? TabQueue : TabHistory;
     }
     catch
     {
       // Default to History if we can't determine the source
-      _activeTab = 1;
+      _activeTab = TabHistory;
+      _isRadioActive = false;
     }
   }
 

--- a/src/Radio.Web/Components/Shared/SourceTypeHelper.cs
+++ b/src/Radio.Web/Components/Shared/SourceTypeHelper.cs
@@ -35,4 +35,40 @@ public static class SourceTypeHelper
     "TestTone" => "testtone",
     _ => "file"
   };
+
+  /// <summary>
+  /// Gets the CSS custom-property name (e.g. <c>--source-radio</c>) for the
+  /// per-source accent colour. Used by SourceBubble, the IN cluster swatch
+  /// in MainLayout, and the source-color dot in NowPlayingDock.
+  /// Falls back to <c>--accent-primary</c> for unknown / unmapped types.
+  /// </summary>
+  public static string GetAccentVar(string sourceType) => sourceType switch
+  {
+    "Vinyl" => "--source-vinyl",
+    "FilePlayer" or "File" => "--source-file",
+    "Radio" or "RTLSDRCore" or "RF320" => "--source-radio",
+    "Bluetooth" => "--source-bluetooth",
+    "GenericUSB" or "USB" => "--source-usb",
+    _ => "--accent-primary"
+  };
+
+  /// <summary>
+  /// Single source of truth for which source types have a dedicated detail
+  /// surface (radio control panel, Bluetooth pairing page). Consumed by
+  /// <c>MainLayout</c> to drive the chevron affordance on <c>SourceBubble</c>
+  /// (handoff §P1·2) and by other places that need to gate detail-only UI.
+  ///
+  /// Future source types default to <c>false</c> and must be added explicitly.
+  /// </summary>
+  public static bool HasDetail(string sourceType) =>
+    SourcesWithDetail.Contains(sourceType);
+
+  private static readonly HashSet<string> SourcesWithDetail =
+    new(StringComparer.OrdinalIgnoreCase)
+    {
+      "Radio",
+      "RTLSDRCore",
+      "RF320",
+      "Bluetooth"
+    };
 }

--- a/src/Radio.Web/Components/Shared/SourceTypeHelper.cs
+++ b/src/Radio.Web/Components/Shared/SourceTypeHelper.cs
@@ -71,4 +71,26 @@ public static class SourceTypeHelper
       "RF320",
       "Bluetooth"
     };
+
+  /// <summary>
+  /// Single source of truth for the "radio family" — the set of source types
+  /// that share the radio control panel + tuning workflow. Consumed by
+  /// <c>MainLayout.IsRadioSource</c> (chevron click → "/" + show radio panel)
+  /// and <c>QueueHistoryPanel</c> (default-tab selection treats the whole
+  /// family as one source). Deliberately distinct from <see cref="HasDetail"/>
+  /// — Bluetooth has a detail surface but is not part of the radio family.
+  ///
+  /// Future radio-style source types default to <c>false</c> and must be added
+  /// explicitly. Returns <c>false</c> for null / empty inputs.
+  /// </summary>
+  public static bool IsRadioFamily(string? sourceType) =>
+    !string.IsNullOrEmpty(sourceType) && RadioFamilyTypes.Contains(sourceType);
+
+  private static readonly HashSet<string> RadioFamilyTypes =
+    new(StringComparer.OrdinalIgnoreCase)
+    {
+      "Radio",
+      "RTLSDRCore",
+      "RF320"
+    };
 }

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -2281,3 +2281,482 @@ body {
   height: 10px;
   border-radius: 2px;
 }
+
+
+/* ─── §N  Now Playing Dock (PR 5) ─────────────────────────────────────────── */
+
+/*
+ * 64px persistent player strip pinned to the bottom of .content-area on every
+ * route except Home (handoff §P1·1). When mounted, .content-area applies the
+ * .has-dock modifier so .page-transition shrinks by 64px and routed page
+ * content never slides under the dock. The dock is absolute-positioned, so
+ * page content keeps the full content-area as its scroll viewport otherwise.
+ */
+
+.content-area.has-dock .page-transition {
+  height: calc(100% - 64px);
+}
+
+.now-playing-dock {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 64px;
+  display: grid;
+  grid-template-columns: 48px minmax(200px, 1fr) auto auto minmax(200px, 1.6fr) auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  background: var(--surface-overlay);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-top: 1px solid var(--surface-separator);
+  cursor: pointer;
+  z-index: 5;
+}
+
+.now-playing-dock-art {
+  width: 48px;
+  height: 48px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--surface-inset);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.now-playing-dock-art img {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  display: block;
+}
+
+.now-playing-dock-art .rzi {
+  font-size: 24px;
+  color: var(--text-low);
+}
+
+/* Fixed min-width on the metadata block — keeps the dock layout stable when the
+ * track changes between a short and long title (handoff §P1·1 acceptance:
+ * "no layout shift on track change"). */
+.now-playing-dock-text {
+  min-width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+}
+
+.now-playing-dock-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-high);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+
+.now-playing-dock-artist {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-medium);
+  line-height: 1.2;
+}
+
+.now-playing-dock-artist .source-color-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.now-playing-dock-artist-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.now-playing-dock-bars {
+  /* Inherits .now-playing-bars sizing (height: 16px, three 3px spans). The dock
+   * just narrows the gap and adds a steady width so the surrounding grid cells
+   * don't reflow when the bars appear/disappear on play/pause. */
+  width: 18px;
+}
+
+.now-playing-dock-bars-placeholder {
+  width: 18px;
+  height: 16px;
+}
+
+.now-playing-dock-elapsed,
+.now-playing-dock-total {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-medium);
+  min-width: 40px;
+  text-align: right;
+}
+
+.now-playing-dock-progress {
+  height: 3px;
+  background: var(--surface-separator);
+  border-radius: 2px;
+  min-width: 200px;
+  position: relative;
+  overflow: hidden;
+}
+
+.now-playing-dock-progress-bar {
+  height: 100%;
+  background: var(--accent-primary);
+  border-radius: 2px;
+  transition: width 200ms linear;
+  width: 0%;
+}
+
+.now-playing-dock-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.now-playing-dock-btn {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--text-medium);
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.now-playing-dock-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-high);
+}
+
+.now-playing-dock-btn .rzi {
+  font-size: 20px;
+}
+
+.now-playing-dock-btn-primary {
+  color: var(--accent-primary);
+}
+
+.now-playing-dock-btn-primary .rzi {
+  font-size: 22px;
+}
+
+
+/* ─── §O  Queue Split Layout (PR 5) ───────────────────────────────────────── */
+
+/*
+ * Two-column queue/history panel (handoff §P1·4). Left column (flex 1.6) holds
+ * a tab strip plus the list itself; right column (flex 1) holds three stacked
+ * context tiles: Queue Total LED, Up Next thumbs, Save-as-Playlist CTA. The
+ * tabs swap the list contents without remounting the right column.
+ */
+
+.queue-split {
+  display: flex;
+  gap: 12px;
+  height: 100%;
+  min-height: 0;
+}
+
+.queue-split-list-col {
+  flex: 1.6;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
+.queue-split-context-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+  min-width: 0;
+  padding: 8px 0;
+  overflow: hidden;
+}
+
+/* Tab strip — mono uppercase, --accent-dim on the active pill. Matches the
+ * VisualizerPanel mode picker treatment (PR 4) for cross-panel consistency. */
+.queue-split-tabstrip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--surface-separator);
+  flex-shrink: 0;
+}
+
+.queue-split-tab {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-medium);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+  min-height: 32px;
+}
+
+.queue-split-tab:hover {
+  color: var(--text-high);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.queue-split-tab.is-active {
+  background: var(--accent-dim);
+  color: var(--accent-primary);
+  border-color: rgba(92, 212, 232, 0.35);
+}
+
+.queue-split-tab-spacer {
+  flex: 1;
+}
+
+.queue-split-kebab {
+  background: transparent;
+  border: none;
+  color: var(--text-medium);
+  font-size: 18px;
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.queue-split-kebab:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-high);
+}
+
+.queue-split-list-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ── Queue Total tile ── */
+.queue-total-tile {
+  background: var(--surface-overlay);
+  border: 1px solid var(--surface-separator);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.queue-total-tile-value {
+  font-family: var(--font-led);
+  font-size: 30px;
+  color: var(--signal-amber);
+  letter-spacing: 0.02em;
+  line-height: 1.0;
+}
+
+.queue-total-tile-sub {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-medium);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Up Next tile ── */
+.up-next-tile {
+  background: var(--surface-overlay);
+  border: 1px solid var(--surface-separator);
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.up-next-tile-header {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-low);
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+  margin-bottom: 2px;
+}
+
+.up-next-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow: hidden;
+}
+
+.up-next-row-thumb {
+  width: 32px;
+  height: 32px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--surface-inset);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.up-next-row-thumb img {
+  width: 32px;
+  height: 32px;
+  object-fit: cover;
+}
+
+.up-next-row-thumb .rzi {
+  font-size: 16px;
+  color: var(--text-low);
+}
+
+.up-next-row-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.up-next-row-title {
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+
+.up-next-row-artist {
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+
+/* Progressive dimming on the next 3 queue items — visual hierarchy that
+ * mirrors the spec's "text-high → text-medium → text-low" cascade. */
+.up-next-row.dim-1 .up-next-row-title { color: var(--text-high); }
+.up-next-row.dim-1 .up-next-row-artist { color: var(--text-medium); }
+.up-next-row.dim-2 .up-next-row-title { color: var(--text-medium); }
+.up-next-row.dim-2 .up-next-row-artist { color: var(--text-low); }
+.up-next-row.dim-3 .up-next-row-title { color: var(--text-low); }
+.up-next-row.dim-3 .up-next-row-artist { color: var(--text-low); opacity: 0.7; }
+
+.up-next-empty {
+  font-size: 12px;
+  color: var(--text-low);
+  font-style: italic;
+  padding: 6px 0;
+}
+
+/* ── Save-as-playlist CTA tile ── */
+.save-playlist-tile {
+  background: transparent;
+  border: 1px solid var(--accent-primary);
+  color: var(--accent-primary);
+  border-radius: 8px;
+  padding: 14px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+  text-align: center;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.save-playlist-tile:hover:not(:disabled) {
+  background: var(--accent-dim);
+}
+
+.save-playlist-tile:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  border-color: var(--surface-separator);
+  color: var(--text-low);
+}
+
+/* ── History stats tile (shown in the right column when History tab is active) ── */
+.history-stats-tile {
+  background: var(--surface-overlay);
+  border: 1px solid var(--surface-separator);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.history-stats-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.history-stats-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-low);
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+}
+
+.history-stats-value {
+  font-size: 14px;
+  color: var(--text-high);
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 60%;
+}
+
+.history-stats-value-led {
+  font-family: var(--font-led);
+  font-size: 22px;
+  color: var(--signal-amber);
+  letter-spacing: 0.02em;
+}

--- a/tests/Radio.Web.Tests/Components/Shared/NowPlayingDockTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/NowPlayingDockTests.cs
@@ -1,0 +1,199 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Radzen;
+using Radio.Web.Components.Shared;
+using Radio.Web.Services.ApiClients;
+using Radio.Web.Services.Hub;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for the <see cref="NowPlayingDock"/> persistent player strip
+/// introduced by PR 5 of the design tightening arc (handoff §P1·1).
+///
+/// The dock renders even with no API server reachable — the initial refresh
+/// just swallows the connection-refused exception and leaves the component
+/// in its empty-state shape. We exercise:
+///
+/// <list type="bullet">
+///   <item>Structural fingerprint: art block, metadata block, progress bar, controls.</item>
+///   <item>The metadata column declares <c>min-width: 200px</c> via CSS class
+///         so a track change doesn't cause horizontal layout shift.</item>
+///   <item>Progress bar carries the ARIA role + min/max/now attributes so the
+///         screen reader can announce playback position.</item>
+///   <item>Controls expose individual <c>aria-label</c>s for the three actions.</item>
+/// </list>
+///
+/// We do NOT exercise live SignalR pushes here — the hub never connects in the
+/// test rig, so we can't simulate a server-initiated NowPlayingChanged event
+/// without a custom fake. The empty-state asserts are sufficient to lock the
+/// rendering contract; richer interaction tests would belong in an E2E run.
+/// </summary>
+public class NowPlayingDockTests : TestContext
+{
+  private readonly ILoggerFactory _loggerFactory;
+
+  public NowPlayingDockTests()
+  {
+    _loggerFactory = new NullLoggerFactory();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+
+    var configuration = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>
+      {
+        { "ApiBaseUrl", "http://localhost:5000" }
+      })
+      .Build();
+
+    Services.AddSingleton<IConfiguration>(configuration);
+    Services.AddSingleton(_loggerFactory);
+    Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+
+    Services.AddRadzenComponents();
+
+    Services.AddHttpClient<AudioApiService>();
+
+    Services.AddSingleton(sp =>
+      new AudioStateHubService(
+        NullLogger<AudioStateHubService>.Instance,
+        sp.GetRequiredService<IConfiguration>()
+      )
+    );
+  }
+
+  protected override void Dispose(bool disposing)
+  {
+    if (disposing)
+    {
+      _loggerFactory?.Dispose();
+    }
+    base.Dispose(disposing);
+  }
+
+  [Fact]
+  public void NowPlayingDock_RendersRootContainer()
+  {
+    var cut = RenderComponent<NowPlayingDock>();
+    cut.FindAll(".now-playing-dock").Count.Should().Be(1);
+  }
+
+  [Fact]
+  public void NowPlayingDock_RendersAllSevenColumns()
+  {
+    // The grid template defined by §N expects: art → text → bars/placeholder
+    // → elapsed → progress → total → controls. We assert one of each is in DOM.
+    var cut = RenderComponent<NowPlayingDock>();
+    cut.FindAll(".now-playing-dock-art").Count.Should().Be(1);
+    cut.FindAll(".now-playing-dock-text").Count.Should().Be(1);
+    cut.FindAll(".now-playing-dock-elapsed").Count.Should().Be(1);
+    cut.FindAll(".now-playing-dock-progress").Count.Should().Be(1);
+    cut.FindAll(".now-playing-dock-total").Count.Should().Be(1);
+    cut.FindAll(".now-playing-dock-controls").Count.Should().Be(1);
+  }
+
+  [Fact]
+  public void NowPlayingDock_EmptyState_ShowsBarPlaceholder_NotEqBars()
+  {
+    // With no SignalR data, IsPlaying defaults to false. The dock renders the
+    // bars-placeholder block (preserves grid width) instead of the EQ animation.
+    var cut = RenderComponent<NowPlayingDock>();
+    cut.FindAll(".now-playing-dock-bars-placeholder").Count.Should().Be(1);
+    cut.FindAll(".now-playing-dock-bars").Count.Should().Be(0);
+  }
+
+  [Fact]
+  public void NowPlayingDock_EmptyState_DisplaysNoTrackPlaying()
+  {
+    // The empty-state title surfaces the friendly placeholder from
+    // DisplayNames.Track / NowPlayingPanel parity ("No Track Playing").
+    var cut = RenderComponent<NowPlayingDock>();
+    cut.Markup.Should().Contain("No Track Playing");
+  }
+
+  [Fact]
+  public void NowPlayingDock_EmptyState_DisplaysElapsedZeroAndTotalDash()
+  {
+    // Without a position payload, elapsed shows "0:00" and total shows the
+    // canonical em-dash so the layout doesn't flicker to "—:—" on load.
+    var cut = RenderComponent<NowPlayingDock>();
+    cut.Find(".now-playing-dock-elapsed").TextContent.Trim().Should().Be("0:00");
+    cut.Find(".now-playing-dock-total").TextContent.Trim().Should().Be("—");
+  }
+
+  [Fact]
+  public void NowPlayingDock_ProgressBar_HasZeroPercentWidth_ByDefault()
+  {
+    // No duration → no progress. The bar must still render so the column slot
+    // is occupied, but its inner element should be 0% wide.
+    var cut = RenderComponent<NowPlayingDock>();
+    var bar = cut.Find(".now-playing-dock-progress-bar");
+    bar.GetAttribute("style").Should().Contain("width: 0");
+  }
+
+  [Fact]
+  public void NowPlayingDock_ProgressBar_DeclaresAriaRoleAndRange()
+  {
+    // Screen-reader announcement requires role=progressbar plus min/max/now.
+    var cut = RenderComponent<NowPlayingDock>();
+    var progress = cut.Find(".now-playing-dock-progress");
+    progress.GetAttribute("role").Should().Be("progressbar");
+    progress.GetAttribute("aria-valuemin").Should().Be("0");
+    progress.HasAttribute("aria-valuemax").Should().BeTrue();
+    progress.HasAttribute("aria-valuenow").Should().BeTrue();
+  }
+
+  [Fact]
+  public void NowPlayingDock_Controls_HaveDistinctAriaLabels()
+  {
+    // Each transport button advertises its action so a kiosk user with
+    // screen-reader assistance can choose between prev / play-pause / next.
+    var cut = RenderComponent<NowPlayingDock>();
+    var buttons = cut.FindAll(".now-playing-dock-btn");
+    buttons.Count.Should().Be(3);
+
+    var labels = buttons
+      .Select(b => b.GetAttribute("aria-label") ?? string.Empty)
+      .ToList();
+    labels.Should().Contain("Previous track");
+    // Empty state → IsPlaying=false → button label reads "Play".
+    labels.Should().Contain("Play");
+    labels.Should().Contain("Next track");
+  }
+
+  [Fact]
+  public void NowPlayingDock_RegionRole_AnnouncesDockName()
+  {
+    // The whole strip is wrapped as a region so AT can address it as a unit.
+    var cut = RenderComponent<NowPlayingDock>();
+    var root = cut.Find(".now-playing-dock");
+    root.GetAttribute("role").Should().Be("region");
+    root.GetAttribute("aria-label").Should().Be("Now playing dock");
+  }
+
+  [Fact]
+  public void NowPlayingDock_Markup_NeverContains_FractionalSecondsTimespan()
+  {
+    // Regression guard: any raw TimeSpan.ToString() reintroduced into the dock
+    // would surface fractional-seconds. The Durations.FormatTrack helper rounds
+    // to whole seconds, so this pattern must never appear in the rendered DOM.
+    var cut = RenderComponent<NowPlayingDock>();
+    cut.Markup.Should().NotMatchRegex(@"\d+:\d{2}:\d{2}\.\d{4,}");
+  }
+
+  [Fact]
+  public void NowPlayingDock_SourceColorDot_RendersInsideArtistBlock()
+  {
+    // The 8×8 source-color dot is a visual handle for "what's playing this"
+    // — it sits at the start of the artist line. Empty state shows it with
+    // the fallback --text-low colour (no source known yet).
+    var cut = RenderComponent<NowPlayingDock>();
+    var artist = cut.Find(".now-playing-dock-artist");
+    var dot = artist.QuerySelector(".source-color-dot");
+    dot.Should().NotBeNull("the source-color dot lives inside the artist row");
+    dot!.GetAttribute("style").Should().Contain("--text-low");
+  }
+}

--- a/tests/Radio.Web.Tests/Components/Shared/NowPlayingDockTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/NowPlayingDockTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
@@ -6,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Radzen;
 using Radio.Web.Components.Shared;
+using Radio.Web.Models;
 using Radio.Web.Services.ApiClients;
 using Radio.Web.Services.Hub;
 
@@ -195,5 +197,99 @@ public class NowPlayingDockTests : TestContext
     var dot = artist.QuerySelector(".source-color-dot");
     dot.Should().NotBeNull("the source-color dot lives inside the artist row");
     dot!.GetAttribute("style").Should().Contain("--text-low");
+  }
+
+  // ─── State-handling regressions (PR 5 polisher L2 + tester nit #1) ─────────
+  // The hub service exposes NowPlayingChanged as a typed event. To exercise the
+  // dock's OnNowPlayingChanged handler from a unit test we reach in via
+  // reflection and invoke the multicast delegate directly — the same approach
+  // a SignalR-style fake would use, just inlined.
+
+  /// <summary>
+  /// Pull the dock's subscribed handler off <see cref="AudioStateHubService"/>'s
+  /// <c>NowPlayingChanged</c> event via reflection and invoke it with the supplied
+  /// payload. Lets us simulate a hub push without standing up a real connection.
+  /// </summary>
+  private static async Task FireNowPlayingChangedAsync(AudioStateHubService hub, NowPlayingDto? dto)
+  {
+    var field = typeof(AudioStateHubService).GetField("NowPlayingChanged",
+      BindingFlags.NonPublic | BindingFlags.Instance);
+    field.Should().NotBeNull("NowPlayingChanged backing field must exist");
+    var del = (Func<NowPlayingDto?, Task>?)field!.GetValue(hub);
+    if (del != null)
+    {
+      await del.Invoke(dto);
+    }
+  }
+
+  [Fact]
+  public async Task Dock_NullNowPlayingDto_ClearsState()
+  {
+    // After a real DTO populates the dock, a follow-up null payload (source
+    // went silent) must reset every field — title, subtitle, elapsed, total —
+    // back to the empty-state placeholders. Otherwise the previous track's
+    // metadata lingers indefinitely.
+    var hub = Services.GetRequiredService<AudioStateHubService>();
+    var cut = RenderComponent<NowPlayingDock>();
+
+    var populated = new NowPlayingDto
+    {
+      Title = "Hey Jude",
+      Artist = "The Beatles",
+      SourceType = "FilePlayer",
+      IsPlaying = true,
+      Position = TimeSpan.FromSeconds(45),
+      Duration = TimeSpan.FromMinutes(7)
+    };
+    await cut.InvokeAsync(() => FireNowPlayingChangedAsync(hub, populated));
+    cut.Markup.Should().Contain("Hey Jude");
+
+    // Now fire null — dock should fall back to the placeholder shape.
+    await cut.InvokeAsync(() => FireNowPlayingChangedAsync(hub, null));
+
+    cut.Markup.Should().Contain("No Track Playing");
+    cut.Markup.Should().NotContain("Hey Jude");
+    cut.Find(".now-playing-dock-elapsed").TextContent.Trim().Should().Be("0:00");
+    cut.Find(".now-playing-dock-total").TextContent.Trim().Should().Be("—");
+    cut.FindAll(".now-playing-dock-bars-placeholder").Count.Should().Be(1);
+    cut.FindAll(".now-playing-dock-bars").Count.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Dock_NowPlayingDtoWithoutPosition_ZerosElapsedAndTotal()
+  {
+    // Radio sources push DTOs without Position/Duration. Before the fix, those
+    // fields were skipped (only updated if HasValue) so stale numbers from a
+    // previous File source would persist. Verify the dock zeros them now.
+    var hub = Services.GetRequiredService<AudioStateHubService>();
+    var cut = RenderComponent<NowPlayingDock>();
+
+    // First push a file source with real position/duration to load stale state.
+    var file = new NowPlayingDto
+    {
+      Title = "Yesterday",
+      Artist = "The Beatles",
+      SourceType = "FilePlayer",
+      IsPlaying = true,
+      Position = TimeSpan.FromSeconds(30),
+      Duration = TimeSpan.FromMinutes(2) + TimeSpan.FromSeconds(5)
+    };
+    await cut.InvokeAsync(() => FireNowPlayingChangedAsync(hub, file));
+    cut.Find(".now-playing-dock-elapsed").TextContent.Trim().Should().Be("0:30");
+
+    // Now switch to a radio source — no position, no duration.
+    var radio = new NowPlayingDto
+    {
+      Title = "104.3 KSFI",
+      Artist = "—",
+      SourceType = "Radio",
+      IsPlaying = true,
+      Position = null,
+      Duration = null
+    };
+    await cut.InvokeAsync(() => FireNowPlayingChangedAsync(hub, radio));
+
+    cut.Find(".now-playing-dock-elapsed").TextContent.Trim().Should().Be("0:00");
+    cut.Find(".now-playing-dock-total").TextContent.Trim().Should().Be("—");
   }
 }

--- a/tests/Radio.Web.Tests/Components/Shared/QueueHistoryPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/QueueHistoryPanelTests.cs
@@ -14,15 +14,18 @@ using Radio.Web.Services.Hub;
 namespace Radio.Web.Tests.Components.Shared;
 
 /// <summary>
-/// bUnit tests for <see cref="QueueHistoryPanel"/> introduced by PR 3 of the design
-/// tightening arc. Focuses on the currently-playing row treatment (amber-left border
-/// + ▶ glyph) and absence of raw <see cref="TimeSpan"/> formatting in queue rows.
+/// bUnit tests for <see cref="QueueHistoryPanel"/>.
+///
+/// Originally introduced by PR 3 (now-playing row treatment + duration formatting
+/// invariants), expanded by PR 5 to cover the queue-split layout (handoff §P1·4):
+/// the panel now renders a two-column shape (list 1.6 / context 1) with a tab
+/// strip up top, a Queue Total LED tile, an Up Next tile, a Save-as-Playlist CTA,
+/// and a kebab menu replacing the inline ADD / CLEAR header buttons.
 ///
 /// Per the FileBrowserDialog test pattern, the QueueApi / HistoryApi clients return
 /// null when no server is running, so RefreshQueueAsync sets <c>_queueItems</c> to
-/// empty and the queue grid is hidden. To exercise the currently-playing branch we
-/// would need to mock the QueueApi — the existing test rig doesn't, so we only assert
-/// the empty-state and no-fractional-seconds invariants that hold without a server.
+/// empty and the queue grid is hidden. Empty-state assertions are sufficient to lock
+/// the structural contract; richer interaction tests belong in an E2E run.
 /// </summary>
 public class QueueHistoryPanelTests : TestContext
 {
@@ -149,6 +152,140 @@ public class QueueHistoryPanelTests : TestContext
     };
     QueueHistoryPanel.SumQueueRuntime(items)
       .Should().Be(TimeSpan.FromMinutes(2) + TimeSpan.FromSeconds(15));
+  }
+
+  // ── PR 5: queue-split layout assertions ──
+
+  [Fact]
+  public void QueueHistoryPanel_RendersSplitLayout_WithListAndContextColumns()
+  {
+    // The two-column split (handoff §P1·4) replaces the single RadzenTabs body.
+    // Both columns must be in the DOM regardless of API availability.
+    var cut = RenderComponent<QueueHistoryPanel>();
+    cut.FindAll(".queue-split").Count.Should().Be(1);
+    cut.FindAll(".queue-split-list-col").Count.Should().Be(1);
+    cut.FindAll(".queue-split-context-col").Count.Should().Be(1);
+  }
+
+  [Fact]
+  public void QueueHistoryPanel_TabStrip_RendersQueueAndHistoryPills()
+  {
+    // Default state shows Queue and History tabs. The Radio pill is conditional
+    // on the active source being a radio family member, which isn't available
+    // here without an API, so it should NOT render.
+    var cut = RenderComponent<QueueHistoryPanel>();
+    var tabs = cut.FindAll(".queue-split-tab");
+    tabs.Count.Should().BeGreaterThanOrEqualTo(2);
+
+    var tabLabels = tabs.Select(t => t.TextContent.Trim()).ToList();
+    tabLabels.Should().Contain(s => s.StartsWith("Queue"));
+    tabLabels.Should().Contain("History");
+  }
+
+  [Fact]
+  public void QueueHistoryPanel_TabStrip_RendersKebabButton()
+  {
+    // The ADD / CLEAR header buttons move into a kebab menu (handoff §P1·4 step 4).
+    // The kebab affordance itself is always present; its menu opens on click.
+    var cut = RenderComponent<QueueHistoryPanel>();
+    cut.FindAll(".queue-split-kebab").Count.Should().Be(1);
+  }
+
+  [Fact]
+  public void QueueHistoryPanel_QueueTab_RightColumn_ShowsAllThreeTiles()
+  {
+    // The right column on the Queue tab carries the Queue Total LED, Up Next
+    // thumbs, and Save-as-Playlist CTA. The Save CTA is disabled when the
+    // queue is empty. (The component's default tab resolves to History when
+    // there is no API server because SetDefaultTabForSourceAsync's catch-all
+    // picks History — so we click into Queue explicitly first.)
+    var cut = RenderComponent<QueueHistoryPanel>();
+    ClickTab(cut, "Queue");
+    cut.FindAll(".queue-total-tile").Count.Should().Be(1);
+    cut.FindAll(".up-next-tile").Count.Should().Be(1);
+    var savePlaylist = cut.FindAll(".save-playlist-tile");
+    savePlaylist.Count.Should().Be(1);
+    savePlaylist[0].HasAttribute("disabled").Should().BeTrue(
+      "the Save-as-playlist CTA is disabled when the queue is empty");
+  }
+
+  [Fact]
+  public void QueueHistoryPanel_QueueTotalTile_ShowsLedValueAndSubLine()
+  {
+    // The LED value is the only place in the right column using --font-led
+    // amber — locked here so a future refactor of design tokens trips this test.
+    var cut = RenderComponent<QueueHistoryPanel>();
+    ClickTab(cut, "Queue");
+    var ledValue = cut.Find(".queue-total-tile-value");
+    ledValue.TextContent.Trim().Should().NotBeEmpty();
+    cut.FindAll(".queue-total-tile-sub").Count.Should().Be(1);
+  }
+
+  [Fact]
+  public void QueueHistoryPanel_UpNextTile_EmptyState_ShowsPlaceholder()
+  {
+    // With an empty queue, the Up Next tile renders a friendly placeholder
+    // instead of stub rows — keeps the right column from feeling broken.
+    var cut = RenderComponent<QueueHistoryPanel>();
+    ClickTab(cut, "Queue");
+    cut.FindAll(".up-next-empty").Count.Should().Be(1);
+  }
+
+  [Fact]
+  public void QueueHistoryPanel_OpeningKebab_ShowsAddFilesAndClearAllItems()
+  {
+    // Click the kebab — the menu fly-out should list Add Files and Clear All
+    // (per the handoff §P1·4 spec, those move out of the inline header strip).
+    var cut = RenderComponent<QueueHistoryPanel>();
+    cut.Find(".queue-split-kebab").Click();
+    cut.Markup.Should().Contain("Add Files");
+    cut.Markup.Should().Contain("Clear All");
+  }
+
+  [Fact]
+  public void QueueHistoryPanel_SwitchingToHistoryTab_SwapsRightColumnContent()
+  {
+    // Clicking the History tab moves _activeTab → TabHistory; the queue-total /
+    // up-next / save-cta tiles are replaced by the history-stats tile inside the
+    // same right-column flex container (it is NOT remounted, just its children
+    // change). We assert the tile-presence transition.
+    var cut = RenderComponent<QueueHistoryPanel>();
+    ClickTab(cut, "Queue");
+    cut.FindAll(".queue-total-tile").Count.Should().Be(1);
+    cut.FindAll(".history-stats-tile").Count.Should().Be(0);
+
+    // Now click History.
+    ClickTab(cut, "History");
+    cut.FindAll(".queue-total-tile").Count.Should().Be(0);
+    cut.FindAll(".up-next-tile").Count.Should().Be(0);
+    cut.FindAll(".history-stats-tile").Count.Should().Be(1);
+  }
+
+  [Fact]
+  public void QueueHistoryPanel_HistoryStatsTile_HasTotalPlaysTopTrackTopArtistRows()
+  {
+    var cut = RenderComponent<QueueHistoryPanel>();
+    ClickTab(cut, "History");
+
+    var labels = cut.FindAll(".history-stats-label")
+      .Select(e => e.TextContent.Trim())
+      .ToList();
+    labels.Should().Contain("Total Plays");
+    labels.Should().Contain("Top Track");
+    labels.Should().Contain("Top Artist");
+  }
+
+  /// <summary>
+  /// Click the tab whose visible label starts with the given prefix
+  /// (e.g. "Queue" matches "Queue · 0" + spillover when the count is set).
+  /// </summary>
+  private static void ClickTab(IRenderedComponent<QueueHistoryPanel> cut, string labelPrefix)
+  {
+    var tab = cut.FindAll(".queue-split-tab")
+      .FirstOrDefault(t => t.TextContent.TrimStart().StartsWith(labelPrefix, StringComparison.Ordinal));
+    tab.Should().NotBeNull(
+      $"the {labelPrefix} tab must exist in the tab strip");
+    tab!.Click();
   }
 
   private static QueueItemDto MakeItem(string? duration) => new(

--- a/tests/Radio.Web.Tests/Components/Shared/SourceTypeHelperTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/SourceTypeHelperTests.cs
@@ -68,4 +68,75 @@ public class SourceTypeHelperTests
   {
     SourceTypeHelper.GetAccentVar(sourceType).Should().Be(expected);
   }
+
+  // ─── IsRadioFamily ────────────────────────────────────────────────────────
+  // IsRadioFamily is the SSOT for the radio control panel + tuning workflow.
+  // It is deliberately a narrower set than HasDetail — Bluetooth has a detail
+  // surface (pairing page) but is NOT a radio source and must return false here.
+  // Two call sites delegate to this method: MainLayout.IsRadioSource (chevron
+  // click dispatch) and QueueHistoryPanel._isRadioActive (default-tab gating).
+
+  [Fact]
+  public void IsRadioFamily_Radio_True()
+  {
+    SourceTypeHelper.IsRadioFamily("Radio").Should().BeTrue();
+  }
+
+  [Fact]
+  public void IsRadioFamily_RTLSDRCore_True()
+  {
+    SourceTypeHelper.IsRadioFamily("RTLSDRCore").Should().BeTrue();
+  }
+
+  [Fact]
+  public void IsRadioFamily_RF320_True()
+  {
+    SourceTypeHelper.IsRadioFamily("RF320").Should().BeTrue();
+  }
+
+  [Fact]
+  public void IsRadioFamily_Bluetooth_False()
+  {
+    // Important boundary: Bluetooth has detail (HasDetail==true) but is NOT a
+    // radio family member. The two matrices are related but distinct.
+    SourceTypeHelper.IsRadioFamily("Bluetooth").Should().BeFalse();
+  }
+
+  [Theory]
+  [InlineData("File")]
+  [InlineData("FilePlayer")]
+  [InlineData("USB")]
+  [InlineData("GenericUSB")]
+  [InlineData("Vinyl")]
+  [InlineData("TestTone")]
+  [InlineData("Spotify")]
+  [InlineData("UnknownFutureSource")]
+  public void IsRadioFamily_NonRadioSources_False(string sourceType)
+  {
+    SourceTypeHelper.IsRadioFamily(sourceType).Should().BeFalse();
+  }
+
+  [Fact]
+  public void IsRadioFamily_CaseInsensitive_True()
+  {
+    // Matches the OrdinalIgnoreCase contract used by HasDetail — capitalization
+    // drift between JSON deserialization and constant strings must not break
+    // the chevron-click → radio-panel dispatch.
+    SourceTypeHelper.IsRadioFamily("radio").Should().BeTrue();
+    SourceTypeHelper.IsRadioFamily("RADIO").Should().BeTrue();
+    SourceTypeHelper.IsRadioFamily("rtlsdrcore").Should().BeTrue();
+    SourceTypeHelper.IsRadioFamily("rf320").Should().BeTrue();
+  }
+
+  [Fact]
+  public void IsRadioFamily_Null_False()
+  {
+    SourceTypeHelper.IsRadioFamily(null).Should().BeFalse();
+  }
+
+  [Fact]
+  public void IsRadioFamily_Empty_False()
+  {
+    SourceTypeHelper.IsRadioFamily(string.Empty).Should().BeFalse();
+  }
 }

--- a/tests/Radio.Web.Tests/Components/Shared/SourceTypeHelperTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/SourceTypeHelperTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using Radio.Web.Components.Shared;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// Unit tests for <see cref="SourceTypeHelper"/>. The helper is the single
+/// source of truth for the per-source-type matrix that drives the topbar
+/// (icon + data attribute + accent var + chevron-affordance gating).
+///
+/// PR 5 of the design tightening arc (handoff §P1·2) added <c>HasDetail</c>
+/// + <c>GetAccentVar</c> to this helper so the chevron / detail-surface
+/// dispatch and the source-color dot (NowPlayingDock, IN cluster) share
+/// one matrix. These tests pin the matrix so adding a new source type
+/// elsewhere can't accidentally drift the chevron behaviour.
+/// </summary>
+public class SourceTypeHelperTests
+{
+  [Theory]
+  [InlineData("Radio")]
+  [InlineData("RTLSDRCore")]
+  [InlineData("RF320")]
+  [InlineData("Bluetooth")]
+  public void HasDetail_ReturnsTrue_ForRadioFamilyAndBluetooth(string sourceType)
+  {
+    SourceTypeHelper.HasDetail(sourceType).Should().BeTrue();
+  }
+
+  [Theory]
+  [InlineData("File")]
+  [InlineData("FilePlayer")]
+  [InlineData("Vinyl")]
+  [InlineData("GenericUSB")]
+  [InlineData("USB")]
+  [InlineData("TTS")]
+  [InlineData("TestTone")]
+  [InlineData("Spotify")]
+  [InlineData("")]
+  public void HasDetail_ReturnsFalse_ForSourcesWithoutDedicatedSurface(string sourceType)
+  {
+    SourceTypeHelper.HasDetail(sourceType).Should().BeFalse();
+  }
+
+  [Fact]
+  public void HasDetail_IsCaseInsensitive()
+  {
+    // The hash set uses OrdinalIgnoreCase so the API surface is robust to
+    // capitalization drift between consumers (e.g. JSON deserialization
+    // can occasionally re-case enum strings).
+    SourceTypeHelper.HasDetail("RADIO").Should().BeTrue();
+    SourceTypeHelper.HasDetail("radio").Should().BeTrue();
+    SourceTypeHelper.HasDetail("bluetooth").Should().BeTrue();
+  }
+
+  [Theory]
+  [InlineData("Radio", "--source-radio")]
+  [InlineData("RTLSDRCore", "--source-radio")]
+  [InlineData("RF320", "--source-radio")]
+  [InlineData("Bluetooth", "--source-bluetooth")]
+  [InlineData("FilePlayer", "--source-file")]
+  [InlineData("File", "--source-file")]
+  [InlineData("Vinyl", "--source-vinyl")]
+  [InlineData("GenericUSB", "--source-usb")]
+  [InlineData("USB", "--source-usb")]
+  [InlineData("", "--accent-primary")]
+  [InlineData("UnknownFutureSource", "--accent-primary")]
+  public void GetAccentVar_MapsKnownSourceTypes_AndFallsBackToAccentPrimary(string sourceType, string expected)
+  {
+    SourceTypeHelper.GetAccentVar(sourceType).Should().Be(expected);
+  }
+}


### PR DESCRIPTION
## Summary

PR 5 of the Radio Console design tightening arc — lands handoff items §P1·1, §P1·2, §P1·4 in one cycle.

- **NowPlayingDock** (§P1·1) — 64px persistent player strip pinned to the bottom of `.content-area` on every route except Home. Live updates via SignalR (`AudioStateHubService.NowPlayingChanged` + `PlaybackStateChanged`), click title/art to navigate Home, transport controls (prev/play-pause/next) with stopPropagation.
- **Source-pill semantics** (§P1·2) — Tap on `SourceBubble` body now ALWAYS switches source. The chevron handles the panel/detail dispatch separately. `SourceTypeHelper.HasDetail` is the single source of truth for which source types get a chevron (Radio family + Bluetooth).
- **Queue split layout** (§P1·4) — `QueueHistoryPanel` is now a two-column flex split (list `1.6` + context `1`). Tab strip up top (Queue · N / History / Radio?). Right column carries Queue Total LED tile, Up Next thumbs with progressive dimming, accent-bordered Save-as-playlist CTA. History tab swaps the right column to a stats tile (Total Plays + Top Track + Top Artist) without remounting. `ADD FILES / LOAD PLAYLIST / CLEAR ALL` move into a kebab menu (`⋮`) in the list-column header.

Hard dependencies on PR 2 (SourceBubble + chevron + RawName) and PR 3 (`Durations.FormatLong` + `DisplayNames.Track`) — both merged.

## Resolved spec ambiguities (baked into this PR)

1. **`HasDetail` matrix** — `Radio`, `RTLSDRCore`, `RF320`, `Bluetooth` get the chevron. `File`, `USB`, all future types must opt in explicitly via `SourceTypeHelper.SourcesWithDetail`.
2. **Chevron-tap dispatch** — Radio family → `/` + `RadioPanelToggleService.ShowRadioPanelAsync()`; Bluetooth → `/bluetooth`.
3. **`ShowRadioPanelAsync` already existed** on `RadioPanelToggleService` (idempotent shows). Used as-is.
4. **Default-tab fallback** — when API is unavailable or doesn't report a primary source, default is the History tab (preserves pre-PR-5 behaviour). FilePlayer source resolves to Queue tab.

## Acceptance — handoff §P1·1

- [x] Navigating `/` → `/devices` reveals dock; back to `/` removes it. (Wired via `NavigationManager.LocationChanged`; bUnit tests cover the conditional mount.)
- [x] Dock shows same track/state as home within one SignalR round-trip. (Subscribes to the same `AudioStateHubService` events.)
- [x] Tapping title navigates home. (`HandleNavigateHome` handler on root.)
- [x] No layout shift on track change. (`.now-playing-dock-text { min-width: 200px; }` + a stable bars-placeholder when paused.)

## Acceptance — handoff §P1·2

- [x] Tapping a source pill body switches source exactly once, never opens a panel. (`HandleSourceToggleAsync` rewritten.)
- [x] Active source pill shows chevron only when detail surface exists. (`HasDetail` matrix in `SourceTypeHelper`; verified by `SourceTypeHelperTests`.)
- [x] Tapping the chevron opens detail; the rest of the pill does not. (Existing `@onclick:stopPropagation` on `.source-bubble-chevron` from PR 2.)

## Acceptance — handoff §P1·4

- [x] Content area fills when queue has ≥1 track (no large empty void). (Right-column tiles always rendered.)
- [x] Tapping History tab swaps list without remounting right column. (Right column re-renders content based on `_activeTab`, never remounts.)
- [x] Save-as-playlist tile triggers existing save dialog. (`OpenSavePlaylistDialogAsync` preserved.)

## Test plan

- [x] `dotnet build src/Radio.Web/Radio.Web.csproj --configuration Release -p:NuGetAudit=false` — 0 errors (pre-existing IDE0011 warnings on unrelated files).
- [x] `dotnet test tests/Radio.Web.Tests --configuration Release -p:NuGetAudit=false` — 296/296 passing.
- [x] `dotnet test --configuration Release -p:NuGetAudit=false` — full suite green except the pre-existing `AudioEngineInitializationServiceTests.StartAsync_EnumeratesDevices` failure (Coordinator task #10).
- [ ] **Known UAT gap**: browser-driven UAT at 1920×720 (dock appears on `/devices`, hides on `/`; queue split lays out correctly with real data; kebab menu opens/closes). Coordinator dispatches the Tester for browser UAT in the next cycle.

## CI note

CI fails project-wide on `NuGetAudit` (warnings-as-errors for unbumped CVE-vulnerable packages — task #6 pending). Local builds pass with `-p:NuGetAudit=false`. Not blocking on local gates.

## Operator note

No deploy-affecting changes — pure UI / formatting layer. Existing radio-api and radio-web systemd services don't need restart beyond the normal deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)