### PR TITLE
docs: commit radio controller handoff (Arc 2 of design-tightening)

### DIFF
--- a/docs/design-handoffs/design_handoff_radio_console/Design Analysis.html
+++ b/docs/design-handoffs/design_handoff_radio_console/Design Analysis.html
@@ -1,0 +1,1932 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=1280" />
+<title>Radio Console — Design Analysis</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --surface-base:        #0D0D0F;
+    --surface-raised:      #141416;
+    --surface-inset:       #0A0A0C;
+    --surface-overlay:     #1A1A1D;
+    --surface-separator:   #1F1F22;
+    --surface-hairline:    #25252A;
+
+    --accent:              #5CD4E8;
+    --accent-dim:          rgba(92, 212, 232, 0.10);
+    --accent-glow:         rgba(92, 212, 232, 0.25);
+
+    --amber:               #F0A830;
+    --amber-glow:          rgba(240, 168, 48, 0.30);
+
+    --source-vinyl:        #A78BFA;
+    --source-radio:        #F0A830;
+    --source-bt:           #60A5FA;
+    --source-usb:          #4ADE80;
+    --source-file:         #5CD4E8;
+
+    --sig-red:             #F87171;
+    --sig-amber:           #FBBF24;
+    --sig-green:           #4ADE80;
+
+    --text-hi:             #F0EFF4;
+    --text-md:             #9CA3AF;
+    --text-lo:             #4B5563;
+    --text-dim:            #353841;
+
+    --font-body:           'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    --font-mono:           'JetBrains Mono', 'SF Mono', Consolas, monospace;
+    --font-led:            'Share Tech Mono', 'JetBrains Mono', monospace;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--surface-base);
+    color: var(--text-hi);
+    font-family: var(--font-body);
+    font-size: 15px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  ::selection { background: var(--accent-glow); color: var(--text-hi); }
+
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  /* ──────────── Layout shell ──────────── */
+  .shell {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 48px 120px;
+  }
+
+  /* ──────────── Top fixed nav rail (mimics product chrome) ──────────── */
+  .rail {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    height: 64px;
+    background: var(--surface-base);
+    border-bottom: 1px solid var(--surface-separator);
+    display: flex;
+    align-items: center;
+    padding: 0 48px;
+    gap: 24px;
+    backdrop-filter: blur(12px);
+  }
+  .rail-brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-md);
+  }
+  .rail-brand .dot {
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 10px var(--accent-glow);
+  }
+  .rail-clock {
+    margin-left: auto;
+    font-family: var(--font-led);
+    font-size: 18px;
+    color: var(--amber);
+    text-shadow: 0 0 8px var(--amber-glow);
+    letter-spacing: 4px;
+  }
+  .rail-toc {
+    display: flex;
+    gap: 4px;
+    font-size: 12px;
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .rail-toc a {
+    padding: 6px 10px;
+    border-radius: 6px;
+    color: var(--text-md);
+  }
+  .rail-toc a:hover {
+    background: var(--accent-dim);
+    color: var(--text-hi);
+    text-decoration: none;
+  }
+
+  /* ──────────── Hero ──────────── */
+  .hero {
+    padding: 96px 0 64px;
+    border-bottom: 1px solid var(--surface-separator);
+    margin-bottom: 56px;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 20px;
+  }
+  .eyebrow::before {
+    content: "";
+    display: inline-block;
+    width: 24px;
+    height: 1px;
+    background: var(--accent);
+    vertical-align: middle;
+    margin-right: 10px;
+  }
+  h1 {
+    font-size: 56px;
+    line-height: 1.05;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    margin: 0 0 24px;
+    max-width: 16ch;
+    text-wrap: balance;
+  }
+  h1 em {
+    font-style: normal;
+    color: var(--accent);
+  }
+  .lede {
+    font-size: 19px;
+    color: var(--text-md);
+    max-width: 68ch;
+    text-wrap: pretty;
+  }
+
+  .meta-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1px;
+    background: var(--surface-separator);
+    border: 1px solid var(--surface-separator);
+    border-radius: 10px;
+    overflow: hidden;
+    margin-top: 48px;
+  }
+  .meta-cell {
+    background: var(--surface-base);
+    padding: 18px 20px;
+  }
+  .meta-cell .k {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-lo);
+  }
+  .meta-cell .v {
+    font-size: 17px;
+    color: var(--text-hi);
+    margin-top: 6px;
+  }
+
+  /* ──────────── Section heads ──────────── */
+  section { margin-bottom: 96px; }
+  .section-head {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    margin-bottom: 36px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--surface-separator);
+  }
+  .section-num {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--accent);
+    letter-spacing: 0.1em;
+  }
+  h2 {
+    font-size: 32px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin: 0;
+  }
+  .section-sub {
+    color: var(--text-md);
+    margin-left: auto;
+    font-size: 14px;
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  h3 {
+    font-size: 20px;
+    font-weight: 600;
+    margin: 0 0 8px;
+    letter-spacing: -0.005em;
+  }
+
+  p { margin: 0 0 12px; color: var(--text-md); text-wrap: pretty; }
+  p strong { color: var(--text-hi); font-weight: 600; }
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.88em;
+    background: var(--surface-inset);
+    padding: 1px 6px;
+    border-radius: 4px;
+    color: var(--text-hi);
+    border: 1px solid var(--surface-separator);
+  }
+
+  /* ──────────── Strengths grid ──────────── */
+  .strengths {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+  .strength {
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-separator);
+    border-radius: 10px;
+    padding: 20px;
+  }
+  .strength .check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    background: rgba(74, 222, 128, 0.10);
+    color: var(--sig-green);
+    margin-bottom: 12px;
+    font-weight: 600;
+  }
+  .strength h4 {
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0 0 6px;
+    color: var(--text-hi);
+  }
+  .strength p {
+    font-size: 13px;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* ──────────── Issue cards ──────────── */
+  .issue {
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-separator);
+    border-radius: 12px;
+    padding: 28px 32px;
+    margin-bottom: 16px;
+    display: grid;
+    grid-template-columns: 1.1fr 1fr;
+    gap: 32px;
+    align-items: start;
+  }
+  .issue.no-mock { grid-template-columns: 1fr; }
+  .issue-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 14px;
+  }
+  .severity {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    padding: 4px 10px;
+    border-radius: 4px;
+    text-transform: uppercase;
+  }
+  .sev-p0 { background: rgba(248, 113, 113, 0.12); color: var(--sig-red); border: 1px solid rgba(248, 113, 113, 0.25); }
+  .sev-p1 { background: rgba(251, 191, 36, 0.10); color: var(--sig-amber); border: 1px solid rgba(251, 191, 36, 0.25); }
+  .sev-p2 { background: rgba(92, 212, 232, 0.08); color: var(--accent); border: 1px solid rgba(92, 212, 232, 0.25); }
+  .tag {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-lo);
+    text-transform: uppercase;
+    letter-spacing: 0.10em;
+    padding: 3px 8px;
+    border: 1px solid var(--surface-hairline);
+    border-radius: 4px;
+  }
+  .issue h3 { margin-bottom: 12px; }
+  .issue p { font-size: 14px; }
+  .issue .fix {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px dashed var(--surface-hairline);
+  }
+  .fix .label {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--accent);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+
+  ul.tight { margin: 0; padding-left: 18px; color: var(--text-md); font-size: 14px; }
+  ul.tight li { margin-bottom: 4px; }
+  ul.tight li::marker { color: var(--text-lo); }
+
+  /* ──────────── Mini-mocks ──────────── */
+  .mock {
+    background: var(--surface-inset);
+    border: 1px solid var(--surface-separator);
+    border-radius: 10px;
+    padding: 16px;
+    font-size: 13px;
+  }
+  .mock-label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-lo);
+    margin-bottom: 12px;
+  }
+  .mock-label .pill {
+    background: var(--surface-overlay);
+    padding: 2px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--surface-hairline);
+  }
+  .mock-row + .mock-row { margin-top: 12px; }
+
+  /* Top bar mock */
+  .tb-mock {
+    background: var(--surface-base);
+    border: 1px solid var(--surface-separator);
+    border-radius: 8px;
+    padding: 10px 14px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    height: 64px;
+  }
+  .tb-clock {
+    font-family: var(--font-led);
+    color: var(--amber);
+    text-shadow: 0 0 6px var(--amber-glow);
+    font-size: 16px;
+    letter-spacing: 3px;
+  }
+  .tb-sep {
+    width: 1px; height: 36px;
+    background: var(--surface-separator);
+  }
+  .tb-group {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    background: var(--surface-inset);
+    border: 1px solid var(--surface-separator);
+    border-radius: 28px;
+    padding: 3px 10px;
+  }
+  .tb-group-lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.10em;
+    color: var(--text-lo);
+    padding: 0 6px;
+  }
+  .tb-icon {
+    width: 38px; height: 38px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-md);
+    font-size: 16px;
+    position: relative;
+    background: transparent;
+  }
+  .tb-icon.on {
+    background: rgba(240, 168, 48, 0.12);
+    color: var(--amber);
+  }
+  .tb-icon.on::after {
+    content: "";
+    position: absolute;
+    bottom: 4px; left: 25%; right: 25%;
+    height: 2px;
+    background: currentColor;
+    border-radius: 1px;
+  }
+  .tb-nav {
+    margin-left: auto;
+    display: flex;
+    gap: 2px;
+  }
+
+  /* "After" top bar — clearer zoning */
+  .tb-after {
+    flex-direction: column;
+    align-items: stretch;
+    height: auto;
+    padding: 10px 14px;
+    gap: 8px;
+  }
+  .tb-after-row { display: flex; align-items: center; gap: 10px; }
+  .tb-cluster {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px 10px;
+    border-right: 1px solid var(--surface-separator);
+  }
+  .tb-cluster:last-child { border-right: none; }
+  .tb-cluster-lbl {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--text-lo);
+  }
+  .tb-cluster-val {
+    color: var(--text-hi);
+    font-size: 13px;
+    font-weight: 500;
+  }
+  .tb-cluster-val .swatch {
+    display: inline-block;
+    width: 8px; height: 8px;
+    border-radius: 2px;
+    margin-right: 6px;
+    vertical-align: 1px;
+  }
+
+  /* Source bubble strip */
+  .src-strip {
+    display: flex;
+    gap: 6px;
+  }
+  .src-bubble {
+    height: 44px;
+    padding: 0 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border-radius: 22px;
+    background: var(--surface-inset);
+    border: 1px solid var(--surface-separator);
+    color: var(--text-md);
+    font-size: 13px;
+    font-weight: 500;
+  }
+  .src-bubble .ic {
+    width: 22px; height: 22px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--surface-overlay);
+    font-size: 12px;
+    color: var(--text-md);
+  }
+  .src-bubble.act {
+    background: rgba(240, 168, 48, 0.10);
+    border-color: rgba(240, 168, 48, 0.35);
+    color: var(--amber);
+  }
+  .src-bubble.act .ic { background: rgba(240, 168, 48, 0.25); color: var(--amber); }
+  .src-bubble.dis { opacity: 0.4; }
+
+  /* Metrics tile mock */
+  .metric-tile {
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-separator);
+    border-radius: 8px;
+    padding: 16px;
+  }
+  .metric-tile .cat {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    color: var(--text-lo);
+    text-transform: uppercase;
+  }
+  .metric-tile .name {
+    font-size: 13px;
+    color: var(--text-md);
+    margin-top: 4px;
+  }
+  .metric-tile .val {
+    font-family: var(--font-mono);
+    font-size: 28px;
+    color: var(--accent);
+    margin-top: 6px;
+    font-weight: 500;
+  }
+  .metric-tile .val .unit {
+    font-size: 13px;
+    color: var(--text-md);
+    margin-left: 4px;
+  }
+  .metric-tile .delta {
+    font-size: 11px;
+    color: var(--sig-green);
+    margin-top: 2px;
+    font-family: var(--font-mono);
+  }
+  .metric-tile.bug .val { color: var(--sig-red); }
+  .spark {
+    height: 24px;
+    margin-top: 8px;
+  }
+
+  /* Queue row mocks */
+  .queue-mock {
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-separator);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .qrow {
+    display: grid;
+    grid-template-columns: 24px 1fr 56px 28px;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--surface-separator);
+    font-size: 13px;
+  }
+  .qrow:last-child { border-bottom: none; }
+  .qrow.now {
+    background: rgba(240, 168, 48, 0.06);
+    border-left: 3px solid var(--amber);
+    padding-left: 11px;
+  }
+  .qrow .num {
+    font-family: var(--font-mono);
+    color: var(--text-lo);
+    text-align: center;
+    font-size: 12px;
+  }
+  .qrow.now .num { color: var(--amber); }
+  .qrow .title { color: var(--text-hi); font-weight: 500; }
+  .qrow .sub { color: var(--text-md); font-size: 12px; }
+  .qrow .dur {
+    font-family: var(--font-mono);
+    color: var(--text-md);
+    font-size: 12px;
+    text-align: right;
+  }
+  .qrow .x { color: var(--text-lo); text-align: center; }
+  .qrow.bad .dur { color: var(--sig-red); font-size: 10px; }
+
+  /* File browser mock */
+  .fb-mock {
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-separator);
+    border-radius: 8px;
+    padding: 14px;
+  }
+  .fb-field {
+    background: var(--surface-inset);
+    border: 1px solid var(--surface-separator);
+    border-radius: 6px;
+    padding: 8px 12px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-md);
+    word-break: break-all;
+  }
+  .fb-field.bad { color: var(--sig-red); font-size: 10px; line-height: 1.4; }
+  .fb-field .ph { color: var(--text-lo); }
+  .fb-chips {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+  }
+  .fb-chip {
+    height: 28px;
+    padding: 0 10px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--surface-inset);
+    border: 1px solid var(--surface-separator);
+    border-radius: 14px;
+    font-size: 12px;
+    color: var(--text-md);
+    font-family: var(--font-mono);
+  }
+
+  /* Now playing dock mock */
+  .dock {
+    background: var(--surface-overlay);
+    border: 1px solid var(--surface-separator);
+    border-radius: 8px;
+    padding: 10px 14px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    backdrop-filter: blur(20px);
+  }
+  .dock .art {
+    width: 44px; height: 44px;
+    background: linear-gradient(135deg, #2a2a30, #1a1a1f);
+    border-radius: 6px;
+    flex-shrink: 0;
+    position: relative;
+    overflow: hidden;
+  }
+  .dock .art::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(
+      135deg,
+      rgba(255,255,255,0.04) 0 6px,
+      transparent 6px 12px
+    );
+  }
+  .dock .meta { flex: 1; min-width: 0; }
+  .dock .t { color: var(--text-hi); font-size: 13px; font-weight: 600; }
+  .dock .a { color: var(--text-md); font-size: 12px; }
+  .dock .eq {
+    display: flex;
+    gap: 2px;
+    align-items: flex-end;
+    height: 14px;
+    margin-right: 4px;
+  }
+  .dock .eq span {
+    width: 3px;
+    background: var(--accent);
+    border-radius: 1px;
+  }
+  .dock .eq span:nth-child(1) { height: 60%; }
+  .dock .eq span:nth-child(2) { height: 100%; }
+  .dock .eq span:nth-child(3) { height: 40%; }
+  .dock .tcontrols {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-md);
+    font-size: 18px;
+  }
+  .dock .tcontrols .pp {
+    width: 36px; height: 36px;
+    border-radius: 50%;
+    background: var(--accent);
+    color: var(--surface-base);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Two-column compare */
+  .compare {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+  .compare .mock { margin: 0; }
+
+  /* Roadmap */
+  .roadmap {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1px;
+    background: var(--surface-separator);
+    border: 1px solid var(--surface-separator);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  .phase {
+    background: var(--surface-base);
+    padding: 24px;
+  }
+  .phase .pnum {
+    font-family: var(--font-led);
+    color: var(--amber);
+    font-size: 22px;
+    letter-spacing: 4px;
+    text-shadow: 0 0 6px var(--amber-glow);
+  }
+  .phase .pname {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 6px 0 14px;
+    color: var(--text-hi);
+  }
+  .phase ul {
+    margin: 0;
+    padding-left: 18px;
+    font-size: 13px;
+    color: var(--text-md);
+  }
+  .phase ul li { margin-bottom: 6px; }
+
+  /* Page audit table */
+  .ptable {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+  }
+  .ptable th, .ptable td {
+    text-align: left;
+    padding: 14px 18px;
+    vertical-align: top;
+    border-bottom: 1px solid var(--surface-separator);
+  }
+  .ptable th {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-lo);
+    font-weight: 500;
+    background: var(--surface-raised);
+  }
+  .ptable td.name { color: var(--text-hi); font-weight: 600; width: 18%; }
+  .ptable td.is { color: var(--text-md); width: 38%; }
+  .ptable td.fix { color: var(--text-md); }
+  .ptable td.fix strong { color: var(--text-hi); }
+
+  /* Footer */
+  .endplate {
+    margin-top: 80px;
+    padding-top: 24px;
+    border-top: 1px solid var(--surface-separator);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: var(--text-lo);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+</style>
+</head>
+<body>
+
+<!-- ───────────── Top sticky rail ───────────── -->
+<header class="rail">
+  <div class="rail-brand">
+    <span class="dot"></span>
+    <span>Radio.Web · Design Review</span>
+  </div>
+  <nav class="rail-toc">
+    <a href="#context">Context</a>
+    <a href="#strengths">Strengths</a>
+    <a href="#issues">Issues</a>
+    <a href="#pages">Pages</a>
+    <a href="#system">System</a>
+    <a href="#roadmap">Roadmap</a>
+  </nav>
+  <div class="rail-clock" id="clock">--:--</div>
+</header>
+
+<div class="shell">
+
+  <!-- ───────────── Hero ───────────── -->
+  <section class="hero">
+    <div class="eyebrow">Deep design analysis · v1</div>
+    <h1>The console is <em>beautiful</em>. The product underneath it is <em>leaking</em>.</h1>
+    <p class="lede">
+      The 1920×720 broadcast-console aesthetic is genuinely strong — DSEG amber LEDs over a calm
+      dark surface, a confident cyan accent, generous touch targets, and per-source color coding all
+      do real work. But the surface is sitting on top of an interface that is still showing the
+      user its raw machinery: <code>FilePlayer-da7eb94888fa43aab0021…</code> as a "source name",
+      <code>00:03:00.6628571</code> as a track duration, <code>850.4%</code> as a memory reading,
+      escaped JSON in a filter input, and a <strong>debug-only distortion marker</strong> living in
+      production chrome. The work below is mostly about <strong>finishing the surface</strong> so
+      the design language can do its job.
+    </p>
+
+    <div class="meta-row">
+      <div class="meta-cell">
+        <div class="k">Stack</div>
+        <div class="v">Blazor Server · Radzen · SignalR</div>
+      </div>
+      <div class="meta-cell">
+        <div class="k">Viewport</div>
+        <div class="v">1920 × 720 · touch-first kiosk</div>
+      </div>
+      <div class="meta-cell">
+        <div class="k">Surfaces audited</div>
+        <div class="v">9 pages · 5 shared panels · 3 dialogs</div>
+      </div>
+      <div class="meta-cell">
+        <div class="k">Findings</div>
+        <div class="v">5 P0 · 8 P1 · 11 P2</div>
+      </div>
+    </div>
+  </section>
+
+
+  <!-- ───────────── Context ───────────── -->
+  <section id="context">
+    <div class="section-head">
+      <span class="section-num">01</span>
+      <h2>What we're looking at</h2>
+      <span class="section-sub">Setting the frame</span>
+    </div>
+
+    <div style="display: grid; grid-template-columns: 1.2fr 1fr; gap: 32px; align-items: start;">
+      <div>
+        <p>
+          Radio.Web is a Blazor Server kiosk app that runs on a fixed 1920×720 touchscreen — likely
+          a Raspberry Pi driving a wide-format panel. It controls a multi-source audio engine
+          (FM/AM radio over RTL-SDR, Bluetooth, USB, vinyl, local files, Google Cast) and surfaces
+          a single home view with three columns: <strong>Now Playing</strong>, <strong>Queue /
+          History</strong>, and <strong>Visualizer</strong>. Secondary pages — Devices, Metrics,
+          History, System, Phone, File Browser — share an 80px top bar that doubles as the global
+          source/output router.
+        </p>
+        <p>
+          The aesthetic brief is "professional broadcast console / recording-studio rack mount" —
+          DSEG segmented-LCD type in amber for time and frequency, a single electric-cyan accent
+          for active state, and a calm dark palette (<code>#0D0D0F</code> base,
+          <code>#141416</code> raised). The design system is well-articulated in
+          <code>design-system.css</code>: tokens for surfaces, accents, source colors, touch sizes,
+          animation timing.
+        </p>
+        <p>
+          <strong>The mismatch:</strong> the design system promises a calm, opinionated instrument
+          panel. The screenshots deliver something closer to a half-finished admin tool with a
+          beautiful skin on top — raw API IDs, debug controls, broken units, and pages that have
+          one component and acres of empty void below.
+        </p>
+      </div>
+
+      <!-- Real top-bar reproduction so we share a reference -->
+      <div class="mock">
+        <div class="mock-label">
+          <span>Current top bar · approximation</span>
+          <span class="pill">1920 × 80</span>
+        </div>
+        <div class="tb-mock">
+          <div class="tb-clock">11:29</div>
+          <div class="tb-sep"></div>
+          <div class="tb-group">
+            <span class="tb-group-lbl">In</span>
+            <span class="tb-icon">♪</span>
+            <span class="tb-icon on" style="color: var(--source-radio); background: rgba(240,168,48,0.12);">📻</span>
+            <span class="tb-icon">⌁</span>
+            <span class="tb-icon">▼</span>
+          </div>
+          <div class="tb-sep"></div>
+          <div class="tb-group">
+            <span class="tb-group-lbl">Out</span>
+            <span class="tb-icon on" style="color: var(--accent); background: var(--accent-dim);">▣</span>
+            <span class="tb-icon">▤</span>
+            <span class="tb-icon">⌁</span>
+          </div>
+          <span class="tb-icon" title="debug" style="color: var(--text-lo); margin-left:6px;">🐞</span>
+          <div class="tb-nav">
+            <span class="tb-icon on" style="color: var(--accent);">⌂</span>
+            <span class="tb-icon">≡</span>
+            <span class="tb-icon">▥</span>
+            <span class="tb-icon">⌥</span>
+            <span class="tb-icon">⌖</span>
+            <span class="tb-icon">⏱</span>
+            <span class="tb-icon">⚙</span>
+            <span class="tb-icon">☎</span>
+            <span class="tb-icon">⏻</span>
+          </div>
+        </div>
+        <p style="font-size: 12px; margin-top: 14px; color: var(--text-lo);">
+          Three icon groups sharing one bar, ten of them shaped identically.
+          The bar is doing routing, navigation, and a debug action at the same time —
+          users can't tell from shape alone what each pill <em>does</em>.
+        </p>
+      </div>
+    </div>
+  </section>
+
+
+  <!-- ───────────── Strengths ───────────── -->
+  <section id="strengths">
+    <div class="section-head">
+      <span class="section-num">02</span>
+      <h2>Don't break these</h2>
+      <span class="section-sub">Real strengths · keep them</span>
+    </div>
+
+    <div class="strengths">
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>Token-first design system</h4>
+        <p>One CSS file owns surfaces, accents, type, motion, and touch sizes. Already the right
+        plumbing — most of the work below is enforcement, not invention.</p>
+      </div>
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>Per-source color coding</h4>
+        <p>Vinyl violet, radio amber, Bluetooth blue, USB green, file cyan — a smart, learnable
+        mapping that pays off across the whole app once enforced.</p>
+      </div>
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>DSEG LED type as a signature</h4>
+        <p>Amber segmented display for time, frequency and ghost-segment backgrounds is the single
+        most distinctive visual move in the app. Don't dilute it by using it on regular UI.</p>
+      </div>
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>Real touch sizing</h4>
+        <p>48/56/64px tokens are defined and route toggles hit them. Better than 90% of admin-style
+        Blazor apps in the wild.</p>
+      </div>
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>SignalR-driven live state</h4>
+        <p>Now playing, queue count, sleep, source — all push-updated. The user never has to
+        refresh. Lean into this with more live state where it currently isn't.</p>
+      </div>
+      <div class="strength">
+        <div class="check">✓</div>
+        <h4>Three-column home</h4>
+        <p>Now Playing · Queue · Visualizer reading left-to-right is the right shape for a kiosk.
+        Most of the design work for the home page is already done.</p>
+      </div>
+    </div>
+  </section>
+
+
+  <!-- ───────────── Issues ───────────── -->
+  <section id="issues">
+    <div class="section-head">
+      <span class="section-num">03</span>
+      <h2>What's leaking through</h2>
+      <span class="section-sub">P0 → P2 · sorted by user pain</span>
+    </div>
+
+
+    <!-- ─── ISSUE 1: top bar overload ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p0">P0</span>
+          <span class="tag">Information architecture</span>
+          <span class="tag">MainLayout</span>
+        </div>
+        <h3>The top bar is three different toolbars stacked into one row</h3>
+        <p>
+          Eighty pixels of vertical space are doing four jobs at once: telling time, routing
+          <em>input</em>, routing <em>output</em>, exposing nine global nav targets — plus a
+          temporary debug button. Every cluster uses the same circular-pill shape, so a user can't
+          tell from form alone whether a pill <em>switches a route</em> or <em>navigates a
+          page</em>. The route toggles also conflate two actions (switch source / open detail) by
+          tap counting.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Split the bar into <strong>three visually distinct zones</strong>: a status zone
+            (clock + currently-playing pill), a routing zone (clearly labeled IN → OUT with a
+            connector glyph between them), and a nav zone (rectangular icon+label buttons, not
+            circles).</li>
+            <li>Make active source <em>and</em> active output visible as <strong>typeset names</strong>,
+            not just colored pills — operators shouldn't have to remember the color code.</li>
+            <li>Move the <strong>debug distortion marker</strong> behind a dev-tools toggle. It
+            doesn't belong in production chrome.</li>
+            <li>Replace tap-count-to-disambiguate with an explicit affordance: long-press, or a
+            chevron that opens detail.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Proposed top bar</span><span class="pill">After</span></div>
+        <div class="tb-mock tb-after">
+          <div class="tb-after-row" style="gap: 16px;">
+            <div class="tb-cluster" style="border:none; padding-left:0;">
+              <span class="tb-cluster-lbl">Time</span>
+              <span class="tb-cluster-val" style="font-family: var(--font-led); color: var(--amber); letter-spacing:2px;">11:29</span>
+            </div>
+            <div class="tb-cluster">
+              <span class="tb-cluster-lbl">In · Source</span>
+              <span class="tb-cluster-val"><span class="swatch" style="background: var(--source-radio);"></span>FM Radio · 88.5</span>
+            </div>
+            <div style="color: var(--text-lo); font-size: 18px;">→</div>
+            <div class="tb-cluster">
+              <span class="tb-cluster-lbl">Out · Destination</span>
+              <span class="tb-cluster-val"><span class="swatch" style="background: var(--accent);"></span>Living Room (Cast)</span>
+            </div>
+            <div class="tb-nav" style="gap: 4px;">
+              <span class="tb-icon" style="width:auto; padding:0 10px; border-radius:6px; background: var(--accent-dim); color: var(--accent); font-size: 11px; letter-spacing:0.1em; font-family: var(--font-mono); text-transform: uppercase;">Home</span>
+              <span class="tb-icon" style="width:auto; padding:0 10px; border-radius:6px; color: var(--text-md); font-size: 11px; letter-spacing:0.1em; font-family: var(--font-mono); text-transform: uppercase;">Queue·45</span>
+              <span class="tb-icon" style="width:auto; padding:0 10px; border-radius:6px; color: var(--text-md); font-size: 11px; letter-spacing:0.1em; font-family: var(--font-mono); text-transform: uppercase;">Radio</span>
+              <span class="tb-icon" style="width:auto; padding:0 10px; border-radius:6px; color: var(--text-md); font-size: 11px; letter-spacing:0.1em; font-family: var(--font-mono); text-transform: uppercase;">More</span>
+            </div>
+          </div>
+          <div class="tb-after-row src-strip">
+            <span class="src-bubble"><span class="ic">♪</span>File</span>
+            <span class="src-bubble act"><span class="ic">📻</span>Radio</span>
+            <span class="src-bubble"><span class="ic">⌁</span>Bluetooth</span>
+            <span class="src-bubble dis"><span class="ic">⌖</span>Vinyl · offline</span>
+            <span class="src-bubble"><span class="ic">⎘</span>USB</span>
+          </div>
+        </div>
+        <p style="font-size:12px; margin-top:10px; color: var(--text-lo);">
+          Routing reads as a sentence: <em>FM Radio → Living Room</em>. Source pills move below
+          with full labels — discoverable, learnable, and a "disabled / offline" state stops
+          looking like a faded icon.
+        </p>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 2: UUID source names ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p0">P0</span>
+          <span class="tag">Data hygiene</span>
+          <span class="tag">All pages</span>
+        </div>
+        <h3>API IDs are leaking into the UI as labels</h3>
+        <p>
+          The Audio Source dropdown in older screenshots shows
+          <code>FilePlayer-da7eb94888fa43aab0021…</code> — a UUID-suffixed internal ID being
+          rendered as a human label. Devices show
+          <code>1 - LG TV SSCR2 (AMD High Definition Audio Device)</code> straight from WASAPI.
+          Tracks fall back to <code>Track 8</code>, <code>Track 9</code>… when metadata is missing.
+          These are <em>all</em> the same problem: the app is showing internal identifiers because
+          the display-name layer is missing or thin.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>One <code>DisplayName</code> projection on every domain DTO, computed server-side.
+            Never bind a raw <code>Id</code>, <code>RawName</code>, or filename to a user-facing
+            string.</li>
+            <li>Filename fallback: parse leading <em>track-number / disc-number</em>, strip
+            extension, title-case. <code>08 - We're Ready.flac</code> → <strong>We're Ready</strong>
+            with subtitle <em>Track 8</em>.</li>
+            <li>Device names: ship a curated alias map for common adapters (VB-Audio, Realtek,
+            HDMI…), with the existing <code>FriendlyNameOverride</code> as the user-edit layer.
+            Show the alias by default, the raw name on long-press.</li>
+            <li>Sources: drop the GUID suffix entirely from the client model. The UI never needs
+            instance identity.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Source dropdown</span><span class="pill">Before · after</span></div>
+        <div class="compare">
+          <div class="mock" style="background: var(--surface-raised);">
+            <div style="font-family: var(--font-mono); font-size: 10px; color: var(--text-lo); margin-bottom:6px;">BEFORE</div>
+            <div class="fb-field" style="color: var(--text-hi);">FilePlayer-da7eb94888fa43aab0021…</div>
+            <div class="fb-field" style="color: var(--text-hi); margin-top:6px;">1 - LG TV SSCR2 (AMD High Definition Audio Device)</div>
+            <div class="fb-field" style="color: var(--text-hi); margin-top:6px;">CABLE In 16ch (VB-Audio Virtual Cable)</div>
+          </div>
+          <div class="mock" style="background: var(--surface-raised);">
+            <div style="font-family: var(--font-mono); font-size: 10px; color: var(--accent); margin-bottom:6px;">AFTER</div>
+            <div class="fb-field" style="color: var(--text-hi);">File Player <span class="ph">· local</span></div>
+            <div class="fb-field" style="color: var(--text-hi); margin-top:6px;">LG TV <span class="ph">· HDMI</span></div>
+            <div class="fb-field" style="color: var(--text-hi); margin-top:6px;">VB-Audio Cable In <span class="ph">· 16-channel</span></div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 3: durations ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p0">P0</span>
+          <span class="tag">Formatting</span>
+          <span class="tag">Queue · NowPlaying</span>
+        </div>
+        <h3>Durations are raw <code>TimeSpan.ToString()</code></h3>
+        <p>
+          The queue is showing track lengths as <code>00:03:00.6628571</code> —
+          <em>hours:minutes:seconds.ticks</em>. No one reads tracks in tick precision. It also
+          makes every column header wider than it needs to be, eating horizontal space the table
+          can't afford. Same problem on History (sub-second precision on date/time).
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>One <code>FormatDuration(TimeSpan)</code> helper used everywhere: <code>3:00</code>
+            under an hour, <code>1:02:14</code> over an hour, em-dash for unknown.</li>
+            <li>Right-align all duration columns in a tabular-figures monospaced style — already
+            in your <code>--font-mono</code> token.</li>
+            <li>History date format: <code>Today 08:40</code>, <code>Yesterday 14:22</code>,
+            <code>Feb 6 · 11:05</code> — relative within 48 hours, absolute beyond.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Queue rows</span><span class="pill">After</span></div>
+        <div class="queue-mock">
+          <div class="qrow now">
+            <span class="num">▶</span>
+            <span>
+              <div class="title">Track 8</div>
+              <div class="sub">Cary High Chorus · Fall Concert 2006</div>
+            </span>
+            <span class="dur">3:00</span>
+            <span class="x">×</span>
+          </div>
+          <div class="qrow">
+            <span class="num">2</span>
+            <span>
+              <div class="title">I'm Not in Love</div>
+              <div class="sub">10cc · Very Best Of</div>
+            </span>
+            <span class="dur">6:04</span>
+            <span class="x">×</span>
+          </div>
+          <div class="qrow">
+            <span class="num">3</span>
+            <span>
+              <div class="title">Bixby Canyon Bridge</div>
+              <div class="sub">Death Cab for Cutie · Narrow Stairs</div>
+            </span>
+            <span class="dur">5:15</span>
+            <span class="x">×</span>
+          </div>
+          <div class="qrow bad" style="opacity:0.5;">
+            <span class="num">4</span>
+            <span>
+              <div class="title">Track 9</div>
+              <div class="sub">Cary High Chorus · Fall Concert 2006</div>
+            </span>
+            <span class="dur" style="color:var(--text-md); font-size:12px;">2:20</span>
+            <span class="x">×</span>
+          </div>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 4: metrics units bug ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p0">P0</span>
+          <span class="tag">Units · trust</span>
+          <span class="tag">Metrics</span>
+        </div>
+        <h3>"Memory Usage Mb: 850.4%" — units are detached from values</h3>
+        <p>
+          The metrics dashboard is rendering every value into the same template
+          (<code>{value}{suffix}</code>) without knowing what unit the metric is in. So
+          <strong>Memory Usage Mb</strong> ends up labelled <strong>850.4%</strong>, signal
+          strength is unitless, latency reads as a bare number, and the underscored category names
+          (<code>TTS</code>, <code>RADIO</code>) look like backend leakage. The dashboard is
+          actively eroding trust in its own numbers.
+        </p>
+        <p>
+          The page is also a wall of identical tiles — 16+ scalars rendered with zero hierarchy and
+          zero time context. A metrics dashboard with no <em>trend</em> is a list with extra steps.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Metric registry has the unit baked in (<code>%</code>, <code>MB</code>,
+            <code>ms</code>, <code>count</code>, <code>req/min</code>). Tile reads it; never
+            assumes <code>%</code>.</li>
+            <li>Group tiles by <strong>category</strong> with real sub-headers (System / Audio /
+            Radio / Library / TTS) instead of a tiny grey prefix per tile.</li>
+            <li>Inline <strong>sparkline</strong> for any time-series metric over the selected
+            window — a single <code>&lt;svg&gt;</code> per tile is enough to turn "wall of
+            numbers" into a status board.</li>
+            <li>Color the value only when it's <em>actionable</em>: green for healthy, amber when
+            approaching a threshold, red when over. Don't paint every value cyan.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Metric tiles</span><span class="pill">Before · after</span></div>
+        <div class="compare">
+          <div class="metric-tile bug">
+            <div class="cat">SYSTEM</div>
+            <div class="name">Memory Usage Mb</div>
+            <div class="val">850.4<span class="unit">%</span></div>
+          </div>
+          <div class="metric-tile">
+            <div class="cat">System · Memory</div>
+            <div class="name">Heap in use</div>
+            <div class="val">850<span class="unit">MB</span></div>
+            <div class="delta">▲ 4% vs 1h ago</div>
+            <svg class="spark" viewBox="0 0 120 24" preserveAspectRatio="none">
+              <polyline fill="none" stroke="#5CD4E8" stroke-width="1.5"
+                points="0,18 10,16 20,17 30,14 40,15 50,12 60,13 70,10 80,11 90,8 100,9 110,7 120,6"/>
+              <polyline fill="rgba(92,212,232,0.10)" stroke="none"
+                points="0,18 10,16 20,17 30,14 40,15 50,12 60,13 70,10 80,11 90,8 100,9 110,7 120,6 120,24 0,24"/>
+            </svg>
+          </div>
+        </div>
+        <div class="compare" style="margin-top:10px;">
+          <div class="metric-tile bug">
+            <div class="cat">RADIO</div>
+            <div class="name">Signal Strength</div>
+            <div class="val">65.39</div>
+          </div>
+          <div class="metric-tile">
+            <div class="cat">Radio · Reception</div>
+            <div class="name">Signal strength</div>
+            <div class="val" style="color: var(--sig-green);">65<span class="unit">%</span></div>
+            <div class="delta" style="color: var(--text-md);">Stable · last 5 min</div>
+            <svg class="spark" viewBox="0 0 120 24" preserveAspectRatio="none">
+              <polyline fill="none" stroke="#4ADE80" stroke-width="1.5"
+                points="0,12 10,11 20,13 30,10 40,9 50,11 60,10 70,9 80,10 90,11 100,9 110,10 120,9"/>
+            </svg>
+          </div>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 5: file browser JSON ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p0">P0</span>
+          <span class="tag">Bug</span>
+          <span class="tag">File Browser</span>
+        </div>
+        <h3>The Filter field is showing escaped JSON</h3>
+        <p>
+          The screenshot of the File Browser shows a Filter dropdown whose value reads
+          <code>"\u0022\u0022\\\u0022\\\\\\\\\u0022\\\\\\\\…</code> — a JSON string that was
+          serialized one too many times and is now being rendered as text inside the input. This
+          is the kind of bug that <em>quietly</em> tells a user the system isn't trustworthy.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Find the binding path — likely a filter that's <code>JsonSerializer.Serialize</code>'d
+            for persistence and then bound directly back to a <code>RadzenDropDown</code> value.
+            It should deserialize before bind.</li>
+            <li>Treat the filter as <strong>chips</strong>, not a text input. Each token is one
+            extension (<code>.mp3</code>, <code>.flac</code>, <code>.wav</code>) with an × — no
+            escaping ever needs to happen.</li>
+            <li>The breadcrumb under the input (<code>Home / D:\</code>) is also wired oddly — it
+            shows <code>D:\</code> while the drive selector says <code>C:\</code>. Single source of
+            truth for "current path".</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Filter input</span><span class="pill">Before · after</span></div>
+        <div class="fb-mock">
+          <div style="font-family: var(--font-mono); font-size: 10px; color: var(--text-lo); margin-bottom:6px;">BEFORE</div>
+          <div class="fb-field bad">"\u0022\u0022\\\u0022\\\\\\\\\u0022\\\\\\\\\\\\\\\\\u0022\\\\\\\\\\\\\\\\\\\\\\\\…</div>
+        </div>
+        <div class="fb-mock" style="margin-top:12px;">
+          <div style="font-family: var(--font-mono); font-size: 10px; color: var(--accent); margin-bottom:6px;">AFTER · chips</div>
+          <div class="fb-chips">
+            <span class="fb-chip">.mp3 ×</span>
+            <span class="fb-chip">.flac ×</span>
+            <span class="fb-chip">.wav ×</span>
+            <span class="fb-chip" style="color: var(--text-lo);">+ add type</span>
+          </div>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 6: half-empty pages ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p1">P1</span>
+          <span class="tag">Density</span>
+          <span class="tag">Radio · Devices · Queue · Visualizer</span>
+        </div>
+        <h3>Most secondary pages use 30% of the screen and waste the rest</h3>
+        <p>
+          The radio page renders a small spinner in the middle of an otherwise blank 640px-tall
+          canvas. Devices shows six rows and stops. Queue lists 3 items and leaves ~480px of empty
+          dark. The kiosk has a fixed viewport — there is no fold to scroll to. Empty space below
+          content reads as "broken" or "still loading", not "minimalist".
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Treat each page as a <strong>fixed dashboard</strong>, not a scrolling list.
+            Allocate every region of the 640px content area to a real purpose.</li>
+            <li><strong>Queue</strong>: pair the list with a right-side panel — total runtime,
+            upcoming next 3 with art, "save as playlist" CTA. Already have the data.</li>
+            <li><strong>Devices</strong>: split into two columns (Outputs | Cast destinations),
+            and add a bottom strip with the actively-routed device state.</li>
+            <li><strong>Radio</strong>: while the panel loads, show a skeleton that matches its
+            actual shape (frequency well + band buttons + meter), not a centered spinner.</li>
+            <li><strong>Visualizer</strong>: the chart should fill its panel, not sit in a 60%-width
+            box with empty bands. Also make VU / WAVE / SPECTRUM a segmented control, not three
+            tiny outline buttons hugging the corner.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Queue page · split layout</span><span class="pill">After</span></div>
+        <div style="display: grid; grid-template-columns: 1.5fr 1fr; gap: 8px;">
+          <div class="queue-mock">
+            <div class="qrow now">
+              <span class="num">▶</span>
+              <span><div class="title">Track 8</div><div class="sub">Cary High Chorus</div></span>
+              <span class="dur">3:00</span>
+              <span class="x">×</span>
+            </div>
+            <div class="qrow">
+              <span class="num">2</span>
+              <span><div class="title">I'm Not in Love</div><div class="sub">10cc</div></span>
+              <span class="dur">6:04</span><span class="x">×</span>
+            </div>
+            <div class="qrow">
+              <span class="num">3</span>
+              <span><div class="title">Bixby Canyon</div><div class="sub">Death Cab</div></span>
+              <span class="dur">5:15</span><span class="x">×</span>
+            </div>
+          </div>
+          <div style="display: grid; gap:8px;">
+            <div class="metric-tile">
+              <div class="cat">Queue</div>
+              <div class="name">Total runtime</div>
+              <div class="val" style="color: var(--amber); font-family: var(--font-led); letter-spacing:2px;">2:48:15</div>
+            </div>
+            <div class="metric-tile">
+              <div class="cat">Up next</div>
+              <div class="name" style="color:var(--text-hi); margin-top:6px;">I'm Not in Love</div>
+              <div class="name" style="color:var(--text-md);">Bixby Canyon Bridge</div>
+              <div class="name" style="color:var(--text-lo);">Track 10</div>
+            </div>
+            <div class="metric-tile">
+              <div class="cat">Action</div>
+              <div class="name" style="color: var(--accent); margin-top:4px;">＋  Save as playlist</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 7: no global now playing ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p1">P1</span>
+          <span class="tag">Persistence</span>
+          <span class="tag">All non-home pages</span>
+        </div>
+        <h3>You lose Now Playing the moment you leave Home</h3>
+        <p>
+          The Now Playing panel is mounted only at <code>/</code>. As soon as you tap into
+          Devices, Metrics, History, System, or Phone, the user has <em>no visible playback
+          state</em> — no track, no transport, no progress, no source. They can see the queue
+          count on the nav icon and that's it. On a kiosk with no back-pocket phone next to it,
+          that's a real loss.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Add a <strong>persistent mini-dock</strong> at the bottom edge of every non-home
+            page: 56px tall, art thumbnail · title/artist · transport · progress · source dot.
+            Tapping the title takes you home.</li>
+            <li>SignalR is already pushing this state — no new wiring, just a shared component
+            in <code>MainLayout</code> that hides on <code>/</code> (where Now Playing already
+            owns the column).</li>
+            <li>The dock also gives sleep/wake a visible anchor — pulse it dim during sleep
+            instead of blacking the whole screen.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Persistent dock</span><span class="pill">All non-home pages</span></div>
+        <div class="dock">
+          <div class="art"></div>
+          <div class="meta">
+            <div class="t">Track 8</div>
+            <div class="a">Cary High Chorus · 3:00</div>
+          </div>
+          <div class="eq"><span></span><span></span><span></span></div>
+          <div style="flex:1; height:3px; background: var(--surface-separator); border-radius:2px; overflow:hidden;">
+            <div style="width:42%; height:100%; background: var(--accent);"></div>
+          </div>
+          <div class="tcontrols">
+            ⏮ <span class="pp">▶</span> ⏭
+          </div>
+        </div>
+        <p style="font-size:12px; margin-top:10px; color: var(--text-lo);">
+          Backdrop-blurred, sits over the page above it. Disappears on <code>/</code> where the
+          dedicated Now Playing column owns the job.
+        </p>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 8: source toggle semantics ─── -->
+    <article class="issue">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p1">P1</span>
+          <span class="tag">Interaction</span>
+          <span class="tag">MainLayout · HandleSourceToggleAsync</span>
+        </div>
+        <h3>The source toggle does two different things depending on tap count</h3>
+        <p>
+          Reading <code>HandleSourceToggleAsync</code>: a first tap on a non-active source switches
+          to it. A tap on the <em>already</em>-active radio source toggles the Radio Control panel
+          on the home page. A tap on the active vinyl/bluetooth source navigates to its dedicated
+          page. The user can't predict from looking at the button which of those three things
+          they're about to get.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Source pill = <strong>one action</strong>: switch to that source. Period.</li>
+            <li>"Open detail view" is a separate affordance — a chevron on the active pill, or a
+            dedicated "Source detail" tile in the home layout that's always visible when the
+            active source has one (Radio, Bluetooth).</li>
+            <li>The Radio Control panel currently <em>replaces</em> the Queue/History panel on
+            home. That's a non-obvious state change. Reserve a small persistent strip in the
+            center column for source-specific controls, and keep Queue/History below.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mock">
+        <div class="mock-label"><span>Source pill states</span><span class="pill">After</span></div>
+        <div class="src-strip" style="flex-wrap: wrap;">
+          <span class="src-bubble"><span class="ic">♪</span>File</span>
+          <span class="src-bubble act">
+            <span class="ic">📻</span>FM Radio · 88.5
+            <span style="margin-left:4px; color: var(--amber); opacity:0.7;">›</span>
+          </span>
+          <span class="src-bubble"><span class="ic">⌁</span>Bluetooth</span>
+          <span class="src-bubble dis"><span class="ic">⌖</span>Vinyl · offline</span>
+        </div>
+        <p style="font-size:12px; margin-top:10px; color: var(--text-lo);">
+          The active pill grows a chevron — <em>that's</em> the "open detail" affordance. Tap the
+          body to stay on the source; tap the chevron to open its dedicated panel.
+        </p>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 9: visualizer placement ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p1">P1</span>
+          <span class="tag">Hierarchy</span>
+          <span class="tag">VisualizerPanel</span>
+        </div>
+        <h3>The visualizer panel buries its own modes and shows raw debug</h3>
+        <p>
+          On the home page right column, the visualizer canvas takes ~70% of its panel, three mode
+          buttons (VU / WAVE / SPECTRUM) live in a top-right corner as small outlined chips, a
+          green <strong>Connected</strong> pill sits next to them, and the canvas itself has
+          <strong>"Updates: 22/sec"</strong> burned in as yellow Comic-Sans-y caption text at the
+          bottom-left. That's debug telemetry sitting on a primary visualization.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Mode picker should be a <strong>segmented control across the top</strong> of the
+            panel, full-width — it's the primary control of this view.</li>
+            <li>"Connected" status belongs as a small dot on the panel header, not a labeled pill.
+            And only show <em>red</em> when it's not connected; green-when-fine is noise.</li>
+            <li>"Updates: 22/sec" is dev info — gate it behind the same dev-tools toggle as the
+            distortion marker.</li>
+            <li>Make the visualization itself <strong>fill the panel</strong>. Add per-mode chrome
+            (frequency labels, dB scale) only where it materially helps reading the signal.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 10: scrollbars hidden ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p1">P1</span>
+          <span class="tag">Discoverability</span>
+          <span class="tag">design-system.css §19</span>
+        </div>
+        <h3>Hidden scrollbars + no overflow cue = invisible content</h3>
+        <p>
+          <code>* { scrollbar-width: none; } *::-webkit-scrollbar { display: none; }</code> hides
+          every scrollbar globally. The justification in the comment is "kiosk touch UI" — fine,
+          but the screenshots show several pages (Queue with 45 tracks, Devices, System tabs)
+          where there's clearly more content below the fold and <strong>nothing tells the user
+          that</strong>. The History page also crops a tall content block at ~520px with no
+          gradient or chevron.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Keep the bar hidden, but add a <strong>thin always-visible thumb</strong> (~3px
+            wide, 30% opacity) on scrollable panels so the user knows there's more.</li>
+            <li>Or: a fading mask at the bottom edge of any panel whose content is taller than its
+            box. The CSS is one declaration:
+            <code>mask-image: linear-gradient(to bottom, #000 calc(100% - 24px), transparent)</code>.</li>
+            <li>For touch lists, add a momentum-style "✨ scroll for more · N items below"
+            sentinel that fades in when more is hidden.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 11: empty/loading states ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p2">P2</span>
+          <span class="tag">States</span>
+          <span class="tag">Cross-cutting</span>
+        </div>
+        <h3>Loading and empty states are mostly centered spinners</h3>
+        <p>
+          Radio panel: centered <code>RadzenProgressBarCircular</code> in a 640×688 void. Queue
+          panel before data: blank. Devices when there are no Cast devices: nothing. The
+          design-system already defines <code>.skeleton-text</code>, <code>.skeleton-card</code>,
+          <code>.empty-state</code>, and a shimmer animation — they just aren't used.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Replace every spinner with a <strong>shape-matched skeleton</strong>: Now Playing
+            shows blurred art placeholder + 2 text bars + transport row; Radio shows freq-well +
+            band buttons + meter; Queue shows 6 ghosted rows.</li>
+            <li>Build a small <code>&lt;EmptyState Icon Title Action /&gt;</code> Razor component
+            and use it everywhere — current empty handling is ad-hoc.</li>
+            <li>For network/API failures, surface a single inline banner (not a Radzen toast that
+            pops outside the kiosk surface) with a retry button at touch size.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 12: debug button ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p2">P2</span>
+          <span class="tag">Production hygiene</span>
+          <span class="tag">MainLayout.razor:51</span>
+        </div>
+        <h3>The "distortion marker" debug button is in the production top bar</h3>
+        <p>
+          The comment in <code>MainLayout.razor</code> literally says
+          <em>"Debug: Distortion Marker (temporary — remove when done diagnosing)"</em>. It's still
+          there. It will be there in six months. It pops a 1-second color flash on every press —
+          a touch-friendly target for accidental input.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Move it behind a build-flag gate (<code>#if DEBUG</code>) or a
+            <code>config.diagnostics.enabled</code> setting that defaults false.</li>
+            <li>Better: a hidden <strong>tap-and-hold-corner gesture</strong> opens a dev panel
+            with this and any other diagnostic actions (audio frame dump, log download). The
+            corner is invisible to normal users and free in screen real estate.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 13: contrast & font weight ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p2">P2</span>
+          <span class="tag">Legibility</span>
+          <span class="tag">Type system</span>
+        </div>
+        <h3>Secondary text leans too dim for a 2-foot kiosk viewing distance</h3>
+        <p>
+          <code>--text-medium: #9CA3AF</code> on <code>--surface-base: #0D0D0F</code> hits ~6.8:1 —
+          fine on paper, fine on a desk monitor. On a glossy 12.5" touchscreen at 2-3 feet,
+          combined with smaller body text (13–14px in side panels), several places in the
+          screenshots read as "noise" rather than information. The History "Statistics" sub-labels
+          and the metric category prefixes are good examples.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Bump <code>--text-medium</code> to ~<code>#B5BCC9</code> (~9:1) for body, and reserve
+            the current value for <em>tertiary</em> metadata only.</li>
+            <li>Minimum size for any persistent UI string is 14px. Headers and metric values that
+            people glance at across the room should be 18–20px+.</li>
+            <li>Touch-screen calibration matters: ship the theme in two flavors —
+            <code>desk</code> (current) and <code>kiosk</code> (heavier base weight, ~10% larger
+            type scale, slightly elevated contrast) — and pick at startup based on a config flag.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+
+    <!-- ─── ISSUE 14: status semantics ─── -->
+    <article class="issue no-mock">
+      <div>
+        <div class="issue-head">
+          <span class="severity sev-p2">P2</span>
+          <span class="tag">Semantics</span>
+          <span class="tag">Devices · Audio Engine</span>
+        </div>
+        <h3>Status badges all look like "Available" — including the broken ones</h3>
+        <p>
+          On the System Stats page: <strong>Audio Engine State: Active - FilePlayer (Stopped)</strong>
+          — both "Active" and "Stopped" in the same string with no visual indicator of whether
+          this is good or bad. On Devices, every row says <code>Available</code> in the same blue
+          pill that <code>Default</code> uses. Cast disconnect/connect uses transient toasts that
+          don't persist.
+        </p>
+        <div class="fix">
+          <div class="label">Recommendation</div>
+          <ul class="tight">
+            <li>Reserve <strong>color</strong> for state, <strong>pills</strong> for active /
+            default markers, and <strong>plain text</strong> for "Available" (it's the steady
+            state, not a status).</li>
+            <li>Parse the Audio Engine string into a structured tuple: <em>{ active, current
+            source, current state }</em>. Render with three distinct affordances.</li>
+            <li>Persist Cast connect/disconnect to a small <strong>event ribbon</strong> below the
+            dock — last 3 events, auto-clear after 30s. Toasts that don't stick are forgotten
+            information.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+  </section>
+
+
+  <!-- ───────────── Page-by-page ───────────── -->
+  <section id="pages">
+    <div class="section-head">
+      <span class="section-num">04</span>
+      <h2>Page-by-page summary</h2>
+      <span class="section-sub">One row per surface</span>
+    </div>
+
+    <table class="ptable">
+      <thead>
+        <tr><th>Page</th><th>What's there now</th><th>What to add or change</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="name">Home <span style="color:var(--text-lo); font-weight:400;">/</span></td>
+          <td class="is">3-column: Now Playing 520 · Queue/History 688 · Visualizer 710.
+          Strong shape, but the middle column flips between Queue and Radio Control with no
+          breadcrumb back to Queue.</td>
+          <td class="fix">Add a thin <strong>mode toggle</strong> in the middle column header
+          (Queue · History · Radio) so the user knows what they're looking at and can switch back.
+          Make the Visualizer mode picker live in <em>its</em> panel header, full width.</td>
+        </tr>
+        <tr>
+          <td class="name">Radio <span style="color:var(--text-lo); font-weight:400;">/radio</span></td>
+          <td class="is">Currently shows a centered spinner over an empty 640px void on first
+          load. Real content (frequency well, band buttons, signal meter, presets) takes ~50% of
+          the page when loaded.</td>
+          <td class="fix">Shape-matched skeleton on load. Use the right half for <strong>presets
+          + RDS now-playing</strong>, currently absent. Promote frequency entry from a dialog to
+          an inline numpad on the right column.</td>
+        </tr>
+        <tr>
+          <td class="name">Queue <span style="color:var(--text-lo); font-weight:400;">/ via home</span></td>
+          <td class="is">Title-only header, ADD FILES / CLEAR ALL in opposite corner of the
+          screen from the items. Trash icon as the only row action. No reorder. Duration in
+          ticks.</td>
+          <td class="fix">Drag handle on the left (already a touch token at 56px), kebab on the
+          right with reorder/jump/save. Side panel with total runtime + up-next preview.
+          Sticky "playing now" indicator at the top of the list.</td>
+        </tr>
+        <tr>
+          <td class="name">Devices <span style="color:var(--text-lo); font-weight:400;">/devices</span></td>
+          <td class="is">Single flat table; same blue pill for "Default" and "Available" so they
+          read as related states.</td>
+          <td class="fix">Split into <strong>Outputs | Cast targets</strong>. "Available" is the
+          baseline, no badge. Add a small device card on the right showing current routing,
+          format (sample rate · channels), and a "Test tone" button.</td>
+        </tr>
+        <tr>
+          <td class="name">Metrics <span style="color:var(--text-lo); font-weight:400;">/metrics</span></td>
+          <td class="is">16+ identical scalar tiles, unit bugs (850.4%), no grouping, no trend.</td>
+          <td class="fix">Group by category with sub-headers; per-tile sparkline; semantic value
+          color (green/amber/red against threshold); fix the unit registry.</td>
+        </tr>
+        <tr>
+          <td class="name">History <span style="color:var(--text-lo); font-weight:400;">/history</span></td>
+          <td class="is">Heavy filter bar; "Plays by Source" rendered as ~equal blue chips
+          (39/66/43/2) so the eye can't read the distribution.</td>
+          <td class="fix">Replace the chip row with a <strong>horizontal bar chart</strong> (one
+          line, five segments, source-colored). Smarter date formatting. The History table is
+          fine — just give it more vertical space by collapsing the filter into a single row.</td>
+        </tr>
+        <tr>
+          <td class="name">System <span style="color:var(--text-lo); font-weight:400;">/system</span></td>
+          <td class="is">Tab strip with 7 tabs in one row, mixed icon weights. System Stats cards
+          have uneven heights. Audio Engine State card is half-empty.</td>
+          <td class="fix">Consider <strong>left-rail tabs</strong> (vertical) on this page — 7 is
+          a lot for a horizontal strip on touch. Use a 2×3 metric grid with uniform card
+          heights and a single tall "platform" card on the right.</td>
+        </tr>
+        <tr>
+          <td class="name">Phone <span style="color:var(--text-lo); font-weight:400;">/phone</span></td>
+          <td class="is">Has its own scoped CSS file — not audited from screenshots.</td>
+          <td class="fix">Make sure it uses the same dock/route-toggle vocabulary as the rest of
+          the app; phone is an output, not a separate paradigm.</td>
+        </tr>
+        <tr>
+          <td class="name">File Browser <span style="color:var(--text-lo); font-weight:400;">dialog</span></td>
+          <td class="is">JSON-escape bug in filter; breadcrumb / drive mismatch; small folder
+          icons.</td>
+          <td class="fix">Filter as chips. One source of truth for current path. Larger folder
+          icons (current ones are ~24px, should be 36–40px for touch list rows). Recent paths
+          docked to the right.</td>
+        </tr>
+        <tr>
+          <td class="name">Bluetooth <span style="color:var(--text-lo); font-weight:400;">/bluetooth</span></td>
+          <td class="is">Not in screenshots; exists in <code>Pages/</code>.</td>
+          <td class="fix">Treat as a parallel of the Radio detail surface: device list + pairing
+          status + current AVRCP metadata + volume / EQ. Same chrome.</td>
+        </tr>
+        <tr>
+          <td class="name">Diagnostic <span style="color:var(--text-lo); font-weight:400;">/diagnostic</span></td>
+          <td class="is">Internal page.</td>
+          <td class="fix">Move the distortion marker, fingerprint detail panel, and "Updates/sec"
+          telemetry here behind a gesture-unlocked entry.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+
+  <!-- ───────────── System-level ───────────── -->
+  <section id="system">
+    <div class="section-head">
+      <span class="section-num">05</span>
+      <h2>System-level recommendations</h2>
+      <span class="section-sub">Cuts across pages</span>
+    </div>
+
+    <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px;">
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">A. One formatting layer</h4>
+        <p>Create <code>Radio.Web/Formatting/</code> with <code>FormatDuration</code>,
+        <code>FormatTimestamp</code>, <code>FormatFrequency</code>, <code>FormatBytes</code>,
+        <code>FormatPercent</code>, <code>FormatDeviceName</code>, <code>FormatSourceName</code>.
+        Forbid passing raw DTOs into Razor templates. This single discipline removes ~half the P0
+        findings above.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">B. Skeleton + empty kit</h4>
+        <p>Three Razor components: <code>&lt;Skeleton Shape="now-playing | radio | list" /&gt;</code>,
+        <code>&lt;EmptyState Icon Title Body Action /&gt;</code>,
+        <code>&lt;ErrorState Title Detail Retry /&gt;</code>. Every async-bound surface uses one of
+        these in its <code>@if(_loading)</code> branch.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">C. Persistent now-playing dock</h4>
+        <p>Mount once in <code>MainLayout</code>, hide on <code>/</code>. Reads from the same
+        <code>AudioStateHubService</code> already feeding the home page. ~80 lines of Razor +
+        a slot in the layout grid.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">D. Dev-tools gate</h4>
+        <p>Triple-tap the top-right corner of the clock to unlock a dev tray containing the
+        distortion marker, fingerprint event log, updates/sec, frame dump, log download. Locks
+        again after 30s of no interaction.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">E. Motion budget</h4>
+        <p>You have 30+ <code>@keyframes</code> defined. The screenshots don't show any of them
+        in play. Pick six (page-transition, list-add, list-remove, ken-burns, eq-bounce,
+        track-change) and enforce them on the surfaces that need them. Delete or hide the rest
+        until they're used — they're vocabulary debt right now.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">F. Sleep is a screen, not a JS hack</h4>
+        <p>The current sleep flow blacks the screen via JS + a Blazor call. Treat sleep as a
+        first-class route (<code>/sleep</code>) with an ambient view — large clock, faint album
+        art, a single "tap anywhere" hint. Wake on any interaction. Makes the device feel less
+        like "off" and more like "resting".</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">G. Accessibility passes you'll want anyway</h4>
+        <p>Add <code>aria-label</code> on every icon-only button (90% of the top bar). Make
+        focus rings visible — currently
+        <code>-webkit-tap-highlight-color: transparent</code> across the board removes both touch
+        and keyboard feedback. Use Radzen's <code>Tooltip</code> on the icon nav so the labels
+        appear on long-press.</p>
+      </div>
+
+      <div class="strength" style="background: var(--surface-raised);">
+        <h4 style="color: var(--accent); margin-bottom: 10px;">H. Tighter "source / output" model in UI</h4>
+        <p>Currently three things hold related state: <code>SourcesApiService</code>,
+        <code>DevicesApiService</code>, <code>AudioStateHubService</code>. The UI binds to each
+        separately and races on first load (you'll see brief mismatches in the screenshots —
+        topbar shows FilePlayer source while Now Playing card says Radio). One Razor-side
+        <code>RoutingViewModel</code> that <em>derives</em> from the hub and exposes <code>{
+        source, output, route, isReady }</code> would remove a class of glitches.</p>
+      </div>
+
+    </div>
+  </section>
+
+
+  <!-- ───────────── Roadmap ───────────── -->
+  <section id="roadmap">
+    <div class="section-head">
+      <span class="section-num">06</span>
+      <h2>Suggested order of attack</h2>
+      <span class="section-sub">Three phases · ~3 sprints</span>
+    </div>
+
+    <div class="roadmap">
+      <div class="phase">
+        <div class="pnum">01</div>
+        <div class="pname">Stop the bleeding</div>
+        <ul>
+          <li>Formatting layer for durations, timestamps, sizes</li>
+          <li>Fix the metrics unit registry · kill <code>850.4%</code></li>
+          <li>Fix the File Browser filter JSON-escape bug</li>
+          <li>Strip the distortion-marker debug from production chrome</li>
+          <li>UUID-suffixed source IDs out of dropdowns</li>
+        </ul>
+      </div>
+      <div class="phase">
+        <div class="pnum">02</div>
+        <div class="pname">Finish the surface</div>
+        <ul>
+          <li>Persistent now-playing dock on non-home pages</li>
+          <li>Skeleton kit + EmptyState component, applied everywhere</li>
+          <li>Redesigned top bar — labeled route + nav zones</li>
+          <li>Single-action source pills + explicit "open detail" affordance</li>
+          <li>Metrics: groups, sparklines, semantic color</li>
+        </ul>
+      </div>
+      <div class="phase">
+        <div class="pnum">03</div>
+        <div class="pname">Polish + scale</div>
+        <ul>
+          <li>Queue split layout, history bar chart, devices two-column</li>
+          <li>Visualizer mode picker promoted to panel header</li>
+          <li>Dev-tools gesture + diagnostic page consolidation</li>
+          <li>Sleep as a first-class ambient screen</li>
+          <li>Accessibility + focus pass; <code>kiosk</code> type-scale variant</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+
+  <div class="endplate">
+    <span>Radio.Web · Design Review</span>
+    <span>· · ·</span>
+    <span>Generated · v1 · 2026</span>
+  </div>
+
+</div>
+
+<script>
+  // Light: live clock in the rail
+  function tick() {
+    const d = new Date();
+    const h = String(d.getHours()).padStart(2, '0');
+    const m = String(d.getMinutes()).padStart(2, '0');
+    document.getElementById('clock').textContent = h + ':' + m;
+  }
+  tick();
+  setInterval(tick, 30000);
+</script>
+</body>
+</html>

--- a/docs/design-handoffs/design_handoff_radio_console/Handoff Canvas.html
+++ b/docs/design-handoffs/design_handoff_radio_console/Handoff Canvas.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Radio Console — Visual Handoff</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<style>
+  html, body { margin: 0; padding: 0; background: #f0eee9; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="mocks.jsx"></script>
+<script type="text/babel" src="app.jsx"></script>
+</head>
+<body>
+<div id="root"></div>
+</body>
+</html>

--- a/docs/design-handoffs/design_handoff_radio_console/IMPLEMENTATION.md
+++ b/docs/design-handoffs/design_handoff_radio_console/IMPLEMENTATION.md
@@ -1,0 +1,570 @@
+# Implementation Script — Radio Console Design Tightening
+
+> **For the implementing agent (Claude Code or human):**
+> This script maps one canvas artboard → one set of file changes. Land changes in the order given. Do not start any section whose status is not `[APPROVED]`.
+>
+> Every section uses the same shape:
+> 1. **Reference** — which artboard / which finding
+> 2. **Files** — exact paths to touch
+> 3. **Steps** — numbered, concrete
+> 4. **Acceptance** — checkable criteria
+> 5. **Notes** — gotchas, dependencies, what NOT to change
+>
+> Tokens to use are in `src/Radio.Web/wwwroot/css/design-system.css`. Do not invent new colors, type, or spacing — extend the token block first if you genuinely need a new value.
+
+---
+
+## P0 — Fix before anything else
+
+These are bugs, data hygiene problems, and production-hygiene issues that the design system can't paper over.
+
+---
+
+### P0·0 — Formatting layer (foundation)
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Underpins P0·2, P0·3, P1·3 and the Metrics work in P0·4.
+**Files:**
+- `src/Radio.Web/Formatting/Durations.cs` (new)
+- `src/Radio.Web/Formatting/Timestamps.cs` (new)
+- `src/Radio.Web/Formatting/DisplayNames.cs` (new)
+- `src/Radio.Web/Formatting/Units.cs` (new)
+- `src/Radio.Web/_Imports.razor` (add `@using Radio.Web.Formatting`)
+
+**Steps:**
+
+1. Create the `Radio.Web.Formatting` namespace as a flat folder of `static class` helpers. No DI, no state.
+
+2. `Durations.FormatTrack(TimeSpan t)`:
+   - `t < 1 hour` → `"{m}:{ss:00}"` (e.g. `3:00`)
+   - `t >= 1 hour` → `"{h}:{mm:00}:{ss:00}"` (e.g. `1:02:14`)
+   - `t.TotalSeconds < 1 || t == TimeSpan.Zero` → `"—"`
+   - `null` → `"—"`
+
+3. `Durations.FormatLong(TimeSpan t)` for queue totals: always `h:mm:ss` form (e.g. `2:48:15`).
+
+4. `Timestamps.FormatRelative(DateTime utc)`:
+   - Same calendar day → `"Today {HH:mm}"`
+   - Yesterday → `"Yesterday {HH:mm}"`
+   - Older than 48h → `"{MMM d} · {HH:mm}"`
+   - Caller is responsible for converting from UTC to local before display.
+
+5. `DisplayNames.Source(AudioSourceDto s)`:
+   - Strip any `-{guid}` suffix from `Id` if `Name` is missing.
+   - Return `Name` if set, else humanized `Type` (`"FilePlayer"` → `"File Player"`).
+   - **Never** return the raw `Id`.
+
+6. `DisplayNames.Device(AudioDeviceDto d, IDictionary<string,string>? aliasMap = null)`:
+   - Apply `aliasMap` first (e.g. `"CABLE Input (VB-Audio Virtual Cable)" → "VB-Audio Cable"`). The map should live in `appsettings.json` under `Devices:Aliases`.
+   - Strip trailing parenthesized hardware-driver suffixes when the head is sufficiently descriptive (`"LG TV SSCR2 (AMD High Definition Audio Device)"` → `"LG TV"`).
+   - Strip leading `"N - "` enumeration prefixes.
+   - Cap at 40 chars with ellipsis.
+
+7. `DisplayNames.Track(NowPlayingDto np)`:
+   - Prefer `np.Title` if non-empty and not literally `"Track {n}"` filename-derived.
+   - When `Title` looks generic, attempt to parse the source `FilePath`: strip extension, strip leading `^\d+[\s\-_]+` (track number), title-case if all-lowercase.
+   - Subtitle is `np.Artist ?? "—"`.
+
+8. `Units` enum and `Units.Format(double value, Units unit)`:
+   ```csharp
+   public enum Units {
+     Percent,       // 35.7%
+     Megabytes,     // 850 MB
+     Milliseconds,  // 215 ms (>=1000 → "1.2 s")
+     Count,         // 135,725
+     PerMinute,     // 12.4/min
+     Frequency,     // 88.5 MHz (uses existing FrequencyFormatter)
+     Decibels,      // -3 dB
+     Bare           // 65
+   }
+   ```
+   - Always thousands-separated for `Count`.
+   - One decimal for `Percent` if value < 10, else integer.
+
+**Acceptance:**
+
+- [ ] All four files compile, exist under `Radio.Web.Formatting`, are referenced from at least one Razor file by end of P0·1.
+- [ ] `Durations.FormatTrack(TimeSpan.FromSeconds(180.6628))` → `"3:00"`.
+- [ ] `DisplayNames.Source` never returns a string containing a GUID character span (regex: `[0-9a-f]{8}-[0-9a-f]{4}`).
+- [ ] No `.ToString()` on a `TimeSpan` remains anywhere in `Components/` after P0·3 lands.
+
+**Notes:**
+
+This file is small but it is the single biggest leverage in the package — three later P0s depend on it. Land this first, even if it goes out behind a feature flag.
+
+---
+
+### P0·1 — Top bar redesign
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0 — fix before anything else` → **"Top bar redesign"**
+**Files:**
+- `src/Radio.Web/Components/Layout/MainLayout.razor`
+- `src/Radio.Web/wwwroot/css/design-system.css` (`§5 Top Bar`, `§6 Route Toggle`, `§7 Navigation Icons`)
+
+**Steps:**
+
+1. **Bump topbar height** from `80px` → `120px` in `design-system.css §2`:
+   - `--topbar-height: 120px;`
+   - `--content-height: 600px;`
+   - Verify nothing else hard-codes 720/640 split (search the project for `640px` and `80px`).
+
+2. **Restructure the topbar** in `MainLayout.razor` from one flex row into a two-row stack inside `.topbar`:
+   - Row 1 (`.topbar-primary`, 64px) — Time cluster | In cluster | `→` glyph | Out cluster | nav pill strip.
+   - Row 2 (`.topbar-sources`, 56px) — Source bubble strip, left-aligned.
+
+3. **Add `.cluster` styles** in `design-system.css §5`:
+   - `.cluster-label` — uses `var(--font-mono)`, `10px`, `0.16em` letter-spacing, `var(--text-low)`, uppercase.
+   - `.cluster-value` — `15px`, `var(--text-high)`, `font-weight: 500`. May contain an inline `--font-led` numeric span for frequency / clock time.
+   - `.cluster-swatch` — `8×8` square, `2px` radius, used to show the source / output color dot inline with the value.
+
+4. **Replace the nine circular `.nav-icon` buttons** with rectangular `.nav-pill`:
+   - `height: 56px; padding: 0 16px; border-radius: 10px;`
+   - Contains label text (Inter, `12px`, `0.10em` letter-spacing, uppercase, 500 weight) — no more icon-only navigation in the top row.
+   - Active state: `background: var(--accent-dim); color: var(--accent);`
+   - Badge variant for Queue count: `<span class="nav-badge">45</span>` styled as amber pill, 10px font.
+
+5. **Source bubbles** — extract into `Components/Shared/SourceBubble.razor`:
+   - Props: `Icon`, `Label`, `Sub`, `Accent` (CSS variable name), `IsActive`, `IsDisabled`, `HasDetail`, `OnSwitch`, `OnOpenDetail`.
+   - Render: pill shape (`height: 48px; border-radius: 24px`), 28×28 round icon chip on the left, label + optional sub.
+   - When `IsActive`, use `background: {accent}14; border: 1px solid {accent}55; color: {accent};`.
+   - When `IsActive && HasDetail`, render a trailing `›` glyph as a separate focusable element bound to `OnOpenDetail`.
+   - When `IsDisabled`, `opacity: 0.4; pointer-events: none;` and append " · offline" to the sub.
+
+6. **Remove the inline `RadzenButton` debug distortion marker** from `MainLayout.razor` (lines ~48–55). Move it to the dev tray in P2·2. Until P2·2 ships, gate it behind `#if DEBUG` so it never appears in release builds.
+
+7. **Sticky/fixed positioning:** the existing `position: fixed` on `.topbar` is fine; just verify the content offset (`margin-top` on `.content-area`) tracks `--topbar-height` not a hard 80.
+
+**Acceptance:**
+
+- [ ] Top bar matches the "After" artboard within ±2px on a 1920-wide preview.
+- [ ] No circular pill remains anywhere in the top bar.
+- [ ] Active source AND active output both show their human name, not just a colored icon.
+- [ ] Debug button is gone from release builds.
+- [ ] Content pages still vertically fit (600px content area) without scrollbars on Home/Devices/Queue.
+
+**Notes:**
+
+The current `route-toggle` CSS class is referenced from `MainLayout.razor` only. Safe to delete after the migration. The `data-source` attribute mechanism (per-source color) moves onto `SourceBubble` — keep the attribute name so any existing tests don't break.
+
+---
+
+### P0·2 — Surface clean display names
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0` → **"Source & device names"**
+**Files:**
+- `src/Radio.Web/Components/Layout/MainLayout.razor`
+- `src/Radio.Web/Components/Shared/NowPlayingPanel.razor`
+- `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor`
+- `src/Radio.Web/Components/Pages/DeviceManagementPage.razor`
+- `src/Radio.Web/Components/Dialogs/FileBrowserDialog.razor`
+- `src/Radio.Web/appsettings.json` (`Devices:Aliases` map)
+
+**Steps:**
+
+1. Add `Devices:Aliases` to `appsettings.json`:
+   ```json
+   "Devices": {
+     "Aliases": {
+       "CABLE Input (VB-Audio Virtual Cable)": "VB-Audio Cable In",
+       "CABLE In 16ch (VB-Audio Virtual Cable)":  "VB-Audio Cable 16ch",
+       "Realtek Digital Output (Realtek USB Audio)": "Realtek USB · S/PDIF"
+     }
+   }
+   ```
+   Bind into a typed `DevicesOptions` and inject where needed.
+
+2. In every place that currently binds a raw DTO field to a string template, replace with the appropriate `DisplayNames.*` call from P0·0.
+   - In MainLayout: source bubble `Label` = `DisplayNames.Source(source)`.
+   - In NowPlayingPanel: title/subtitle = `DisplayNames.Track(np)`.
+   - In Device tables: name = `DisplayNames.Device(d, aliasMap)`.
+
+3. Add a `title` attribute (HTML tooltip) on every display-name element so the **raw** name is reachable on hover — useful for debugging and accessibility.
+
+**Acceptance:**
+
+- [ ] No GUID character span (`[0-9a-f]{8}-[0-9a-f]{4}`) appears in any user-visible text on Home, Devices, Queue, History, File Browser.
+- [ ] `Track 8` / `Track 9` from `Cary High Chorus / Fall Concert 2006` displays as the parsed file name when available.
+- [ ] Long device strings are capped at 40 chars + ellipsis; full name on hover.
+
+**Notes:**
+
+Don't change the DTOs themselves — keep the raw fields available server-side. Only the *display projection* changes.
+
+---
+
+### P0·3 — Duration & timestamp formatting
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0` → **"Queue rows & duration format"**
+**Files:**
+- `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor`
+- `src/Radio.Web/Components/Shared/NowPlayingPanel.razor`
+- `src/Radio.Web/Components/Pages/PlayHistoryPage.razor`
+
+**Steps:**
+
+1. Replace every `@track.Duration.ToString()` with `@Durations.FormatTrack(track.Duration)`.
+2. Replace every progress-display `@_elapsed.ToString(@"mm\:ss")` with `@Durations.FormatTrack(_elapsed)` to handle the `>1h` long-form case.
+3. PlayHistory: replace the Date/Time column format with `@Timestamps.FormatRelative(row.PlayedAtUtc.ToLocalTime())`.
+4. Add `font-variant-numeric: tabular-nums;` to any element that displays a duration so columns line up.
+5. Right-align duration columns in tables.
+6. Add the now-playing accent treatment to the queue list:
+   - Currently-playing row gets `border-left: 3px solid var(--signal-amber);` and the number cell shows `▶` instead of its index.
+
+**Acceptance:**
+
+- [ ] No `00:03:00.6628571`-style duration appears anywhere.
+- [ ] Queue rows have a clear "this is what's playing" indicator (amber left border + ▶ glyph).
+- [ ] History "Date/Time" column reads as `Today 08:40`, `Yesterday 14:22`, or `Feb 6 · 11:05` depending on age.
+
+---
+
+### P0·4 — Metrics dashboard — units, grouping, sparklines
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0` → **"Metrics tiles"**
+**Files:**
+- `src/Radio.Web/Components/Pages/MetricsDashboardPage.razor`
+- `src/Radio.Web/Components/Shared/MetricTile.razor` (new)
+- `src/Radio.Web/Components/Shared/Sparkline.razor` (new)
+- API/model: wherever `MetricDescriptor` is declared (likely `Radio.Metrics`) — add a `Unit` field.
+
+**Steps:**
+
+1. **Add a `Unit` enum** to each metric descriptor on the server side. Defaults to `Bare` when unknown. Match the enum in `Radio.Web.Formatting.Units`.
+
+2. **`MetricTile.razor`** — parameters:
+   ```
+   Category (string, e.g. "System · Memory")
+   Name (string, e.g. "Heap in use")
+   Value (double)
+   Unit (Units)
+   Series (IReadOnlyList<double>?, last N samples) — optional
+   Thresholds (double? warn, double? critical) — optional
+   ```
+   Render:
+   - Top: category in mono, 10px, uppercase, low contrast.
+   - Middle: name in body, 13px, medium contrast.
+   - Big value: `--font-mono`, 30px, color computed from thresholds (green / amber / red), or `--text-high` when no threshold.
+   - Sparkline: if `Series` provided, render `<Sparkline />` matched to value color.
+
+3. **`Sparkline.razor`** — pure inline SVG, `viewBox="0 0 120 28" preserveAspectRatio="none"`, takes a `IReadOnlyList<double>` and a `Stroke` parameter. Filled area at 10% opacity below the line.
+
+4. **Restructure `MetricsDashboardPage.razor`**:
+   - Group tiles by category. Render each group with a sub-header (mono, 11px, uppercase, low contrast, 14px bottom margin).
+   - 2- or 4-column grid depending on density target.
+   - Remove the wall-of-tiles layout.
+
+5. **Specific fixes from the current screenshots:**
+   - `Memory Usage Mb` value is in MB not %. Unit = `Megabytes`. Tile shows `850 MB`, not `850.4%`.
+   - `Signal Strength` value is bare. Unit = `Percent`. Tile shows `65%`.
+   - `Frequency Changes` is a count — Unit = `Count`, format with thousands separator.
+   - `Latency Ms` — Unit = `Milliseconds`, formatter auto-converts to `s` above 1000.
+
+**Acceptance:**
+
+- [ ] Memory usage tile reads `850 MB` (or current value with unit `MB`) — never `%`.
+- [ ] Each tile shows a sparkline when time-series data is available for that metric in the selected window.
+- [ ] Category headers replace the per-tile category prefix.
+- [ ] Tile value color matches threshold semantics (green/amber/red) — not every tile is cyan.
+
+---
+
+### P0·5 — File Browser filter — chips, no string
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0` → **"File browser filter"**
+**Files:**
+- `src/Radio.Web/Components/Dialogs/FileBrowserDialog.razor`
+
+**Steps:**
+
+1. Locate the current filter state. It is almost certainly a `string` bound to a `RadzenDropDown` whose value is being JSON-serialized for persistence and re-bound on load without deserializing. Find the persistence boundary (look for `JsonSerializer.Serialize` calls referencing a filter or for `LocalStorage`-backed filter persistence).
+
+2. Replace with:
+   - `List<string> _filterExtensions = new();`
+   - On load, deserialize from persistence into the list directly. If the persisted blob is the double-escaped form, run a one-time repair pass (parse repeatedly until you get a `string[]`, then take it).
+
+3. Render as a row of `RadzenChip` elements, each with a remove `×`. Append a dashed `＋ add type` chip that opens a small popover with a curated set of common extensions (`.mp3 .flac .wav .m4a .aac .ogg .opus .wma`).
+
+4. Wire the filter into the file list query: case-insensitive `EndsWith` match across the list.
+
+**Acceptance:**
+
+- [ ] No escaped JSON ever appears in the filter UI.
+- [ ] Chips reorder and remove cleanly; persistence round-trips without re-escaping.
+- [ ] Adding `.mp3` filters the file list immediately, no Apply button.
+
+**Notes:**
+
+Also fix the breadcrumb / drive selector mismatch noted in the audit — the screenshot shows drive `C:\` selected while the breadcrumb reads `D:\`. They should bind to the same source of truth (`_currentPath`).
+
+---
+
+## P1 — Big quality wins
+
+These don't fix bugs, they fix the *shape* of the product.
+
+---
+
+### P1·1 — Persistent Now Playing dock
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1 — big quality wins` → **"Persistent Now Playing dock"**
+**Files:**
+- `src/Radio.Web/Components/Shared/NowPlayingDock.razor` (new)
+- `src/Radio.Web/Components/Layout/MainLayout.razor`
+- `src/Radio.Web/wwwroot/css/design-system.css` (new `§N Dock`)
+
+**Steps:**
+
+1. Build `NowPlayingDock.razor`:
+   - Height: 64px, sits at the bottom edge of the content area.
+   - Layout (left → right): art thumbnail 48×48 → title + artist → 3-bar EQ animation (existing `.now-playing-bars` keyframes) → elapsed `mm:ss` → progress bar (3px, `--accent`) → total `mm:ss` → ⏮ play/pause ⏭.
+   - Subscribes to `AudioStateHubService.NowPlayingChanged` and `.PlaybackStateChanged` only — no additional polling.
+   - On click anywhere on the title/art block, `NavigationManager.NavigateTo("/")`.
+   - Backdrop: `background: var(--surface-overlay); backdrop-filter: blur(20px); border-top: 1px solid var(--surface-separator);`.
+
+2. Mount in `MainLayout.razor`:
+   - Place inside `.content-area` as a sibling of `.page-transition`, absolute-positioned to the bottom.
+   - Render only when `NavigationManager.ToBaseRelativePath(Uri) is not "" or "/"` — i.e. not on Home (where `NowPlayingPanel` owns the column).
+   - When dock is rendered, reduce `.page-transition`'s effective height by 64px so content doesn't slide under it.
+
+3. Add the source color dot next to the artist line (8×8 square, 2px radius) using the existing `--source-*` variables.
+
+**Acceptance:**
+
+- [ ] Navigating from `/` → `/devices` reveals the dock; navigating back to `/` removes it cleanly.
+- [ ] The dock shows the same track / state as the home page within one SignalR round-trip.
+- [ ] Tapping the title takes the user home.
+- [ ] No layout shift when track changes (use `min-width: 200px` on the metadata block).
+
+---
+
+### P1·2 — Source pill semantics
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1` → **"Source pill semantics"**
+**Files:**
+- `src/Radio.Web/Components/Layout/MainLayout.razor` (method `HandleSourceToggleAsync`)
+- `src/Radio.Web/Components/Shared/SourceBubble.razor` (from P0·1)
+
+**Steps:**
+
+1. Delete the second-tap-toggles-panel and second-tap-navigates branches in `HandleSourceToggleAsync`. Tapping a source's body **always** switches to that source. Period.
+
+2. In `SourceBubble.razor`, render the active pill with a trailing `›` chevron when `HasDetail == true`. The chevron is a separate clickable element with its own `OnOpenDetail` handler. Stop the click event from bubbling to the body.
+
+3. `HasDetail` is true for source types that have a dedicated detail surface: `Radio`, `RTLSDRCore`, `RF320`, `Bluetooth`. Not for `File`, `USB`.
+
+4. When chevron is tapped:
+   - Radio family → `NavigateTo("/")` + show Radio control panel via `RadioPanelToggleService.ShowRadioPanelAsync()`.
+   - Bluetooth → `NavigateTo("/bluetooth")`.
+
+5. The current `RadioPanelToggleService` should no longer be flipped by source-tap. Only by explicit chevron tap or by an in-panel close. Audit calls to `ToggleRadioPanelAsync()` and remove the tap-driven ones.
+
+**Acceptance:**
+
+- [ ] Tapping any source pill switches to that source exactly once, never opens a panel.
+- [ ] The active source pill shows a chevron only when a detail surface exists.
+- [ ] Tapping the chevron opens that detail; the rest of the pill does not.
+
+---
+
+### P1·3 — Visualizer panel — promoted mode picker
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1` → **"Visualizer panel"**
+**Files:**
+- `src/Radio.Web/Components/Shared/VisualizerPanel.razor`
+
+**Steps:**
+
+1. Replace the corner mode chip group (VU / WAVE / SPECTRUM) with a full-width 3-segment header inside the panel:
+   - Grid layout, 3 equal columns, 44px tall.
+   - Mono font, 12px, uppercase, `0.10em` letter-spacing.
+   - Active segment: `background: var(--accent-dim); color: var(--accent);` with a 2px underline accent.
+   - Inactive segments: `color: var(--text-medium);` separated by 1px `var(--surface-separator)` borders.
+
+2. The canvas/SVG visualization fills the remaining vertical space. Remove the current padding around it.
+
+3. Move the "Connected" pill to a single 8px dot at the top-right of the panel header, color `var(--signal-green)` when connected, `var(--signal-red)` when not. No text label — the dot is enough.
+
+4. Remove the burned-in `"Updates: 22/sec"` yellow caption from the canvas. Add it to the dev tray in P2·2.
+
+5. Frequency-band axis labels (`375Hz / 750Hz / 1.1kHz / 1.5kHz`) should sit *under* the canvas in a thin (16px) strip, mono font, 10px, low contrast — not inside the canvas overlapping the bars.
+
+**Acceptance:**
+
+- [ ] Mode picker is the obvious primary control of the panel.
+- [ ] Canvas fills the available height/width with no debug telemetry overlaid.
+- [ ] Connection state is a small dot, not a pill.
+
+---
+
+### P1·4 — Queue split layout
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1` → **"Queue page — split layout"**
+**Files:**
+- `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor`
+
+**Steps:**
+
+1. Split the panel into two columns: `flex: 1.6` (list) | `flex: 1` (context). 12px gap.
+
+2. Add a tab strip at the top of the list column:
+   - Three pills: `Queue · N` / `History` / `Radio` (the third only when the active source is a radio type).
+   - Use the existing `--accent-dim` for active background, mono font, 12px uppercase 0.10em letter-spacing.
+
+3. Right context panel — three stacked tiles:
+   - **Queue Total** — `--font-led`, 30px, amber, shows `Durations.FormatLong(totalRuntime)` plus a sub-line: `{count} tracks · ends ~{nowPlus(total):HH:mm}`.
+   - **Up next** — three 32×32 album-art thumbnails with title + artist, each line dimmed progressively (text-high → text-medium → text-low).
+   - **Save as playlist** — accent-bordered CTA tile with `＋ Save as playlist` text.
+
+4. The current ADD FILES / CLEAR ALL header buttons move into a kebab menu in the list-column header. They should not occupy a whole top row.
+
+**Acceptance:**
+
+- [ ] The content area is filled when the queue has 1+ tracks (no large empty void below).
+- [ ] Tapping the History tab swaps the list contents without remounting the right column (the right column updates its content to "History stats" — total plays, top track, top artist).
+- [ ] Save-as-playlist tile triggers the existing save dialog.
+
+---
+
+### P1·5 — Skeleton loading states
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1` → **"Skeleton loading states"**
+**Files:**
+- `src/Radio.Web/Components/Shared/Skeleton.razor` (new)
+- All loading branches across `NowPlayingPanel`, `RadioControlPanel`, `QueueHistoryPanel`, `VisualizerPanel`, `DeviceManagementPage`, `PlayHistoryPage`.
+
+**Steps:**
+
+1. Build `Skeleton.razor` with one parameter:
+   ```
+   public enum Shape { NowPlaying, Radio, ListRow, DeviceRow, MetricTile, Visualizer }
+   [Parameter] public Shape Shape { get; set; }
+   ```
+   Each shape renders a shape-matched arrangement of the existing `.skeleton-*` divs from `design-system.css §17`. Sizes match the real component layout.
+
+2. Replace every `RadzenProgressBarCircular` used as a generic loading indicator with `<Skeleton Shape="..." />`.
+
+3. Keep `RadzenProgressBarCircular` only for *modal / determinate* progress (e.g. file scan progress bar).
+
+**Acceptance:**
+
+- [ ] No centered spinner in a panel-body loading branch anywhere in `Components/`.
+- [ ] First-load on Radio shows a freq-well shape + band buttons + meter outlines, then animates to real content.
+
+---
+
+## P2 — System polish
+
+Things that change how the device feels in the room.
+
+---
+
+### P2·1 — Sleep as a screen
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `System polish` → **"Sleep — ambient screen"**
+**Files:**
+- `src/Radio.Web/Components/Pages/Sleep.razor` (new — route `/sleep`)
+- `src/Radio.Web/wwwroot/js/idle-dimmer.js` (existing — modify to navigate, not overlay)
+- `src/Radio.Web/Components/Layout/MainLayout.razor` (`HandleSleepButtonAsync`)
+
+**Steps:**
+
+1. Build `/sleep` page with `@layout EmptyLayout` (no top bar):
+   - Background `#050507` with a radial amber glow at center, very subtle.
+   - 160×160 faint album art block at center, 40% opacity.
+   - Large clock below: `--font-led`, **96px**, amber, with a strong glow shadow.
+   - Track title + artist line at 18px in a very dim color.
+   - Hint text at the bottom: `tap anywhere to wake`, mono 11px, very dim, uppercase, letter-spaced.
+
+2. `HandleSleepButtonAsync` in `MainLayout`: call `SystemApi.SetSleepAsync(true)` then `NavigationManager.NavigateTo("/sleep")`.
+
+3. `Sleep.razor` has a full-screen `@onclick` handler that calls `SystemApi.SetSleepAsync(false)` then `NavigationManager.NavigateTo("/")`.
+
+4. `idle-dimmer.js` no longer overlays the page; it navigates to `/sleep` when idle.
+
+5. SignalR `SleepStateChanged` event still drives the page — if the server reports wake-from-elsewhere while we're on `/sleep`, navigate home.
+
+**Acceptance:**
+
+- [ ] Tapping the sleep button takes the user to `/sleep` with a fade-in.
+- [ ] Tapping anywhere on `/sleep` wakes and returns to last route.
+- [ ] No black overlay hack remains in JS.
+
+---
+
+### P2·2 — Dev tools gesture & tray
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `System polish` → **"Dev tools"**
+**Files:**
+- `src/Radio.Web/Components/Shared/DevTray.razor` (new)
+- `src/Radio.Web/Components/Layout/MainLayout.razor`
+- `src/Radio.Web/wwwroot/js/dev-gesture.js` (new)
+
+**Steps:**
+
+1. Add a 48×48 invisible hit area in the top-right corner of the topbar. Counts taps client-side via `dev-gesture.js`. Three taps within 1.5s call into Blazor (`DotNetObjectReference`) → toggle `_isDevTrayOpen`.
+
+2. `DevTray.razor` is positioned-fixed at top-right, slides down with a small drop shadow:
+   - Header: `● Dev Tray · unlocked · auto-lock 0:30`.
+   - 2×3 grid of action cards:
+     - **Mark distortion** — calls `AudioApi.ReportDistortionAsync()` (the action currently on the topbar button).
+     - **Updates: NN/sec** — live visualizer telemetry (moved from `VisualizerPanel`).
+     - **Dump audio frame** — last 5s buffer dump.
+     - **Download logs** — last hour, zip.
+     - **Fingerprint events** — opens the existing fingerprint detail panel.
+     - **Engine state** — readable string of the current `AudioStateHubService` state.
+   - Auto-locks after 30s of no interaction with the tray (a timer driven by `DevTray.razor`).
+
+3. Move the distortion-marker button **out** of `MainLayout.razor` entirely.
+
+**Acceptance:**
+
+- [ ] No dev-only UI is visible in production chrome without the gesture.
+- [ ] The gesture works at native 1920×720 touch resolution.
+- [ ] Tray auto-locks after 30s.
+
+---
+
+## Cross-cutting nice-to-haves
+
+These don't have their own canvas artboards but should land alongside the P0/P1 work in the same files.
+
+- **Hidden scrollbars** — `design-system.css §19` currently hides every scrollbar. Add a thin (3px) always-visible thumb just on `.panel-body` and `.queue-list-wrapper` so the "more content below" hint exists. CSS:
+  ```css
+  .panel-body { scrollbar-width: thin; scrollbar-color: var(--text-low) transparent; }
+  .panel-body::-webkit-scrollbar { display: block; width: 3px; }
+  .panel-body::-webkit-scrollbar-thumb { background: var(--text-low); border-radius: 2px; }
+  ```
+- **Bump `--text-medium`** from `#9CA3AF` to `#B5BCC9` in `design-system.css §2` for better legibility at touchscreen viewing distance.
+- **`aria-label` on every icon-only button** in `MainLayout` (Sleep, Queue badge, debug if it stays).
+- **Visible focus rings**: keep `-webkit-tap-highlight-color: transparent` for touch, but add `:focus-visible` outlines with `outline: 2px solid var(--accent); outline-offset: 2px;`.
+
+## What NOT to change
+
+- The DSEG amber LED treatment for time / frequency. It is the strongest visual element in the app — keep it on `.display-frequency`, `.topbar-clock`, sleep screen, queue total. Do not extend it to regular UI text.
+- The per-source color mapping (`--source-vinyl / -file / -radio / -bluetooth / -usb`). Already correct.
+- The three-column home page split (520 / fill / 710). The proportions work.
+- SignalR push patterns. They are the right architecture for this app.
+
+---
+
+## Build / verify checklist
+
+After landing each section:
+
+- [ ] `dotnet build` clean.
+- [ ] `dotnet test` green (`tests/Radio.Web.Tests`).
+- [ ] Run E2E suite (`scripts/run-e2e-tests.ps1` or `.sh`).
+- [ ] Eyeball the affected page in the dev build at native 1920×720 — content fits, no scrollbars except where intended, no debug UI visible.
+- [ ] Take a fresh screenshot into `screenshots/{page}.png` (overwrite the current one) so the next design pass starts from a current baseline.

--- a/docs/design-handoffs/design_handoff_radio_console/README.md
+++ b/docs/design-handoffs/design_handoff_radio_console/README.md
@@ -1,0 +1,52 @@
+# Handoff: Radio Console — Design Tightening Pass
+
+## Overview
+
+This package contains a curated set of design improvements for the **Radio.Web** Blazor Server kiosk app (the 1920×720 multi-source audio console at `src/Radio.Web/`). It is the deliverable from a design-review pass that audited the current screens (`screenshots/*.png`) against `design-system.css` and the shared panel components.
+
+The goal is not a rebuild. The aesthetic — broadcast-console dark + DSEG amber LED + electric cyan accent + per-source color coding — is intact and good. The package fixes **what's leaking through the surface** (raw IDs, raw `TimeSpan`s, unit bugs, debug controls in production chrome, half-empty pages) and **promotes a few components** that were sitting in the corner doing real work (Visualizer mode picker, source-pill detail affordance).
+
+## About the design files
+
+The HTML files in this folder are **design references**, not code to copy into the app:
+
+- `Design Analysis.html` — long-form audit identifying 5 P0, 8 P1, and 11 P2 findings, with severity ratings and rationale.
+- `Handoff Canvas.html` (+ `design-canvas.jsx`, `mocks.jsx`, `app.jsx`) — a pan/zoom canvas of **12 focused before/after artboards**, one per proposed change. This is what the developer should treat as the visual spec.
+
+Both files are styled in the project's own design language (same tokens, same fonts where shippable). The real implementation happens **in the existing Blazor codebase** using its existing components (Radzen, the design-system tokens, the SignalR hub) — not by porting HTML into the app.
+
+## Fidelity
+
+**High-fidelity for visuals, behaviour-spec for interactions.**
+
+- Spacing, colors, typography, and component shapes shown in the canvas mocks should be matched within ±2px and exact token values (mocks use the same hex values as `design-system.css`).
+- Interaction details (gestures, state machines, route changes) are written out in `IMPLEMENTATION.md`. The mocks are static — they cannot show motion or transitions, so the script is the source of truth there.
+
+## How to use this package
+
+1. **Review `Handoff Canvas.html`** first. The user has labeled which artboards are approved, parked, or need iteration via the inline edit / drag-reorder controls.
+2. **Read `IMPLEMENTATION.md`**. Each section maps one canvas artboard → one or more files in `src/Radio.Web/` with concrete steps, code references, and acceptance criteria.
+3. **Skip any section marked `[PARKED]` or `[NEEDS ITERATION]`** at the top — those are not approved yet.
+4. **Land changes in the order given** (P0 → P1 → P2). P0 includes one new file (`Formatting/DisplayNames.cs`) that several later changes depend on.
+
+## Status legend
+
+Each change in `IMPLEMENTATION.md` carries one of:
+
+| Status | Meaning |
+|---|---|
+| `[APPROVED]` | Ship as specified. |
+| `[PENDING REVIEW]` | Drafted but not yet locked. Don't start. |
+| `[NEEDS ITERATION]` | User has comments; see the inline note for what to change. |
+| `[PARKED]` | Out of scope for this pass. |
+
+## Files in this folder
+
+- `README.md` — this file.
+- `IMPLEMENTATION.md` — the developer script, one section per change.
+- `Design Analysis.html` — long-form audit with rationale and severity ratings.
+- `Handoff Canvas.html` + `design-canvas.jsx` + `mocks.jsx` + `app.jsx` — visual specs.
+
+## Design tokens
+
+All values referenced in the implementation script already exist in `src/Radio.Web/wwwroot/css/design-system.css`. Do **not** introduce new tokens; if a value is needed that isn't tokenized, add it to design-system.css first under the appropriate section (`§2 CSS Custom Properties`) and reference it from there.

--- a/docs/design-handoffs/design_handoff_radio_console/app.jsx
+++ b/docs/design-handoffs/design_handoff_radio_console/app.jsx
@@ -1,0 +1,83 @@
+// handoff-app.jsx — assemble the design canvas
+
+const { useEffect } = React;
+
+function App() {
+  useEffect(() => { document.title = 'Radio Console — Visual Handoff'; }, []);
+
+  return (
+    <DesignCanvas>
+
+      <DCSection
+        id="p0"
+        title="P0 — fix before anything else"
+        subtitle="Bugs and IDs leaking through the surface. Each of these makes the product look unfinished or untrustworthy."
+      >
+        <DCArtboard id="topbar" label="Top bar redesign" width={1920} height={420}>
+          <Mock_TopBar />
+        </DCArtboard>
+
+        <DCArtboard id="naming" label="Source &amp; device names" width={880} height={460}>
+          <Mock_Naming />
+        </DCArtboard>
+
+        <DCArtboard id="queue" label="Queue rows &amp; duration format" width={1280} height={540}>
+          <Mock_Queue />
+        </DCArtboard>
+
+        <DCArtboard id="metrics" label="Metrics tiles — units, groups, trends" width={1280} height={580}>
+          <Mock_Metrics />
+        </DCArtboard>
+
+        <DCArtboard id="fbfilter" label="File browser filter — chips" width={880} height={360}>
+          <Mock_FbFilter />
+        </DCArtboard>
+      </DCSection>
+
+
+      <DCSection
+        id="p1"
+        title="P1 — big quality wins"
+        subtitle="Behavioural / structural fixes. The product feels twice as finished after these land."
+      >
+        <DCArtboard id="dock" label="Persistent Now Playing dock" width={1920} height={760}>
+          <Mock_Dock />
+        </DCArtboard>
+
+        <DCArtboard id="pill" label="Source pill semantics — one action + chevron" width={1100} height={320}>
+          <Mock_PillSemantics />
+        </DCArtboard>
+
+        <DCArtboard id="viz" label="Visualizer panel — promoted mode picker" width={1480} height={620}>
+          <Mock_Visualizer />
+        </DCArtboard>
+
+        <DCArtboard id="qsplit" label="Queue page — split layout" width={1200} height={660}>
+          <Mock_QueueSplit />
+        </DCArtboard>
+
+        <DCArtboard id="skel" label="Skeleton loading states" width={1280} height={660}>
+          <Mock_Skeleton />
+        </DCArtboard>
+      </DCSection>
+
+
+      <DCSection
+        id="system"
+        title="System polish"
+        subtitle="Things that change how the product feels in the room, not just how it looks on a screenshot."
+      >
+        <DCArtboard id="sleep" label="Sleep — ambient screen" width={1920} height={760}>
+          <Mock_Sleep />
+        </DCArtboard>
+
+        <DCArtboard id="dev" label="Dev tools — gesture-gated tray" width={880} height={620}>
+          <Mock_DevTools />
+        </DCArtboard>
+      </DCSection>
+
+    </DesignCanvas>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/docs/design-handoffs/design_handoff_radio_console/design-canvas.jsx
+++ b/docs/design-handoffs/design_handoff_radio_console/design-canvas.jsx
@@ -1,0 +1,966 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), deletable, labels/titles are
+// inline-editable, and any artboard can be opened in a fullscreen focus
+// overlay (←/→/Esc). State persists to a .design-canvas.state.json sidecar
+// via the host bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    // isolation:isolate contains artboard content's z-indexes so a
+    // z-indexed child (sticky navbar etc.) can't paint over .dc-header or
+    // the .dc-menu popover that drops into the top of the card.
+    '.dc-card{isolation:isolate;transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    // Per-artboard header: grip + label on the left, delete/expand on the
+    // right. Single flex row; when the artboard's on-screen width is too
+    // narrow for both the label yields (ellipsis, then hidden entirely below
+    // ~4ch via the container query) and the buttons stay on the row.
+    '.dc-header{position:absolute;bottom:100%;left:-4px;margin-bottom:calc(4px * var(--dc-inv-zoom,1));z-index:2;',
+    '  display:flex;align-items:center;container-type:inline-size}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px;flex:1 1 auto;min-width:0}',
+    '.dc-grip{flex:0 0 auto;cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s,opacity .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{flex:1 1 auto;min-width:0;cursor:pointer;border-radius:4px;padding:3px 6px;',
+    '  display:flex;align-items:center;transition:background .12s;overflow:hidden}',
+    // Below ~4ch of label room: hide the label entirely, and drop the grip to
+    // hover-only (same reveal rule as .dc-btns) so a narrow header is clean
+    // until the card is moused.
+    '@container (max-width: 110px){',
+    '  .dc-labeltext{display:none}',
+    '  .dc-grip{opacity:0}',
+    '  [data-dc-slot]:hover .dc-grip{opacity:1}',
+    '}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-labeltext .dc-editable{overflow:hidden;text-overflow:ellipsis;max-width:100%}',
+    '.dc-labeltext .dc-editable:focus{overflow:visible;text-overflow:clip}',
+    '.dc-btns{flex:0 0 auto;margin-left:auto;display:flex;gap:2px;opacity:0;transition:opacity .12s}',
+    '[data-dc-slot]:hover .dc-btns,.dc-btns:has(.dc-menu){opacity:1}',
+    '.dc-expand,.dc-kebab{width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center;',
+    '  font:inherit;transition:background .12s,color .12s}',
+    '.dc-expand:hover,.dc-kebab:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    // Slot hosting an open menu floats above later siblings (which otherwise
+    // paint on top — same z-index:auto, later DOM order) so the popup isn't
+    // clipped by the next card.
+    '[data-dc-slot]:has(.dc-menu){z-index:10}',
+    '.dc-menu{position:absolute;top:100%;right:0;margin-top:4px;background:#fff;border-radius:8px;',
+    '  box-shadow:0 8px 28px rgba(0,0,0,.18),0 0 0 1px rgba(0,0,0,.05);padding:4px;min-width:160px;z-index:10}',
+    '.dc-menu button{display:block;width:100%;padding:7px 10px;border:0;background:transparent;',
+    '  border-radius:5px;font-family:inherit;font-size:13px;font-weight:500;line-height:1.2;',
+    '  color:#29261b;cursor:pointer;text-align:left;transition:background .12s;white-space:nowrap}',
+    '.dc-menu button:hover{background:rgba(0,0,0,.05)}',
+    '.dc-menu hr{border:0;border-top:1px solid rgba(0,0,0,.08);margin:4px 2px}',
+    '.dc-menu .dc-danger{color:#c96442}',
+    '.dc-menu .dc-danger:hover{background:rgba(201,100,66,.1)}',
+    // Chrome (titles / labels / buttons) counter-scales against the viewport
+    // zoom so it stays a constant on-screen size. --dc-inv-zoom is set by
+    // DCViewport on every transform update and inherits to all descendants —
+    // any overlay inside the world (e.g. a TweaksPanel on an artboard) can use
+    // it the same way.
+    //
+    // The header uses transform:scale (out-of-flow, so layout impact doesn't
+    // matter) with its world-space width set to card-width / inv-zoom so that
+    // after counter-scaling its on-screen width exactly matches the card's —
+    // that's what lets the container query + text-overflow behave against the
+    // card's visible edge at every zoom level.
+    //
+    // The section head uses CSS zoom instead of transform so its layout box
+    // grows with the counter-scale, pushing the card row down — otherwise the
+    // constant-screen-size title would overflow into the (shrinking) world-
+    // space gap and overlap the artboard headers at low zoom.
+    '.dc-header{width:calc((100% + 4px) / var(--dc-inv-zoom,1));',
+    '  transform:scale(var(--dc-inv-zoom,1));transform-origin:bottom left}',
+    '.dc-sectionhead{zoom:var(--dc-inv-zoom,1)}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// Recursively unwrap React.Fragment so <>…</> grouping doesn't hide
+// DCSection/DCArtboard children from the type-based walks below.
+function dcFlatten(children) {
+  const out = [];
+  React.Children.forEach(children, (c) => {
+    if (c && c.type === React.Fragment) out.push(...dcFlatten(c.props.children));
+    else out.push(c);
+  });
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, hidden
+// artboards, focused artboard). Order/titles/labels/hidden persist to a
+// .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Fragments are flattened; wrapping in other
+  // elements still opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  dcFlatten(children).forEach((sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const abs = [];
+    dcFlatten(sec.props.children).forEach((ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (aid) abs.push([aid, ab]);
+    });
+    // hidden is scoped to one source revision — when the agent regenerates
+    // (artboard-ID set changes), prior deletes don't apply to new content.
+    const srcKey = abs.map(([k]) => k).join('\x1f');
+    const hidden = persisted.srcKey === srcKey ? (persisted.hidden || []) : [];
+    const srcIds = [];
+    abs.forEach(([aid, ab]) => {
+      if (hidden.includes(aid)) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+  // Persist viewport across reloads so the user lands back where they were
+  // after an agent edit or browser refresh. The sandbox origin is already
+  // per-project; pathname keeps multiple canvas files in one project apart.
+  const tfKey = 'dc-viewport:' + location.pathname;
+  const saveT = React.useRef(0);
+
+  const lastPostedScale = React.useRef();
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (!el) return;
+    el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+    // Exposed for zoom-invariant chrome (labels, buttons, TweaksPanel).
+    el.style.setProperty('--dc-inv-zoom', String(1 / scale));
+    // Keep the host toolbar's % readout in sync with the canvas scale. Pan
+    // ticks leave scale unchanged — skip the cross-frame post for those.
+    if (lastPostedScale.current !== scale) {
+      lastPostedScale.current = scale;
+      window.parent.postMessage({ type: '__dc_zoom', scale }, '*');
+    }
+    clearTimeout(saveT.current);
+    saveT.current = setTimeout(() => {
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    }, 200);
+  }, [tfKey]);
+
+  React.useLayoutEffect(() => {
+    const flush = () => {
+      clearTimeout(saveT.current);
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    };
+    try {
+      const s = JSON.parse(localStorage.getItem(tfKey) || 'null');
+      if (s && Number.isFinite(s.x) && Number.isFinite(s.y) && Number.isFinite(s.scale)) {
+        tf.current = { x: s.x, y: s.y, scale: Math.min(maxScale, Math.max(minScale, s.scale)) };
+        apply();
+      }
+    } catch {}
+    // Flush on pagehide and unmount so a reload within the 200ms debounce
+    // window doesn't drop the last pan/zoom.
+    window.addEventListener('pagehide', flush);
+    return () => { window.removeEventListener('pagehide', flush); flush(); };
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // --dc-inv-zoom consumers (.dc-sectionhead's CSS zoom, each section's
+      // marginBottom) reflow on every scale change, vertically shifting the
+      // world layout — so a world point mathematically pinned under the cursor
+      // drifts as you zoom (content creeps up on zoom-in, down on zoom-out).
+      // Anchor the DOM element under the cursor instead: record its screen Y,
+      // apply the transform + --dc-inv-zoom, then cancel whatever vertical
+      // drift the reflow introduced so it stays put on screen.
+      let marker = null, markerY0 = 0;
+      if (k !== 1) {
+        const hit = document.elementFromPoint(cx, cy);
+        marker = hit && hit.closest ? hit.closest('[data-dc-slot],[data-dc-section]') : null;
+        if (marker) markerY0 = marker.getBoundingClientRect().top;
+      }
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+      if (marker) {
+        // A pure zoom around (cx, cy) maps screen Y → cy + (Y - cy) * k. Any
+        // departure after the --dc-inv-zoom reflow is the layout drift.
+        const drift = marker.getBoundingClientRect().top - (cy + (markerY0 - cy) * k);
+        if (Math.abs(drift) > 0.1) { t.y -= drift; apply(); }
+      }
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if ((e.ctrlKey || e.metaKey) && !isMouseWheel(e)) {
+        // trackpad pinch, or ctrl/cmd + smooth-scroll mouse. Notched
+        // wheels fall through to the fixed-step branch below.
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    // Host-driven zoom (toolbar % menu). Zooms around viewport centre so the
+    // visible midpoint stays fixed — matching the host's iframe-zoom feel.
+    const onHostMsg = (e) => {
+      const d = e.data;
+      if (d && d.type === '__dc_set_zoom' && typeof d.scale === 'number') {
+        const r = vp.getBoundingClientRect();
+        zoomAt(r.left + r.width / 2, r.top + r.height / 2, d.scale / tf.current.scale);
+      } else if (d && d.type === '__dc_probe') {
+        // Host's [readyGen] reset asks whether a canvas is present; it
+        // fires on the iframe's native 'load', which for canvases with
+        // images/fonts is after our mount-time announce, so re-announce.
+        // Clear the pan-tick guard so apply() re-posts the current scale
+        // even if it's unchanged — the host just reset dcScale to 1.
+        window.parent.postMessage({ type: '__dc_present' }, '*');
+        lastPostedScale.current = undefined;
+        apply();
+      }
+    };
+    window.addEventListener('message', onHostMsg);
+    // Announce canvas mode so the host toolbar proxies its % control here
+    // instead of scaling the iframe element (which would just shrink the
+    // viewport window of an infinite canvas). The apply() that follows emits
+    // the initial __dc_zoom so the toolbar % is correct before first pinch.
+    // lastPostedScale reset mirrors the __dc_probe handler: the layout
+    // effect's restore-path apply() may already have posted the restored
+    // scale (before __dc_present), so clear the guard to re-post it in order.
+    window.parent.postMessage({ type: '__dc_present' }, '*');
+    lastPostedScale.current = undefined;
+    apply();
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      window.removeEventListener('message', onHostMsg);
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(dcFlatten(children));
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+  // Must match DesignCanvas's srcKey computation exactly (it filters falsy
+  // IDs), or onDelete persists a srcKey that DesignCanvas never recognizes.
+  const allIds = artboards.map((a) => a.props.id ?? a.props.label).filter(Boolean);
+  const srcKey = allIds.join('\x1f');
+  const hidden = sec.srcKey === srcKey ? (sec.hidden || []) : [];
+  const srcOrder = allIds.filter((k) => !hidden.includes(k));
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  // marginBottom counter-scales so the on-screen gap between sections stays
+  // constant — otherwise at low zoom the (world-space) gap collapses while
+  // the screen-constant sectionhead below it doesn't, and the title reads as
+  // belonging to the section above. paddingBottom below is just enough for
+  // the 24px artboard-header (abs-positioned above each card) plus ~8px, so
+  // the title sits tight against its own row at every zoom.
+  return (
+    <div data-dc-section={sid}
+      style={{ marginBottom: 'calc(80px * var(--dc-inv-zoom, 1))', position: 'relative' }}>
+      <div style={{ padding: '0 60px' }}>
+        <div className="dc-sectionhead" style={{ paddingBottom: 36 }}>
+          <DCEditable tag="div" value={sec.title ?? title}
+            onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+            style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+          {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onDelete={() => ctx && ctx.patchSection(sid, (x) => ({
+              hidden: [...(x.srcKey === srcKey ? (x.hidden || []) : []), k],
+              srcKey,
+            }))}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+// Per-artboard export (kind: 'png' | 'html'). Both paths share the same
+// self-contained clone: computed styles baked in, @font-face / <img> /
+// inline-style background-image urls inlined as data URIs. PNG wraps the
+// clone in foreignObject→canvas at 3× the artboard's natural width×height
+// (same pipeline the host uses for page captures); HTML wraps it in a
+// minimal standalone document. Both are independent of viewport zoom.
+async function dcExport(node, w, h, name, kind) {
+  try { await document.fonts.ready; } catch {}
+  const toDataURL = (url) => fetch(url).then((r) => r.blob()).then((b) => new Promise((res) => {
+    const fr = new FileReader(); fr.onload = () => res(fr.result); fr.onerror = () => res(url); fr.readAsDataURL(b);
+  })).catch(() => url);
+
+  // Collect @font-face rules. ss.cssRules throws SecurityError on
+  // cross-origin sheets (e.g. fonts.googleapis.com) — in that case fetch
+  // the CSS text directly (those endpoints send ACAO:*) and regex-extract
+  // the blocks. @import and @media/@supports are walked so nested
+  // @font-face rules aren't missed.
+  const fontRules = [], pending = [], seen = new Set();
+  const scrapeCss = (href) => {
+    if (seen.has(href)) return; seen.add(href);
+    pending.push(fetch(href).then((r) => r.text()).then((css) => {
+      for (const m of css.match(/@font-face\s*{[^}]*}/g) || []) fontRules.push({ css: m, base: href });
+      for (const m of css.matchAll(/@import\s+(?:url\()?['"]?([^'")\s;]+)/g))
+        scrapeCss(new URL(m[1], href).href);
+    }).catch(() => {}));
+  };
+  const walk = (rules, base) => {
+    for (const r of rules) {
+      if (r.type === CSSRule.FONT_FACE_RULE) fontRules.push({ css: r.cssText, base });
+      else if (r.type === CSSRule.IMPORT_RULE && r.styleSheet) {
+        const ibase = r.styleSheet.href || base;
+        try { walk(r.styleSheet.cssRules, ibase); } catch { scrapeCss(ibase); }
+      } else if (r.cssRules) walk(r.cssRules, base);
+    }
+  };
+  for (const ss of document.styleSheets) {
+    const base = ss.href || location.href;
+    try { walk(ss.cssRules, base); } catch { if (ss.href) scrapeCss(ss.href); }
+  }
+  while (pending.length) await pending.shift();
+  const fontCss = (await Promise.all(fontRules.map(async (rule) => {
+    let out = rule.css, m; const re = /url\((['"]?)([^'")]+)\1\)/g;
+    while ((m = re.exec(rule.css))) {
+      if (m[2].indexOf('data:') === 0) continue;
+      let abs; try { abs = new URL(m[2], rule.base).href; } catch { continue; }
+      out = out.split(m[0]).join('url("' + await toDataURL(abs) + '")');
+    }
+    return out;
+  }))).join('\n');
+
+  const cloneStyled = (src) => {
+    if (src.nodeType === 8 || (src.nodeType === 1 && src.tagName === 'SCRIPT')) return document.createTextNode('');
+    const dst = src.cloneNode(false);
+    if (src.nodeType === 1) {
+      const cs = getComputedStyle(src); let txt = '';
+      for (let i = 0; i < cs.length; i++) txt += cs[i] + ':' + cs.getPropertyValue(cs[i]) + ';';
+      dst.setAttribute('style', txt + 'animation:none;transition:none;');
+      if (src.tagName === 'CANVAS') try { const im = document.createElement('img'); im.src = src.toDataURL(); im.setAttribute('style', txt); return im; } catch {}
+    }
+    for (let c = src.firstChild; c; c = c.nextSibling) dst.appendChild(cloneStyled(c));
+    return dst;
+  };
+  const clone = cloneStyled(node);
+  clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+  // Drop the card's own shadow/radius so the export is a flush w×h rect;
+  // the artboard's own background (if any) is already in the computed style.
+  clone.style.boxShadow = 'none'; clone.style.borderRadius = '0';
+
+  const jobs = [];
+  clone.querySelectorAll('img').forEach((el) => {
+    const s = el.getAttribute('src');
+    if (s && s.indexOf('data:') !== 0) jobs.push(toDataURL(el.src).then((d) => el.setAttribute('src', d)));
+  });
+  [clone, ...clone.querySelectorAll('*')].forEach((el) => {
+    const bg = el.style.backgroundImage; if (!bg) return;
+    let m; const re = /url\(["']?([^"')]+)["']?\)/g;
+    while ((m = re.exec(bg))) {
+      const tok = m[0], url = m[1];
+      if (url.indexOf('data:') === 0) continue;
+      jobs.push(toDataURL(url).then((d) => { el.style.backgroundImage = el.style.backgroundImage.split(tok).join('url("' + d + '")'); }));
+    }
+  });
+  await Promise.all(jobs);
+
+  const xml = new XMLSerializer().serializeToString(clone);
+  const save = (blob, ext) => {
+    if (!blob) return;
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob); a.download = name + '.' + ext; a.click();
+    setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+  };
+
+  if (kind === 'html') {
+    const html = '<!doctype html><html><head><meta charset="utf-8"><title>' + name + '</title>' +
+      (fontCss ? '<style>' + fontCss + '</style>' : '') +
+      '</head><body style="margin:0">' + xml + '</body></html>';
+    return save(new Blob([html], { type: 'text/html' }), 'html');
+  }
+
+  // PNG: the SVG's own width/height must be the output resolution — an
+  // <img>-loaded SVG rasterizes at its intrinsic size, so sizing it at 1×
+  // and ctx.scale()-ing up would just upscale a 1× bitmap. viewBox maps the
+  // w×h foreignObject onto the px·w × px·h SVG canvas so the browser renders
+  // the HTML at full resolution.
+  const px = 3;
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + w * px + '" height="' + h * px +
+    '" viewBox="0 0 ' + w + ' ' + h + '"><foreignObject width="' + w + '" height="' + h + '">' +
+    (fontCss ? '<style><![CDATA[' + fontCss + ']]></style>' : '') + xml + '</foreignObject></svg>';
+  const img = new Image();
+  await new Promise((res, rej) => {
+    img.onload = res; img.onerror = () => rej(new Error('svg load failed'));
+    img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+  });
+  const cv = document.createElement('canvas');
+  cv.width = w * px; cv.height = h * px;
+  cv.getContext('2d').drawImage(img, 0, 0);
+  cv.toBlob((blob) => save(blob, 'png'), 'image/png');
+}
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus, onDelete }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+  const cardRef = React.useRef(null);
+  const menuRef = React.useRef(null);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [confirming, setConfirming] = React.useState(false);
+
+  // ⋯ menu: close on any outside pointerdown. Two-click delete lives inside
+  // the menu — first click arms the row, second commits; closing disarms.
+  React.useEffect(() => {
+    if (!menuOpen) { setConfirming(false); return; }
+    const off = (e) => { if (!menuRef.current || !menuRef.current.contains(e.target)) setMenuOpen(false); };
+    document.addEventListener('pointerdown', off, true);
+    return () => document.removeEventListener('pointerdown', off, true);
+  }, [menuOpen]);
+
+  const doExport = (kind) => {
+    setMenuOpen(false);
+    if (!cardRef.current) return;
+    const name = String(label || id || 'artboard').replace(/[^\w\s.-]+/g, '_');
+    dcExport(cardRef.current, width, height, name, kind)
+      .catch((e) => console.error('[design-canvas] export failed:', e));
+  };
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-header" data-noncommentable="" style={{ color: DC.label }} onPointerDown={(e) => e.stopPropagation()}>
+        <div className="dc-labelrow">
+          <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+            <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+          </div>
+          <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+            <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+              style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+          </div>
+        </div>
+        <div className="dc-btns">
+          <div ref={menuRef} style={{ position: 'relative' }}>
+            <button className="dc-kebab" title="More" onClick={() => setMenuOpen((o) => !o)}>
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><circle cx="2.5" cy="6" r="1.1"/><circle cx="6" cy="6" r="1.1"/><circle cx="9.5" cy="6" r="1.1"/></svg>
+            </button>
+            {menuOpen && (
+              <div className="dc-menu" onPointerDown={(e) => e.stopPropagation()}>
+                <button onClick={() => doExport('png')}>Download PNG</button>
+                <button onClick={() => doExport('html')}>Download HTML</button>
+                <hr />
+                <button className="dc-danger"
+                  onClick={() => { if (confirming) { setMenuOpen(false); onDelete(); } else setConfirming(true); }}>
+                  {confirming ? 'Click again to delete' : 'Delete'}
+                </button>
+              </div>
+            )}
+          </div>
+          <button className="dc-expand" onClick={onFocus} title="Focus">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+          </button>
+        </div>
+      </div>
+      <div ref={cardRef} className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    // Sections whose artboards are all deleted have slotIds:[] — step past
+    // them to the next non-empty section so ↑/↓ doesn't dead-end.
+    const n = sectionOrder.length;
+    for (let i = 1; i < n; i++) {
+      const ns = sectionOrder[(((secIdx + d * i) % n) + n) % n];
+      const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+      if (first) { ctx.setFocus(`${ns}/${first}`); return; }
+    }
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.filter((sid) => sectionMeta[sid].slotIds.length).map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/docs/design-handoffs/design_handoff_radio_console/mocks.jsx
+++ b/docs/design-handoffs/design_handoff_radio_console/mocks.jsx
@@ -1,0 +1,1065 @@
+// handoff-mocks.jsx — Mock components for each proposed change in the
+// Radio.Web design analysis. Each component renders at a specific fixed
+// size meant to be wrapped in a <DCArtboard>. Styling is intentionally
+// inline so this file is self-contained and doesn't compete with the
+// design-canvas chrome's CSS.
+
+const T = {
+  base:       '#0D0D0F',
+  raised:     '#141416',
+  inset:      '#0A0A0C',
+  overlay:    '#1A1A1D',
+  sep:        '#1F1F22',
+  hair:       '#25252A',
+
+  accent:     '#5CD4E8',
+  accentDim:  'rgba(92,212,232,0.10)',
+  accentGlow: 'rgba(92,212,232,0.25)',
+  amber:      '#F0A830',
+  amberGlow:  'rgba(240,168,48,0.30)',
+
+  sVinyl:     '#A78BFA',
+  sRadio:     '#F0A830',
+  sBT:        '#60A5FA',
+  sUSB:       '#4ADE80',
+  sFile:      '#5CD4E8',
+
+  red:        '#F87171',
+  yellow:     '#FBBF24',
+  green:      '#4ADE80',
+
+  hi:         '#F0EFF4',
+  md:         '#9CA3AF',
+  lo:         '#4B5563',
+  dim:        '#353841',
+
+  body:       "'Inter', -apple-system, BlinkMacSystemFont, sans-serif",
+  mono:       "'JetBrains Mono', 'SF Mono', Consolas, monospace",
+  led:        "'Share Tech Mono', 'JetBrains Mono', monospace",
+};
+
+/* ─────────── shared atoms ─────────── */
+const Stage = ({ w, h, pad = 0, children, style }) => (
+  <div style={{
+    width: w, height: h, background: T.base, color: T.hi,
+    fontFamily: T.body, fontSize: 14, lineHeight: 1.45,
+    overflow: 'hidden', boxSizing: 'border-box', padding: pad,
+    ...style,
+  }}>{children}</div>
+);
+
+const SectionLabel = ({ kicker, title, after }) => (
+  <div style={{
+    display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+    padding: '14px 20px 10px', borderBottom: `1px solid ${T.sep}`,
+  }}>
+    <div>
+      <div style={{
+        fontFamily: T.mono, fontSize: 10, letterSpacing: '0.16em',
+        textTransform: 'uppercase', color: after ? T.accent : T.red,
+      }}>{kicker}</div>
+      <div style={{ fontSize: 13, color: T.hi, marginTop: 2 }}>{title}</div>
+    </div>
+    <div style={{
+      fontFamily: T.mono, fontSize: 10, letterSpacing: '0.14em',
+      textTransform: 'uppercase', color: T.lo,
+    }}>{after ? 'After' : 'Before'}</div>
+  </div>
+);
+
+const Divider = () => (
+  <div style={{ width: 1, background: T.sep, alignSelf: 'stretch' }} />
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   1. P0 — Top bar redesign
+   ════════════════════════════════════════════════════════════ */
+
+const Icon = ({ ch, color = T.md, size = 18 }) => (
+  <span style={{ fontSize: size, color, lineHeight: 1, display: 'inline-block' }}>{ch}</span>
+);
+
+const TbCircle = ({ children, on, accent, w = 64 }) => (
+  <div style={{
+    width: w, height: 64, borderRadius: 32,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    background: on ? (accent ? `${accent}1F` : T.accentDim) : 'transparent',
+    color: on ? (accent || T.accent) : T.md,
+    position: 'relative',
+  }}>
+    {children}
+    {on && <span style={{
+      position: 'absolute', bottom: 2, left: '25%', right: '25%',
+      height: 2, background: accent || T.accent, borderRadius: 1,
+    }} />}
+  </div>
+);
+
+const TopBarBefore = () => (
+  <div style={{
+    width: '100%', height: 80, background: T.base,
+    borderBottom: `1px solid ${T.sep}`,
+    display: 'flex', alignItems: 'center', padding: '0 16px', gap: 16,
+  }}>
+    <div style={{
+      fontFamily: T.led, fontSize: 24, color: T.amber,
+      textShadow: `0 0 8px ${T.amberGlow}`, letterSpacing: 4, minWidth: 100,
+    }}>11:29</div>
+    <div style={{ width: 1, height: 48, background: T.sep }} />
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 2,
+      background: T.inset, border: `1px solid ${T.sep}`,
+      borderRadius: 36, padding: '4px 12px',
+    }}>
+      <span style={{
+        fontFamily: T.mono, fontSize: 12, textTransform: 'uppercase',
+        letterSpacing: '0.10em', color: T.lo, padding: '0 6px',
+      }}>In</span>
+      <TbCircle><Icon ch="♪" /></TbCircle>
+      <TbCircle on accent={T.sRadio}><Icon ch="📻" size={20} /></TbCircle>
+      <TbCircle><Icon ch="⌁" /></TbCircle>
+      <TbCircle><Icon ch="▼" /></TbCircle>
+      <TbCircle><Icon ch="⎘" /></TbCircle>
+    </div>
+    <div style={{ width: 1, height: 48, background: T.sep }} />
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 2,
+      background: T.inset, border: `1px solid ${T.sep}`,
+      borderRadius: 36, padding: '4px 12px',
+    }}>
+      <span style={{
+        fontFamily: T.mono, fontSize: 12, textTransform: 'uppercase',
+        letterSpacing: '0.10em', color: T.lo, padding: '0 6px',
+      }}>Out</span>
+      <TbCircle on><Icon ch="🔊" size={18} /></TbCircle>
+      <TbCircle><Icon ch="🔈" size={18} /></TbCircle>
+      <TbCircle><Icon ch="📺" size={18} /></TbCircle>
+      <TbCircle w={120}>
+        <Icon ch="📡" /><span style={{ fontSize: 11, color: T.md, marginLeft: 4 }}>Cast</span>
+      </TbCircle>
+    </div>
+    <TbCircle><Icon ch="🐞" size={20} color={T.lo} /></TbCircle>
+    <div style={{ marginLeft: 'auto', display: 'flex', gap: 2 }}>
+      <TbCircle on w={56}><Icon ch="⌂" size={22} color={T.accent} /></TbCircle>
+      <TbCircle w={56}><Icon ch="≡" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="▥" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="⌥" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="⌖" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="⏱" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="⚙" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="☎" size={22} /></TbCircle>
+      <TbCircle w={56}><Icon ch="⏻" size={22} /></TbCircle>
+    </div>
+  </div>
+);
+
+const NavPill = ({ label, badge, on }) => (
+  <div style={{
+    height: 56, padding: '0 16px',
+    display: 'inline-flex', alignItems: 'center', gap: 8,
+    borderRadius: 10,
+    background: on ? T.accentDim : 'transparent',
+    color: on ? T.accent : T.md,
+    fontFamily: T.mono, fontSize: 12, letterSpacing: '0.10em',
+    textTransform: 'uppercase', fontWeight: 500,
+    position: 'relative',
+  }}>
+    {label}
+    {badge && <span style={{
+      background: T.amber, color: T.base, fontSize: 10, fontWeight: 700,
+      borderRadius: 8, padding: '2px 6px', fontFamily: T.mono,
+    }}>{badge}</span>}
+  </div>
+);
+
+const SourceBubble = ({ ch, label, sub, color = T.md, accent, disabled, chev }) => (
+  <div style={{
+    height: 48, padding: '0 16px',
+    display: 'inline-flex', alignItems: 'center', gap: 10,
+    borderRadius: 24,
+    background: accent ? `${accent}14` : T.inset,
+    border: `1px solid ${accent ? `${accent}55` : T.sep}`,
+    color: accent || color,
+    opacity: disabled ? 0.4 : 1,
+    fontSize: 14, fontWeight: 500,
+  }}>
+    <span style={{
+      width: 28, height: 28, borderRadius: 14,
+      background: accent ? `${accent}33` : T.overlay,
+      display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+      fontSize: 14, color: accent || T.md,
+    }}>{ch}</span>
+    <span>{label}{sub && <span style={{
+      color: accent ? `${accent}cc` : T.lo, fontSize: 12, marginLeft: 6,
+    }}>· {sub}</span>}</span>
+    {chev && <span style={{
+      marginLeft: 4, color: accent || T.md, opacity: 0.7, fontSize: 16,
+    }}>›</span>}
+  </div>
+);
+
+const TopBarAfter = () => (
+  <div style={{
+    width: '100%', background: T.base,
+    borderBottom: `1px solid ${T.sep}`,
+    padding: '12px 24px',
+    display: 'flex', flexDirection: 'column', gap: 10,
+  }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 28 }}>
+      <div>
+        <div style={{
+          fontFamily: T.mono, fontSize: 10, letterSpacing: '0.16em',
+          textTransform: 'uppercase', color: T.lo,
+        }}>Time</div>
+        <div style={{
+          fontFamily: T.led, fontSize: 22, color: T.amber,
+          textShadow: `0 0 8px ${T.amberGlow}`, letterSpacing: 4,
+        }}>11:29</div>
+      </div>
+      <div style={{ width: 1, height: 40, background: T.sep }} />
+      <div>
+        <div style={{
+          fontFamily: T.mono, fontSize: 10, letterSpacing: '0.16em',
+          textTransform: 'uppercase', color: T.lo,
+        }}>In · Source</div>
+        <div style={{ fontSize: 15, color: T.hi, marginTop: 4, fontWeight: 500 }}>
+          <span style={{
+            display: 'inline-block', width: 8, height: 8, borderRadius: 2,
+            background: T.sRadio, marginRight: 8, verticalAlign: 1,
+          }} />
+          FM Radio · <span style={{ fontFamily: T.led, color: T.amber, letterSpacing: 2 }}>88.5</span>
+        </div>
+      </div>
+      <div style={{ color: T.lo, fontSize: 18, alignSelf: 'flex-end', marginBottom: 4 }}>→</div>
+      <div>
+        <div style={{
+          fontFamily: T.mono, fontSize: 10, letterSpacing: '0.16em',
+          textTransform: 'uppercase', color: T.lo,
+        }}>Out · Destination</div>
+        <div style={{ fontSize: 15, color: T.hi, marginTop: 4, fontWeight: 500 }}>
+          <span style={{
+            display: 'inline-block', width: 8, height: 8, borderRadius: 2,
+            background: T.accent, marginRight: 8, verticalAlign: 1,
+          }} />
+          Living Room <span style={{ color: T.md, fontWeight: 400 }}>· Cast</span>
+        </div>
+      </div>
+      <div style={{ marginLeft: 'auto', display: 'flex', gap: 4 }}>
+        <NavPill label="Home" on />
+        <NavPill label="Queue" badge="45" />
+        <NavPill label="Radio" />
+        <NavPill label="History" />
+        <NavPill label="Devices" />
+        <NavPill label="System" />
+      </div>
+    </div>
+    <div style={{ display: 'flex', gap: 8 }}>
+      <SourceBubble ch="♪" label="File" />
+      <SourceBubble ch="📻" label="Radio" sub="88.5" accent={T.sRadio} chev />
+      <SourceBubble ch="⌁" label="Bluetooth" />
+      <SourceBubble ch="⌖" label="Vinyl" sub="offline" disabled />
+      <SourceBubble ch="⎘" label="USB" />
+    </div>
+  </div>
+);
+
+const Mock_TopBar = () => (
+  <Stage w={1920} h={420}>
+    <SectionLabel kicker="Current" title="Three clusters of identical circular pills · debug button live · IDs unlabeled" />
+    <TopBarBefore />
+    <div style={{ height: 28 }} />
+    <SectionLabel kicker="Proposed" title="Labeled routing reads as a sentence · pill sources strip · rectangular nav · debug gated"
+      after />
+    <TopBarAfter />
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   2. P0 — Source / device naming
+   ════════════════════════════════════════════════════════════ */
+
+const NameRow = ({ raw, sub, danger }) => (
+  <div style={{
+    padding: '12px 16px', borderBottom: `1px solid ${T.sep}`,
+    display: 'flex', flexDirection: 'column', gap: 2,
+    fontFamily: danger ? T.mono : T.body,
+    fontSize: danger ? 12 : 14,
+    color: danger ? T.red : T.hi,
+  }}>
+    <span style={danger ? { wordBreak: 'break-all' } : null}>{raw}</span>
+    {sub && <span style={{ fontSize: 12, color: T.md, fontFamily: T.body }}>{sub}</span>}
+  </div>
+);
+
+const Mock_Naming = () => (
+  <Stage w={880} h={460} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{ display: 'flex', flex: 1 }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Raw API leakage" title="Audio Source · Devices · Tracks" />
+        <div style={{ flex: 1, background: T.raised, margin: '12px 16px', borderRadius: 8, border: `1px solid ${T.sep}` }}>
+          <NameRow raw="FilePlayer-da7eb94888fa43aab0021b8c0a4c2e1f7" danger />
+          <NameRow raw="1 - LG TV SSCR2 (AMD High Definition Audio Device)" danger />
+          <NameRow raw="CABLE In 16ch (VB-Audio Virtual Cable)" danger />
+          <NameRow raw="Track 8" sub="00:03:00.6628571" />
+        </div>
+      </div>
+      <Divider />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Display layer" title="DisplayName projection on every DTO" after />
+        <div style={{ flex: 1, background: T.raised, margin: '12px 16px', borderRadius: 8, border: `1px solid ${T.sep}` }}>
+          <NameRow raw="File Player" sub="Local · 45 tracks queued" />
+          <NameRow raw="LG TV" sub="HDMI · 5.1 surround capable" />
+          <NameRow raw="VB-Audio Cable" sub="16-channel virtual" />
+          <NameRow raw="We're Ready" sub="3:00 · from file name «08 - We're Ready.flac»" />
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   3. P0 — Queue formatting
+   ════════════════════════════════════════════════════════════ */
+
+const QRowBefore = ({ n, title, art, dur, active }) => (
+  <div style={{
+    display: 'grid', gridTemplateColumns: '24px 1fr 140px 24px',
+    alignItems: 'center', gap: 12, padding: '14px 16px',
+    borderBottom: `1px solid ${T.sep}`,
+    background: active ? 'rgba(92,212,232,0.06)' : 'transparent',
+  }}>
+    <span style={{ fontFamily: T.mono, color: T.lo, fontSize: 12 }}>{n}</span>
+    <div>
+      <div style={{ color: active ? T.accent : T.hi, fontSize: 14, fontWeight: 500 }}>{title}</div>
+      <div style={{ color: T.md, fontSize: 12 }}>{art}</div>
+    </div>
+    <span style={{ fontFamily: T.mono, color: T.md, fontSize: 11 }}>{dur}</span>
+    <span style={{ color: T.lo, textAlign: 'center' }}>×</span>
+  </div>
+);
+
+const QRowAfter = ({ n, title, art, alb, dur, active }) => (
+  <div style={{
+    display: 'grid', gridTemplateColumns: '28px 1fr 56px 24px',
+    alignItems: 'center', gap: 14, padding: '12px 16px',
+    borderBottom: `1px solid ${T.sep}`,
+    background: active ? 'rgba(240,168,48,0.06)' : 'transparent',
+    borderLeft: active ? `3px solid ${T.amber}` : '3px solid transparent',
+    paddingLeft: 13,
+  }}>
+    <span style={{
+      fontFamily: T.mono, color: active ? T.amber : T.lo, fontSize: 13, textAlign: 'center',
+    }}>{active ? '▶' : n}</span>
+    <div>
+      <div style={{ color: T.hi, fontSize: 15, fontWeight: 500 }}>{title}</div>
+      <div style={{ color: T.md, fontSize: 13 }}>{art} · {alb}</div>
+    </div>
+    <span style={{
+      fontFamily: T.mono, color: T.md, fontSize: 13, textAlign: 'right',
+      fontVariantNumeric: 'tabular-nums',
+    }}>{dur}</span>
+    <span style={{ color: T.lo, textAlign: 'center', fontSize: 16 }}>×</span>
+  </div>
+);
+
+const Mock_Queue = () => (
+  <Stage w={1280} h={540} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{ display: 'flex', flex: 1 }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Raw TimeSpan in column" title="Sub-tick precision · column eats space · no playing indicator" />
+        <div style={{ flex: 1, padding: 16 }}>
+          <div style={{
+            background: T.raised, borderRadius: 8, border: `1px solid ${T.sep}`,
+          }}>
+            <QRowBefore n="0" title="Track 8" art="Cary High Chorus" dur="00:03:00.6628571" active />
+            <QRowBefore n="1" title="I'm Not in Love" art="10cc" dur="00:06:04.9044897" />
+            <QRowBefore n="2" title="Track 9" art="Cary High Chorus" dur="00:02:19.9640816" />
+            <QRowBefore n="3" title="Bixby Canyon Bridge" art="Death Cab for Cutie" dur="00:05:15.4546938" />
+            <QRowBefore n="4" title="Track 10" art="Cary High Chorus" dur="00:01:17.1395918" />
+            <QRowBefore n="5" title="Track 11" art="Cary High Chorus" dur="00:02:00.5551020" />
+          </div>
+        </div>
+      </div>
+      <Divider />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Formatted · amber accent for now-playing" title="FormatDuration() · accent border · tabular numerals" after />
+        <div style={{ flex: 1, padding: 16 }}>
+          <div style={{
+            background: T.raised, borderRadius: 8, border: `1px solid ${T.sep}`,
+          }}>
+            <QRowAfter n="1" title="We're Ready" art="Boston" alb="Third Stage" dur="3:00" active />
+            <QRowAfter n="2" title="I'm Not in Love" art="10cc" alb="The Original Soundtrack" dur="6:04" />
+            <QRowAfter n="3" title="Track 9" art="Cary High Chorus" alb="Fall Concert 2006" dur="2:20" />
+            <QRowAfter n="4" title="Bixby Canyon Bridge" art="Death Cab for Cutie" alb="Narrow Stairs" dur="5:15" />
+            <QRowAfter n="5" title="Hot for Teacher" art="Van Halen" alb="1984" dur="4:42" />
+            <QRowAfter n="6" title="Don't Look Back" art="Boston" alb="Don't Look Back" dur="5:58" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   4. P0 — Metrics tiles
+   ════════════════════════════════════════════════════════════ */
+
+const TileBefore = ({ cat, name, val, suffix }) => (
+  <div style={{
+    background: T.raised, borderRadius: 8, padding: 16,
+    border: `1px solid ${T.sep}`,
+  }}>
+    <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.12em' }}>{cat}</div>
+    <div style={{ fontSize: 13, color: T.md, marginTop: 4 }}>{name}</div>
+    <div style={{ fontFamily: T.mono, fontSize: 28, color: T.accent, marginTop: 6, fontWeight: 500 }}>
+      {val}<span style={{ fontSize: 13, color: T.md }}>{suffix}</span>
+    </div>
+  </div>
+);
+
+const Sparkline = ({ stroke = T.accent, pts }) => (
+  <svg viewBox="0 0 120 28" preserveAspectRatio="none" style={{ width: '100%', height: 28, marginTop: 8, display: 'block' }}>
+    <polyline fill={`${stroke}1A`} stroke="none" points={`${pts} 120,28 0,28`} />
+    <polyline fill="none" stroke={stroke} strokeWidth="1.5" points={pts} />
+  </svg>
+);
+
+const TileAfter = ({ cat, name, val, suffix, delta, deltaColor = T.green, valColor, spark }) => (
+  <div style={{
+    background: T.raised, borderRadius: 8, padding: 16,
+    border: `1px solid ${T.sep}`,
+  }}>
+    <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.10em', textTransform: 'uppercase' }}>{cat}</div>
+    <div style={{ fontSize: 13, color: T.md, marginTop: 4 }}>{name}</div>
+    <div style={{ fontFamily: T.mono, fontSize: 30, color: valColor || T.hi, marginTop: 6, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>
+      {val}<span style={{ fontSize: 13, color: T.md, marginLeft: 4 }}>{suffix}</span>
+    </div>
+    {delta && <div style={{ fontSize: 11, color: deltaColor, marginTop: 2, fontFamily: T.mono }}>{delta}</div>}
+    {spark && <Sparkline {...spark} />}
+  </div>
+);
+
+const Mock_Metrics = () => (
+  <Stage w={1280} h={580} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{ display: 'flex', flex: 1 }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Unit & hierarchy bugs" title="850.4% memory · raw category prefixes · no trend" />
+        <div style={{ flex: 1, padding: 16, display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 12, gridAutoRows: 'min-content' }}>
+          <TileBefore cat="SYSTEM" name="Memory Usage Mb" val="850.4" suffix="%" />
+          <TileBefore cat="RADIO"  name="Signal Strength" val="65.39" />
+          <TileBefore cat="SYSTEM" name="Disk Usage Percent" val="35.7" suffix="%" />
+          <TileBefore cat="TTS"    name="Latency Ms" val="215" />
+          <TileBefore cat="RADIO"  name="Frequency Changes" val="261" />
+          <TileBefore cat="API"    name="Requests Total" val="135725" />
+        </div>
+      </div>
+      <Divider />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Grouped · sparklines · semantic color" title="One registry knows the unit · trend is part of the value" after />
+        <div style={{ flex: 1, padding: 16, overflow: 'hidden' }}>
+          <div style={{ fontFamily: T.mono, fontSize: 11, color: T.lo, letterSpacing: '0.14em', textTransform: 'uppercase', marginBottom: 8 }}>System</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 10, marginBottom: 14 }}>
+            <TileAfter cat="Memory" name="Heap in use" val="850" suffix="MB" delta="▲ 4% vs 1h ago"
+              spark={{ pts: '0,20 10,18 20,19 30,16 40,17 50,14 60,15 70,12 80,13 90,10 100,11 110,9 120,7', stroke: T.accent }} />
+            <TileAfter cat="Disk" name="Usage" val="35.7" suffix="%" valColor={T.green} delta="Stable"
+              spark={{ pts: '0,16 30,16 60,16 90,15 120,16', stroke: T.green }} />
+          </div>
+          <div style={{ fontFamily: T.mono, fontSize: 11, color: T.lo, letterSpacing: '0.14em', textTransform: 'uppercase', marginBottom: 8 }}>Radio</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 10 }}>
+            <TileAfter cat="Reception" name="Signal strength" val="65" suffix="%" valColor={T.green} delta="Stable · last 5 min"
+              spark={{ pts: '0,14 10,12 20,14 30,11 40,10 50,12 60,11 70,10 80,11 90,12 100,10 110,11 120,10', stroke: T.green }} />
+            <TileAfter cat="Tuning" name="Frequency changes · 24h" val="261" delta="▲ 12 today · last at 11:14" deltaColor={T.md} />
+          </div>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   5. P0 — File browser filter chips
+   ════════════════════════════════════════════════════════════ */
+
+const Mock_FbFilter = () => (
+  <Stage w={880} h={360} pad={20} style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+    <div>
+      <div style={{ fontFamily: T.mono, fontSize: 10, color: T.red, letterSpacing: '0.16em', textTransform: 'uppercase' }}>
+        Current — JSON re-serialization leaks
+      </div>
+      <div style={{
+        marginTop: 8, background: T.raised, border: `1px solid ${T.sep}`,
+        borderRadius: 8, padding: 14,
+      }}>
+        <div style={{ fontFamily: T.mono, fontSize: 11, color: T.lo, letterSpacing: '0.10em', textTransform: 'uppercase', marginBottom: 6 }}>Filter</div>
+        <div style={{
+          background: T.inset, border: `1px solid ${T.sep}`, borderRadius: 6,
+          padding: '10px 12px', fontFamily: T.mono, fontSize: 10, color: T.red,
+          wordBreak: 'break-all', lineHeight: 1.5,
+        }}>
+          "\u0022\u0022\\\u0022\\\\\\\\\u0022\\\\\\\\\\\\\\\\\u0022\\\\\\\\\\\\\\\\\\\\\\\\\u0022…
+        </div>
+      </div>
+    </div>
+    <div>
+      <div style={{ fontFamily: T.mono, fontSize: 10, color: T.accent, letterSpacing: '0.16em', textTransform: 'uppercase' }}>
+        Proposed — chips · one extension per chip · nothing to escape
+      </div>
+      <div style={{
+        marginTop: 8, background: T.raised, border: `1px solid ${T.sep}`,
+        borderRadius: 8, padding: 14,
+      }}>
+        <div style={{ fontFamily: T.mono, fontSize: 11, color: T.lo, letterSpacing: '0.10em', textTransform: 'uppercase', marginBottom: 8 }}>Show only</div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {['.mp3', '.flac', '.wav', '.m4a'].map((x) => (
+            <span key={x} style={{
+              height: 32, padding: '0 12px',
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              background: T.accentDim, border: `1px solid ${T.accent}55`,
+              borderRadius: 16, fontSize: 13, color: T.accent,
+              fontFamily: T.mono,
+            }}>{x} <span style={{ opacity: 0.6, fontSize: 14 }}>×</span></span>
+          ))}
+          <span style={{
+            height: 32, padding: '0 12px',
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+            background: 'transparent', border: `1px dashed ${T.sep}`,
+            borderRadius: 16, fontSize: 13, color: T.lo, fontFamily: T.mono,
+          }}>＋ add type</span>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   6. P1 — Persistent Now Playing dock
+   ════════════════════════════════════════════════════════════ */
+
+const FakePage = ({ title, children }) => (
+  <div style={{ flex: 1, padding: 24, display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <div style={{ fontSize: 22, fontWeight: 600, color: T.hi }}>{title}</div>
+    {children}
+  </div>
+);
+
+const SkelRow = ({ w = '100%', h = 12 }) => (
+  <div style={{ width: w, height: h, background: T.raised, borderRadius: 4 }} />
+);
+
+const Dock = () => (
+  <div style={{
+    height: 64, background: T.overlay, borderTop: `1px solid ${T.sep}`,
+    padding: '0 24px',
+    display: 'flex', alignItems: 'center', gap: 14,
+    backdropFilter: 'blur(20px)',
+  }}>
+    <div style={{
+      width: 48, height: 48, borderRadius: 6, flexShrink: 0,
+      background: 'linear-gradient(135deg, #2a2a30, #1a1a1f)',
+      position: 'relative', overflow: 'hidden',
+    }}>
+      <div style={{
+        position: 'absolute', inset: 0,
+        backgroundImage: `repeating-linear-gradient(135deg, rgba(255,255,255,0.05) 0 6px, transparent 6px 12px)`,
+      }} />
+    </div>
+    <div style={{ minWidth: 200 }}>
+      <div style={{ color: T.hi, fontSize: 14, fontWeight: 600 }}>We're Ready</div>
+      <div style={{ color: T.md, fontSize: 12 }}>
+        <span style={{
+          display: 'inline-block', width: 8, height: 8, borderRadius: 2,
+          background: T.sFile, marginRight: 6, verticalAlign: 1,
+        }} />
+        Boston · Third Stage
+      </div>
+    </div>
+    <div style={{ display: 'flex', gap: 2, alignItems: 'flex-end', height: 16, marginRight: 4 }}>
+      <span style={{ width: 3, height: 9, background: T.accent, borderRadius: 1 }} />
+      <span style={{ width: 3, height: 16, background: T.accent, borderRadius: 1 }} />
+      <span style={{ width: 3, height: 6, background: T.accent, borderRadius: 1 }} />
+    </div>
+    <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 10 }}>
+      <span style={{ fontFamily: T.mono, fontSize: 11, color: T.md, fontVariantNumeric: 'tabular-nums' }}>1:18</span>
+      <div style={{ flex: 1, height: 3, background: T.sep, borderRadius: 2, overflow: 'hidden' }}>
+        <div style={{ width: '44%', height: '100%', background: T.accent }} />
+      </div>
+      <span style={{ fontFamily: T.mono, fontSize: 11, color: T.md, fontVariantNumeric: 'tabular-nums' }}>3:00</span>
+    </div>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: T.md, fontSize: 20 }}>
+      <span>⏮</span>
+      <span style={{
+        width: 40, height: 40, borderRadius: 20, background: T.accent, color: T.base,
+        display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 16,
+      }}>▶</span>
+      <span>⏭</span>
+    </div>
+  </div>
+);
+
+const Mock_Dock = () => (
+  <Stage w={1920} h={760} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{
+      height: 64, background: T.base, borderBottom: `1px solid ${T.sep}`,
+      display: 'flex', alignItems: 'center', padding: '0 24px', gap: 20,
+    }}>
+      <div style={{ fontFamily: T.led, fontSize: 18, color: T.amber, letterSpacing: 3, textShadow: `0 0 6px ${T.amberGlow}` }}>11:29</div>
+      <div style={{ width: 1, height: 32, background: T.sep }} />
+      <div style={{ color: T.md, fontSize: 13 }}>FM Radio · 88.5 → Living Room</div>
+      <div style={{ marginLeft: 'auto', display: 'flex', gap: 4 }}>
+        <NavPill label="Home" />
+        <NavPill label="Devices" on />
+        <NavPill label="Metrics" />
+        <NavPill label="System" />
+      </div>
+    </div>
+    <FakePage title="Device Management">
+      <div style={{
+        background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8,
+        padding: 0, overflow: 'hidden',
+      }}>
+        {['VB-Audio Cable', 'Arctis Pro Wireless', 'LG TV · HDMI', 'Realtek USB', 'HTTP Audio Stream'].map((d, i) => (
+          <div key={d} style={{
+            padding: '14px 18px', display: 'flex', alignItems: 'center', gap: 14,
+            borderBottom: i < 4 ? `1px solid ${T.sep}` : 'none',
+            background: i === 0 ? 'rgba(92,212,232,0.04)' : 'transparent',
+          }}>
+            <span style={{ color: i === 0 ? T.accent : T.md, fontSize: 18 }}>{i === 0 ? '★' : '○'}</span>
+            <span style={{ color: T.hi, fontSize: 15, fontWeight: 500, flex: 1 }}>{d}</span>
+            {i === 0 && <span style={{
+              fontFamily: T.mono, fontSize: 11, color: T.accent,
+              background: T.accentDim, padding: '2px 8px', borderRadius: 4, letterSpacing: '0.1em', textTransform: 'uppercase',
+            }}>Default</span>}
+            <span style={{ color: T.md, fontSize: 13 }}>Output</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ flex: 1 }} />
+    </FakePage>
+    <Dock />
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   7. P1 — Source pill semantics
+   ════════════════════════════════════════════════════════════ */
+
+const Mock_PillSemantics = () => (
+  <Stage w={1100} h={320} pad={24} style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+    <div>
+      <div style={{ fontFamily: T.mono, fontSize: 10, color: T.red, letterSpacing: '0.16em', textTransform: 'uppercase' }}>
+        Current — one button, three different actions, no chevron
+      </div>
+      <div style={{ marginTop: 12, display: 'flex', gap: 8, fontSize: 12, color: T.lo, fontFamily: T.mono }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="📻" label="Radio" accent={T.sRadio} />
+          <span>tap → switch source</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="📻" label="Radio" accent={T.sRadio} />
+          <span style={{ color: T.amber }}>tap again → toggle home panel</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="⌁" label="Bluetooth" accent={T.sBT} />
+          <span style={{ color: T.amber }}>tap again → navigate /bluetooth</span>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div style={{ fontFamily: T.mono, fontSize: 10, color: T.accent, letterSpacing: '0.16em', textTransform: 'uppercase' }}>
+        Proposed — body switches source · chevron opens detail
+      </div>
+      <div style={{ marginTop: 12, display: 'flex', gap: 8, fontSize: 12, color: T.lo, fontFamily: T.mono }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="📻" label="Radio" sub="88.5" accent={T.sRadio} chev />
+          <span>body → switch  ·  ›  → detail</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="⌁" label="Bluetooth" sub="JBL Charge" accent={T.sBT} chev />
+          <span>body → switch  ·  ›  → device list</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+          <SourceBubble ch="♪" label="File" />
+          <span>no detail · just switches</span>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   8. P1 — Visualizer panel
+   ════════════════════════════════════════════════════════════ */
+
+const VizSpectrum = ({ bars = 32, w = '100%', h = 380, color = T.accent }) => {
+  const data = Array.from({ length: bars }, (_, i) => {
+    const x = i / bars;
+    return 0.35 + 0.6 * Math.abs(Math.sin(x * 6 + 1)) * (1 - x * 0.4);
+  });
+  return (
+    <svg viewBox={`0 0 ${bars * 10} 100`} preserveAspectRatio="none" style={{ width: w, height: h, display: 'block' }}>
+      {data.map((v, i) => (
+        <rect key={i} x={i * 10 + 1.5} y={100 - v * 90} width={7} height={v * 90}
+              fill={color} opacity={0.75 + 0.25 * v} />
+      ))}
+    </svg>
+  );
+};
+
+const Mock_Visualizer = () => (
+  <Stage w={1480} h={620} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{ display: 'flex', flex: 1 }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Current" title="Mode picker in corner · debug telemetry overlaid · canvas inset from edges" />
+        <div style={{ flex: 1, padding: 16 }}>
+          <div style={{ height: '100%', background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, padding: 16, position: 'relative' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+              <div style={{ color: T.hi, fontSize: 14 }}>Visualizer</div>
+              <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+                <span style={{ background: T.green, color: T.base, padding: '2px 8px', borderRadius: 10, fontSize: 10, fontWeight: 600 }}>Connected</span>
+                <span style={{ border: `1px solid ${T.accent}`, color: T.accent, padding: '2px 8px', borderRadius: 4, fontSize: 11 }}>VU</span>
+                <span style={{ border: `1px solid ${T.sep}`, color: T.md, padding: '2px 8px', borderRadius: 4, fontSize: 11 }}>WAVE</span>
+                <span style={{ border: `1px solid ${T.sep}`, color: T.md, padding: '2px 8px', borderRadius: 4, fontSize: 11 }}>SPEC</span>
+              </div>
+            </div>
+            <div style={{ position: 'relative', background: T.inset, borderRadius: 4, height: 360, overflow: 'hidden' }}>
+              <VizSpectrum h={360} bars={28} />
+              <div style={{
+                position: 'absolute', bottom: 8, left: 8,
+                color: T.yellow, fontFamily: T.mono, fontSize: 11, fontWeight: 600,
+              }}>Updates: 22/sec</div>
+              <div style={{
+                position: 'absolute', bottom: 8, left: '50%', transform: 'translateX(-50%)',
+                color: T.lo, fontFamily: T.mono, fontSize: 9, display: 'flex', gap: 60,
+              }}>
+                <span>375Hz</span><span>750Hz</span><span>1.1kHz</span><span>1.5kHz</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Divider />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <SectionLabel kicker="Promoted" title="Mode picker = top segmented control · canvas fills · dev telemetry gated" after />
+        <div style={{ flex: 1, padding: 16 }}>
+          <div style={{ height: '100%', background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+            <div style={{
+              display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)',
+              borderBottom: `1px solid ${T.sep}`,
+            }}>
+              {['VU Meter', 'Waveform', 'Spectrum'].map((m, i) => (
+                <div key={m} style={{
+                  padding: '14px 0', textAlign: 'center',
+                  background: i === 2 ? T.accentDim : 'transparent',
+                  color: i === 2 ? T.accent : T.md,
+                  fontFamily: T.mono, fontSize: 12, letterSpacing: '0.10em',
+                  textTransform: 'uppercase', fontWeight: 600,
+                  borderRight: i < 2 ? `1px solid ${T.sep}` : 'none',
+                  position: 'relative',
+                }}>
+                  {m}
+                  {i === 2 && <span style={{
+                    position: 'absolute', bottom: 0, left: '20%', right: '20%',
+                    height: 2, background: T.accent,
+                  }} />}
+                </div>
+              ))}
+            </div>
+            <div style={{ flex: 1, position: 'relative', background: T.inset }}>
+              <VizSpectrum h="100%" bars={48} />
+              <div style={{
+                position: 'absolute', top: 12, right: 12,
+                width: 8, height: 8, borderRadius: 4, background: T.green,
+                boxShadow: `0 0 8px ${T.green}`,
+              }} />
+              <div style={{
+                position: 'absolute', bottom: 8, left: 0, right: 0,
+                color: T.lo, fontFamily: T.mono, fontSize: 10, display: 'flex',
+                justifyContent: 'space-around',
+              }}>
+                <span>250Hz</span><span>500Hz</span><span>1kHz</span><span>2kHz</span><span>4kHz</span><span>8kHz</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   9. P1 — Queue split layout
+   ════════════════════════════════════════════════════════════ */
+
+const Mock_QueueSplit = () => (
+  <Stage w={1200} h={660} style={{ display: 'flex', flexDirection: 'column' }}>
+    <SectionLabel kicker="Center column of Home" title="Queue list + context panel · uses the whole 640px of vertical content area"
+      after />
+    <div style={{ flex: 1, padding: 16, display: 'flex', gap: 12 }}>
+      <div style={{ flex: 1.6, display: 'flex', flexDirection: 'column' }}>
+        <div style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          padding: '6px 10px 12px',
+        }}>
+          <div style={{ display: 'flex', gap: 4 }}>
+            <span style={{
+              padding: '6px 14px', background: T.accentDim, color: T.accent,
+              borderRadius: 6, fontFamily: T.mono, fontSize: 12,
+              letterSpacing: '0.10em', textTransform: 'uppercase', fontWeight: 600,
+            }}>Queue · 45</span>
+            <span style={{
+              padding: '6px 14px', color: T.md,
+              borderRadius: 6, fontFamily: T.mono, fontSize: 12,
+              letterSpacing: '0.10em', textTransform: 'uppercase', fontWeight: 600,
+            }}>History</span>
+            <span style={{
+              padding: '6px 14px', color: T.md,
+              borderRadius: 6, fontFamily: T.mono, fontSize: 12,
+              letterSpacing: '0.10em', textTransform: 'uppercase', fontWeight: 600,
+            }}>Radio</span>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <span style={{ color: T.accent, fontSize: 16 }}>＋</span>
+            <span style={{ color: T.md, fontSize: 16 }}>⋮</span>
+          </div>
+        </div>
+        <div style={{
+          flex: 1, background: T.raised, borderRadius: 8, border: `1px solid ${T.sep}`,
+          overflow: 'hidden',
+        }}>
+          <QRowAfter n="1" title="We're Ready" art="Boston" alb="Third Stage" dur="3:00" active />
+          <QRowAfter n="2" title="I'm Not in Love" art="10cc" alb="Original Soundtrack" dur="6:04" />
+          <QRowAfter n="3" title="Bixby Canyon Bridge" art="Death Cab" alb="Narrow Stairs" dur="5:15" />
+          <QRowAfter n="4" title="Hot for Teacher" art="Van Halen" alb="1984" dur="4:42" />
+          <QRowAfter n="5" title="Don't Look Back" art="Boston" alb="Don't Look Back" dur="5:58" />
+          <QRowAfter n="6" title="Foreplay / Long Time" art="Boston" alb="Boston" dur="7:48" />
+          <QRowAfter n="7" title="More Than a Feeling" art="Boston" alb="Boston" dur="4:44" />
+        </div>
+      </div>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 12, marginTop: 50 }}>
+        <div style={{ background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, padding: 16 }}>
+          <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.14em', textTransform: 'uppercase' }}>Queue Total</div>
+          <div style={{ fontFamily: T.led, fontSize: 30, color: T.amber, marginTop: 6, letterSpacing: 4, textShadow: `0 0 8px ${T.amberGlow}` }}>
+            2:48:15
+          </div>
+          <div style={{ color: T.md, fontSize: 12, marginTop: 4 }}>45 tracks · ends ~14:17</div>
+        </div>
+        <div style={{ background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, padding: 16 }}>
+          <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.14em', textTransform: 'uppercase', marginBottom: 8 }}>Up next</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {[
+              ['I\'m Not in Love', '10cc', T.hi],
+              ['Bixby Canyon Bridge', 'Death Cab', T.md],
+              ['Hot for Teacher', 'Van Halen', T.lo],
+            ].map(([t, a, c]) => (
+              <div key={t} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                <div style={{ width: 32, height: 32, background: T.overlay, borderRadius: 4, flexShrink: 0 }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ color: c, fontSize: 13, fontWeight: 500, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{t}</div>
+                  <div style={{ color: T.lo, fontSize: 11 }}>{a}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div style={{ background: T.raised, border: `1px solid ${T.accent}55`, borderRadius: 8, padding: 14, display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ color: T.accent, fontSize: 18 }}>＋</span>
+          <span style={{ color: T.accent, fontSize: 14, fontWeight: 500 }}>Save as playlist</span>
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   10. P1 — Skeleton loading
+   ════════════════════════════════════════════════════════════ */
+
+const Skel = ({ w, h, br = 4 }) => (
+  <div style={{ width: w, height: h, background: `linear-gradient(90deg, ${T.raised} 0%, ${T.overlay} 50%, ${T.raised} 100%)`, backgroundSize: '200% 100%', borderRadius: br, animation: 'shimmer 1.4s infinite' }} />
+);
+
+const Mock_Skeleton = () => (
+  <Stage w={1280} h={660} style={{ display: 'flex', flexDirection: 'column' }}>
+    <SectionLabel kicker="Loading states" title="Shape-matched skeletons replace centered spinners on every primary panel"
+      after />
+    <style>{`@keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }`}</style>
+    <div style={{ flex: 1, padding: 16, display: 'flex', gap: 12 }}>
+      <div style={{ width: 360, background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, padding: 16, display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.12em', textTransform: 'uppercase' }}>Now Playing · loading</div>
+        <Skel w={280} h={280} br={8} />
+        <Skel w="80%" h={18} />
+        <Skel w="60%" h={14} />
+        <div style={{ flex: 1 }} />
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
+          <Skel w={40} h={40} br={20} />
+          <Skel w={56} h={56} br={28} />
+          <Skel w={40} h={40} br={20} />
+        </div>
+      </div>
+      <div style={{ flex: 1, background: T.raised, border: `1px solid ${T.sep}`, borderRadius: 8, padding: 20, display: 'flex', flexDirection: 'column', gap: 18 }}>
+        <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.12em', textTransform: 'uppercase' }}>Radio control · loading</div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <Skel w={64} h={36} br={6} />
+          <Skel w={64} h={36} br={6} />
+          <Skel w={64} h={36} br={6} />
+        </div>
+        <div style={{ background: T.inset, borderRadius: 8, padding: 24, textAlign: 'center', border: `1px solid ${T.sep}` }}>
+          <Skel w={300} h={56} br={4} />
+        </div>
+        <div>
+          <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 6 }}>Signal</div>
+          <div style={{ display: 'flex', gap: 2 }}>
+            {Array.from({ length: 20 }).map((_, i) => (
+              <Skel key={i} w={20} h={20} br={2} />
+            ))}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 8, marginTop: 'auto' }}>
+          <Skel w={48} h={48} br={24} />
+          <Skel w={48} h={48} br={24} />
+          <Skel w={64} h={48} br={24} />
+          <Skel w={48} h={48} br={24} />
+          <Skel w={48} h={48} br={24} />
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   11. P2 — Sleep screen ambient
+   ════════════════════════════════════════════════════════════ */
+
+const Mock_Sleep = () => (
+  <Stage w={1920} h={760} style={{ background: '#050507', position: 'relative' }}>
+    <div style={{
+      position: 'absolute', inset: 0,
+      background: 'radial-gradient(ellipse at center, rgba(240,168,48,0.06) 0%, transparent 60%)',
+    }} />
+    <div style={{
+      position: 'absolute', inset: 0, display: 'flex',
+      alignItems: 'center', justifyContent: 'center', flexDirection: 'column', gap: 28,
+    }}>
+      <div style={{
+        width: 160, height: 160, borderRadius: 16,
+        background: 'linear-gradient(135deg, #1a1517 0%, #0d0a0c 100%)',
+        position: 'relative', overflow: 'hidden',
+        boxShadow: '0 20px 80px rgba(240,168,48,0.08)',
+        opacity: 0.4,
+      }}>
+        <div style={{ position: 'absolute', inset: 0, backgroundImage: `repeating-linear-gradient(135deg, rgba(240,168,48,0.05) 0 10px, transparent 10px 20px)` }} />
+      </div>
+      <div style={{
+        fontFamily: T.led, fontSize: 96, color: T.amber,
+        textShadow: `0 0 24px ${T.amberGlow}, 0 0 60px rgba(240,168,48,0.15)`,
+        letterSpacing: 14,
+      }}>11:29</div>
+      <div style={{
+        fontFamily: T.body, fontSize: 18, color: T.dim,
+        letterSpacing: '0.08em',
+      }}>We're Ready · Boston</div>
+      <div style={{
+        fontFamily: T.mono, fontSize: 11, color: '#1f1a1d',
+        letterSpacing: '0.18em', textTransform: 'uppercase',
+        marginTop: 60,
+      }}>tap anywhere to wake</div>
+    </div>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   12. P2 — Dev tools gesture & tray
+   ════════════════════════════════════════════════════════════ */
+
+const Mock_DevTools = () => (
+  <Stage w={880} h={620} style={{ display: 'flex', flexDirection: 'column' }}>
+    <SectionLabel kicker="Production hygiene" title="Distortion marker + telemetry hidden behind a corner gesture"
+      after />
+    <div style={{ flex: 1, padding: 20, display: 'flex', flexDirection: 'column', gap: 16, overflow: 'hidden' }}>
+      <div style={{
+        position: 'relative', height: 64, background: T.base,
+        border: `1px solid ${T.sep}`, borderRadius: 6,
+        display: 'flex', alignItems: 'center', padding: '0 16px', gap: 16,
+      }}>
+        <div style={{ fontFamily: T.led, fontSize: 18, color: T.amber, letterSpacing: 3, textShadow: `0 0 6px ${T.amberGlow}` }}>11:29</div>
+        <span style={{ color: T.md, fontSize: 13 }}>FM Radio · 88.5 → Living Room</span>
+        <div style={{
+          position: 'absolute', top: 0, right: 0, width: 48, height: 48,
+          border: `1px dashed ${T.accent}55`,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <span style={{ fontSize: 10, color: T.accent, fontFamily: T.mono, letterSpacing: '0.10em' }}>3×TAP</span>
+        </div>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+        <div style={{ fontSize: 20, color: T.accent, marginTop: 4 }}>↓</div>
+        <div style={{ color: T.md, fontSize: 13 }}>
+          Triple-tap the clock corner to unlock the dev tray. Re-locks after 30s idle.
+        </div>
+      </div>
+      <div style={{
+        background: T.raised, border: `1px solid ${T.accent}55`,
+        borderRadius: 8, padding: 14,
+        boxShadow: `0 8px 32px rgba(0,0,0,0.4)`,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+          <div style={{ fontFamily: T.mono, fontSize: 10, color: T.accent, letterSpacing: '0.14em', textTransform: 'uppercase' }}>
+            ● Dev Tray  ·  unlocked
+          </div>
+          <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo }}>auto-lock 0:27</div>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+          {[
+            ['🐞', 'Mark distortion', 'reports a flag at current playback offset'],
+            ['📊', 'Updates: 22/sec', 'live visualizer telemetry'],
+            ['💾', 'Dump audio frame', 'last 5s buffered'],
+            ['📜', 'Download logs', 'last hour · zip'],
+            ['🔧', 'Fingerprint events', '12 events · last 5 min'],
+            ['🧪', 'Engine state', 'Active · FilePlayer · Stopped'],
+          ].map(([ic, t, sub]) => (
+            <div key={t} style={{
+              padding: 12, background: T.inset, borderRadius: 6,
+              border: `1px solid ${T.sep}`,
+              display: 'flex', gap: 10, alignItems: 'flex-start',
+            }}>
+              <span style={{ fontSize: 16 }}>{ic}</span>
+              <div>
+                <div style={{ color: T.hi, fontSize: 13, fontWeight: 500 }}>{t}</div>
+                <div style={{ color: T.lo, fontSize: 11 }}>{sub}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  </Stage>
+);
+
+
+/* ─────────── publish ─────────── */
+Object.assign(window, {
+  Mock_TopBar,
+  Mock_Naming,
+  Mock_Queue,
+  Mock_Metrics,
+  Mock_FbFilter,
+  Mock_Dock,
+  Mock_PillSemantics,
+  Mock_Visualizer,
+  Mock_QueueSplit,
+  Mock_Skeleton,
+  Mock_Sleep,
+  Mock_DevTools,
+});

--- a/docs/design-handoffs/design_handoff_radio_controller/Design Analysis.html
+++ b/docs/design-handoffs/design_handoff_radio_controller/Design Analysis.html
@@ -1,0 +1,502 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=1200" />
+<title>Radio Controller — Design Analysis</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --surface-base:        #0D0D0F;
+    --surface-raised:      #141416;
+    --surface-inset:       #0A0A0C;
+    --surface-overlay:     #1A1A1D;
+    --surface-separator:   #1F1F22;
+    --surface-hairline:    #25252A;
+
+    --accent:              #5CD4E8;
+    --accent-dim:          rgba(92, 212, 232, 0.10);
+    --accent-glow:         rgba(92, 212, 232, 0.25);
+
+    --amber:               #F0A830;
+    --amber-glow:          rgba(240, 168, 48, 0.30);
+
+    --sig-red:             #F87171;
+    --sig-amber:           #FBBF24;
+    --sig-green:           #4ADE80;
+
+    --text-hi:             #F0EFF4;
+    --text-md:             #9CA3AF;
+    --text-lo:             #6B7280;
+    --text-dim:            #353841;
+
+    --font-body:           'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    --font-mono:           'JetBrains Mono', 'SF Mono', Consolas, monospace;
+    --font-led:            'Share Tech Mono', 'JetBrains Mono', monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; padding: 0;
+    background: var(--surface-base); color: var(--text-hi);
+    font-family: var(--font-body); font-size: 15px; line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+  ::selection { background: var(--accent-glow); color: var(--text-hi); }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  .shell { max-width: 920px; margin: 0 auto; padding: 0 48px 120px; }
+
+  /* Sticky rail */
+  .rail {
+    position: sticky; top: 0; z-index: 50; height: 56px;
+    background: rgba(13,13,15,0.9); backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--surface-separator);
+    display: flex; align-items: center; padding: 0 48px; gap: 24px;
+  }
+  .rail-brand {
+    display: flex; align-items: center; gap: 12px;
+    font-family: var(--font-mono); font-size: 11px;
+    letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-md);
+  }
+  .rail-brand .dot { width: 8px; height: 8px; border-radius: 50%;
+    background: var(--amber); box-shadow: 0 0 8px var(--amber-glow); }
+  .rail-doc { margin-left: auto; font-family: var(--font-mono); font-size: 11px;
+    color: var(--text-lo); letter-spacing: 0.10em; }
+
+  /* Hero */
+  .hero { padding: 96px 0 48px; }
+  .hero h1 {
+    font-family: var(--font-mono); font-size: 36px; font-weight: 600;
+    letter-spacing: -0.01em; margin: 0 0 18px;
+    color: var(--text-hi); line-height: 1.15;
+  }
+  .hero .deck { font-size: 17px; color: var(--text-md); max-width: 64ch; }
+  .hero .meta {
+    margin-top: 36px;
+    display: flex; gap: 32px;
+    font-family: var(--font-mono); font-size: 12px;
+    color: var(--text-lo); letter-spacing: 0.10em; text-transform: uppercase;
+  }
+  .hero .meta span { display: flex; align-items: center; gap: 6px; }
+  .hero .meta b { color: var(--text-hi); font-weight: 500; }
+
+  /* Section */
+  section { padding: 48px 0; border-top: 1px solid var(--surface-separator); }
+  section h2 {
+    font-family: var(--font-mono); font-size: 11px;
+    color: var(--text-lo); letter-spacing: 0.18em;
+    text-transform: uppercase; margin: 0 0 8px;
+  }
+  section .h2-title {
+    font-size: 26px; font-weight: 500; margin: 0 0 12px;
+    color: var(--text-hi); letter-spacing: -0.01em;
+  }
+  section .lede {
+    font-size: 16px; color: var(--text-md); max-width: 64ch; margin: 0 0 36px;
+  }
+
+  /* Finding */
+  .finding {
+    margin: 28px 0; padding: 24px 28px;
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-hairline);
+    border-radius: 6px;
+  }
+  .finding header {
+    display: flex; align-items: baseline; gap: 14px;
+    margin-bottom: 14px;
+  }
+  .finding .num {
+    font-family: var(--font-led); font-size: 18px; color: var(--amber);
+    text-shadow: 0 0 6px var(--amber-glow);
+    min-width: 38px;
+  }
+  .finding .title {
+    flex: 1; font-size: 18px; font-weight: 500; color: var(--text-hi);
+  }
+  .finding .sev {
+    font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.16em;
+    text-transform: uppercase; padding: 3px 10px; border-radius: 3px;
+  }
+  .sev.p0 { color: var(--sig-red); background: rgba(248,113,113,0.10); border: 1px solid rgba(248,113,113,0.30); }
+  .sev.p1 { color: var(--sig-amber); background: rgba(251,191,36,0.10); border: 1px solid rgba(251,191,36,0.30); }
+  .sev.p2 { color: var(--accent); background: var(--accent-dim); border: 1px solid var(--accent-glow); }
+
+  .finding .label {
+    font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.14em;
+    color: var(--text-lo); text-transform: uppercase;
+    margin: 18px 0 6px;
+  }
+  .finding p { margin: 0 0 12px; color: var(--text-md); }
+  .finding p:last-child { margin-bottom: 0; }
+  .finding strong { color: var(--text-hi); font-weight: 500; }
+  .finding code {
+    font-family: var(--font-mono); font-size: 13px;
+    color: var(--amber); background: var(--surface-inset);
+    padding: 1px 6px; border-radius: 3px;
+    border: 1px solid var(--surface-separator);
+  }
+  .finding ul { padding-left: 22px; margin: 0 0 12px; color: var(--text-md); }
+  .finding ul li { margin-bottom: 4px; }
+  .finding ul li::marker { color: var(--text-dim); }
+
+  /* TOC */
+  .toc {
+    margin: 36px 0 0; padding: 24px 28px;
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-hairline);
+    border-radius: 6px;
+  }
+  .toc h3 {
+    font-family: var(--font-mono); font-size: 10px; color: var(--text-lo);
+    letter-spacing: 0.18em; text-transform: uppercase; margin: 0 0 14px;
+  }
+  .toc ol { padding: 0; margin: 0; list-style: none; counter-reset: t; }
+  .toc ol li {
+    counter-increment: t;
+    display: grid; grid-template-columns: 28px 70px 1fr 80px;
+    align-items: baseline; gap: 12px;
+    padding: 8px 0;
+    border-bottom: 1px dashed var(--surface-separator);
+    font-size: 14px;
+  }
+  .toc ol li:last-child { border-bottom: 0; }
+  .toc ol li::before {
+    content: counter(t, decimal-leading-zero);
+    font-family: var(--font-led); font-size: 13px; color: var(--amber);
+    text-align: right;
+  }
+  .toc ol li .ssev {
+    font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+  .ssev.p0 { color: var(--sig-red); }
+  .ssev.p1 { color: var(--sig-amber); }
+  .ssev.p2 { color: var(--accent); }
+  .toc ol li a { color: var(--text-hi); }
+  .toc ol li .target {
+    font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em;
+    color: var(--text-lo); text-transform: uppercase; text-align: right;
+  }
+</style>
+</head>
+<body>
+
+<header class="rail">
+  <div class="rail-brand"><span class="dot"></span> RADIO.WEB · DESIGN REVIEW</div>
+  <div class="rail-doc">02 · CONTROLLER PASS</div>
+</header>
+
+<main class="shell">
+
+  <div class="hero">
+    <h1>Radio Controller<br/>tuner, recognition, gain.</h1>
+    <p class="deck">
+      A follow-up to the first Radio.Web review. That pass audited the chrome — top bar,
+      sources, queue, metrics. It explicitly did not touch the radio control surfaces because
+      they only render on the live device. This document closes that gap: seven findings across
+      four screens, all observed on hardware.
+    </p>
+    <div class="meta">
+      <span><b>4</b> SCREENS</span>
+      <span><b>7</b> FINDINGS</span>
+      <span><b>3</b> P0 / <b>3</b> P1 / <b>1</b> P2</span>
+      <span>RTL-SDR · DSEG · 1920 × 720</span>
+    </div>
+
+    <div class="toc">
+      <h3>Findings</h3>
+      <ol>
+        <li><span class="ssev p0">P0</span><a href="#f1">Signal meter can read 118 %</a><span class="target">RadioControlPanel.razor</span></li>
+        <li><span class="ssev p0">P0</span><a href="#f2">AGC strip is half-empty whenever AGC is on</a><span class="target">RadioControlPanel.razor</span></li>
+        <li><span class="ssev p0">P0</span><a href="#f3">"80 %" appears in every confidence cell</a><span class="target">NowPlayingPanel.razor</span></li>
+        <li><span class="ssev p1">P1</span><a href="#f4">Tuner header & RDS info under-promoted</a><span class="target">RadioControlPanel.razor</span></li>
+        <li><span class="ssev p1">P1</span><a href="#f5">Memory presets duplicate the frequency in the name</a><span class="target">RadioControlPanel.razor</span></li>
+        <li><span class="ssev p1">P1</span><a href="#f6">Source / gain / search status are three pills</a><span class="target">NowPlayingPanel.razor</span></li>
+        <li><span class="ssev p2">P2</span><a href="#f7">Gain popover has no feedback meter</a><span class="target">MainLayout.razor</span></li>
+      </ol>
+    </div>
+  </div>
+
+
+  <section>
+    <h2>P0 — bugs and confusing readouts</h2>
+    <div class="h2-title">Things that mislead the user every time the device boots.</div>
+    <p class="lede">
+      Each of these has been observed on hardware. They aren't visual nitpicks — they are
+      functional defects that make the radio source look broken or untrustworthy.
+    </p>
+
+    <article class="finding" id="f1">
+      <header>
+        <div class="num">01</div>
+        <div class="title">Signal meter can read 118 %</div>
+        <div class="sev p0">P0</div>
+      </header>
+
+      <div class="label">Observed</div>
+      <p>
+        On <strong>92.30 MHz FM</strong> with a strong local signal the meter reads
+        <code>118 %</code> while the 20-segment bar is fully lit. A moment earlier it read
+        <code>111 %</code>. Percentages above 100 % shouldn't exist; the bar can't fill any
+        further so the number contradicts the visual.
+      </p>
+
+      <div class="label">Why it happens</div>
+      <p>
+        The value bound to <code>SignalStrength</code> is a raw RTL-SDR power reading that's not
+        normalised to a calibrated full-scale, and the segment colouring inside
+        <code>RadioControlPanel.razor</code> (<code>i &lt; 12 ? green : i &lt; 17 ? amber : red</code>)
+        assumes a 0–100 input domain that the data doesn't promise.
+      </p>
+
+      <div class="label">Proposed direction</div>
+      <ul>
+        <li>Switch the readout to a <strong>calibrated dBu scale</strong> (–60 → 0 dBu) and
+            label it <code>RSSI</code>, not "Signal %".</li>
+        <li>Drop scale labels under the bar (<code>−60 −30 −12 0 dBu</code>) so the user can
+            anchor what each segment means.</li>
+        <li>Lift "overdriven front-end" to its own <code>CLIP</code> pill next to the value —
+            don't encode it as "more than 100 %". CLIP only lights when the input
+            is actually saturating; otherwise the bar is a clean 0–100 fill.</li>
+      </ul>
+      <p>See canvas: <strong>P0 / Signal meter — 118 % is impossible</strong>.</p>
+    </article>
+
+
+    <article class="finding" id="f2">
+      <header>
+        <div class="num">02</div>
+        <div class="title">AGC strip is half-empty whenever AGC is on</div>
+        <div class="sev p0">P0</div>
+      </header>
+
+      <div class="label">Observed</div>
+      <p>
+        The strip below the scan buttons has two cells: the AGC toggle on the left, and a slot
+        on the right that holds a manual <code>GAIN</code> slider. When AGC is on, the slider
+        is hidden — the right cell becomes a blank rectangle. The strip changes height between
+        states.
+      </p>
+
+      <div class="label">Why it matters</div>
+      <p>
+        Two real problems. First, the user can't see what gain the tuner has chosen — turning
+        AGC off is a leap into the dark. Second, the empty cell makes the panel look
+        unfinished; it reads as a layout bug, not a deliberate state.
+      </p>
+
+      <div class="label">Proposed direction</div>
+      <ul>
+        <li>Treat the strip as <strong>two fixed cells</strong> that are always full.</li>
+        <li>The AGC cell carries the toggle plus an <code>AUTO</code> / <code>OFF</code> pill
+            — the state is part of the label, not just the switch position.</li>
+        <li>The right cell shows the currently active gain in both states: when AGC is on,
+            "<em>Tuner is choosing — 28.0 dB</em>"; when off, the slider and its range.</li>
+      </ul>
+      <p>See canvas: <strong>P0 / AGC / gain strip — never half-empty</strong>.</p>
+    </article>
+
+
+    <article class="finding" id="f3">
+      <header>
+        <div class="num">03</div>
+        <div class="title">"80 %" appears in every confidence cell</div>
+        <div class="sev p0">P0</div>
+      </header>
+
+      <div class="label">Observed</div>
+      <p>
+        The song-recognition panel (the table that replaces the album art when "Searching"
+        is the current state) has a <code>Conf%</code> column. Every populated row reads
+        <strong>80 %</strong>. The two failed rows read <code>--</code>. The column is
+        carrying no information.
+      </p>
+
+      <div class="label">Why it happens</div>
+      <p>
+        The confidence value coming back from the fingerprinter is a coarse bucket (the
+        library returns one of a few discrete grades), and the display is treating it as a
+        free-form number. "80 %" is the threshold above which a match qualifies — not a
+        per-track score.
+      </p>
+
+      <div class="label">Proposed direction</div>
+      <ul>
+        <li>Replace the numeric column with a <strong>three-pip indicator + word label</strong>
+            (<em>Strong / Likely / Possible / No match</em>). The pip count encodes the bucket;
+            the word resolves it.</li>
+        <li>Drop the <code>Art</code> column (just a ✓ / ✗) and use the cover-art square as
+            the row leader — present art renders, absent art gets a <code>♪</code> placeholder.</li>
+        <li>Lift the currently-playing row out of the table as a <strong>NOW</strong> anchor,
+            with the rest of history dimmed below under an <strong>EARLIER</strong> heading.
+            This is the actual question the user is asking when they look at the panel.</li>
+        <li>Remove the <code>Fingerprints: 4.1/min · Lookups: 4.1/min</code> telemetry from
+            the header — it belongs in the dev tray, not the user-facing panel.</li>
+      </ul>
+      <p>See canvas: <strong>P0 / Song recognition — kill the 80 % column</strong>.</p>
+    </article>
+  </section>
+
+
+  <section>
+    <h2>P1 — structural improvements</h2>
+    <div class="h2-title">The product feels twice as finished after these.</div>
+
+    <article class="finding" id="f4">
+      <header>
+        <div class="num">04</div>
+        <div class="title">Tuner header & RDS info under-promoted</div>
+        <div class="sev p1">P1</div>
+      </header>
+
+      <div class="label">Observed</div>
+      <p>
+        The label <code>TUNER</code> sits at 9 px in the top-left corner with 0.45 opacity.
+        The RDS station name and program type collapse to one tiny line under the frequency
+        display: <code>Don · CLASSIC ROCK</code>. The user has to know the panel is
+        broadcasting RDS data to even notice it.
+      </p>
+
+      <div class="label">Proposed direction</div>
+      <ul>
+        <li>Promote <code>TUNER</code> to a real <strong>section header</strong> at the top of
+            the centre column, with a band/range sub-header on the right
+            (<code>FM · 76–108 MHz</code>).</li>
+        <li>Make band buttons <strong>tall pills</strong> with the band sub-range underneath
+            (AM <em>535–1700 kHz</em>, FM <em>76–108 MHz</em>, etc.). Existing 32 px buttons
+            are too small for the kiosk touch surface anyway.</li>
+        <li>Lift RDS to a <strong>card above the frequency display</strong> — station name in
+            the cyan accent, program type in a chip. Add an <code>RT</code> line below the
+            display that shows the rolling RadioText where supported.</li>
+      </ul>
+      <p>See canvas: <strong>P1 / Tuner header & RDS</strong>.</p>
+    </article>
+
+
+    <article class="finding" id="f5">
+      <header>
+        <div class="num">05</div>
+        <div class="title">Memory presets duplicate the frequency in the name</div>
+        <div class="sev p1">P1</div>
+      </header>
+
+      <div class="label">Observed</div>
+      <p>
+        Each preset reads <code>WB - 162.55 MHz</code> on the first line and
+        <code>162.55 MHz · WB</code> on the second. The slot number is rendered as a
+        9 px corner ghost at 20 % opacity. The "save" dialog seeds the name with the
+        frequency, so users never override it.
+      </p>
+
+      <div class="label">Proposed direction</div>
+      <ul>
+        <li>Restructure each row into <strong>three columns</strong>: slot number (left, mono,
+            always visible), name (middle, body, can be the RDS station call sign), frequency
+            (right, in DSEG amber).</li>
+        <li>When saving from the tuner, <strong>seed the name with the RDS station name</strong>
+            if available, never the frequency.</li>
+        <li>Show <strong>empty slots</strong> in the bank as dashed placeholders — the user
+            can see how much capacity remains and tap to save into a chosen slot.</li>
+        <li>Show <strong>"7 of 16"</strong> in the header so capacity is one glance away.</li>
+      </ul>
+      <p>See canvas: <strong>P1 / Memory presets</strong>.</p>
+    </article>
+
+
+    <article class="finding" id="f6">
+      <header>
+        <div class="num">06</div>
+        <div class="title">Source / gain / search status are three pills</div>
+        <div class="sev p1">P1</div>
+      </header>
+
+      <div class="label">Observed</div>
+      <p>
+        On the Radio Main Page the now-playing column has three pills: green
+        <code>● Searching</code> top-left, purple <code>SDR RADIO (RTL-SDR)</code> mid-top, and
+        cyan <code>0dB</code> top-right. They are colour-coded but visually unrelated — three
+        floating tags doing related work in three different corners.
+      </p>
+
+      <p>
+        Worse, nothing on the album art tells the user whether the song name shown
+        (<em>Dirty Laundry · Don Henley · I Can't Stand Still</em>) was matched by the
+        fingerprinter or supplied as RDS metadata. The confidence the panel <em>does</em>
+        compute never reaches the song display.
+      </p>
+
+      <div class="label">Proposed direction</div>
+      <ul>
+        <li>Consolidate the three pills into a <strong>single status strip</strong> across the
+            top of the now-playing column: source · frequency · RDS station · gain. Each cell
+            keeps its semantic colour but the relationship is now structural.</li>
+        <li>Attach the <strong>match confidence</strong> to the song title where the user
+            reads it — three pips + a word ("Strong match · 12 s ago"). This is the same
+            indicator used in the recognition panel; consistency.</li>
+      </ul>
+      <p>See canvas: <strong>P1 / Now Playing status</strong>.</p>
+    </article>
+  </section>
+
+
+  <section>
+    <h2>P2 — polish</h2>
+    <div class="h2-title">Smaller surfaces that punch above their pixel count.</div>
+
+    <article class="finding" id="f7">
+      <header>
+        <div class="num">07</div>
+        <div class="title">Gain popover has no feedback meter</div>
+        <div class="sev p2">P2</div>
+      </header>
+
+      <div class="label">Observed</div>
+      <p>
+        Tapping the small <code>0dB</code> pill on the now-playing column opens a 300 px
+        popover with a single slider labelled <code>SDR Radio (RTL-SDR) Level</code>. Range
+        runs from <code>−∞</code> to <code>+6 dB</code>. There is no signal feedback while
+        the user is dragging — adjusting the gain requires waiting for the next track to play
+        to know whether the change improved anything.
+      </p>
+
+      <div class="label">Proposed direction</div>
+      <ul>
+        <li>Add a <strong>live vertical peak meter</strong> beside the slider in the popover.
+            User drags, watches the peak reach into the green / amber / red zone, releases.</li>
+        <li>Show an <strong>AUTO pill</strong> in the popover header that mirrors the tuner
+            AGC state. When AUTO is on, the slider <em>dims</em> rather than disappearing —
+            the user can see what the tuner has chosen.</li>
+        <li>Trim the title to <code>SDR · RTL-SDR / RF gain</code>; the existing string is the
+            internal source ID.</li>
+        <li>Add a <strong>Reset to 0 dB</strong> button in the popover footer so the user has
+            a one-tap escape.</li>
+      </ul>
+      <p>See canvas: <strong>P2 / Gain control popover</strong>.</p>
+    </article>
+  </section>
+
+
+  <section>
+    <h2>What's NOT in this pass</h2>
+    <div class="h2-title">Out of scope, on purpose.</div>
+    <ul style="color: var(--text-md); max-width: 64ch;">
+      <li>The album-art column itself — the proportions, the gradient backdrop, the typography
+          inside. These read well as-is.</li>
+      <li>The scan controls (◀ SCAN / SCAN ▶ buttons). The current bezelled hardware buttons
+          are good — the only change in the canvas is that they pair with the new AGC strip
+          underneath them.</li>
+      <li>The visualizer column on the right (VU / Wave / Spectrum). Already handled in the
+          first handoff pass — see
+          <code>design_handoff_radio_console/IMPLEMENTATION.md § P1·3</code>.</li>
+      <li>The top bar source pills and route toggle. Same — see § P0·1 of the prior pass.</li>
+    </ul>
+  </section>
+
+</main>
+
+</body>
+</html>

--- a/docs/design-handoffs/design_handoff_radio_controller/Handoff Canvas.html
+++ b/docs/design-handoffs/design_handoff_radio_controller/Handoff Canvas.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Radio Controller — Visual Handoff</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<style>
+  html, body { margin: 0; padding: 0; background: #f0eee9; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="mocks.jsx"></script>
+<script type="text/babel" src="app.jsx"></script>
+</head>
+<body>
+<div id="root"></div>
+</body>
+</html>

--- a/docs/design-handoffs/design_handoff_radio_controller/IMPLEMENTATION.md
+++ b/docs/design-handoffs/design_handoff_radio_controller/IMPLEMENTATION.md
@@ -1,0 +1,377 @@
+# Implementation Script — Radio Controller Polish
+
+> **For the implementing agent (Claude Code or human):**
+> Companion to `design_handoff_radio_console/IMPLEMENTATION.md`. That script
+> handled the shell. This one covers the four radio-source surfaces.
+>
+> Land changes in priority order (P0 → P1 → P2). Do **not** start any
+> section whose status is not `[APPROVED]`.
+>
+> All tokens referenced live in
+> `src/Radio.Web/wwwroot/css/design-system.css`. Do not invent new tokens;
+> extend the token block first if you need a value that isn't there.
+
+---
+
+## Status legend
+
+| Status | Meaning |
+|---|---|
+| `[APPROVED]` | Ship as specified. |
+| `[PENDING REVIEW]` | Drafted, not locked. Don't start. |
+| `[NEEDS ITERATION]` | User has comments; see the inline note. |
+| `[PARKED]` | Out of scope. |
+
+All findings below default to `[PENDING REVIEW]`.
+
+---
+
+## P0 — bugs
+
+---
+
+### P0·1 — Signal meter clamp + CLIP indicator
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0` → **"Signal meter — 118 % is impossible"**, Analysis § 01
+**Files:**
+- `src/Radio.Web/Components/Shared/RadioControlPanel.razor` (`.rcp-meter` block)
+- `src/Radio.Web/Components/Shared/RadioControlPanel.razor` (`@code` — value mapping)
+- `src/Radio.Web/wwwroot/css/design-system.css` (`§N Signal meter` — add scale labels)
+- API/model: wherever `RadioStateDto.SignalStrength` is produced — surface a separate
+  `IsOverdriven` / `Clip` boolean.
+
+**Steps:**
+
+1. **Clamp at the API boundary.** In whatever service projects the raw RTL-SDR power
+   reading into `RadioStateDto.SignalStrength`, clamp the value to `[0, 100]`. Drop the
+   absolute value into a separate `RssiDbu` field (mapped from the raw reading to a
+   −60 → 0 dBu range; use a linear fit if the device doesn't expose a calibrated curve).
+   Add a `Clip` boolean that is `true` when the raw value exceeded the calibrated
+   full-scale.
+
+2. **Update the meter markup** in `RadioControlPanel.razor`:
+   - Replace the `<span class="rcp-meter-value">@_radioState.SignalStrength%</span>` with
+     two siblings: a `CLIP` pill (rendered only when `_radioState.Clip` is true) and
+     a dBu readout (`@_radioState.RssiDbu dBu`).
+   - Add a scale-label strip under the meter bar with four mono labels:
+     `−60`, `−30`, `−12`, `0 dBu`.
+
+3. **Update the segment logic.** Drive the 20-segment fill off the *clamped* percent value;
+   the per-segment colour thresholds (green / amber / red at `i < 12 / 17 / else`) stay.
+
+4. **Style the CLIP pill** in `design-system.css`. Mono, 9 px, uppercase, 1 px solid
+   `var(--signal-red)`, background `rgba(248,113,113,0.10)`, box-shadow
+   `0 0 6px rgba(248,113,113,0.4)` while active.
+
+5. Update the SCANNING indicator's stop-threshold check to use the clamped value or
+   the dBu reading consistently. `_radioState.ScanStopThreshold` should be a dBu
+   value in the proposed scheme, not a percentage.
+
+**Acceptance:**
+
+- [ ] Signal value never exceeds 100 % in the UI for any raw input.
+- [ ] CLIP pill appears only when the front-end is actually overdriving.
+- [ ] dBu scale labels render under the bar in mono 8–9 px.
+
+**Notes:**
+
+If recalibrating to dBu is risky, ship step 1's clamp + clip flag first as a hot-fix,
+then layer the dBu conversion behind a feature flag.
+
+---
+
+### P0·2 — AGC strip: always-full two-cell layout
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0` → **"AGC / gain strip — never half-empty"**, Analysis § 02
+**Files:**
+- `src/Radio.Web/Components/Shared/RadioControlPanel.razor` (`.rcp-sdr-controls` block,
+  including the `<RadzenSwitch>` for AGC and the conditional slider).
+
+**Steps:**
+
+1. Rewrite the `.rcp-sdr-controls` flex into a **fixed two-cell grid**:
+   - Left cell: 130 px wide, contains the AGC toggle and an inline `AUTO` / `OFF` chip.
+   - Right cell: flex 1, always rendered, content swaps on AGC state.
+
+2. **Left cell behaviour:**
+   - Tap the cell anywhere → toggle AGC (the existing `<RadzenSwitch>` becomes a styled
+     button with the same handler).
+   - The chip reads `AUTO` (green border + soft fill) when on, `OFF` (dim border, no fill)
+     when off.
+
+3. **Right cell behaviour:**
+   - When AGC is **on**: render `"Tuner is choosing"` (mono 11 px, low contrast) on the
+     left, and the current gain reading on the right (`28.0 dB` in amber, mono, tabular).
+     The right value is bound to a server-pushed `AppliedGain` field on `RadioStateDto`.
+   - When AGC is **off**: render the existing slider with two new affordances — a
+     leading current-value pill (`28 dB` amber, fixed width 56 px so width doesn't
+     jitter as it changes) and a trailing range hint (`0 – 50` in dim mono).
+
+4. **Add `AppliedGain` to `RadioStateDto`.** When AGC is on, this is the value the device
+   reports it has selected. When AGC is off, this is the value the user set. Either way,
+   the right cell can show one number bound to one field.
+
+5. Remove the empty-cell branch (`<div class="rcp-gain-slot"> … @if (!_radioState.AutoGain && _radioState.Gain.HasValue) { … }</div>`) — the right cell is *always* populated.
+
+**Acceptance:**
+
+- [ ] Toggling AGC does not change the height of the strip.
+- [ ] When AGC is on, a numeric gain value is visible in the right cell.
+- [ ] The slider's "current value" pill never wraps, never grows or shrinks across the
+      slider's range.
+
+---
+
+### P0·3 — Song recognition panel: confidence bucket + stream layout
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P0` → **"Song recognition — kill the 80 % column"**, Analysis § 03
+**Files:**
+- `src/Radio.Web/Components/Shared/NowPlayingPanel.razor` (the searching/recognition table
+  branch — render when `_searching && _matches.Any()`)
+- `src/Radio.Web/Components/Shared/ConfidencePips.razor` *(new)*
+- `src/Radio.Web/Models/ApiModels.cs` — change `Confidence` from `double` to a
+  `ConfidenceBucket` enum (`None`, `Possible`, `Likely`, `Strong`).
+
+**Steps:**
+
+1. **Server side.** In whichever fingerprinter projection lives on the API side, fold the
+   raw match score into a bucket:
+   - `Strong` — score ≥ 0.90
+   - `Likely` — 0.80 ≤ score < 0.90
+   - `Possible` — 0.60 ≤ score < 0.80
+   - `None` — no match returned
+   Expose as `ConfidenceBucket Confidence` on the match DTO. Drop the raw score from the
+   API surface (keep it in logs).
+
+2. **Create `ConfidencePips.razor`.** Three 5 × 10 px pips with rounded 1 px corners.
+   Parameter: `Bucket`. Pips light according to the bucket:
+   - `Strong` → 3 pips, full green
+   - `Likely` → 2 pips, light-green
+   - `Possible` → 1 pip, amber
+   - `None` → 0 pips
+   The mono label (`Strong` / `Likely` / `Possible` / `No match`) sits to the right.
+
+3. **Rewrite the recognition section** in `NowPlayingPanel.razor`. Drop the
+   `<table>` entirely. Render a flex column of rows:
+   - **NOW header** (mono 9 px, amber, 0.20em letter-spacing) once, above the
+     currently-playing match (the row whose `MatchId` equals `_radioState.NowPlayingMatchId`).
+   - **EARLIER header** below the now row.
+   - Each row is a grid: art (34 × 34) · title + artist · `<ConfidencePips />` · time-ago.
+   - The active row has a 2 px amber left border, a small amber dot in the top-right corner
+     of the art square, and an `now` label instead of a time-ago.
+   - Failed-lookup rows render with `track = "No match in window"` in italics, dimmed.
+
+4. **Remove the telemetry strip** (`Fingerprints: X/min · Lookups: Y/min`) from the panel
+   header. If the value matters, move it to the dev tray (see prior handoff § P2·2).
+
+5. **Drop the `Art` column entirely.** Use the cover-art square as the row leader —
+   present art renders the bitmap, absent art renders a `♪` placeholder in `var(--text-dim)`.
+
+**Acceptance:**
+
+- [ ] No row in the panel contains the literal text `80%`.
+- [ ] The currently-playing match is visually anchored at the top of the stream with a
+      "NOW" header.
+- [ ] A row with no fingerprint match reads as a sentence (`"No match in window"`), not
+      as `--`.
+- [ ] Confidence reads as a word and a row of pips, never as a percentage.
+
+---
+
+## P1 — structural
+
+---
+
+### P1·1 — Tuner section header + RDS card + tall band buttons
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1` → **"Tuner header & RDS"**, Analysis § 04
+**Files:**
+- `src/Radio.Web/Components/Shared/RadioControlPanel.razor` (`.rcp-module-label`,
+  `.rcp-band-group`, `.rcp-band-btn`, `.rcp-rds-info` blocks)
+- `src/Radio.Web/Components/Shared/RdsCard.razor` *(new)*
+
+**Steps:**
+
+1. **Promote the header.** Replace the absolute-positioned `.rcp-module-label` with a real
+   header row at the top of `.rcp-tuner`:
+   - Left: `<h3>Tuner</h3>` in Inter 14 px medium.
+   - Right: band + range, mono 10 px, amber, uppercase (`FM · 76–108 MHz`).
+   - 1 px bottom border, 24 px top margin on the content below.
+
+2. **Tall band pills.** Update `.rcp-band-btn`:
+   - Increase to `min-width: 64px; padding: 8px 14px 6px;`
+   - Inner layout: two lines (label `13 px / 700 / 0.08em`, sub `8 px / 0.14em / dim`).
+   - The sub-range string comes from `RadioBandModel.Range` — add the field if it isn't
+     already there, populate from `RadioBandModel.GetBandInfo()` server-side.
+
+3. **Extract `RdsCard.razor`** from the existing inline `.rcp-rds-info`:
+   - Renders only when `RdsStationName` is present.
+   - Layout: mono `RDS` label (9 px dim), station name in cyan accent (mono 14 px,
+     0.18em letter-spacing, with the existing text-shadow glow), program-type chip on
+     the right.
+   - Mount **above** the frequency well, not below.
+
+4. **Add an `RT` (RadioText) line below the frequency well**. Mono 11 px, low contrast,
+   one-line ellipsis, bound to `RadioStateDto.RdsRadioText`. Hide entirely if empty.
+   Scroll horizontally with `text-overflow: ellipsis` for now; a marquee variant is a
+   future-work item, not part of this pass.
+
+**Acceptance:**
+
+- [ ] Tuner header is visible and reads as a heading, not a label.
+- [ ] Band pills are at least 56 px tall and show their range sub-text.
+- [ ] When RDS is present, the station name appears above the frequency display and is
+      the most visually prominent text on the panel after the frequency itself.
+
+---
+
+### P1·2 — Memory presets: slot · name · frequency three-column row
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1` → **"Memory presets"**, Analysis § 05
+**Files:**
+- `src/Radio.Web/Components/Shared/RadioControlPanel.razor` (`.rcp-presets`,
+  `.rcp-preset-item`, `OpenSavePresetDialog` method)
+- `src/Radio.Web/Models/ApiModels.cs` — add `SlotNumber` to `RadioPresetDto` (the
+  ordinal already exists implicitly via `OrderBy(CreatedAt)`; promote it to a real field).
+
+**Steps:**
+
+1. **Restructure each row** as a CSS grid `22px 1fr 64px`:
+   - Slot number: mono 10 px, right-aligned, `var(--text-lo)` (becomes `var(--signal-amber)`
+     when the preset is the active one).
+   - Name + band stack: name `var(--text-high)` 12 px medium, band line below at mono
+     9 px dim.
+   - Frequency: DSEG (`var(--font-led)`) at 13 px, right-aligned, amber, with the existing
+     glow shadow when active.
+
+2. **Preset header**:
+   - Left: `MEMORY · 7 of 16` (current count / capacity, mono, dim).
+   - Right: hint text — `HOLD <kbd>FM</kbd> TO SAVE` — instead of the icon button.
+     The save action becomes a long-press on the active band pill rather than a separate
+     button.
+
+3. **Empty slots.** Always render the next empty slot as a dashed-border placeholder so
+   capacity is legible. Don't render *all* empty slots — that's noise; render the next
+   one to-be-filled plus one more.
+
+4. **Save-preset dialog.** When the user invokes "save current," seed the name field
+   with `RadioStateDto.RdsStationName` if present, else
+   `DisplayNames.Band(_radioState.Band) + " " + _radioState.FrequencyFormatted` only
+   as a last-resort fallback. **Never** seed with the raw frequency.
+
+5. Capacity is a per-band concept on the device (16 FM slots, 4 WB slots, etc.). Wire the
+   header count to the band-specific capacity.
+
+**Acceptance:**
+
+- [ ] No preset row contains the same frequency twice.
+- [ ] Slot numbers are always visible (not hover-only or 20 %-opacity ghosts).
+- [ ] The save flow defaults to the RDS station name when one is present.
+
+---
+
+### P1·3 — Now Playing status: unified strip + match badge
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P1` → **"Now Playing status"**, Analysis § 06
+**Files:**
+- `src/Radio.Web/Components/Shared/NowPlayingPanel.razor`
+- `src/Radio.Web/wwwroot/css/design-system.css` (new `§N Status strip`)
+
+**Steps:**
+
+1. **Build a `.np-status-strip`** across the top of the now-playing column. Four cells,
+   1 px separators, flex layout:
+   - Source: 8 × 8 square in source colour + name (`SDR · RTL-SDR`).
+   - Frequency: DSEG 12 px + `MHz` chip (only present when the active source is a tuner).
+   - RDS station: cyan accent name + dim `RDS` tag, ellipsis on overflow.
+   - Gain: cyan tappable cell that opens the gain popover (see P2·1).
+2. **Remove the three independent pills** (`Searching` green, `SDR RADIO (RTL-SDR)`
+   purple, `0dB` cyan) — they fold into the strip.
+3. **Attach the match badge to the song title** inside the album-art card. Render
+   `<ConfidencePips Bucket="@_match.Confidence" />` followed by `"Strong match · 12 s ago"`
+   in the relative-time format. When the song is from RDS and not the fingerprinter,
+   the line reads `RDS · station-supplied`; when neither, hide the badge entirely
+   (don't fake it).
+4. The strip uses `backdrop-filter: blur(8px); background: rgba(20,20,22,0.85);`
+   only when there's album art behind it; otherwise solid `var(--surface-raised)`.
+
+**Acceptance:**
+
+- [ ] Source, frequency, RDS station, and gain are visually one component.
+- [ ] Match confidence is visible directly under the song title and is the same widget
+      used in the recognition panel (P0·3).
+- [ ] No floating, unrelated pills in opposing corners.
+
+---
+
+## P2 — polish
+
+---
+
+### P2·1 — Gain control popover: peak meter + AUTO + reset
+
+**Status:** `[PENDING REVIEW]`
+**Reference:** Canvas → `P2` → **"Gain control popover"**, Analysis § 07
+**Files:**
+- `src/Radio.Web/Components/Layout/MainLayout.razor` (the gain dropdown — currently inline)
+  → extract to `src/Radio.Web/Components/Shared/GainControlPopover.razor`.
+- `src/Radio.Web/Services/Hub/AudioVisualizationHubService.cs` — expose a peak-sample
+  stream for the active source.
+
+**Steps:**
+
+1. **Extract the popover.** Move the existing slider into `GainControlPopover.razor`,
+   parametered by source type. Replace the inline `<div class="overlay">` in MainLayout
+   with a single `<GainControlPopover />` element wired to a service that tracks which
+   source's popover is open.
+
+2. **Layout the popover** as a 340 px card:
+   - Header row: source kicker + "RF gain" title on the left; an `Auto on` / `Auto off`
+     pill on the right that toggles AGC.
+   - Body: 124 px tall, three columns:
+     - Vertical peak meter (16 px wide), driven by hub samples at ~20 fps.
+     - Vertical slider (DSEG amber knob, dashed `0 dB` tick at the midpoint).
+     - Scale label column (`+6 / +3 / 0 / −12 / −24 / −∞`).
+   - Footer: large DSEG current value on the left (24 px amber), `Reset to 0 dB` button
+     on the right.
+
+3. **Wire the peak meter.** Subscribe to the active visualization hub's RMS/peak stream
+   in `OnInitializedAsync`; keep a hold value that decays at 0.5 dB / 200 ms. Reuse the
+   visualizer panel's existing animation cadence so we don't add a second source of
+   redraws.
+
+4. **AUTO state.** When AGC is on, dim the slider knob and track to ~35 % opacity and
+   block pointer events. Don't hide them — the user can still see what the tuner has
+   chosen.
+
+5. **Trim the title.** "SDR Radio (RTL-SDR) Level" → kicker `SDR · RTL-SDR` + title
+   `RF gain`. Apply the same pattern to non-tuner sources (Vinyl, File, etc.) — the
+   kicker is the source DisplayName, the title is "Gain" or the appropriate device verb.
+
+6. **Reset button.** Tapping `Reset to 0 dB` sets the slider to 0 (unity gain) and posts
+   a single hub message. Greyed out when AGC is on.
+
+**Acceptance:**
+
+- [ ] User can see the signal moving while dragging the gain slider.
+- [ ] AGC state is visible inside the popover, not just on the toggle below.
+- [ ] One-tap reset is available and labelled.
+
+---
+
+## Land order recap
+
+1. P0·1 — signal meter clamp (smallest blast radius, hot-fixable today).
+2. P0·2 — AGC strip layout (no API changes if `AppliedGain` already exists; add if not).
+3. P0·3 — recognition panel rewrite (touches DTO + UI; do it as a single PR).
+4. P1·1 — tuner header + RDS (visual only, can ride on top of P0·1).
+5. P1·2 — preset rows (DTO field + UI).
+6. P1·3 — status strip (last UI change because it folds together work that P0·3 set up).
+7. P2·1 — gain popover (depends on the visualization hub being reachable from the
+   popover's render mode; verify before starting).

--- a/docs/design-handoffs/design_handoff_radio_controller/README.md
+++ b/docs/design-handoffs/design_handoff_radio_controller/README.md
@@ -1,0 +1,43 @@
+# Handoff: Radio Controller — Tuner & Recognition
+
+## What this is
+
+A companion package to `design_handoff_radio_console/`. That earlier pass audited the whole Radio.Web shell (top bar, sources, queue, metrics, etc.) but explicitly **did not touch the radio source surfaces** — the tuner, the song-recognition table, and the gain popover only exist on real hardware (the device with the RTL-SDR plugged in), so they weren't part of the original screenshot set.
+
+The user re-ran the device, captured those screens, and this package picks up where the earlier handoff stopped.
+
+## Scope
+
+Four screens, seven proposed changes:
+
+1. **Radio Main Page** — the now-playing column when the active source is a tuner. Status pills are scattered across three corners; match confidence is invisible.
+2. **Radio Control Page** — the centred tuner (band selector, frequency, signal meter, scan controls, AGC, memory bank).
+3. **Radio Song Recognition** — the fingerprint match table that replaces the album art when "Searching" is the now-playing state.
+4. **Radio Gain Control popover** — opens from the `0dB` pill; sets RTL-SDR analog gain.
+
+## About the design files
+
+- `Design Analysis.html` — long-form audit. Reads end-to-end like a design review; one section per finding, with current-state notes, severity, and proposed direction.
+- `Handoff Canvas.html` (+ `design-canvas.jsx`, `mocks.jsx`, `app.jsx`) — pan/zoom canvas of seven before/after artboards plus one composed "Tuner page after" view. This is the visual spec.
+- `IMPLEMENTATION.md` — developer script. Each finding mapped to the Razor file(s) it touches with concrete numbered steps.
+
+The canvas mocks are styled in the same broadcast-console language as the live UI (DSEG amber LED, cyan accent, dark warm-black surface) — same token names where they exist in `design-system.css`.
+
+## How to read the canvas
+
+The first artboard ("Tuner page · 1920 × 720") is the **composed after-state** — everything below it explained as one screen. Use it as the reference image; use the per-finding artboards to see what changed and why.
+
+## Status
+
+All findings are `[PENDING REVIEW]` — drafted, but not approved. Mark each one `[APPROVED]` / `[NEEDS ITERATION]` / `[PARKED]` directly in `IMPLEMENTATION.md` before you ship anything.
+
+## Files in this folder
+
+- `README.md` — this file.
+- `Design Analysis.html` — long-form audit.
+- `Handoff Canvas.html` + `design-canvas.jsx` + `mocks.jsx` + `app.jsx` — visual specs.
+- `IMPLEMENTATION.md` — per-finding developer script.
+
+## Tokens
+
+All values reference `src/Radio.Web/wwwroot/css/design-system.css`. The mocks use the same hex codes (`--surface-base #0D0D0F`, `--accent-primary #5CD4E8`, `--signal-amber #F0A830`, `--font-led DSEG14Classic-Bold`). No new tokens are introduced; if one is needed, add it to design-system.css §2 first and reference from there.

--- a/docs/design-handoffs/design_handoff_radio_controller/app.jsx
+++ b/docs/design-handoffs/design_handoff_radio_controller/app.jsx
@@ -1,0 +1,73 @@
+// app.jsx — Radio Controller design improvement canvas
+const { useEffect } = React;
+
+function App() {
+  useEffect(() => { document.title = 'Radio Controller — Visual Handoff'; }, []);
+
+  return (
+    <DesignCanvas>
+
+      <DCSection
+        id="composed"
+        title="Composed — the tuner page after"
+        subtitle="The complete proposed Radio source view, pulling together every change in this package. Shown first so the rest of the canvas has context."
+      >
+        <DCArtboard id="tuner-composed" label="Tuner page · 1920 × 720" width={1920} height={780}>
+          <Mock_TunerComposed />
+        </DCArtboard>
+      </DCSection>
+
+
+      <DCSection
+        id="p0"
+        title="P0 — bugs and confusing readouts"
+        subtitle="Things that actively mislead the user. Each of these has been seen wrong on the live device."
+      >
+        <DCArtboard id="signal" label="Signal meter — 118 % is impossible" width={1280} height={460}>
+          <Mock_SignalMeter />
+        </DCArtboard>
+
+        <DCArtboard id="agc" label="AGC / gain strip — never half-empty" width={1280} height={520}>
+          <Mock_AgcStrip />
+        </DCArtboard>
+
+        <DCArtboard id="conf" label="Song recognition — kill the 80 % column" width={1480} height={720}>
+          <Mock_SongRecognition />
+        </DCArtboard>
+      </DCSection>
+
+
+      <DCSection
+        id="p1"
+        title="P1 — structural improvements"
+        subtitle="The product feels twice as finished after these land."
+      >
+        <DCArtboard id="header" label="Tuner header & RDS — promote what the user actually needs" width={1280} height={560}>
+          <Mock_TunerHeader />
+        </DCArtboard>
+
+        <DCArtboard id="presets" label="Memory presets — name, slot, frequency in three columns" width={1100} height={620}>
+          <Mock_Presets />
+        </DCArtboard>
+
+        <DCArtboard id="status" label="Now Playing status — one strip, not three pills" width={1280} height={620}>
+          <Mock_NowPlayingStatus />
+        </DCArtboard>
+      </DCSection>
+
+
+      <DCSection
+        id="p2"
+        title="P2 — polish"
+        subtitle="Smaller surfaces that punch above their pixel count."
+      >
+        <DCArtboard id="gain-pop" label="Gain control popover — peak meter + AUTO + reset" width={1280} height={520}>
+          <Mock_GainPopover />
+        </DCArtboard>
+      </DCSection>
+
+    </DesignCanvas>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/docs/design-handoffs/design_handoff_radio_controller/design-canvas.jsx
+++ b/docs/design-handoffs/design_handoff_radio_controller/design-canvas.jsx
@@ -1,0 +1,966 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), deletable, labels/titles are
+// inline-editable, and any artboard can be opened in a fullscreen focus
+// overlay (←/→/Esc). State persists to a .design-canvas.state.json sidecar
+// via the host bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    // isolation:isolate contains artboard content's z-indexes so a
+    // z-indexed child (sticky navbar etc.) can't paint over .dc-header or
+    // the .dc-menu popover that drops into the top of the card.
+    '.dc-card{isolation:isolate;transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    // Per-artboard header: grip + label on the left, delete/expand on the
+    // right. Single flex row; when the artboard's on-screen width is too
+    // narrow for both the label yields (ellipsis, then hidden entirely below
+    // ~4ch via the container query) and the buttons stay on the row.
+    '.dc-header{position:absolute;bottom:100%;left:-4px;margin-bottom:calc(4px * var(--dc-inv-zoom,1));z-index:2;',
+    '  display:flex;align-items:center;container-type:inline-size}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px;flex:1 1 auto;min-width:0}',
+    '.dc-grip{flex:0 0 auto;cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s,opacity .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{flex:1 1 auto;min-width:0;cursor:pointer;border-radius:4px;padding:3px 6px;',
+    '  display:flex;align-items:center;transition:background .12s;overflow:hidden}',
+    // Below ~4ch of label room: hide the label entirely, and drop the grip to
+    // hover-only (same reveal rule as .dc-btns) so a narrow header is clean
+    // until the card is moused.
+    '@container (max-width: 110px){',
+    '  .dc-labeltext{display:none}',
+    '  .dc-grip{opacity:0}',
+    '  [data-dc-slot]:hover .dc-grip{opacity:1}',
+    '}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-labeltext .dc-editable{overflow:hidden;text-overflow:ellipsis;max-width:100%}',
+    '.dc-labeltext .dc-editable:focus{overflow:visible;text-overflow:clip}',
+    '.dc-btns{flex:0 0 auto;margin-left:auto;display:flex;gap:2px;opacity:0;transition:opacity .12s}',
+    '[data-dc-slot]:hover .dc-btns,.dc-btns:has(.dc-menu){opacity:1}',
+    '.dc-expand,.dc-kebab{width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center;',
+    '  font:inherit;transition:background .12s,color .12s}',
+    '.dc-expand:hover,.dc-kebab:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    // Slot hosting an open menu floats above later siblings (which otherwise
+    // paint on top — same z-index:auto, later DOM order) so the popup isn't
+    // clipped by the next card.
+    '[data-dc-slot]:has(.dc-menu){z-index:10}',
+    '.dc-menu{position:absolute;top:100%;right:0;margin-top:4px;background:#fff;border-radius:8px;',
+    '  box-shadow:0 8px 28px rgba(0,0,0,.18),0 0 0 1px rgba(0,0,0,.05);padding:4px;min-width:160px;z-index:10}',
+    '.dc-menu button{display:block;width:100%;padding:7px 10px;border:0;background:transparent;',
+    '  border-radius:5px;font-family:inherit;font-size:13px;font-weight:500;line-height:1.2;',
+    '  color:#29261b;cursor:pointer;text-align:left;transition:background .12s;white-space:nowrap}',
+    '.dc-menu button:hover{background:rgba(0,0,0,.05)}',
+    '.dc-menu hr{border:0;border-top:1px solid rgba(0,0,0,.08);margin:4px 2px}',
+    '.dc-menu .dc-danger{color:#c96442}',
+    '.dc-menu .dc-danger:hover{background:rgba(201,100,66,.1)}',
+    // Chrome (titles / labels / buttons) counter-scales against the viewport
+    // zoom so it stays a constant on-screen size. --dc-inv-zoom is set by
+    // DCViewport on every transform update and inherits to all descendants —
+    // any overlay inside the world (e.g. a TweaksPanel on an artboard) can use
+    // it the same way.
+    //
+    // The header uses transform:scale (out-of-flow, so layout impact doesn't
+    // matter) with its world-space width set to card-width / inv-zoom so that
+    // after counter-scaling its on-screen width exactly matches the card's —
+    // that's what lets the container query + text-overflow behave against the
+    // card's visible edge at every zoom level.
+    //
+    // The section head uses CSS zoom instead of transform so its layout box
+    // grows with the counter-scale, pushing the card row down — otherwise the
+    // constant-screen-size title would overflow into the (shrinking) world-
+    // space gap and overlap the artboard headers at low zoom.
+    '.dc-header{width:calc((100% + 4px) / var(--dc-inv-zoom,1));',
+    '  transform:scale(var(--dc-inv-zoom,1));transform-origin:bottom left}',
+    '.dc-sectionhead{zoom:var(--dc-inv-zoom,1)}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// Recursively unwrap React.Fragment so <>…</> grouping doesn't hide
+// DCSection/DCArtboard children from the type-based walks below.
+function dcFlatten(children) {
+  const out = [];
+  React.Children.forEach(children, (c) => {
+    if (c && c.type === React.Fragment) out.push(...dcFlatten(c.props.children));
+    else out.push(c);
+  });
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, hidden
+// artboards, focused artboard). Order/titles/labels/hidden persist to a
+// .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Fragments are flattened; wrapping in other
+  // elements still opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  dcFlatten(children).forEach((sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const abs = [];
+    dcFlatten(sec.props.children).forEach((ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (aid) abs.push([aid, ab]);
+    });
+    // hidden is scoped to one source revision — when the agent regenerates
+    // (artboard-ID set changes), prior deletes don't apply to new content.
+    const srcKey = abs.map(([k]) => k).join('\x1f');
+    const hidden = persisted.srcKey === srcKey ? (persisted.hidden || []) : [];
+    const srcIds = [];
+    abs.forEach(([aid, ab]) => {
+      if (hidden.includes(aid)) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+  // Persist viewport across reloads so the user lands back where they were
+  // after an agent edit or browser refresh. The sandbox origin is already
+  // per-project; pathname keeps multiple canvas files in one project apart.
+  const tfKey = 'dc-viewport:' + location.pathname;
+  const saveT = React.useRef(0);
+
+  const lastPostedScale = React.useRef();
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (!el) return;
+    el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+    // Exposed for zoom-invariant chrome (labels, buttons, TweaksPanel).
+    el.style.setProperty('--dc-inv-zoom', String(1 / scale));
+    // Keep the host toolbar's % readout in sync with the canvas scale. Pan
+    // ticks leave scale unchanged — skip the cross-frame post for those.
+    if (lastPostedScale.current !== scale) {
+      lastPostedScale.current = scale;
+      window.parent.postMessage({ type: '__dc_zoom', scale }, '*');
+    }
+    clearTimeout(saveT.current);
+    saveT.current = setTimeout(() => {
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    }, 200);
+  }, [tfKey]);
+
+  React.useLayoutEffect(() => {
+    const flush = () => {
+      clearTimeout(saveT.current);
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    };
+    try {
+      const s = JSON.parse(localStorage.getItem(tfKey) || 'null');
+      if (s && Number.isFinite(s.x) && Number.isFinite(s.y) && Number.isFinite(s.scale)) {
+        tf.current = { x: s.x, y: s.y, scale: Math.min(maxScale, Math.max(minScale, s.scale)) };
+        apply();
+      }
+    } catch {}
+    // Flush on pagehide and unmount so a reload within the 200ms debounce
+    // window doesn't drop the last pan/zoom.
+    window.addEventListener('pagehide', flush);
+    return () => { window.removeEventListener('pagehide', flush); flush(); };
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // --dc-inv-zoom consumers (.dc-sectionhead's CSS zoom, each section's
+      // marginBottom) reflow on every scale change, vertically shifting the
+      // world layout — so a world point mathematically pinned under the cursor
+      // drifts as you zoom (content creeps up on zoom-in, down on zoom-out).
+      // Anchor the DOM element under the cursor instead: record its screen Y,
+      // apply the transform + --dc-inv-zoom, then cancel whatever vertical
+      // drift the reflow introduced so it stays put on screen.
+      let marker = null, markerY0 = 0;
+      if (k !== 1) {
+        const hit = document.elementFromPoint(cx, cy);
+        marker = hit && hit.closest ? hit.closest('[data-dc-slot],[data-dc-section]') : null;
+        if (marker) markerY0 = marker.getBoundingClientRect().top;
+      }
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+      if (marker) {
+        // A pure zoom around (cx, cy) maps screen Y → cy + (Y - cy) * k. Any
+        // departure after the --dc-inv-zoom reflow is the layout drift.
+        const drift = marker.getBoundingClientRect().top - (cy + (markerY0 - cy) * k);
+        if (Math.abs(drift) > 0.1) { t.y -= drift; apply(); }
+      }
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if ((e.ctrlKey || e.metaKey) && !isMouseWheel(e)) {
+        // trackpad pinch, or ctrl/cmd + smooth-scroll mouse. Notched
+        // wheels fall through to the fixed-step branch below.
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    // Host-driven zoom (toolbar % menu). Zooms around viewport centre so the
+    // visible midpoint stays fixed — matching the host's iframe-zoom feel.
+    const onHostMsg = (e) => {
+      const d = e.data;
+      if (d && d.type === '__dc_set_zoom' && typeof d.scale === 'number') {
+        const r = vp.getBoundingClientRect();
+        zoomAt(r.left + r.width / 2, r.top + r.height / 2, d.scale / tf.current.scale);
+      } else if (d && d.type === '__dc_probe') {
+        // Host's [readyGen] reset asks whether a canvas is present; it
+        // fires on the iframe's native 'load', which for canvases with
+        // images/fonts is after our mount-time announce, so re-announce.
+        // Clear the pan-tick guard so apply() re-posts the current scale
+        // even if it's unchanged — the host just reset dcScale to 1.
+        window.parent.postMessage({ type: '__dc_present' }, '*');
+        lastPostedScale.current = undefined;
+        apply();
+      }
+    };
+    window.addEventListener('message', onHostMsg);
+    // Announce canvas mode so the host toolbar proxies its % control here
+    // instead of scaling the iframe element (which would just shrink the
+    // viewport window of an infinite canvas). The apply() that follows emits
+    // the initial __dc_zoom so the toolbar % is correct before first pinch.
+    // lastPostedScale reset mirrors the __dc_probe handler: the layout
+    // effect's restore-path apply() may already have posted the restored
+    // scale (before __dc_present), so clear the guard to re-post it in order.
+    window.parent.postMessage({ type: '__dc_present' }, '*');
+    lastPostedScale.current = undefined;
+    apply();
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      window.removeEventListener('message', onHostMsg);
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(dcFlatten(children));
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+  // Must match DesignCanvas's srcKey computation exactly (it filters falsy
+  // IDs), or onDelete persists a srcKey that DesignCanvas never recognizes.
+  const allIds = artboards.map((a) => a.props.id ?? a.props.label).filter(Boolean);
+  const srcKey = allIds.join('\x1f');
+  const hidden = sec.srcKey === srcKey ? (sec.hidden || []) : [];
+  const srcOrder = allIds.filter((k) => !hidden.includes(k));
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  // marginBottom counter-scales so the on-screen gap between sections stays
+  // constant — otherwise at low zoom the (world-space) gap collapses while
+  // the screen-constant sectionhead below it doesn't, and the title reads as
+  // belonging to the section above. paddingBottom below is just enough for
+  // the 24px artboard-header (abs-positioned above each card) plus ~8px, so
+  // the title sits tight against its own row at every zoom.
+  return (
+    <div data-dc-section={sid}
+      style={{ marginBottom: 'calc(80px * var(--dc-inv-zoom, 1))', position: 'relative' }}>
+      <div style={{ padding: '0 60px' }}>
+        <div className="dc-sectionhead" style={{ paddingBottom: 36 }}>
+          <DCEditable tag="div" value={sec.title ?? title}
+            onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+            style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+          {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onDelete={() => ctx && ctx.patchSection(sid, (x) => ({
+              hidden: [...(x.srcKey === srcKey ? (x.hidden || []) : []), k],
+              srcKey,
+            }))}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+// Per-artboard export (kind: 'png' | 'html'). Both paths share the same
+// self-contained clone: computed styles baked in, @font-face / <img> /
+// inline-style background-image urls inlined as data URIs. PNG wraps the
+// clone in foreignObject→canvas at 3× the artboard's natural width×height
+// (same pipeline the host uses for page captures); HTML wraps it in a
+// minimal standalone document. Both are independent of viewport zoom.
+async function dcExport(node, w, h, name, kind) {
+  try { await document.fonts.ready; } catch {}
+  const toDataURL = (url) => fetch(url).then((r) => r.blob()).then((b) => new Promise((res) => {
+    const fr = new FileReader(); fr.onload = () => res(fr.result); fr.onerror = () => res(url); fr.readAsDataURL(b);
+  })).catch(() => url);
+
+  // Collect @font-face rules. ss.cssRules throws SecurityError on
+  // cross-origin sheets (e.g. fonts.googleapis.com) — in that case fetch
+  // the CSS text directly (those endpoints send ACAO:*) and regex-extract
+  // the blocks. @import and @media/@supports are walked so nested
+  // @font-face rules aren't missed.
+  const fontRules = [], pending = [], seen = new Set();
+  const scrapeCss = (href) => {
+    if (seen.has(href)) return; seen.add(href);
+    pending.push(fetch(href).then((r) => r.text()).then((css) => {
+      for (const m of css.match(/@font-face\s*{[^}]*}/g) || []) fontRules.push({ css: m, base: href });
+      for (const m of css.matchAll(/@import\s+(?:url\()?['"]?([^'")\s;]+)/g))
+        scrapeCss(new URL(m[1], href).href);
+    }).catch(() => {}));
+  };
+  const walk = (rules, base) => {
+    for (const r of rules) {
+      if (r.type === CSSRule.FONT_FACE_RULE) fontRules.push({ css: r.cssText, base });
+      else if (r.type === CSSRule.IMPORT_RULE && r.styleSheet) {
+        const ibase = r.styleSheet.href || base;
+        try { walk(r.styleSheet.cssRules, ibase); } catch { scrapeCss(ibase); }
+      } else if (r.cssRules) walk(r.cssRules, base);
+    }
+  };
+  for (const ss of document.styleSheets) {
+    const base = ss.href || location.href;
+    try { walk(ss.cssRules, base); } catch { if (ss.href) scrapeCss(ss.href); }
+  }
+  while (pending.length) await pending.shift();
+  const fontCss = (await Promise.all(fontRules.map(async (rule) => {
+    let out = rule.css, m; const re = /url\((['"]?)([^'")]+)\1\)/g;
+    while ((m = re.exec(rule.css))) {
+      if (m[2].indexOf('data:') === 0) continue;
+      let abs; try { abs = new URL(m[2], rule.base).href; } catch { continue; }
+      out = out.split(m[0]).join('url("' + await toDataURL(abs) + '")');
+    }
+    return out;
+  }))).join('\n');
+
+  const cloneStyled = (src) => {
+    if (src.nodeType === 8 || (src.nodeType === 1 && src.tagName === 'SCRIPT')) return document.createTextNode('');
+    const dst = src.cloneNode(false);
+    if (src.nodeType === 1) {
+      const cs = getComputedStyle(src); let txt = '';
+      for (let i = 0; i < cs.length; i++) txt += cs[i] + ':' + cs.getPropertyValue(cs[i]) + ';';
+      dst.setAttribute('style', txt + 'animation:none;transition:none;');
+      if (src.tagName === 'CANVAS') try { const im = document.createElement('img'); im.src = src.toDataURL(); im.setAttribute('style', txt); return im; } catch {}
+    }
+    for (let c = src.firstChild; c; c = c.nextSibling) dst.appendChild(cloneStyled(c));
+    return dst;
+  };
+  const clone = cloneStyled(node);
+  clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+  // Drop the card's own shadow/radius so the export is a flush w×h rect;
+  // the artboard's own background (if any) is already in the computed style.
+  clone.style.boxShadow = 'none'; clone.style.borderRadius = '0';
+
+  const jobs = [];
+  clone.querySelectorAll('img').forEach((el) => {
+    const s = el.getAttribute('src');
+    if (s && s.indexOf('data:') !== 0) jobs.push(toDataURL(el.src).then((d) => el.setAttribute('src', d)));
+  });
+  [clone, ...clone.querySelectorAll('*')].forEach((el) => {
+    const bg = el.style.backgroundImage; if (!bg) return;
+    let m; const re = /url\(["']?([^"')]+)["']?\)/g;
+    while ((m = re.exec(bg))) {
+      const tok = m[0], url = m[1];
+      if (url.indexOf('data:') === 0) continue;
+      jobs.push(toDataURL(url).then((d) => { el.style.backgroundImage = el.style.backgroundImage.split(tok).join('url("' + d + '")'); }));
+    }
+  });
+  await Promise.all(jobs);
+
+  const xml = new XMLSerializer().serializeToString(clone);
+  const save = (blob, ext) => {
+    if (!blob) return;
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob); a.download = name + '.' + ext; a.click();
+    setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+  };
+
+  if (kind === 'html') {
+    const html = '<!doctype html><html><head><meta charset="utf-8"><title>' + name + '</title>' +
+      (fontCss ? '<style>' + fontCss + '</style>' : '') +
+      '</head><body style="margin:0">' + xml + '</body></html>';
+    return save(new Blob([html], { type: 'text/html' }), 'html');
+  }
+
+  // PNG: the SVG's own width/height must be the output resolution — an
+  // <img>-loaded SVG rasterizes at its intrinsic size, so sizing it at 1×
+  // and ctx.scale()-ing up would just upscale a 1× bitmap. viewBox maps the
+  // w×h foreignObject onto the px·w × px·h SVG canvas so the browser renders
+  // the HTML at full resolution.
+  const px = 3;
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + w * px + '" height="' + h * px +
+    '" viewBox="0 0 ' + w + ' ' + h + '"><foreignObject width="' + w + '" height="' + h + '">' +
+    (fontCss ? '<style><![CDATA[' + fontCss + ']]></style>' : '') + xml + '</foreignObject></svg>';
+  const img = new Image();
+  await new Promise((res, rej) => {
+    img.onload = res; img.onerror = () => rej(new Error('svg load failed'));
+    img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+  });
+  const cv = document.createElement('canvas');
+  cv.width = w * px; cv.height = h * px;
+  cv.getContext('2d').drawImage(img, 0, 0);
+  cv.toBlob((blob) => save(blob, 'png'), 'image/png');
+}
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus, onDelete }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+  const cardRef = React.useRef(null);
+  const menuRef = React.useRef(null);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [confirming, setConfirming] = React.useState(false);
+
+  // ⋯ menu: close on any outside pointerdown. Two-click delete lives inside
+  // the menu — first click arms the row, second commits; closing disarms.
+  React.useEffect(() => {
+    if (!menuOpen) { setConfirming(false); return; }
+    const off = (e) => { if (!menuRef.current || !menuRef.current.contains(e.target)) setMenuOpen(false); };
+    document.addEventListener('pointerdown', off, true);
+    return () => document.removeEventListener('pointerdown', off, true);
+  }, [menuOpen]);
+
+  const doExport = (kind) => {
+    setMenuOpen(false);
+    if (!cardRef.current) return;
+    const name = String(label || id || 'artboard').replace(/[^\w\s.-]+/g, '_');
+    dcExport(cardRef.current, width, height, name, kind)
+      .catch((e) => console.error('[design-canvas] export failed:', e));
+  };
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-header" data-noncommentable="" style={{ color: DC.label }} onPointerDown={(e) => e.stopPropagation()}>
+        <div className="dc-labelrow">
+          <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+            <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+          </div>
+          <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+            <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+              style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+          </div>
+        </div>
+        <div className="dc-btns">
+          <div ref={menuRef} style={{ position: 'relative' }}>
+            <button className="dc-kebab" title="More" onClick={() => setMenuOpen((o) => !o)}>
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><circle cx="2.5" cy="6" r="1.1"/><circle cx="6" cy="6" r="1.1"/><circle cx="9.5" cy="6" r="1.1"/></svg>
+            </button>
+            {menuOpen && (
+              <div className="dc-menu" onPointerDown={(e) => e.stopPropagation()}>
+                <button onClick={() => doExport('png')}>Download PNG</button>
+                <button onClick={() => doExport('html')}>Download HTML</button>
+                <hr />
+                <button className="dc-danger"
+                  onClick={() => { if (confirming) { setMenuOpen(false); onDelete(); } else setConfirming(true); }}>
+                  {confirming ? 'Click again to delete' : 'Delete'}
+                </button>
+              </div>
+            )}
+          </div>
+          <button className="dc-expand" onClick={onFocus} title="Focus">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+          </button>
+        </div>
+      </div>
+      <div ref={cardRef} className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    // Sections whose artboards are all deleted have slotIds:[] — step past
+    // them to the next non-empty section so ↑/↓ doesn't dead-end.
+    const n = sectionOrder.length;
+    for (let i = 1; i < n; i++) {
+      const ns = sectionOrder[(((secIdx + d * i) % n) + n) % n];
+      const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+      if (first) { ctx.setFocus(`${ns}/${first}`); return; }
+    }
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.filter((sid) => sectionMeta[sid].slotIds.length).map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/docs/design-handoffs/design_handoff_radio_controller/mocks.jsx
+++ b/docs/design-handoffs/design_handoff_radio_controller/mocks.jsx
@@ -1,0 +1,1356 @@
+// mocks.jsx — Radio Controller design improvement artboards.
+// Each component renders inside a <DCArtboard>. Inline styles only so this
+// file is self-contained and won't fight the canvas chrome.
+
+const T = {
+  base:       '#0D0D0F',
+  raised:     '#141416',
+  inset:      '#0A0A0C',
+  well:       '#040406',
+  sep:        '#1F1F22',
+  hair:       '#25252A',
+
+  accent:     '#5CD4E8',
+  accentDim:  'rgba(92,212,232,0.10)',
+  accentGlow: 'rgba(92,212,232,0.25)',
+  amber:      '#F0A830',
+  amberDim:   'rgba(240,168,48,0.08)',
+  amberGlow:  'rgba(240,168,48,0.30)',
+  amberSoft:  'rgba(240,168,48,0.15)',
+
+  sRadio:     '#F0A830',
+
+  red:        '#F87171',
+  yellow:     '#FBBF24',
+  green:      '#4ADE80',
+  purple:     '#A78BFA',
+
+  hi:         '#F0EFF4',
+  md:         '#9CA3AF',
+  lo:         '#6B7280',
+  dim:        '#353841',
+
+  body:       "'Inter', -apple-system, BlinkMacSystemFont, sans-serif",
+  mono:       "'JetBrains Mono', 'SF Mono', Consolas, monospace",
+  led:        "'Share Tech Mono', 'JetBrains Mono', monospace",
+};
+
+/* ─────────── shared atoms ─────────── */
+const Stage = ({ w, h, pad = 0, children, style }) => (
+  <div style={{
+    width: w, height: h, background: T.base, color: T.hi,
+    fontFamily: T.body, fontSize: 14, lineHeight: 1.45,
+    overflow: 'hidden', boxSizing: 'border-box', padding: pad,
+    ...style,
+  }}>{children}</div>
+);
+
+const Split = ({ children }) => (
+  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1px 1fr', height: '100%' }}>
+    {children[0]}
+    <div style={{ background: T.sep }} />
+    {children[1]}
+  </div>
+);
+
+const Half = ({ title, kicker, kickerColor, children, pad = 0 }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minWidth: 0 }}>
+    <div style={{
+      display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+      padding: '14px 20px 12px', borderBottom: `1px solid ${T.sep}`, flexShrink: 0,
+    }}>
+      <div>
+        <div style={{
+          fontFamily: T.mono, fontSize: 10, letterSpacing: '0.16em',
+          textTransform: 'uppercase', color: kickerColor || T.lo,
+        }}>{kicker}</div>
+        <div style={{ fontSize: 13, color: T.hi, marginTop: 3 }}>{title}</div>
+      </div>
+    </div>
+    <div style={{ flex: 1, minHeight: 0, padding: pad, position: 'relative' }}>
+      {children}
+    </div>
+  </div>
+);
+
+const Caption = ({ children, color = T.md }) => (
+  <div style={{
+    position: 'absolute', bottom: 14, left: 20, right: 20,
+    fontSize: 11.5, lineHeight: 1.5, color,
+    fontFamily: T.body,
+  }}>{children}</div>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   #1 — Signal meter overflow (118%, 111%)
+   The bar is being filled from a value that's not clamped, AND the
+   stage between green/amber/red is hard-coded to 60/85% of an
+   already-overflowing scale. Fix: clamp 0–100, add a separate
+   "headroom" indicator that lights up red only when overdriven.
+   ════════════════════════════════════════════════════════════ */
+
+const SignalBar = ({ pct, bug = false, w = 320 }) => {
+  // 20 segments.
+  const segs = [];
+  for (let i = 0; i < 20; i++) {
+    const filled = pct >= (i + 1) * 5;
+    let color = T.dim;
+    if (filled) {
+      if (i < 12) color = T.green;
+      else if (i < 17) color = T.amber;
+      else color = T.red;
+    }
+    segs.push(
+      <div key={i} style={{
+        flex: 1, height: '100%', borderRadius: 1,
+        background: color,
+        boxShadow: filled ? `0 0 4px ${color}55, inset 0 1px 0 rgba(255,255,255,.18)` : 'none',
+      }} />
+    );
+  }
+  return (
+    <div style={{ width: w }}>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between',
+        fontFamily: T.mono, fontSize: 9.5, letterSpacing: '0.16em',
+        color: T.lo, marginBottom: 6, textTransform: 'uppercase',
+      }}>
+        <span>Signal</span>
+        <span style={{ color: bug ? T.red : T.md }}>{pct}%{bug ? ' ⚠' : ''}</span>
+      </div>
+      <div style={{
+        display: 'flex', gap: 2, height: 14, padding: '3px 4px',
+        background: T.well, borderRadius: 3, border: `1px solid ${T.hair}`,
+        boxShadow: 'inset 0 1px 4px rgba(0,0,0,0.7)',
+      }}>{segs}</div>
+    </div>
+  );
+};
+
+// "After" version: clamped + separate clip indicator + dB label.
+const SignalBarAfter = ({ dbu, clip = false, w = 320 }) => {
+  // 0 dBu = full scale. Show 20 segs from -60 to 0 dBu.
+  // pct = (dbu + 60) / 60 * 100, clamped.
+  const pct = Math.max(0, Math.min(100, ((dbu + 60) / 60) * 100));
+  const segs = [];
+  for (let i = 0; i < 20; i++) {
+    const filled = pct >= (i + 1) * 5;
+    let color = T.dim;
+    if (filled) {
+      if (i < 12) color = T.green;
+      else if (i < 17) color = T.amber;
+      else color = T.red;
+    }
+    segs.push(
+      <div key={i} style={{
+        flex: 1, height: '100%', borderRadius: 1,
+        background: color,
+        boxShadow: filled ? `0 0 4px ${color}55, inset 0 1px 0 rgba(255,255,255,.18)` : 'none',
+      }} />
+    );
+  }
+  return (
+    <div style={{ width: w }}>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+        fontFamily: T.mono, fontSize: 9.5, letterSpacing: '0.16em',
+        color: T.lo, marginBottom: 6, textTransform: 'uppercase',
+      }}>
+        <span>RSSI</span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{
+            fontSize: 9, padding: '1px 6px', borderRadius: 2,
+            color: clip ? T.red : T.dim,
+            border: `1px solid ${clip ? T.red : T.hair}`,
+            background: clip ? 'rgba(248,113,113,0.10)' : 'transparent',
+            boxShadow: clip ? `0 0 6px rgba(248,113,113,0.4)` : 'none',
+            letterSpacing: '0.18em',
+          }}>CLIP</span>
+          <span style={{ color: T.hi, fontVariantNumeric: 'tabular-nums' }}>{dbu > 0 ? '+' : ''}{dbu} dBu</span>
+        </div>
+      </div>
+      <div style={{
+        display: 'flex', gap: 2, height: 14, padding: '3px 4px',
+        background: T.well, borderRadius: 3, border: `1px solid ${T.hair}`,
+        boxShadow: 'inset 0 1px 4px rgba(0,0,0,0.7)',
+      }}>{segs}</div>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between',
+        fontFamily: T.mono, fontSize: 8.5, color: T.dim, marginTop: 3,
+        letterSpacing: '0.10em',
+      }}>
+        <span>−60</span><span>−30</span><span>−12</span><span>0 dBu</span>
+      </div>
+    </div>
+  );
+};
+
+const Mock_SignalMeter = () => (
+  <Stage w={1280} height={460}>
+    <Split>
+      <Half kicker="Before" kickerColor={T.red} title="Signal can read 118 % — bar fills past full and re-uses the green band">
+        <div style={{ padding: '36px 40px', display: 'flex', flexDirection: 'column', gap: 30 }}>
+          <SignalBar pct={65} w={520} />
+          <SignalBar pct={111} bug w={520} />
+          <SignalBar pct={118} bug w={520} />
+        </div>
+        <Caption color={T.md}>
+          The percentage is a raw RTL-SDR power value with no normalisation. When the antenna gain is high or AGC over-corrects, it overshoots 100 %. The bar visually saturates at 20 segments and then the number contradicts the bar.
+        </Caption>
+      </Half>
+      <Half kicker="After" kickerColor={T.accent} title="Clamp to a calibrated dBu scale and surface clipping as its own state">
+        <div style={{ padding: '36px 40px', display: 'flex', flexDirection: 'column', gap: 30 }}>
+          <SignalBarAfter dbu={-22} w={520} />
+          <SignalBarAfter dbu={-3} w={520} />
+          <SignalBarAfter dbu={0} clip w={520} />
+        </div>
+        <Caption color={T.md}>
+          Map the raw value to <span style={{ color: T.hi }}>dBu (−60 → 0)</span>, scale labels appear under the bar, and the <span style={{ color: T.red }}>CLIP</span> pill lights up only when the front-end is actually overdriving. The bar can never exceed 100 % full.
+        </Caption>
+      </Half>
+    </Split>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   #2 — Tuner header + RDS info
+   The current "TUNER" caption is 9 px and tucked in the corner; the
+   RDS station name appears as a tiny "Don · CLASSIC ROCK" between
+   the freq display and the meter. Promote both.
+   ════════════════════════════════════════════════════════════ */
+
+const BandPill = ({ label, active }) => (
+  <div style={{
+    padding: '0 14px', height: 32, display: 'flex', alignItems: 'center',
+    fontFamily: T.mono, fontSize: 11, fontWeight: 700, letterSpacing: '0.10em',
+    color: active ? T.amber : T.lo,
+    background: active
+      ? 'linear-gradient(180deg,#1a1508 0%,#14100a 100%)'
+      : 'linear-gradient(180deg,#161618 0%,#111113 100%)',
+    border: `1px solid ${active ? 'rgba(240,168,48,0.25)' : '#1e1e21'}`,
+    borderBottom: `2px solid ${active ? 'rgba(240,168,48,0.15)' : '#0a0a0c'}`,
+    borderRadius: 3, textShadow: active ? `0 0 8px ${T.amberGlow}` : 'none',
+  }}>{label}</div>
+);
+
+const BandPillTall = ({ label, sub, active }) => (
+  <div style={{
+    padding: '8px 14px 6px', minWidth: 64,
+    display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1,
+    fontFamily: T.mono,
+    color: active ? T.amber : T.md,
+    background: active
+      ? 'linear-gradient(180deg,#1a1508 0%,#14100a 100%)'
+      : 'linear-gradient(180deg,#161618 0%,#111113 100%)',
+    border: `1px solid ${active ? 'rgba(240,168,48,0.30)' : '#1e1e21'}`,
+    borderBottom: `2px solid ${active ? 'rgba(240,168,48,0.20)' : '#0a0a0c'}`,
+    borderRadius: 4,
+    boxShadow: active ? `0 0 12px ${T.amberDim}, inset 0 1px 0 rgba(240,168,48,0.08)` : 'none',
+  }}>
+    <div style={{
+      fontSize: 13, fontWeight: 700, letterSpacing: '0.08em',
+      textShadow: active ? `0 0 8px ${T.amberGlow}` : 'none',
+    }}>{label}</div>
+    <div style={{ fontSize: 8, letterSpacing: '0.14em', color: active ? T.amber : T.dim, opacity: 0.7 }}>{sub}</div>
+  </div>
+);
+
+const FreqDisplayBefore = () => (
+  <div style={{
+    padding: '14px 32px 10px', background: T.well, borderRadius: 6,
+    border: `1px solid #0e0e10`, width: 400, textAlign: 'center',
+    boxShadow: 'inset 0 2px 10px rgba(0,0,0,0.9)',
+  }}>
+    <div style={{
+      fontFamily: T.led, fontSize: 56, color: T.amber, letterSpacing: '0.02em',
+      textShadow: `0 0 14px ${T.amberGlow}`,
+    }}>92.30<span style={{ fontSize: '0.55em', marginLeft: 6, opacity: 0.85 }}>MHz</span></div>
+    <div style={{
+      display: 'flex', justifyContent: 'space-between', marginTop: 8,
+      fontFamily: T.mono, fontSize: 9.5, color: T.lo, letterSpacing: '0.14em',
+    }}>
+      <span>STEP 100 kHz</span>
+      <span style={{
+        color: T.accent, padding: '1px 8px',
+        border: `1px solid ${T.accentGlow}`, borderRadius: 2, fontSize: 8.5,
+        background: T.accentDim,
+      }}>STEREO</span>
+    </div>
+  </div>
+);
+
+const FreqDisplayAfter = () => (
+  <div style={{ width: 460 }}>
+    {/* Station card above frequency */}
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10,
+      padding: '6px 14px', background: '#0c0c0e', borderRadius: 6,
+      border: `1px solid ${T.hair}`,
+    }}>
+      <div style={{
+        fontFamily: T.mono, fontSize: 10, letterSpacing: '0.14em',
+        color: T.dim, fontWeight: 600,
+      }}>RDS</div>
+      <div style={{
+        fontFamily: T.mono, fontSize: 14, fontWeight: 700,
+        color: T.accent, letterSpacing: '0.18em',
+        textShadow: `0 0 10px ${T.accentGlow}`, flex: 1,
+      }}>WRAL-FM</div>
+      <div style={{
+        fontFamily: T.mono, fontSize: 9.5, color: T.md, letterSpacing: '0.12em',
+        padding: '2px 8px', borderRadius: 2,
+        border: `1px solid ${T.hair}`, background: 'rgba(255,255,255,0.03)',
+        textTransform: 'uppercase',
+      }}>Classic Rock</div>
+    </div>
+    {/* Frequency well */}
+    <div style={{
+      padding: '14px 32px 10px', background: T.well, borderRadius: 6,
+      border: `1px solid #0e0e10`, textAlign: 'center',
+      boxShadow: 'inset 0 2px 10px rgba(0,0,0,0.9)',
+    }}>
+      <div style={{
+        fontFamily: T.led, fontSize: 60, color: T.amber, letterSpacing: '0.02em',
+        textShadow: `0 0 14px ${T.amberGlow}`,
+      }}>92.30<span style={{ fontSize: '0.55em', marginLeft: 6, opacity: 0.85 }}>MHz</span></div>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 8,
+        fontFamily: T.mono, fontSize: 9.5, color: T.lo, letterSpacing: '0.14em',
+      }}>
+        <span>STEP 100 kHz · 76–108 MHz</span>
+        <span style={{
+          color: T.accent, padding: '1px 8px',
+          border: `1px solid ${T.accentGlow}`, borderRadius: 2, fontSize: 8.5,
+          background: T.accentDim,
+        }}>STEREO</span>
+      </div>
+    </div>
+    {/* RDS RadioText scroller */}
+    <div style={{
+      marginTop: 8, padding: '6px 14px', background: '#08080a', borderRadius: 4,
+      border: `1px solid #1a1a1c`, display: 'flex', gap: 10, alignItems: 'center',
+      fontFamily: T.mono, fontSize: 11, color: T.md, letterSpacing: '0.04em',
+    }}>
+      <span style={{ color: T.dim, fontSize: 9, letterSpacing: '0.18em' }}>RT</span>
+      <span style={{ flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        Don Henley — Dirty Laundry  ·  Up next: Boston — More Than a Feeling
+      </span>
+    </div>
+  </div>
+);
+
+const Mock_TunerHeader = () => (
+  <Stage w={1280} h={560}>
+    <Split>
+      <Half kicker="Before" kickerColor={T.red} title="Tuner label is 9 px, band buttons are uniform, RDS shrinks to two whispered words">
+        <div style={{ padding: '32px 32px 0', position: 'absolute', inset: 0 }}>
+          <div style={{
+            fontFamily: T.mono, fontSize: 9, fontWeight: 700, letterSpacing: '0.22em',
+            color: T.lo, opacity: 0.45, position: 'absolute', top: 12, left: 22,
+          }}>TUNER</div>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 14, marginTop: 24 }}>
+            <div style={{
+              display: 'flex', gap: 2, padding: 3, background: T.inset, borderRadius: 5,
+              border: `1px solid #1a1a1d`,
+              boxShadow: 'inset 0 1px 4px rgba(0,0,0,0.6)',
+            }}>
+              <BandPill label="AM" />
+              <BandPill label="FM" active />
+              <BandPill label="SW" />
+              <BandPill label="AIR" />
+              <BandPill label="WB" />
+              <BandPill label="VHF" />
+            </div>
+            <FreqDisplayBefore />
+            <div style={{
+              fontFamily: T.mono, fontSize: 11, color: T.accent, letterSpacing: '0.20em',
+              marginTop: 4,
+            }}>Don<span style={{ color: T.dim, margin: '0 8px' }}>·</span><span style={{
+              color: T.md, fontSize: 9.5, padding: '2px 8px', border: `1px solid ${T.hair}`,
+              borderRadius: 2, background: 'rgba(255,255,255,0.03)',
+            }}>CLASSIC ROCK</span></div>
+          </div>
+        </div>
+      </Half>
+      <Half kicker="After" kickerColor={T.accent} title="Promote the band strip to tall pills with band-purpose subtitle, lift the RDS card above the freq display">
+        <div style={{ padding: '24px 32px 0', position: 'absolute', inset: 0 }}>
+          {/* Real header row */}
+          <div style={{
+            display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+            padding: '0 0 16px',
+            borderBottom: `1px solid ${T.sep}`, marginBottom: 24,
+          }}>
+            <div style={{
+              fontFamily: T.body, fontSize: 14, fontWeight: 600, letterSpacing: '0.04em',
+              color: T.hi,
+            }}>Tuner</div>
+            <div style={{
+              fontFamily: T.mono, fontSize: 10, letterSpacing: '0.16em',
+              color: T.amber, textTransform: 'uppercase',
+            }}>FM · 76–108 MHz</div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 16 }}>
+            <div style={{
+              display: 'flex', gap: 3, padding: 3, background: T.inset, borderRadius: 6,
+              border: `1px solid #1a1a1d`,
+              boxShadow: 'inset 0 1px 4px rgba(0,0,0,0.6)',
+            }}>
+              <BandPillTall label="AM" sub="535–1700 kHz" />
+              <BandPillTall label="FM" sub="76–108 MHz" active />
+              <BandPillTall label="SW" sub="1.7–30 MHz" />
+              <BandPillTall label="AIR" sub="118–137 MHz" />
+              <BandPillTall label="WB" sub="WX 1–7" />
+              <BandPillTall label="VHF" sub="136–174 MHz" />
+            </div>
+            <FreqDisplayAfter />
+          </div>
+        </div>
+      </Half>
+    </Split>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   #3 — AGC / gain control strip
+   The current strip has a switch on the left and an EMPTY slot on the
+   right when AGC is on. With AGC off, the slider crowds in. Replace
+   with a single full-width strip that always shows useful info.
+   ════════════════════════════════════════════════════════════ */
+
+const AgcStripBefore = ({ agc }) => (
+  <div style={{
+    display: 'flex', alignItems: 'center', gap: 12, width: 460,
+    padding: '6px 14px', background: T.inset, borderRadius: 4,
+    border: `1px solid #141416`, boxShadow: 'inset 0 1px 3px rgba(0,0,0,0.4)',
+  }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div style={{
+        width: 32, height: 18, borderRadius: 9, padding: 2,
+        background: agc ? 'rgba(167,139,250,0.40)' : '#222',
+        display: 'flex', alignItems: 'center',
+      }}>
+        <div style={{
+          width: 14, height: 14, borderRadius: '50%',
+          background: agc ? T.purple : '#555',
+          transform: agc ? 'translateX(14px)' : 'translateX(0)',
+          transition: 'transform 150ms',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.5)',
+        }} />
+      </div>
+      <span style={{
+        fontFamily: T.mono, fontSize: 11, fontWeight: 700,
+        letterSpacing: '0.12em', color: T.amber,
+      }}>AGC</span>
+    </div>
+    <div style={{
+      flex: 1, minHeight: 18, // empty slot
+    }}>
+      {!agc && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontFamily: T.mono, fontSize: 11, color: T.amber }}>GAIN 28 dB</span>
+          <div style={{ flex: 1, height: 4, borderRadius: 2, background: '#222', position: 'relative' }}>
+            <div style={{ position: 'absolute', inset: '0 44% 0 0', borderRadius: 2, background: T.purple }} />
+            <div style={{
+              position: 'absolute', top: -4, left: '56%', width: 12, height: 12, borderRadius: '50%',
+              background: T.purple, transform: 'translateX(-50%)',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.5)',
+            }} />
+          </div>
+        </div>
+      )}
+    </div>
+  </div>
+);
+
+const AgcStripAfter = ({ agc }) => (
+  <div style={{
+    display: 'flex', alignItems: 'stretch', width: 460,
+    background: T.inset, borderRadius: 4,
+    border: `1px solid #141416`, boxShadow: 'inset 0 1px 3px rgba(0,0,0,0.4)',
+    overflow: 'hidden',
+  }}>
+    {/* Left cell — AGC toggle */}
+    <button style={{
+      all: 'unset',
+      padding: '8px 14px',
+      display: 'flex', alignItems: 'center', gap: 8,
+      cursor: 'pointer', borderRight: `1px solid ${T.hair}`,
+      background: agc ? 'rgba(240,168,48,0.05)' : 'transparent',
+    }}>
+      <span style={{
+        fontFamily: T.mono, fontSize: 11, fontWeight: 700,
+        letterSpacing: '0.14em', color: agc ? T.amber : T.lo,
+      }}>AGC</span>
+      <span style={{
+        fontFamily: T.mono, fontSize: 9, padding: '1px 6px', borderRadius: 2,
+        letterSpacing: '0.18em',
+        color: agc ? T.green : T.dim,
+        border: `1px solid ${agc ? 'rgba(74,222,128,0.30)' : T.hair}`,
+        background: agc ? 'rgba(74,222,128,0.06)' : 'transparent',
+      }}>{agc ? 'AUTO' : 'OFF'}</span>
+    </button>
+    {/* Right cell — always-useful content */}
+    <div style={{ flex: 1, padding: '8px 14px', display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
+      {agc ? (
+        <>
+          <span style={{
+            fontFamily: T.mono, fontSize: 11, color: T.md, letterSpacing: '0.04em',
+          }}>Tuner is choosing</span>
+          <span style={{
+            flex: 1, textAlign: 'right',
+            fontFamily: T.mono, fontSize: 11, color: T.amber, letterSpacing: '0.06em',
+          }}>
+            <span style={{ color: T.dim, marginRight: 6 }}>now</span>28.0 dB
+          </span>
+        </>
+      ) : (
+        <>
+          <span style={{ fontFamily: T.mono, fontSize: 11, color: T.amber, fontWeight: 600 }}>28 dB</span>
+          <div style={{ flex: 1, height: 4, borderRadius: 2, background: '#222', position: 'relative' }}>
+            <div style={{ position: 'absolute', inset: '0 44% 0 0', borderRadius: 2, background: T.amber }} />
+            <div style={{
+              position: 'absolute', top: -4, left: '56%', width: 12, height: 12, borderRadius: '50%',
+              background: T.amber, transform: 'translateX(-50%)',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.6)',
+            }} />
+          </div>
+          <span style={{ fontFamily: T.mono, fontSize: 9, color: T.dim, letterSpacing: '0.14em' }}>0 – 50</span>
+        </>
+      )}
+    </div>
+  </div>
+);
+
+const Mock_AgcStrip = () => (
+  <Stage w={1280} h={520}>
+    <Split>
+      <Half kicker="Before" kickerColor={T.red} title="The right half of the strip is empty when AGC is on">
+        <div style={{ padding: '36px 40px', display: 'flex', flexDirection: 'column', gap: 20 }}>
+          <div>
+            <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, marginBottom: 8, letterSpacing: '0.16em' }}>AGC ON · empty slot</div>
+            <AgcStripBefore agc />
+          </div>
+          <div>
+            <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, marginBottom: 8, letterSpacing: '0.16em' }}>AGC OFF · slider appears</div>
+            <AgcStripBefore agc={false} />
+          </div>
+        </div>
+        <Caption>
+          The strip is a two-column flex with one column doing real work and one column blank. The slider appears/disappears, which means the strip changes height between states.
+        </Caption>
+      </Half>
+      <Half kicker="After" kickerColor={T.accent} title="Two cells, always full. AGC cell shows AUTO/OFF; gain cell shows the chosen-or-manual value">
+        <div style={{ padding: '36px 40px', display: 'flex', flexDirection: 'column', gap: 20 }}>
+          <div>
+            <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, marginBottom: 8, letterSpacing: '0.16em' }}>AGC ON · shows what the tuner chose</div>
+            <AgcStripAfter agc />
+          </div>
+          <div>
+            <div style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, marginBottom: 8, letterSpacing: '0.16em' }}>AGC OFF · slider with range labels</div>
+            <AgcStripAfter agc={false} />
+          </div>
+        </div>
+        <Caption>
+          Same height in both states. When AGC is on the right cell reports the gain the tuner currently selected — turning AGC off is no longer a leap of faith.
+        </Caption>
+      </Half>
+    </Split>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   #4 — Memory presets
+   Current: vertical list, each row is "WB - 162.55 MHz" with a redundant
+   "162.55 MHz WB" right beneath. Slot number is a 9 px ghost in the corner.
+   ════════════════════════════════════════════════════════════ */
+
+const PresetBefore = ({ name, freq, band, slot, active }) => (
+  <div style={{
+    position: 'relative', padding: '7px 10px', borderRadius: 3,
+    border: `1px solid ${active ? 'rgba(240,168,48,0.30)' : 'transparent'}`,
+    background: active ? 'rgba(240,168,48,0.06)' : 'transparent',
+    marginBottom: 2,
+  }}>
+    <div style={{ fontSize: 12, fontWeight: 600, color: T.hi, paddingRight: 24 }}>{name}</div>
+    <div style={{ fontFamily: T.mono, fontSize: 11, color: T.amber, marginTop: 1 }}>
+      {freq} <span style={{ color: T.lo, fontSize: 9, letterSpacing: '0.10em', marginLeft: 4 }}>{band}</span>
+    </div>
+    <div style={{
+      position: 'absolute', right: 8, bottom: 5,
+      fontFamily: T.mono, fontSize: 9, color: T.lo, opacity: 0.20,
+    }}>{String(slot).padStart(2, '0')}</div>
+  </div>
+);
+
+const PresetAfter = ({ name, freq, band, slot, active, empty }) => empty ? (
+  <div style={{
+    display: 'grid', gridTemplateColumns: '22px 1fr 64px', gap: 10, alignItems: 'center',
+    padding: '6px 8px', borderRadius: 3,
+    border: `1px dashed ${T.hair}`,
+    opacity: 0.5,
+    background: 'transparent', marginBottom: 2,
+  }}>
+    <div style={{
+      fontFamily: T.mono, fontSize: 10, color: T.dim, textAlign: 'right',
+      letterSpacing: '0.05em',
+    }}>{String(slot).padStart(2, '0')}</div>
+    <div style={{ fontFamily: T.mono, fontSize: 10, color: T.dim, letterSpacing: '0.12em' }}>EMPTY · long-press to save</div>
+    <div />
+  </div>
+) : (
+  <div style={{
+    display: 'grid', gridTemplateColumns: '22px 1fr 64px', gap: 10, alignItems: 'center',
+    padding: '6px 8px', borderRadius: 3,
+    border: `1px solid ${active ? 'rgba(240,168,48,0.30)' : 'transparent'}`,
+    background: active ? 'rgba(240,168,48,0.06)' : 'transparent',
+    marginBottom: 2,
+  }}>
+    <div style={{
+      fontFamily: T.mono, fontSize: 10,
+      color: active ? T.amber : T.lo, textAlign: 'right',
+      letterSpacing: '0.05em',
+    }}>{String(slot).padStart(2, '0')}</div>
+    <div style={{ minWidth: 0 }}>
+      <div style={{
+        fontSize: 12, fontWeight: 500, color: T.hi,
+        whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+      }}>{name}</div>
+      <div style={{
+        fontFamily: T.mono, fontSize: 9, color: T.lo, letterSpacing: '0.10em', marginTop: 1,
+      }}>{band}</div>
+    </div>
+    <div style={{
+      fontFamily: T.led, fontSize: 13, color: active ? T.amber : T.md,
+      textAlign: 'right', letterSpacing: '0.02em',
+      textShadow: active ? `0 0 6px ${T.amberGlow}` : 'none',
+    }}>{freq}</div>
+  </div>
+);
+
+const Mock_Presets = () => (
+  <Stage w={1100} h={620}>
+    <Split>
+      <Half kicker="Before" kickerColor={T.red} title="Name is the frequency, frequency is also the frequency, slot number is invisible">
+        <div style={{ padding: '20px 24px 0' }}>
+          <div style={{
+            display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+            paddingBottom: 12, borderBottom: `1px solid ${T.sep}`, marginBottom: 12,
+          }}>
+            <div style={{
+              fontFamily: T.mono, fontSize: 9, fontWeight: 700, letterSpacing: '0.18em',
+              color: T.lo,
+            }}>MEMORY</div>
+            <span style={{
+              width: 18, height: 18, borderRadius: 3, background: T.amberDim,
+              border: `1px solid ${T.amberSoft}`,
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              fontFamily: T.mono, fontSize: 10, color: T.amber,
+            }}>＋</span>
+          </div>
+          <PresetBefore slot={1} name="WB - 162.55 MHz"      freq="162.55 MHz" band="WB" />
+          <PresetBefore slot={2} name="FM - 105.10 MHz"      freq="105.10 MHz" band="FM" />
+          <PresetBefore slot={3} name="FM - 106.90 MHz"      freq="106.90 MHz" band="FM" />
+          <PresetBefore slot={4} name="FM - 91.50 MHz"       freq="91.50 MHz"  band="FM" />
+          <PresetBefore slot={5} name="FM WFJA 105.50 MHz"   freq="105.50 MHz" band="FM" />
+          <PresetBefore slot={6} name="FM WSMW 97.75 MHz"    freq="97.75 MHz"  band="FM" />
+          <PresetBefore slot={7} name="FM Rock 92 92.30 MHz" freq="92.30 MHz"  band="FM" active />
+        </div>
+        <Caption>
+          The "Save current" prompt seeds the name with the same string the row already shows below. Eight rows in, the column has been three different formats of the same MHz number.
+        </Caption>
+      </Half>
+      <Half kicker="After" kickerColor={T.accent} title="Slot # on the left, custom name in the middle, big LED frequency on the right">
+        <div style={{ padding: '20px 24px 0' }}>
+          <div style={{
+            display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+            paddingBottom: 12, borderBottom: `1px solid ${T.sep}`, marginBottom: 12,
+          }}>
+            <div style={{
+              fontFamily: T.mono, fontSize: 9, fontWeight: 700, letterSpacing: '0.18em',
+              color: T.lo,
+            }}>MEMORY <span style={{ color: T.dim, marginLeft: 4 }}>· 7 of 16</span></div>
+            <div style={{
+              fontFamily: T.mono, fontSize: 9, letterSpacing: '0.14em', color: T.lo,
+            }}>HOLD <kbd style={{
+              fontFamily: T.mono, fontSize: 9, padding: '0 4px', borderRadius: 2,
+              border: `1px solid ${T.hair}`, background: '#0c0c0e', color: T.md,
+            }}>FM</kbd> TO SAVE</div>
+          </div>
+          <PresetAfter slot={1} name="NOAA Raleigh"  freq="162.55"  band="WB" />
+          <PresetAfter slot={2} name="The River"     freq="105.10"  band="FM" />
+          <PresetAfter slot={3} name="WCMC"          freq="106.90"  band="FM" />
+          <PresetAfter slot={4} name="WUNC"          freq="91.50"   band="FM" />
+          <PresetAfter slot={5} name="WFJA"          freq="105.50"  band="FM" />
+          <PresetAfter slot={6} name="WSMW"          freq="97.75"   band="FM" />
+          <PresetAfter slot={7} name="Rock 92"       freq="92.30"   band="FM" active />
+          <PresetAfter slot={8} empty />
+          <PresetAfter slot={9} empty />
+        </div>
+        <Caption>
+          Saving from the tuner offers the station's RDS name as the default — never the frequency. The first empty slot is always visible so capacity is legible at a glance.
+        </Caption>
+      </Half>
+    </Split>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   #5 — Song recognition panel
+   Current: ASCII-ish table with Src / Match / # / Conf% / Track / Art
+   columns. Conf% is always "80%". Art is a ✓ / ✗. No "now" marker.
+   ════════════════════════════════════════════════════════════ */
+
+const SongRowBefore = ({ src, match, idx, conf, track, art, dim }) => (
+  <tr style={{ opacity: dim ? 0.45 : 1 }}>
+    <td style={{ padding: '5px 8px', color: T.lo, fontSize: 13, fontFamily: T.mono }}>
+      {src === 'mic' ? '🎙' : '📁'}
+    </td>
+    <td style={{ padding: '5px 8px', textAlign: 'center', fontFamily: T.mono, fontSize: 11, color: match ? T.green : T.red }}>{match ? '✓' : '✗'}</td>
+    <td style={{ padding: '5px 8px', fontFamily: T.mono, fontSize: 11, color: T.md, textAlign: 'right' }}>{idx}</td>
+    <td style={{ padding: '5px 8px', fontFamily: T.mono, fontSize: 11, color: T.md }}>{conf ? `${conf}%` : '—'}</td>
+    <td style={{
+      padding: '5px 8px', fontFamily: T.mono, fontSize: 11, color: T.md,
+      maxWidth: 280, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    }}>{track || '—'}</td>
+    <td style={{ padding: '5px 8px', textAlign: 'center', fontFamily: T.mono, fontSize: 11, color: art ? T.green : T.lo }}>{art ? '✓' : ''}</td>
+  </tr>
+);
+
+const ConfPip = ({ level }) => {
+  // level: 0/1/2/3
+  const colors = ['#22251c', '#5C7C3A', '#7FAB46', T.green];
+  return (
+    <div style={{ display: 'inline-flex', gap: 2 }}>
+      {[0, 1, 2].map(i => (
+        <div key={i} style={{
+          width: 5, height: 10, borderRadius: 1,
+          background: i < level ? colors[level] : '#1c1f1a',
+        }} />
+      ))}
+    </div>
+  );
+};
+
+const SongRowAfter = ({ time, conf, track, artist, art, source, active, ago }) => {
+  const confLabel = conf === 3 ? 'Strong' : conf === 2 ? 'Likely' : conf === 1 ? 'Possible' : 'No match';
+  const confColor = conf === 3 ? T.green : conf === 2 ? '#86b96b' : conf === 1 ? T.amber : T.lo;
+  return (
+    <div style={{
+      display: 'grid', gridTemplateColumns: '34px 1fr 80px 60px', gap: 12, alignItems: 'center',
+      padding: '6px 10px', borderRadius: 4,
+      borderLeft: active ? `2px solid ${T.amber}` : '2px solid transparent',
+      background: active ? 'rgba(240,168,48,0.05)' : 'transparent',
+      marginBottom: 1,
+    }}>
+      {/* Art / fallback */}
+      <div style={{
+        width: 34, height: 34, borderRadius: 3,
+        background: art ? `linear-gradient(135deg, #2a1e14, #4a3520)` : '#1a1a1d',
+        border: `1px solid ${T.hair}`,
+        position: 'relative',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: T.dim, fontFamily: T.mono, fontSize: 9,
+      }}>
+        {!art && '♪'}
+        {active && (
+          <span style={{
+            position: 'absolute', top: -3, right: -3, width: 8, height: 8, borderRadius: '50%',
+            background: T.amber, boxShadow: `0 0 6px ${T.amber}`,
+          }} />
+        )}
+      </div>
+      {/* Track */}
+      <div style={{ minWidth: 0 }}>
+        <div style={{
+          fontSize: 12.5, color: active ? T.hi : T.md, fontWeight: active ? 600 : 500,
+          whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+        }}>{track || <span style={{ color: T.lo, fontStyle: 'italic' }}>No match in window</span>}</div>
+        <div style={{
+          fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.04em',
+          whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+        }}>{artist || `source · ${source}`}</div>
+      </div>
+      {/* Confidence */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 6,
+      }}>
+        <ConfPip level={conf} />
+        <span style={{
+          fontFamily: T.mono, fontSize: 9.5, color: confColor, letterSpacing: '0.06em',
+        }}>{confLabel}</span>
+      </div>
+      {/* Time */}
+      <div style={{
+        fontFamily: T.mono, fontSize: 10, color: T.lo, textAlign: 'right', letterSpacing: '0.02em',
+      }}>{active ? 'now' : ago}</div>
+    </div>
+  );
+};
+
+const Mock_SongRecognition = () => (
+  <Stage w={1480} h={720}>
+    <Split>
+      <Half kicker="Before" kickerColor={T.red} title="ASCII table. Six columns of which two are checkboxes and one is always 80 %">
+        <div style={{ padding: '14px 18px 0' }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 12,
+            fontFamily: T.mono, fontSize: 10, color: T.lo,
+            marginBottom: 8, letterSpacing: '0.06em',
+          }}>
+            <span style={{
+              padding: '2px 8px', borderRadius: 12, fontSize: 9,
+              background: 'rgba(74,222,128,0.10)', color: T.green,
+              border: `1px solid rgba(74,222,128,0.30)`,
+            }}>● Searching</span>
+            <span>Fingerprints: 4.1/min</span>
+            <span>Lookups: 4.1/min</span>
+          </div>
+          <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+            <thead>
+              <tr style={{ borderBottom: `1px solid ${T.sep}` }}>
+                {['Src', 'Match', '#', 'Conf%', 'Track', 'Art'].map(h => (
+                  <th key={h} style={{
+                    padding: '6px 8px', textAlign: 'left',
+                    fontFamily: T.mono, fontSize: 9.5, fontWeight: 600,
+                    letterSpacing: '0.14em', color: T.lo, textTransform: 'uppercase',
+                  }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <SongRowBefore src="file" match={false} idx={0} conf={null} track="—"  art={false} dim />
+              <SongRowBefore src="mic"  match={true}  idx={1} conf={80}   track="Dirty Laundry / Don Henley / I Can't S…" art />
+              <SongRowBefore src="file" match={true}  idx={7} conf={80}   track="Dirty Laundry / Don Henley / I Can't S…" art />
+              <SongRowBefore src="file" match={true}  idx={13} conf={80}  track="More Than a Feeling / Boston / Boston"   art />
+              <SongRowBefore src="file" match={true}  idx={9}  conf={80}  track="It's Raining Men / The Weather Girls /…" art />
+              <SongRowBefore src="file" match={true}  idx={13} conf={80}  track="Take Me Home Tonight / Eddie Money / C…" art />
+              <SongRowBefore src="file" match={true}  idx={24} conf={80}  track="American Pie / Don Mclean / American P…" art />
+              <SongRowBefore src="file" match={true}  idx={15} conf={80}  track="I Can't Dance / Genesis / We Can't Dan…" art />
+              <SongRowBefore src="file" match={false} idx={18} conf={null} track="—" art={false} dim />
+              <SongRowBefore src="file" match={true}  idx={1}  conf={80}  track="Centerfield / John Fogerty / Centerfie…" art />
+              <SongRowBefore src="file" match={true}  idx={1}  conf={80}  track="Higher Love / Steve Winwood / Back In …" art />
+            </tbody>
+          </table>
+        </div>
+        <Caption>
+          The user can't tell what's playing right now, can't tell which row is the live mic match versus a historical file lookup, and reads "80 %" eleven times in a column whose only signal is "yes, the fingerprinter found something."
+        </Caption>
+      </Half>
+      <Half kicker="After" kickerColor={T.accent} title="Stream view. Currently-playing match is the anchor; older matches recede; confidence is encoded with bars, not numbers">
+        <div style={{ padding: '14px 18px 0' }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            marginBottom: 12, paddingBottom: 8, borderBottom: `1px solid ${T.sep}`,
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <span style={{
+                width: 6, height: 6, borderRadius: '50%', background: T.green,
+                boxShadow: `0 0 6px ${T.green}`,
+              }} />
+              <span style={{
+                fontFamily: T.mono, fontSize: 10.5, letterSpacing: '0.14em',
+                color: T.md, textTransform: 'uppercase',
+              }}>Listening · 4 / min</span>
+            </div>
+            <div style={{
+              fontFamily: T.mono, fontSize: 9.5, color: T.lo, letterSpacing: '0.10em',
+            }}>SOURCE: SDR + LIBRARY</div>
+          </div>
+          <div style={{
+            fontFamily: T.mono, fontSize: 9, letterSpacing: '0.20em',
+            color: T.amber, marginBottom: 6,
+          }}>NOW</div>
+          <SongRowAfter
+            track="Dirty Laundry" artist="Don Henley · I Can't Stand Still"
+            conf={3} art ago="now" source="mic" active />
+
+          <div style={{
+            fontFamily: T.mono, fontSize: 9, letterSpacing: '0.20em',
+            color: T.dim, margin: '12px 0 6px',
+          }}>EARLIER</div>
+          <SongRowAfter time="08:18" track="More Than a Feeling" artist="Boston" conf={3} art ago="3 min" source="file" />
+          <SongRowAfter time="08:15" track="It's Raining Men" artist="The Weather Girls" conf={2} art ago="6 min" source="file" />
+          <SongRowAfter time="08:12" track="Take Me Home Tonight" artist="Eddie Money" conf={3} art ago="9 min" source="file" />
+          <SongRowAfter time="08:08" track="American Pie" artist="Don McLean" conf={2} ago="13 min" source="file" />
+          <SongRowAfter time="08:04" track={null} artist={null} conf={0} ago="17 min" source="file" />
+          <SongRowAfter time="08:00" track="I Can't Dance" artist="Genesis" conf={1} ago="21 min" source="file" />
+          <SongRowAfter time="07:55" track="Higher Love" artist="Steve Winwood" conf={2} art ago="26 min" source="file" />
+          <SongRowAfter time="07:48" track="Centerfield" artist="John Fogerty" conf={3} art ago="33 min" source="file" />
+        </div>
+      </Half>
+    </Split>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   #6 — Gain control popover
+   The current popover floats above the dB pill and has just a slider
+   from -∞ to +6 dB with no feedback. Add a live peak meter, AUTO state,
+   and a reset button. Use clean min/max labels.
+   ════════════════════════════════════════════════════════════ */
+
+const GainPopBefore = () => (
+  <div style={{
+    width: 320, padding: '14px 16px 12px',
+    background: '#1a1a1c', borderRadius: 8,
+    border: `1px solid ${T.sep}`,
+    boxShadow: '0 12px 32px rgba(0,0,0,0.6)',
+  }}>
+    <div style={{
+      display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+      marginBottom: 12,
+    }}>
+      <div style={{ fontSize: 12.5, color: T.hi, fontWeight: 500 }}>SDR Radio (RTL-SDR) Level</div>
+      <div style={{ fontFamily: T.mono, fontSize: 11, color: T.lo }}>−∞dB</div>
+    </div>
+    <div style={{ height: 4, borderRadius: 2, background: '#2a2a2c', position: 'relative', marginBottom: 6 }}>
+      <div style={{ position: 'absolute', inset: '0 80% 0 0', borderRadius: 2, background: T.purple }} />
+      <div style={{
+        position: 'absolute', top: -6, left: '20%', width: 16, height: 16, borderRadius: '50%',
+        background: T.purple, transform: 'translateX(-50%)',
+      }} />
+    </div>
+    <div style={{
+      display: 'flex', justifyContent: 'space-between',
+      fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.08em',
+    }}>
+      <span>−∞</span><span>0dB</span><span>+6dB</span>
+    </div>
+  </div>
+);
+
+// Vertical peak meter
+const PeakMeter = ({ peak, hold }) => {
+  // peak as 0..1
+  const segs = [];
+  for (let i = 19; i >= 0; i--) {
+    const filled = peak >= (i + 1) / 20;
+    let color = T.dim;
+    if (filled) {
+      if (i < 12) color = T.green;
+      else if (i < 17) color = T.amber;
+      else color = T.red;
+    }
+    segs.push(
+      <div key={i} style={{
+        width: '100%', height: 4, borderRadius: 1,
+        background: color, marginBottom: 1,
+        boxShadow: filled ? `0 0 3px ${color}55` : 'none',
+        position: 'relative',
+      }}>
+        {hold === (i + 1) / 20 && (
+          <div style={{
+            position: 'absolute', inset: 0, border: `1px solid ${T.hi}`, borderRadius: 1,
+          }} />
+        )}
+      </div>
+    );
+  }
+  return (
+    <div style={{
+      width: 16, height: '100%',
+      padding: 3, borderRadius: 3,
+      background: T.well, border: `1px solid ${T.hair}`,
+      boxShadow: 'inset 0 1px 4px rgba(0,0,0,0.7)',
+      display: 'flex', flexDirection: 'column',
+    }}>{segs}</div>
+  );
+};
+
+const GainPopAfter = ({ agc }) => (
+  <div style={{
+    width: 340, padding: '14px 16px 12px',
+    background: '#141416', borderRadius: 8,
+    border: `1px solid ${T.sep}`,
+    boxShadow: '0 12px 32px rgba(0,0,0,0.6)',
+  }}>
+    <div style={{
+      display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+      marginBottom: 14,
+    }}>
+      <div>
+        <div style={{
+          fontFamily: T.mono, fontSize: 9, letterSpacing: '0.18em',
+          color: T.lo, textTransform: 'uppercase',
+        }}>SDR · RTL-SDR</div>
+        <div style={{ fontSize: 13, color: T.hi, fontWeight: 500, marginTop: 2 }}>RF gain</div>
+      </div>
+      <button style={{
+        all: 'unset', cursor: 'pointer',
+        padding: '4px 10px',
+        fontFamily: T.mono, fontSize: 9.5, letterSpacing: '0.14em',
+        color: agc ? T.green : T.md, textTransform: 'uppercase',
+        borderRadius: 12,
+        border: `1px solid ${agc ? 'rgba(74,222,128,0.30)' : T.hair}`,
+        background: agc ? 'rgba(74,222,128,0.06)' : 'transparent',
+      }}>{agc ? '● Auto' : 'Auto off'}</button>
+    </div>
+
+    <div style={{ display: 'flex', gap: 12, height: 124 }}>
+      {/* Peak meter */}
+      <PeakMeter peak={0.7} hold={0.85} />
+      {/* Slider */}
+      <div style={{
+        flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
+        position: 'relative',
+      }}>
+        <div style={{ position: 'relative', height: '100%', display: 'flex', justifyContent: 'center' }}>
+          {/* Track */}
+          <div style={{
+            width: 4, height: '100%', borderRadius: 2,
+            background: '#2a2a2c',
+            position: 'relative',
+            opacity: agc ? 0.35 : 1,
+          }}>
+            <div style={{
+              position: 'absolute', bottom: 0, left: 0, right: 0, height: '52%',
+              background: T.amber, borderRadius: 2,
+              boxShadow: `0 0 8px ${T.amberGlow}`,
+            }} />
+            {/* Tick at 0dB */}
+            <div style={{
+              position: 'absolute', left: -4, right: -4, top: '60%',
+              borderTop: `1px dashed ${T.dim}`,
+            }} />
+          </div>
+          {/* Knob */}
+          <div style={{
+            position: 'absolute', top: '48%', left: '50%',
+            transform: 'translate(-50%,-50%)',
+            width: 22, height: 22, borderRadius: '50%',
+            background: agc ? '#3a3a3c' : T.amber,
+            boxShadow: agc
+              ? '0 1px 3px rgba(0,0,0,0.5)'
+              : `0 1px 3px rgba(0,0,0,0.5), 0 0 8px ${T.amberGlow}`,
+          }} />
+        </div>
+      </div>
+      {/* Scale labels */}
+      <div style={{
+        width: 40, display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
+        fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.06em',
+        textAlign: 'right',
+      }}>
+        <div>+6 dB</div>
+        <div style={{ color: T.dim }}>+3</div>
+        <div style={{ color: T.amber }}>0 dB</div>
+        <div style={{ color: T.dim }}>−12</div>
+        <div style={{ color: T.dim }}>−24</div>
+        <div>−∞</div>
+      </div>
+    </div>
+
+    {/* Footer — value + reset */}
+    <div style={{
+      display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+      marginTop: 12, paddingTop: 12, borderTop: `1px solid ${T.sep}`,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+        <span style={{ fontFamily: T.led, fontSize: 22, color: T.amber, textShadow: `0 0 6px ${T.amberGlow}` }}>
+          {agc ? '—' : '+0.5'}
+        </span>
+        <span style={{ fontFamily: T.mono, fontSize: 10, color: T.lo, letterSpacing: '0.10em' }}>dB</span>
+      </div>
+      <button style={{
+        all: 'unset', cursor: 'pointer',
+        padding: '4px 10px',
+        fontFamily: T.mono, fontSize: 10, letterSpacing: '0.14em',
+        color: T.md, textTransform: 'uppercase',
+        border: `1px solid ${T.hair}`, borderRadius: 4,
+        opacity: agc ? 0.4 : 1,
+      }}>Reset to 0 dB</button>
+    </div>
+  </div>
+);
+
+const Mock_GainPopover = () => (
+  <Stage w={1280} h={520}>
+    <Split>
+      <Half kicker="Before" kickerColor={T.red} title="A bare slider with no feedback; the title is the verbose source ID">
+        <div style={{
+          padding: '40px 40px 0', display: 'flex', justifyContent: 'center',
+          alignItems: 'flex-start',
+        }}>
+          <GainPopBefore />
+        </div>
+        <Caption>
+          User is asked to set an analog gain on a slider that goes to <span style={{ color: T.hi }}>−∞</span> and has no idea whether they're clipping, attenuated, or matched. Adjusting the dB requires guesswork until the next track plays.
+        </Caption>
+      </Half>
+      <Half kicker="After" kickerColor={T.accent} title="Peak meter + AUTO state + reset; the slider stops being a faith-based interface">
+        <div style={{
+          padding: '32px 40px 0', display: 'flex', justifyContent: 'center', gap: 22,
+        }}>
+          <GainPopAfter agc={false} />
+          <GainPopAfter agc />
+        </div>
+        <Caption>
+          The live peak meter shares the popover so you see the signal you're shaping. <span style={{ color: T.green }}>Auto</span> visibly dims the slider rather than hiding it — you can still see what the tuner is choosing for you.
+        </Caption>
+      </Half>
+    </Split>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   #7 — Now Playing source status pill cluster
+   On the radio main page, the "Searching · " pill and the source pill
+   ("SDR RADIO (RTL-SDR)") and the dB pill sit on three separate corners
+   doing related work. Unify them.
+   ════════════════════════════════════════════════════════════ */
+
+const NowPlayingBefore = () => (
+  <div style={{
+    width: 520, height: 520, position: 'relative',
+    background: T.base, padding: 14, boxSizing: 'border-box',
+  }}>
+    {/* Status pill — top left */}
+    <div style={{
+      position: 'absolute', top: 18, left: 18,
+      fontFamily: T.mono, fontSize: 10, letterSpacing: '0.08em',
+      color: T.green, padding: '4px 10px', borderRadius: 12,
+      background: 'rgba(74,222,128,0.10)', border: `1px solid rgba(74,222,128,0.30)`,
+    }}>● Searching</div>
+    {/* Source pill — top right area */}
+    <div style={{
+      position: 'absolute', top: 18, right: 70,
+      fontFamily: T.mono, fontSize: 10, letterSpacing: '0.10em',
+      color: T.purple, padding: '4px 12px', borderRadius: 12,
+      background: 'rgba(167,139,250,0.10)', border: `1px solid rgba(167,139,250,0.30)`,
+    }}>SDR RADIO (RTL-SDR)</div>
+    {/* dB pill — top right */}
+    <div style={{
+      position: 'absolute', top: 18, right: 18,
+      fontFamily: T.mono, fontSize: 10, letterSpacing: '0.10em',
+      color: T.accent, padding: '4px 10px', borderRadius: 12,
+      background: T.accentDim, border: `1px solid ${T.accentGlow}`,
+    }}>0dB</div>
+    {/* Album art */}
+    <div style={{
+      position: 'absolute', bottom: 60, left: 60, right: 60, top: 90,
+      background: 'linear-gradient(135deg, #4a4338 0%, #2c2620 60%, #1a1612 100%)',
+      borderRadius: 4, overflow: 'hidden',
+      boxShadow: '0 4px 20px rgba(0,0,0,0.5)',
+      display: 'flex', alignItems: 'flex-end', padding: 18,
+    }}>
+      <div>
+        <div style={{ fontSize: 22, fontWeight: 600, color: T.hi }}>Dirty Laundry</div>
+        <div style={{ fontSize: 14, color: T.md, marginTop: 2 }}>Don Henley</div>
+        <div style={{ fontSize: 11, color: T.lo, marginTop: 1 }}>FM</div>
+      </div>
+    </div>
+  </div>
+);
+
+const NowPlayingAfter = () => (
+  <div style={{
+    width: 520, height: 520, position: 'relative',
+    background: T.base, padding: 14, boxSizing: 'border-box',
+  }}>
+    {/* Single consolidated status strip — bottom of art */}
+    <div style={{
+      position: 'absolute', top: 18, left: 18, right: 18,
+      display: 'flex', alignItems: 'center', gap: 0,
+      padding: 0, borderRadius: 6,
+      background: 'rgba(20,20,22,0.85)', border: `1px solid ${T.sep}`,
+      backdropFilter: 'blur(8px)', overflow: 'hidden',
+      fontFamily: T.mono, fontSize: 10, letterSpacing: '0.10em',
+    }}>
+      <div style={{
+        padding: '7px 12px', display: 'flex', alignItems: 'center', gap: 8,
+        borderRight: `1px solid ${T.hair}`, color: T.purple,
+      }}>
+        <span style={{ width: 8, height: 8, borderRadius: 2, background: T.purple }} />
+        SDR · RTL-SDR
+      </div>
+      <div style={{
+        padding: '7px 12px', display: 'flex', alignItems: 'center', gap: 6,
+        borderRight: `1px solid ${T.hair}`, color: T.amber,
+      }}>
+        <span style={{ fontFamily: T.led, fontSize: 12, letterSpacing: '0.02em' }}>92.30</span>
+        <span style={{ color: T.lo, fontSize: 8 }}>MHz</span>
+      </div>
+      <div style={{
+        flex: 1, padding: '7px 12px', color: T.md,
+        whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+      }}>
+        <span style={{ color: T.accent, marginRight: 8 }}>WRAL · CLASSIC ROCK</span>
+        <span style={{ color: T.dim }}>RDS</span>
+      </div>
+      <div style={{
+        padding: '7px 12px', color: T.accent,
+        borderLeft: `1px solid ${T.hair}`,
+      }}>0 dB</div>
+    </div>
+
+    {/* Album art */}
+    <div style={{
+      position: 'absolute', bottom: 70, left: 60, right: 60, top: 90,
+      background: 'linear-gradient(135deg, #4a4338 0%, #2c2620 60%, #1a1612 100%)',
+      borderRadius: 4, overflow: 'hidden',
+      boxShadow: '0 4px 20px rgba(0,0,0,0.5)',
+      display: 'flex', alignItems: 'flex-end', padding: 18,
+    }}>
+      <div>
+        <div style={{ fontSize: 22, fontWeight: 600, color: T.hi }}>Dirty Laundry</div>
+        <div style={{ fontSize: 14, color: T.md, marginTop: 2 }}>Don Henley · I Can't Stand Still</div>
+        <div style={{
+          fontFamily: T.mono, fontSize: 10, color: T.green, marginTop: 6,
+          display: 'flex', alignItems: 'center', gap: 6, letterSpacing: '0.10em',
+        }}>
+          <ConfPip level={3} /> STRONG MATCH · 12 s ago
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+const Mock_NowPlayingStatus = () => (
+  <Stage w={1280} h={620}>
+    <Split>
+      <Half kicker="Before" kickerColor={T.red} title="Three pills in three corners doing the same job">
+        <div style={{ padding: '24px 40px 0', display: 'flex', justifyContent: 'center' }}>
+          <NowPlayingBefore />
+        </div>
+        <Caption>
+          "Searching" lives top-left. The source label lives top-right. The dB readout is its own pill. Nothing tells the user whether the song name below was recognised, supplied by RDS, or guessed from history.
+        </Caption>
+      </Half>
+      <Half kicker="After" kickerColor={T.accent} title="One status strip across the top, one match badge on the song">
+        <div style={{ padding: '24px 40px 0', display: 'flex', justifyContent: 'center' }}>
+          <NowPlayingAfter />
+        </div>
+        <Caption>
+          Source, frequency, RDS, and gain are one piece of furniture. The match confidence is attached to the song where you read it, not on a separate pill twelve inches away.
+        </Caption>
+      </Half>
+    </Split>
+  </Stage>
+);
+
+
+/* ════════════════════════════════════════════════════════════
+   #8 — Full Tuner page layout (composed)
+   Pulls #2, #3, #4 into a single 1920-wide assembly so reviewers
+   can see how the changes interact.
+   ════════════════════════════════════════════════════════════ */
+
+const Mock_TunerComposed = () => (
+  <Stage w={1920} h={780} pad={0} style={{ background: '#0a0a0c' }}>
+    {/* topbar stub */}
+    <div style={{
+      height: 64, borderBottom: `1px solid ${T.sep}`, padding: '0 24px',
+      display: 'flex', alignItems: 'center', gap: 20, background: T.base,
+    }}>
+      <div style={{
+        fontFamily: T.led, fontSize: 20, color: T.amber,
+        textShadow: `0 0 6px ${T.amberGlow}`,
+      }}>07:23</div>
+      <div style={{ flex: 1 }} />
+      <div style={{
+        fontFamily: T.mono, fontSize: 11, letterSpacing: '0.12em', color: T.md,
+      }}>RADIO · TUNER</div>
+    </div>
+
+    {/* main row */}
+    <div style={{ display: 'grid', gridTemplateColumns: '380px 1fr 320px', height: 'calc(100% - 64px)' }}>
+      {/* Left: now playing */}
+      <div style={{ borderRight: `1px solid ${T.sep}`, padding: 16, position: 'relative' }}>
+        <NowPlayingAfter />
+      </div>
+      {/* Center: tuner */}
+      <div style={{ padding: '24px 32px 0', borderRight: `1px solid ${T.sep}`, display: 'flex', flexDirection: 'column' }}>
+        <div style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+          padding: '0 0 16px',
+          borderBottom: `1px solid ${T.sep}`, marginBottom: 24,
+        }}>
+          <div style={{ fontSize: 14, fontWeight: 600, color: T.hi }}>Tuner</div>
+          <div style={{
+            fontFamily: T.mono, fontSize: 10, letterSpacing: '0.16em',
+            color: T.amber, textTransform: 'uppercase',
+          }}>FM · 76–108 MHz</div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18 }}>
+          <div style={{
+            display: 'flex', gap: 3, padding: 3, background: T.inset, borderRadius: 6,
+            border: `1px solid #1a1a1d`,
+            boxShadow: 'inset 0 1px 4px rgba(0,0,0,0.6)',
+          }}>
+            <BandPillTall label="AM" sub="535–1700 kHz" />
+            <BandPillTall label="FM" sub="76–108 MHz" active />
+            <BandPillTall label="SW" sub="1.7–30 MHz" />
+            <BandPillTall label="AIR" sub="118–137 MHz" />
+            <BandPillTall label="WB" sub="WX 1–7" />
+            <BandPillTall label="VHF" sub="136–174 MHz" />
+          </div>
+          <FreqDisplayAfter />
+          <SignalBarAfter dbu={-18} w={460} />
+          {/* control row */}
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <button style={{
+              width: 56, height: 48, borderRadius: 6,
+              background: 'linear-gradient(180deg,#161618 0%,#0f0f11 100%)',
+              border: `1px solid #222225`, borderBottom: '2px solid #0a0a0c',
+              color: T.amber, fontSize: 18, cursor: 'pointer',
+            }}>‹</button>
+            <button style={{
+              padding: '0 18px', height: 44, borderRadius: 4,
+              background: 'linear-gradient(180deg,#141416 0%,#0d0d0f 100%)',
+              border: `1px solid #222225`, borderBottom: '2px solid #0a0a0c',
+              color: T.md, fontFamily: T.mono, fontSize: 11, fontWeight: 700,
+              letterSpacing: '0.10em', cursor: 'pointer',
+            }}>⌕ SCAN ◀</button>
+            <button style={{
+              padding: '0 18px', height: 44, borderRadius: 4,
+              background: 'linear-gradient(180deg,#141416 0%,#0d0d0f 100%)',
+              border: `1px solid #222225`, borderBottom: '2px solid #0a0a0c',
+              color: T.md, fontFamily: T.mono, fontSize: 11, fontWeight: 700,
+              letterSpacing: '0.10em', cursor: 'pointer',
+            }}>▶ SCAN ⌕</button>
+            <button style={{
+              width: 56, height: 48, borderRadius: 6,
+              background: 'linear-gradient(180deg,#161618 0%,#0f0f11 100%)',
+              border: `1px solid #222225`, borderBottom: '2px solid #0a0a0c',
+              color: T.amber, fontSize: 18, cursor: 'pointer',
+            }}>›</button>
+          </div>
+          <AgcStripAfter agc />
+        </div>
+      </div>
+      {/* Right: presets */}
+      <div style={{ padding: '20px 18px 0' }}>
+        <div style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+          paddingBottom: 12, borderBottom: `1px solid ${T.sep}`, marginBottom: 12,
+        }}>
+          <div style={{
+            fontFamily: T.mono, fontSize: 9, fontWeight: 700, letterSpacing: '0.18em',
+            color: T.lo,
+          }}>MEMORY <span style={{ color: T.dim, marginLeft: 4 }}>· 7 of 16</span></div>
+          <div style={{
+            fontFamily: T.mono, fontSize: 9, letterSpacing: '0.14em', color: T.lo,
+          }}>HOLD <kbd style={{
+            fontFamily: T.mono, fontSize: 9, padding: '0 4px', borderRadius: 2,
+            border: `1px solid ${T.hair}`, background: '#0c0c0e', color: T.md,
+          }}>FM</kbd> TO SAVE</div>
+        </div>
+        <PresetAfter slot={1} name="NOAA Raleigh"  freq="162.55"  band="WB" />
+        <PresetAfter slot={2} name="The River"     freq="105.10"  band="FM" />
+        <PresetAfter slot={3} name="WCMC"          freq="106.90"  band="FM" />
+        <PresetAfter slot={4} name="WUNC"          freq="91.50"   band="FM" />
+        <PresetAfter slot={5} name="WFJA"          freq="105.50"  band="FM" />
+        <PresetAfter slot={6} name="WSMW"          freq="97.75"   band="FM" />
+        <PresetAfter slot={7} name="Rock 92"       freq="92.30"   band="FM" active />
+        <PresetAfter slot={8} empty />
+      </div>
+    </div>
+  </Stage>
+);


### PR DESCRIPTION
Companion handoff to the radio console design-tightening arc that just landed (#359-#365). Covers the 4 radio-source surfaces (tuner panel, song recognition table, gain popover, now-playing strip) — 7 changes across P0/P1/P2.

Reorganizes handoff packages under `docs/design-handoffs/` (hyphen) for consistency.

## Test plan
- [ ] Visual review of markdown renders cleanly on GitHub
- [ ] No code, no tests, no CI impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)