### PR TITLE
feat(web): signal meter clamp/clip/dBu and AGC two-cell layout

### DIFF
--- a/src/Radio.API/Controllers/RadioController.cs
+++ b/src/Radio.API/Controllers/RadioController.cs
@@ -563,30 +563,14 @@ public class RadioController : ControllerBase
   }
 
   /// <summary>
-  /// Maps an IRadioControl instance to a RadioStateDto.
+  /// Maps an IRadioControl instance to a RadioStateDto. Delegates to
+  /// <see cref="Radio.API.Mappers.RadioStateMapper.MapToRadioStateDto"/> so the
+  /// REST and SignalR paths share one projection (PR 1).
   /// </summary>
   /// <param name="radioSource">The radio source.</param>
   /// <returns>The radio state DTO.</returns>
   private static RadioStateDto MapToRadioStateDto(IRadioControl radioSource)
-  {
-    return new RadioStateDto
-    {
-      Frequency = radioSource.CurrentFrequency.Hertz,
-      Band = radioSource.CurrentBand.ToString(),
-      Step = radioSource.FrequencyStep.Hertz,
-      SignalStrength = radioSource.SignalStrength,
-      Equalizer = radioSource.EqualizerMode.ToString(),
-      DeviceVolume = radioSource.DeviceVolume,
-      IsScanning = radioSource.IsScanning,
-      ScanDirection = radioSource.ScanDirection?.ToString(),
-      ScanStopThreshold = radioSource.ScanStopThreshold,
-      AutoGain = radioSource.AutoGainEnabled,
-      Gain = (int?)radioSource.Gain,
-      IsStereo = radioSource.IsStereo,
-      RdsStationName = radioSource.RdsStationName,
-      RdsProgramType = radioSource.RdsProgramType,
-    };
-  }
+    => Radio.API.Mappers.RadioStateMapper.MapToRadioStateDto(radioSource);
 
   // ===== RADIO PRESET ENDPOINTS =====
 

--- a/src/Radio.API/Mappers/RadioStateMapper.cs
+++ b/src/Radio.API/Mappers/RadioStateMapper.cs
@@ -1,0 +1,120 @@
+using Radio.API.Models;
+using Radio.Core.Interfaces.Audio;
+
+namespace Radio.API.Mappers;
+
+/// <summary>
+/// Centralised projection of <see cref="IRadioControl"/> into
+/// <see cref="RadioStateDto"/>. Both the REST controller and the SignalR
+/// state-update background service depend on this so the two paths cannot
+/// drift out of sync (PR 1 of the Radio Controller Polish arc adds the
+/// <see cref="RadioStateDto.Clip"/>, <see cref="RadioStateDto.RssiDbu"/>,
+/// <see cref="RadioStateDto.AppliedGain"/> fields and re-types
+/// <see cref="RadioStateDto.ScanStopThreshold"/> from int-percent to
+/// double-dBu).
+/// </summary>
+public static class RadioStateMapper
+{
+  // Linear-fit anchors for the raw-percent → dBu projection.
+  //
+  // IRadioControl.SignalStrength is an int already nominally in the 0-100
+  // range, but the device-side scaler has historically produced values up to
+  // ~118 when the front-end is overdriving. The UI must never paint > 100%
+  // (it's a 20-bar meter), so we clamp here and surface the overshoot via
+  // the dedicated <see cref="RadioStateDto.Clip"/> flag plus the
+  // <see cref="RadioStateDto.RssiDbu"/> calibrated readout.
+  //
+  // The fit is linear because no calibrated curve is exposed by the RTL-SDR
+  // or RF320 drivers — see the plan's open question #1. 0% → -60 dBu (noise
+  // floor), 100% → 0 dBu (full-scale reference).
+
+  public const double SignalMinDbu = -60.0;
+  public const double SignalMaxDbu = 0.0;
+
+  /// <summary>
+  /// Projects an <see cref="IRadioControl"/> snapshot into the DTO shape the
+  /// web UI consumes.
+  /// </summary>
+  public static RadioStateDto MapToRadioStateDto(IRadioControl radioSource)
+  {
+    var rawSignal = radioSource.SignalStrength;
+    return new RadioStateDto
+    {
+      Frequency = radioSource.CurrentFrequency.Hertz,
+      Band = radioSource.CurrentBand.ToString(),
+      Step = radioSource.FrequencyStep.Hertz,
+      SignalStrength = ClampSignalPercent(rawSignal),
+      Clip = IsClipping(rawSignal),
+      RssiDbu = SignalToDbu(rawSignal),
+      AppliedGain = ComputeAppliedGain(radioSource),
+      Equalizer = radioSource.EqualizerMode.ToString(),
+      DeviceVolume = radioSource.DeviceVolume,
+      IsScanning = radioSource.IsScanning,
+      ScanDirection = radioSource.ScanDirection?.ToString(),
+      ScanStopThreshold = PercentToDbu(radioSource.ScanStopThreshold),
+      AutoGain = radioSource.AutoGainEnabled,
+      Gain = (int?)radioSource.Gain,
+      IsStereo = radioSource.IsStereo,
+      RdsStationName = radioSource.RdsStationName,
+      RdsProgramType = radioSource.RdsProgramType,
+    };
+  }
+
+  /// <summary>
+  /// Clamps the raw signal-strength int into [0, 100]. Null pass-through so
+  /// "no reading yet" is preserved.
+  /// </summary>
+  public static int? ClampSignalPercent(int? raw)
+  {
+    return raw.HasValue ? Math.Clamp(raw.Value, 0, 100) : null;
+  }
+
+  /// <summary>
+  /// True when the raw front-end power reading exceeded the calibrated
+  /// full-scale reference (100%). Drives the CLIP pill in the meter UI.
+  /// </summary>
+  public static bool IsClipping(int? raw)
+  {
+    return raw.HasValue && raw.Value > 100;
+  }
+
+  /// <summary>
+  /// Linear projection of the clamped percent into the [-60, 0] dBu band.
+  /// Overdrive (raw &gt; 100) saturates at 0 dBu — the <see cref="IsClipping"/>
+  /// flag carries the "above full-scale" signal.
+  /// </summary>
+  public static double SignalToDbu(int? raw)
+  {
+    if (!raw.HasValue)
+    {
+      return SignalMinDbu;
+    }
+
+    var pct = Math.Clamp(raw.Value, 0, 100);
+    return SignalMinDbu + ((SignalMaxDbu - SignalMinDbu) * pct / 100.0);
+  }
+
+  /// <summary>
+  /// Projects the int-percent scan-stop threshold (configured on
+  /// <c>RadioOptions</c>) into the dBu domain so the UI compares
+  /// like-with-like against <see cref="SignalToDbu(int?)"/>.
+  /// </summary>
+  public static double PercentToDbu(int percent)
+  {
+    var pct = Math.Clamp(percent, 0, 100);
+    return SignalMinDbu + ((SignalMaxDbu - SignalMinDbu) * pct / 100.0);
+  }
+
+  /// <summary>
+  /// Returns the live applied gain. Today the device-side AGC selection
+  /// isn't separately surfaced on <see cref="IRadioControl"/>; when AGC is
+  /// on the manual <see cref="IRadioControl.Gain"/> still reflects whatever
+  /// the device most recently reported (RTL-SDR auto-gain leaves the gain
+  /// register populated). Either way the UI binds one float so it doesn't
+  /// have to branch on AGC state.
+  /// </summary>
+  public static double ComputeAppliedGain(IRadioControl radioSource)
+  {
+    return radioSource.Gain;
+  }
+}

--- a/src/Radio.API/Models/RadioDtos.cs
+++ b/src/Radio.API/Models/RadioDtos.cs
@@ -21,9 +21,35 @@ public class RadioStateDto
   public double Step { get; set; }
 
   /// <summary>
-  /// Gets or sets the signal strength as a percentage (0-100).
+  /// Gets or sets the signal strength as a percentage (0-100), clamped at the
+  /// API boundary. Values are guaranteed never to exceed 100% even if the raw
+  /// front-end power reading is overdriven — see <see cref="Clip"/>.
   /// </summary>
   public int? SignalStrength { get; set; }
+
+  /// <summary>
+  /// Gets or sets a value indicating whether the front-end is overdriving
+  /// (raw power exceeded the calibrated full-scale reference). Drives the
+  /// CLIP pill in the signal meter UI; independent of the clamped
+  /// <see cref="SignalStrength"/> percentage.
+  /// </summary>
+  public bool Clip { get; set; }
+
+  /// <summary>
+  /// Gets or sets the received-signal level in dBu, mapped linearly from the
+  /// raw front-end reading into the range [-60, 0]. Surfaced as a separate
+  /// field so the UI can render a calibrated readout alongside the clamped
+  /// percent bar.
+  /// </summary>
+  public double RssiDbu { get; set; }
+
+  /// <summary>
+  /// Gets or sets the gain (in dB) currently applied to the front-end.
+  /// When AGC is on this is the device-chosen value; when AGC is off this
+  /// mirrors the user-set <see cref="Gain"/>. Either way the UI can bind one
+  /// field to display the "live" gain in either mode.
+  /// </summary>
+  public double AppliedGain { get; set; }
 
   /// <summary>
   /// Gets or sets the current equalizer mode.
@@ -74,9 +100,12 @@ public class RadioStateDto
   public string? RdsProgramType { get; set; }
 
   /// <summary>
-  /// Gets or sets the signal strength threshold (0-100) at which scan pauses on a signal.
+  /// Gets or sets the dBu threshold at which scan pauses on a signal.
+  /// Re-typed from <c>int</c> (percent) to <c>double</c> (dBu) in PR 1 of the
+  /// Radio Controller Polish arc so the threshold matches the dBu semantics
+  /// of <see cref="RssiDbu"/>. Greenfield project — no back-compat shim.
   /// </summary>
-  public int ScanStopThreshold { get; set; }
+  public double ScanStopThreshold { get; set; }
 }
 
 /// <summary>

--- a/src/Radio.API/Services/AudioStateUpdateService.cs
+++ b/src/Radio.API/Services/AudioStateUpdateService.cs
@@ -546,6 +546,11 @@ public class AudioStateUpdateService : BackgroundService
            previous.Band != current.Band ||
            Math.Abs(previous.Step - current.Step) > 0.001 ||
            sigDelta > 3 ||
+           previous.Clip != current.Clip ||
+           // Same 3-percent tolerance applied via the dBu mapping (~1.8 dBu)
+           // so the meter doesn't flicker on every minor fluctuation.
+           Math.Abs(previous.RssiDbu - current.RssiDbu) > 1.8 ||
+           Math.Abs(previous.AppliedGain - current.AppliedGain) > 0.1 ||
            previous.Equalizer != current.Equalizer ||
            previous.DeviceVolume != current.DeviceVolume ||
            previous.IsScanning != current.IsScanning ||
@@ -677,25 +682,7 @@ public class AudioStateUpdateService : BackgroundService
   }
 
   private static RadioStateDto MapToRadioStateDto(IRadioControl radioControls)
-  {
-    return new RadioStateDto
-    {
-      Frequency = radioControls.CurrentFrequency.Hertz,
-      Band = radioControls.CurrentBand.ToString(),
-      Step = radioControls.FrequencyStep.Hertz,
-      SignalStrength = radioControls.SignalStrength,
-      Equalizer = radioControls.EqualizerMode.ToString(),
-      DeviceVolume = radioControls.DeviceVolume,
-      IsScanning = radioControls.IsScanning,
-      ScanDirection = radioControls.ScanDirection?.ToString(),
-      ScanStopThreshold = radioControls.ScanStopThreshold,
-      AutoGain = radioControls.AutoGainEnabled,
-      Gain = (int?)radioControls.Gain,
-      IsStereo = radioControls.IsStereo,
-      RdsStationName = radioControls.RdsStationName,
-      RdsProgramType = radioControls.RdsProgramType,
-    };
-  }
+    => RadioStateMapper.MapToRadioStateDto(radioControls);
 
   private BluetoothStatusDto BuildBluetoothStatusDto()
   {

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -87,7 +87,7 @@
               {
                 <span class="rcp-clip-pill">CLIP</span>
               }
-              <span class="rcp-meter-dbu">@_radioState.RssiDbu.ToString("0") dBu</span>
+              <span class="rcp-meter-dbu">@($"{_radioState.RssiDbu.ToString("0").Replace("-", "−")} dBu")</span>
             </span>
           </div>
           <div class="rcp-meter-bar">
@@ -582,14 +582,6 @@
     color: var(--text-low);
     text-transform: uppercase;
     opacity: 0.7;
-  }
-
-  .rcp-meter-value {
-    color: var(--text-medium);
-    font-size: 11px;
-    font-weight: 600;
-    letter-spacing: 0.05em;
-    opacity: 1;
   }
 
   .rcp-meter-bar {

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -76,21 +76,36 @@
         </div>
       }
 
-      <!-- Signal strength meter -->
+      <!-- Signal strength meter (PR 1 of Radio Controller Polish arc) -->
       @if (_radioState.SignalStrength.HasValue)
       {
         <div class="rcp-meter">
           <div class="rcp-meter-header">
             <span>SIGNAL</span>
-            <span class="rcp-meter-value">@_radioState.SignalStrength%</span>
+            <span class="rcp-meter-readout">
+              @if (_radioState.Clip)
+              {
+                <span class="rcp-clip-pill">CLIP</span>
+              }
+              <span class="rcp-meter-dbu">@_radioState.RssiDbu.ToString("0") dBu</span>
+            </span>
           </div>
           <div class="rcp-meter-bar">
+            @{
+              // The DTO clamp guarantees SignalStrength ∈ [0, 100], so the
+              // 20-segment fill never overflows. CLIP is the separate signal —
+              // see the pill above.
+              var clampedPct = _radioState.SignalStrength ?? 0;
+            }
             @for (int i = 0; i < 20; i++)
             {
-              var filled = (_radioState.SignalStrength ?? 0) >= (i + 1) * 5;
+              var filled = clampedPct >= (i + 1) * 5;
               var segClass = i < 12 ? "seg-green" : i < 17 ? "seg-amber" : "seg-red";
               <div class="rcp-meter-seg @(filled ? segClass : "seg-off")"></div>
             }
+          </div>
+          <div class="rcp-meter-scale">
+            <span>−60</span><span>−30</span><span>−12</span><span>0 dBu</span>
           </div>
         </div>
       }
@@ -98,10 +113,10 @@
       <!-- Scanning indicator -->
       @if (_radioState.IsScanning)
       {
-        @if ((_radioState.SignalStrength ?? 0) >= _radioState.ScanStopThreshold)
+        @if (_radioState.RssiDbu >= _radioState.ScanStopThreshold)
         {
           <div class="rcp-scan-signal">
-            SIGNAL @(_radioState.SignalStrength)%
+            SIGNAL @(_radioState.RssiDbu.ToString("0")) dBu
           </div>
         }
         else
@@ -139,24 +154,36 @@
                       Click="FrequencyUpAsync" title="Frequency Up" />
       </div>
 
-      <!-- SDR Controls -->
+      <!-- SDR / gain controls (PR 1 — fixed two-cell grid; right cell always rendered) -->
       @if (_radioState.Gain.HasValue)
       {
-        <div class="rcp-sdr-controls">
-          <div style="display:flex;align-items:center;gap:8px">
-            <RadzenSwitch Value="@_radioState.AutoGain" Change="@(async (bool val) => await HandleAutoGainChangedAsync(val))" />
+        <div class="rcp-sdr-grid">
+          @* Left cell: tappable AGC toggle + AUTO/OFF chip *@
+          <button type="button"
+                  class="rcp-agc-cell"
+                  @onclick="@(async () => await HandleAutoGainChangedAsync(!_radioState.AutoGain))"
+                  aria-pressed="@_radioState.AutoGain.ToString().ToLowerInvariant()"
+                  aria-label="@(_radioState.AutoGain ? "Automatic gain control on — tap to disable" : "Automatic gain control off — tap to enable")">
             <span class="rcp-agc-label">AGC</span>
-          </div>
-          <div class="rcp-gain-slot">
-            @if (!_radioState.AutoGain && _radioState.Gain.HasValue)
+            <span class="@(_radioState.AutoGain ? "rcp-agc-chip-auto" : "rcp-agc-chip-off")">
+              @(_radioState.AutoGain ? "AUTO" : "OFF")
+            </span>
+          </button>
+
+          @* Right cell: always rendered; content swaps on AGC state *@
+          <div class="rcp-gain-cell">
+            @if (_radioState.AutoGain)
             {
-              <div style="flex: 1; display: flex; flex-direction: column;">
-                <span style="font-family: var(--font-mono); font-size: 12px; color: var(--signal-amber);">
-                  GAIN @_radioState.Gain dB
-                </span>
-                <RadzenSlider TValue="int" Value="@_radioState.Gain.Value" Change="@(async (int val) => await HandleGainChangedAsync(val))"
-                              Min="0" Max="50" Step="1" Style="width: 100%;" />
-              </div>
+              <span class="rcp-gain-auto-hint">Tuner is choosing</span>
+              <span class="rcp-gain-auto-value">@_radioState.AppliedGain.ToString("0.0") dB</span>
+            }
+            else
+            {
+              <span class="rcp-gain-pill">@_radioState.AppliedGain.ToString("0") dB</span>
+              <RadzenSlider TValue="int" Value="@_radioState.Gain.Value"
+                            Change="@(async (int val) => await HandleGainChangedAsync(val))"
+                            Min="0" Max="50" Step="1" Style="flex: 1; min-width: 0;" />
+              <span class="rcp-gain-range-hint">0 – 50</span>
             }
           </div>
         </div>
@@ -710,37 +737,10 @@
     box-shadow: none !important;
   }
 
-  /* ── SDR Controls — Recessed Control Strip ── */
-
-  .rcp-sdr-controls {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    width: 100%;
-    max-width: 420px;
-    padding: 6px 14px;
-    background: #0a0a0c;
-    border-radius: 4px;
-    border: 1px solid #141416;
-    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.4);
-  }
-
-  /* Gain slider slot — always present, fills remaining space */
-  .rcp-gain-slot {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    align-items: center;
-  }
-
-  /* AGC label styling */
-  .rcp-agc-label {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    color: var(--signal-amber);
-  }
+  /* ── SDR / AGC controls — see design-system.css §T for the strip and
+     amber-pill styling. The legacy `.rcp-sdr-controls` / `.rcp-gain-slot`
+     rules were removed in PR 1 of the Radio Controller Polish arc when the
+     flex strip became a fixed two-cell grid. ──────────────────────────── */
 
   /* ═══ Presets Memory Bank ═══ */
 

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -292,14 +292,17 @@ public record RadioStateDto(
   int? SignalStrength,
   bool IsScanning,
   string? ScanDirection,
-  int ScanStopThreshold,
+  double ScanStopThreshold,
   int? Gain,
   bool AutoGain,
   string? Equalizer,
   int? DeviceVolume,
   bool IsStereo = false,
   string? RdsStationName = null,
-  string? RdsProgramType = null
+  string? RdsProgramType = null,
+  bool Clip = false,
+  double RssiDbu = 0.0,
+  double AppliedGain = 0.0
 );
 
 public record RadioPowerStateDto(

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -2975,3 +2975,200 @@ body {
      `data-dev-gesture` attribute is the contract; opacity=0 keeps it visually
      absent without removing it from the hit-test tree. */
 }
+
+/* ─── §S  Signal Meter Calibration (Radio Controller Polish PR 1) ─────────── *
+ *
+ * Companion to `.rcp-meter` in RadioControlPanel.razor. Adds the dBu
+ * readout, the CLIP-pill overdrive indicator, and the four-tick scale
+ * label strip under the meter bar. The 20-segment bar itself stays in
+ * RadioControlPanel's inline <style>; only the calibration overlay lives
+ * here because the tokens it consumes (font-mono, signal-red,
+ * text-medium, text-low) come from §2.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+.rcp-meter-readout {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.rcp-clip-pill {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--signal-red);
+  background: rgba(248, 113, 113, 0.10);
+  color: var(--signal-red);
+  box-shadow: 0 0 6px rgba(248, 113, 113, 0.4);
+}
+
+.rcp-meter-dbu {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: var(--text-medium);
+}
+
+.rcp-meter-scale {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 2px 0;
+  font-family: var(--font-mono);
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  color: var(--text-low);
+  opacity: 0.7;
+}
+
+/* ─── §T  AGC Two-Cell Strip (Radio Controller Polish PR 1) ───────────────── *
+ *
+ * Replaces the old flex `.rcp-sdr-controls` strip. The strip is now a
+ * fixed grid: 130px AGC toggle cell on the left, flex gain cell on the
+ * right. Right cell is ALWAYS rendered — when AGC is on it shows the
+ * device-chosen gain ("Tuner is choosing  28.0 dB"); when AGC is off it
+ * shows a fixed-width amber pill (so the value never jitters width),
+ * the slider, and a "0 – 50" range hint.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+.rcp-sdr-grid {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 12px;
+  align-items: stretch;
+  width: 100%;
+  max-width: 420px;
+  padding: 6px;
+  background: #0a0a0c;
+  border-radius: 4px;
+  border: 1px solid #141416;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+.rcp-agc-cell {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #141416 0%, #0d0d0f 100%);
+  border: 1px solid #222225;
+  border-bottom: 2px solid #0a0a0c;
+  color: var(--text-medium);
+  cursor: pointer;
+  transition: all 80ms ease;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+  /* Reset the <button> defaults the browser applies; the cell renders as a
+     tappable surface, not a chrome button. */
+  font: inherit;
+  line-height: 1;
+  appearance: none;
+}
+
+.rcp-agc-cell:hover {
+  border-color: rgba(240, 168, 48, 0.25);
+  background: linear-gradient(180deg, #1a1a1d 0%, #131315 100%);
+}
+
+.rcp-agc-cell:active {
+  transform: translateY(1px);
+  border-bottom-width: 1px;
+}
+
+.rcp-agc-cell:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+.rcp-agc-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--signal-amber);
+}
+
+.rcp-agc-chip-auto,
+.rcp-agc-chip-off {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+.rcp-agc-chip-auto {
+  color: var(--signal-green);
+  border: 1px solid var(--signal-green);
+  background: color-mix(in srgb, var(--signal-green) 10%, transparent);
+}
+
+.rcp-agc-chip-off {
+  color: var(--text-low);
+  border: 1px solid var(--surface-separator);
+  background: transparent;
+}
+
+.rcp-gain-cell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  min-width: 0;
+}
+
+.rcp-gain-pill {
+  flex: 0 0 56px;
+  width: 56px;
+  min-width: 56px;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--signal-amber);
+  border: 1px solid color-mix(in srgb, var(--signal-amber) 33%, transparent);
+  border-radius: 999px;
+  padding: 4px 8px;
+  background: rgba(240, 168, 48, 0.04);
+}
+
+.rcp-gain-range-hint {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--text-low);
+  white-space: nowrap;
+}
+
+.rcp-gain-auto-hint {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  color: var(--text-low);
+}
+
+.rcp-gain-auto-value {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--signal-amber);
+  text-shadow: 0 0 6px rgba(240, 168, 48, 0.18);
+}

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -3044,9 +3044,9 @@ body {
   width: 100%;
   max-width: 420px;
   padding: 6px;
-  background: #0a0a0c;
+  background: var(--surface-inset);
   border-radius: 4px;
-  border: 1px solid #141416;
+  border: 1px solid var(--surface-raised);
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
@@ -3058,7 +3058,7 @@ body {
   padding: 6px 10px;
   border-radius: 4px;
   background: linear-gradient(180deg, #141416 0%, #0d0d0f 100%);
-  border: 1px solid #222225;
+  border: 1px solid var(--surface-separator);
   border-bottom: 2px solid #0a0a0c;
   color: var(--text-medium);
   cursor: pointer;
@@ -3095,6 +3095,12 @@ body {
   color: var(--signal-amber);
 }
 
+/* When AGC is OFF (cell not pressed) the label dims so the amber stays
+   exclusive to the AUTO state. The cell button toggles aria-pressed. */
+.rcp-agc-cell:not([aria-pressed="true"]) .rcp-agc-label {
+  color: var(--text-low);
+}
+
 .rcp-agc-chip-auto,
 .rcp-agc-chip-off {
   display: inline-block;
@@ -3116,7 +3122,7 @@ body {
 
 .rcp-agc-chip-off {
   color: var(--text-low);
-  border: 1px solid var(--surface-separator);
+  border: 1px solid var(--text-low);
   background: transparent;
 }
 
@@ -3142,7 +3148,7 @@ body {
   border: 1px solid color-mix(in srgb, var(--signal-amber) 33%, transparent);
   border-radius: 999px;
   padding: 4px 8px;
-  background: rgba(240, 168, 48, 0.04);
+  background: color-mix(in srgb, var(--signal-amber) 4%, transparent);
 }
 
 .rcp-gain-range-hint {
@@ -3170,5 +3176,5 @@ body {
   font-weight: 700;
   letter-spacing: 0.04em;
   color: var(--signal-amber);
-  text-shadow: 0 0 6px rgba(240, 168, 48, 0.18);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--signal-amber) 18%, transparent);
 }

--- a/tests/Radio.API.Tests/Mappers/RadioStateMapperTests.cs
+++ b/tests/Radio.API.Tests/Mappers/RadioStateMapperTests.cs
@@ -1,0 +1,66 @@
+using Radio.API.Mappers;
+
+namespace Radio.API.Tests.Mappers;
+
+/// <summary>
+/// Locks down the signal-meter projection math introduced in PR 1 of the
+/// Radio Controller Polish arc: clamp at the API boundary, surface
+/// overdrive via a separate <c>Clip</c> flag, and linear-fit raw percent →
+/// dBu in the [-60, 0] band.
+/// </summary>
+public class RadioStateMapperTests
+{
+  [Theory]
+  [InlineData(null, null)]
+  [InlineData(0, 0)]
+  [InlineData(50, 50)]
+  [InlineData(100, 100)]
+  [InlineData(101, 100)]     // 1% overshoot clamped
+  [InlineData(118, 100)]     // historical worst-case from logs
+  [InlineData(-5, 0)]        // negative-clipping clamp
+  public void ClampSignalPercent_ReturnsExpected(int? raw, int? expected)
+  {
+    Assert.Equal(expected, RadioStateMapper.ClampSignalPercent(raw));
+  }
+
+  [Theory]
+  [InlineData(null, false)]
+  [InlineData(0, false)]
+  [InlineData(99, false)]
+  [InlineData(100, false)]
+  [InlineData(101, true)]
+  [InlineData(118, true)]
+  public void IsClipping_TriggersOnlyAbove100(int? raw, bool expected)
+  {
+    Assert.Equal(expected, RadioStateMapper.IsClipping(raw));
+  }
+
+  [Theory]
+  [InlineData(null, -60.0)]
+  [InlineData(0, -60.0)]
+  [InlineData(50, -30.0)]
+  [InlineData(100, 0.0)]
+  [InlineData(118, 0.0)]     // overdrive saturates at 0 dBu — IsClipping carries the rest
+  public void SignalToDbu_LinearFit(int? raw, double expected)
+  {
+    Assert.Equal(expected, RadioStateMapper.SignalToDbu(raw), precision: 3);
+  }
+
+  [Theory]
+  [InlineData(0, -60.0)]
+  [InlineData(50, -30.0)]
+  [InlineData(100, 0.0)]
+  [InlineData(200, 0.0)]
+  [InlineData(-10, -60.0)]
+  public void PercentToDbu_LinearFitWithClamp(int percent, double expected)
+  {
+    Assert.Equal(expected, RadioStateMapper.PercentToDbu(percent), precision: 3);
+  }
+
+  [Fact]
+  public void SignalMinDbu_AndMax_AreNoiseFloorAndFullScale()
+  {
+    Assert.Equal(-60.0, RadioStateMapper.SignalMinDbu);
+    Assert.Equal(0.0, RadioStateMapper.SignalMaxDbu);
+  }
+}

--- a/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
@@ -1,0 +1,316 @@
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using AngleSharp.Dom;
+using Bunit;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Radzen;
+using Radio.Web.Components.Shared;
+using Radio.Web.Models;
+using Radio.Web.Services.ApiClients;
+using Radio.Web.Services.Hub;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for <see cref="RadioControlPanel"/> after PR 1 of the Radio
+/// Controller Polish arc — signal-meter clamp + CLIP pill + dBu readout +
+/// 4-tick scale strip, and the AGC two-cell grid that always renders a value
+/// in the right cell regardless of AGC state.
+/// </summary>
+public class RadioControlPanelTests : TestContext
+{
+  private readonly ILoggerFactory _loggerFactory;
+
+  public RadioControlPanelTests()
+  {
+    _loggerFactory = new NullLoggerFactory();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+
+    var configuration = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>
+      {
+        { "ApiBaseUrl", "http://localhost:5000" },
+      })
+      .Build();
+
+    Services.AddSingleton<IConfiguration>(configuration);
+    Services.AddSingleton(_loggerFactory);
+    Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+
+    Services.AddRadzenComponents();
+
+    // SignalR hub service — never connects in tests, just provides the event
+    // surface so subscriptions don't NRE.
+    Services.AddSingleton(sp =>
+      new AudioStateHubService(
+        NullLogger<AudioStateHubService>.Instance,
+        sp.GetRequiredService<IConfiguration>()));
+  }
+
+  protected override void Dispose(bool disposing)
+  {
+    if (disposing)
+    {
+      _loggerFactory?.Dispose();
+    }
+    base.Dispose(disposing);
+  }
+
+  /// <summary>
+  /// Registers a stub <see cref="RadioApiService"/> backed by a handler that
+  /// responds to <c>GET /api/radio/state</c> with the supplied DTO. Presets
+  /// and bands return empty lists so the panel renders without async error
+  /// banners.
+  /// </summary>
+  private void UseRadioState(RadioStateDto state)
+  {
+    var handler = new RadioStateStubHandler(state);
+    Services.AddSingleton(_ =>
+    {
+      var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5000") };
+      return new RadioApiService(client, NullLogger<RadioApiService>.Instance);
+    });
+  }
+
+  private static RadioStateDto BuildState(
+    int? signalStrength = 50,
+    bool clip = false,
+    double rssiDbu = -30.0,
+    double appliedGain = 0.0,
+    bool autoGain = false,
+    int? gain = 0,
+    double scanStopThreshold = -36.0)
+  {
+    return new RadioStateDto(
+      Frequency: 101_500_000,
+      Band: "FM",
+      Step: 100_000,
+      SignalStrength: signalStrength,
+      IsScanning: false,
+      ScanDirection: null,
+      ScanStopThreshold: scanStopThreshold,
+      Gain: gain,
+      AutoGain: autoGain,
+      Equalizer: "Normal",
+      DeviceVolume: 50,
+      IsStereo: false,
+      RdsStationName: null,
+      RdsProgramType: null,
+      Clip: clip,
+      RssiDbu: rssiDbu,
+      AppliedGain: appliedGain);
+  }
+
+  private IRenderedComponent<RadioControlPanel> RenderPanel(RadioStateDto state)
+  {
+    UseRadioState(state);
+    var cut = RenderComponent<RadioControlPanel>();
+
+    // The panel kicks off async state loads in OnInitializedAsync; bUnit's
+    // WaitForAssertion gives those tasks room to complete and re-render the
+    // meter from the skeleton placeholder.
+    cut.WaitForAssertion(() =>
+    {
+      Assert.DoesNotContain("skeleton", cut.Markup, StringComparison.OrdinalIgnoreCase);
+    }, timeout: TimeSpan.FromSeconds(2));
+
+    return cut;
+  }
+
+  [Fact]
+  public void SignalMeter_RendersClampedValue()
+  {
+    // Even with a hypothetical overdriven raw of 118%, the server-side clamp
+    // means the DTO carries SignalStrength = 100. The meter must paint
+    // exactly 20 lit segments and never surface a literal "118" or a "%"
+    // glyph anywhere in the meter region (the inline <style> uses "100%"
+    // for CSS heights — assertions scope to the meter element only).
+    var state = BuildState(signalStrength: 100, clip: true, rssiDbu: 0.0);
+    var cut = RenderPanel(state);
+
+    Assert.DoesNotContain("118", cut.Markup);
+
+    var meter = cut.Find(".rcp-meter");
+    Assert.DoesNotContain("%", meter.TextContent);
+    Assert.DoesNotContain("118", meter.TextContent);
+
+    // 20 segments total; all should carry one of the lit segment classes.
+    var segs = cut.FindAll(".rcp-meter-seg");
+    Assert.Equal(20, segs.Count);
+    var litCount = segs.Count(IsLitSegment);
+    Assert.Equal(20, litCount);
+  }
+
+  [Fact]
+  public void SignalMeter_ShowsClipPill_WhenClipTrue()
+  {
+    var clipState = BuildState(signalStrength: 100, clip: true, rssiDbu: 0.0);
+    var cut = RenderPanel(clipState);
+
+    var pills = cut.FindAll(".rcp-clip-pill");
+    Assert.Single(pills);
+    Assert.Equal("CLIP", pills[0].TextContent.Trim());
+  }
+
+  [Fact]
+  public void SignalMeter_HidesClipPill_WhenClipFalse()
+  {
+    var state = BuildState(signalStrength: 70, clip: false, rssiDbu: -18.0);
+    var cut = RenderPanel(state);
+
+    Assert.Empty(cut.FindAll(".rcp-clip-pill"));
+  }
+
+  [Fact]
+  public void SignalMeter_RendersDbuReadout()
+  {
+    var state = BuildState(signalStrength: 70, clip: false, rssiDbu: -18.0);
+    var cut = RenderPanel(state);
+
+    var readout = cut.Find(".rcp-meter-dbu");
+    // RssiDbu rendered with "0" format → "-18 dBu". The "−" minus character
+    // in the scale labels is U+2212; ToString("0") emits an ASCII hyphen.
+    Assert.Equal("-18 dBu", readout.TextContent.Trim());
+  }
+
+  [Fact]
+  public void SignalMeter_RendersScaleLabels()
+  {
+    var state = BuildState();
+    var cut = RenderPanel(state);
+
+    var scale = cut.Find(".rcp-meter-scale");
+    var labels = scale.Children.Select(c => c.TextContent.Trim()).ToArray();
+    Assert.Equal(new[] { "−60", "−30", "−12", "0 dBu" }, labels);
+  }
+
+  [Fact]
+  public void AgcStrip_TwoCellGrid_BothPopulated_WhenAgcOn()
+  {
+    var state = BuildState(autoGain: true, appliedGain: 28.0, gain: 0);
+    var cut = RenderPanel(state);
+
+    var grid = cut.Find(".rcp-sdr-grid");
+    var directChildren = grid.Children.ToArray();
+    Assert.Equal(2, directChildren.Length);
+
+    // Left cell — AGC button with AUTO chip
+    var agcChip = cut.Find(".rcp-agc-chip-auto");
+    Assert.Equal("AUTO", agcChip.TextContent.Trim());
+    Assert.Empty(cut.FindAll(".rcp-agc-chip-off"));
+
+    // Right cell — "Tuner is choosing" hint + numeric gain
+    var hint = cut.Find(".rcp-gain-auto-hint");
+    Assert.Equal("Tuner is choosing", hint.TextContent.Trim());
+    var value = cut.Find(".rcp-gain-auto-value");
+    Assert.Contains("28.0", value.TextContent);
+    Assert.Contains("dB", value.TextContent);
+  }
+
+  [Fact]
+  public void AgcStrip_AgcOff_ShowsSlider_AndPill_AndRangeHint()
+  {
+    var state = BuildState(autoGain: false, appliedGain: 28.0, gain: 28);
+    var cut = RenderPanel(state);
+
+    // Pill stays a fixed-width amber chip with "28 dB"
+    var pill = cut.Find(".rcp-gain-pill");
+    Assert.Contains("28", pill.TextContent);
+    Assert.Contains("dB", pill.TextContent);
+
+    // Range hint visible
+    var hint = cut.Find(".rcp-gain-range-hint");
+    Assert.Contains("0", hint.TextContent);
+    Assert.Contains("50", hint.TextContent);
+
+    // Slider present (Radzen renders an input + slider DOM)
+    Assert.NotEmpty(cut.FindAll(".rz-slider"));
+
+    // AGC chip in OFF state
+    var offChip = cut.Find(".rcp-agc-chip-off");
+    Assert.Equal("OFF", offChip.TextContent.Trim());
+    Assert.Empty(cut.FindAll(".rcp-agc-chip-auto"));
+  }
+
+  [Theory]
+  [InlineData(true)]
+  [InlineData(false)]
+  public void AgcStrip_NoEmptyCell_RegardlessOfAgcState(bool autoGain)
+  {
+    // Both AGC on and AGC off must produce exactly two grid children — no
+    // collapsed/empty cell artefacts that would let the strip change height.
+    var state = BuildState(autoGain: autoGain, appliedGain: 12.5, gain: 12);
+    var cut = RenderPanel(state);
+
+    var grid = cut.Find(".rcp-sdr-grid");
+    Assert.Equal(2, grid.Children.Length);
+
+    // Both cells always present, regardless of AGC.
+    Assert.NotNull(cut.Find(".rcp-agc-cell"));
+    Assert.NotNull(cut.Find(".rcp-gain-cell"));
+  }
+
+  [Fact]
+  public void ScanStopThreshold_IsDouble()
+  {
+    // Greenfield rename — confirm via reflection that the DTO's threshold is
+    // a double, not an int (PR 1 re-types from percent → dBu).
+    var prop = typeof(RadioStateDto).GetProperty(
+      nameof(RadioStateDto.ScanStopThreshold),
+      BindingFlags.Public | BindingFlags.Instance);
+    Assert.NotNull(prop);
+    Assert.Equal(typeof(double), prop!.PropertyType);
+  }
+
+  private static bool IsLitSegment(IElement segment)
+  {
+    var cls = segment.ClassName ?? string.Empty;
+    return cls.Contains("seg-green") || cls.Contains("seg-amber") || cls.Contains("seg-red");
+  }
+
+  /// <summary>
+  /// Tiny HTTP stub that returns a fixed <see cref="RadioStateDto"/> for
+  /// <c>/api/radio/state</c> and empty arrays for the auxiliary endpoints
+  /// the panel hits during <c>OnInitializedAsync</c> (<c>/api/radio/presets</c>,
+  /// <c>/api/RadioBands</c>). Anything else gets 404 — the panel logs and
+  /// continues so the page still renders.
+  /// </summary>
+  private sealed class RadioStateStubHandler : HttpMessageHandler
+  {
+    private readonly RadioStateDto _state;
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    public RadioStateStubHandler(RadioStateDto state)
+    {
+      _state = state;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+      HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+      var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+      var response = path switch
+      {
+        "/api/radio/state" => Ok(_state),
+        "/api/radio/presets" => Ok(Array.Empty<RadioPresetDto>()),
+        "/api/RadioBands" => Ok(Array.Empty<Radio.Core.Models.RadioBandModel>()),
+        _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+      };
+      return Task.FromResult(response);
+    }
+
+    private static HttpResponseMessage Ok<T>(T payload)
+    {
+      var json = JsonSerializer.Serialize(payload, Options);
+      return new HttpResponseMessage(HttpStatusCode.OK)
+      {
+        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+      };
+    }
+  }
+}

--- a/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
@@ -173,9 +173,9 @@ public class RadioControlPanelTests : TestContext
     var cut = RenderPanel(state);
 
     var readout = cut.Find(".rcp-meter-dbu");
-    // RssiDbu rendered with "0" format → "-18 dBu". The "−" minus character
-    // in the scale labels is U+2212; ToString("0") emits an ASCII hyphen.
-    Assert.Equal("-18 dBu", readout.TextContent.Trim());
+    // RssiDbu rendered with "0" format then normalized to U+2212 math-minus
+    // so the readout typographically matches the scale labels below.
+    Assert.Equal("−18 dBu", readout.TextContent.Trim());
   }
 
   [Fact]


### PR DESCRIPTION
## Summary

PR 1 of the **Radio Controller Polish arc** (Arc 2). Plan: `docs/superpowers/plans/2026-05-17-radio-controller-polish.md` §PR 1. Handoff spec: `docs/design-handoffs/design_handoff_radio_controller/IMPLEMENTATION.md` §P0·1 + §P0·2.

This PR is bundled per the user-approved spec resolution (single bundle, not hot-fix split): the dBu fit, the clamp, the CLIP pill, the AGC two-cell strip, and the `ScanStopThreshold` re-type all ship together.

## What lands

### API (DTO + projection)
- `RadioStateDto` gains three new fields: `Clip` (bool), `RssiDbu` (double), `AppliedGain` (double).
- `ScanStopThreshold` re-typed from `int` (percent) → `double` (dBu). Greenfield rename per project memory — no back-compat shim. Mirrored on `src/Radio.Web/Models/ApiModels.cs`.
- New `Radio.API.Mappers.RadioStateMapper` centralises the projection so the REST path (`RadioController.GetRadioState`) and the SignalR push path (`AudioStateUpdateService.CheckRadioStateAsync`) share one source of truth.
- Clamp at the API boundary: `SignalStrength` capped at `[0, 100]`. Overdrive surfaced via the dedicated `Clip` flag.
- Linear dBu fit (no calibrated curve on RTL-SDR / RF320 drivers — open question #1 in the plan resolved with a single magic-number pair): 0% → −60 dBu (noise floor), 100% → 0 dBu (full-scale reference).
- SignalR change-detection now broadcasts on Clip flips and dBu/applied-gain deltas (1.8 dBu / 0.1 dB tolerance) so the meter tracks without flicker.

### Web UI (RadioControlPanel.razor)
- `.rcp-meter` now shows a conditional CLIP pill + dBu readout above the bar and a four-tick scale strip (`−60 / −30 / −12 / 0 dBu`) below.
- Old `.rcp-sdr-controls` flex strip replaced by a fixed `.rcp-sdr-grid` two-cell grid (130px AGC toggle | flex gain cell). Right cell is **always** rendered — `Tuner is choosing  28.0 dB` when AGC is on, fixed-width amber pill + slider + range hint when AGC is off — so the strip height never changes with state.
- AGC toggle is now a styled `<button>` for full-cell tap target and `aria-pressed` reflection.
- Scanning indicator now grounds on `RssiDbu >= ScanStopThreshold` (both dBu).

### Design system
- New `§S Signal Meter Calibration` and `§T AGC Two-Cell Strip` sections in `design-system.css`. Tokens reused from `§2`; no new tokens introduced.

### Tests
- `Radio.API.Tests/Mappers/RadioStateMapperTests.cs` — 24 cases locking down clamp, CLIP, dBu fit, percent→dBu projection.
- `Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs` (new file) — 10 cases covering clamp, CLIP pill (on/off), dBu readout text, scale-label glyphs, AGC on/off grid invariants, and the DTO type re-type via reflection.

## Pre-merge fixes

None — local code review caught one `<button>` styling reset (font/line-height/appearance for the AGC tappable cell) which is now in.

## Test plan

- [x] `dotnet build src/Radio.Web/Radio.Web.csproj --configuration Release -p:NuGetAudit=false` → 0 warnings.
- [x] `dotnet test tests/Radio.Web.Tests/Radio.Web.Tests.csproj --configuration Release --verbosity minimal -p:NuGetAudit=false` → 349 passed, 0 failed.
- [x] `dotnet test tests/Radio.API.Tests/Radio.API.Tests.csproj --configuration Release --verbosity minimal -p:NuGetAudit=false` → 251 passed, 1 pre-existing failure (`AudioEngineInitializationServiceTests.StartAsync_EnumeratesDevices` — unrelated, present on `main`).
- [x] Full suite (`dotnet test`) → 2077 passed, 1 pre-existing failure, 3 skipped.
- [ ] **UAT on Ubuntu kiosk (radio host) with live RTL-SDR** — known gap, deferred to user. The bUnit tests cover the rendering invariants; the hardware UAT items in the plan (tune to strong FM, force overdrive close to a powerful local station, toggle AGC mid-stream, scan trigger) require the device and are listed as user UAT.

## Operator note

`ScanStopThreshold` is now a `double` (dBu) on the wire. Any external consumer that read it as an int-percent will need to migrate. The configured value on the server (`RadioOptions.ScanStopThreshold` in `appsettings.json`) is still an int 0–100 and is projected through the same linear fit, so existing config files continue to work — `ScanStopThreshold: 50` becomes −30 dBu in the DTO.

## Acceptance (from plan §PR 1)

P0·1:
- [x] Signal value never exceeds 100% in the UI for any raw input. (Clamp lives in `RadioStateMapper.ClampSignalPercent`; covered by `SignalMeter_RendersClampedValue`.)
- [x] CLIP pill appears only when the front-end is actually overdriving. (Covered by `SignalMeter_ShowsClipPill_WhenClipTrue` + `_HidesClipPill_WhenClipFalse`.)
- [x] dBu scale labels render under the bar in mono 8–9px. (Covered by `SignalMeter_RendersScaleLabels`; CSS sets `font-size: 8px` in §S.)

P0·2:
- [x] Toggling AGC does not change the height of the strip. (Both cells always rendered — covered by `AgcStrip_NoEmptyCell_RegardlessOfAgcState` Theory.)
- [x] When AGC is on, a numeric gain value is visible in the right cell. (Covered by `AgcStrip_TwoCellGrid_BothPopulated_WhenAgcOn`.)
- [x] The slider's "current value" pill never wraps, never grows or shrinks across the slider's range. (Fixed `width: 56px; min-width: 56px;` on `.rcp-gain-pill` in §T.)

## Docs Impact

None. The plan and handoff are reference docs; no audience-facing doc updates required for this PR. (Subsequent PRs in this arc may touch `design/` notes.)

## Builder protocol

Stops after this PR. Coordinator dispatches Tester + Polisher next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)