### PR TITLE
feat(web): confidence bucket DTO + ConfidencePips + recognition stream rewrite

### DIFF
--- a/src/Radio.API/Mappers/AudioDtoMapper.cs
+++ b/src/Radio.API/Mappers/AudioDtoMapper.cs
@@ -164,11 +164,15 @@ public static class AudioDtoMapper
       LastError = snapshot.LastError,
       RecentEvents = snapshot.RecentEvents.Select(e => new FingerprintEventDto
       {
+        MatchId = e.MatchId,
         AudioSource = e.AudioSource,
         SourceType = e.SourceType,
         IsMatch = e.IsMatch,
         Count = e.Count,
-        LastConfidence = e.LastConfidence,
+        // PR 2 of the Radio Controller Polish arc — the raw double is folded
+        // into a coarse bucket at the API boundary and dropped from the wire
+        // shape. The raw score stays on the server-side record for logging.
+        Confidence = ToConfidenceBucket(e.IsMatch, e.LastConfidence),
         Title = e.Title,
         Artist = e.Artist,
         Album = e.Album,
@@ -177,6 +181,39 @@ public static class AudioDtoMapper
         Timestamp = e.Timestamp
       }).ToList()
     };
+  }
+
+  /// <summary>
+  /// Folds a raw fingerprint confidence score into a coarse
+  /// <see cref="ConfidenceBucket"/>. Thresholds:
+  /// ≥ 0.90 → <c>Strong</c>; 0.80–0.89 → <c>Likely</c>;
+  /// 0.60–0.79 → <c>Possible</c>; otherwise <c>None</c>.
+  /// </summary>
+  /// <param name="isMatch">Whether the fingerprint pipeline produced a match.</param>
+  /// <param name="rawConfidence">Raw confidence score on [0, 1], or null when no match.</param>
+  public static ConfidenceBucket ToConfidenceBucket(bool isMatch, double? rawConfidence)
+  {
+    if (!isMatch || rawConfidence is not double score)
+    {
+      return ConfidenceBucket.None;
+    }
+
+    if (score >= 0.90)
+    {
+      return ConfidenceBucket.Strong;
+    }
+
+    if (score >= 0.80)
+    {
+      return ConfidenceBucket.Likely;
+    }
+
+    if (score >= 0.60)
+    {
+      return ConfidenceBucket.Possible;
+    }
+
+    return ConfidenceBucket.None;
   }
 
   /// <summary>

--- a/src/Radio.API/Mappers/RadioStateMapper.cs
+++ b/src/Radio.API/Mappers/RadioStateMapper.cs
@@ -35,7 +35,15 @@ public static class RadioStateMapper
   /// Projects an <see cref="IRadioControl"/> snapshot into the DTO shape the
   /// web UI consumes.
   /// </summary>
-  public static RadioStateDto MapToRadioStateDto(IRadioControl radioSource)
+  /// <param name="radioSource">Radio control snapshot.</param>
+  /// <param name="nowPlayingMatchId">
+  /// Optional <see cref="FingerprintEventDto.MatchId"/> of the fingerprint
+  /// match currently anchored as the playing track. PR 2 of the Radio
+  /// Controller Polish arc — surfaces the active match to the recognition
+  /// stream so the UI can render a NOW header + amber border above the
+  /// correct row. Pass <c>null</c> when no match is currently anchored.
+  /// </param>
+  public static RadioStateDto MapToRadioStateDto(IRadioControl radioSource, string? nowPlayingMatchId = null)
   {
     var rawSignal = radioSource.SignalStrength;
     return new RadioStateDto
@@ -57,6 +65,7 @@ public static class RadioStateMapper
       IsStereo = radioSource.IsStereo,
       RdsStationName = radioSource.RdsStationName,
       RdsProgramType = radioSource.RdsProgramType,
+      NowPlayingMatchId = nowPlayingMatchId,
     };
   }
 

--- a/src/Radio.API/Models/FingerprintStatusDto.cs
+++ b/src/Radio.API/Models/FingerprintStatusDto.cs
@@ -1,6 +1,31 @@
 namespace Radio.API.Models;
 
 /// <summary>
+/// Coarse confidence band for a fingerprint match. PR 2 of the Radio Controller
+/// Polish arc replaces the raw <c>double?</c> confidence on the API surface so the
+/// UI renders a word + pip count instead of a percentage that varies misleadingly
+/// over a narrow dynamic range. Greenfield rename — no back-compat shim.
+/// </summary>
+/// <remarks>
+/// Server-side threshold mapping (folded at the API projection boundary):
+/// <list type="bullet">
+///   <item><description><c>Strong</c>   — raw score ≥ 0.90</description></item>
+///   <item><description><c>Likely</c>   — 0.80 ≤ raw score &lt; 0.90</description></item>
+///   <item><description><c>Possible</c> — 0.60 ≤ raw score &lt; 0.80</description></item>
+///   <item><description><c>None</c>     — no match returned OR raw score &lt; 0.60</description></item>
+/// </list>
+/// The raw score remains in <c>FingerprintEventRecord.LastConfidence</c> for
+/// server-side diagnostic logging; it is intentionally NOT exposed on the DTO.
+/// </remarks>
+public enum ConfidenceBucket
+{
+  None,
+  Possible,
+  Likely,
+  Strong
+}
+
+/// <summary>
 /// DTO for the current fingerprint identification status.
 /// </summary>
 public class FingerprintStatusDto
@@ -18,11 +43,27 @@ public class FingerprintStatusDto
 /// </summary>
 public class FingerprintEventDto
 {
+  /// <summary>
+  /// Stable identifier for this event record, propagated from
+  /// <see cref="Radio.Core.Models.Audio.FingerprintEventRecord.MatchId"/>.
+  /// Used by the UI to anchor the currently-playing match row when
+  /// <c>RadioStateDto.NowPlayingMatchId</c> matches.
+  /// </summary>
+  public string MatchId { get; set; } = string.Empty;
+
   public string AudioSource { get; set; } = string.Empty;
   public string SourceType { get; set; } = string.Empty;
   public bool IsMatch { get; set; }
   public int Count { get; set; }
-  public double? LastConfidence { get; set; }
+
+  /// <summary>
+  /// Coarse confidence band for this match. Replaces the prior raw
+  /// <c>double? LastConfidence</c> field on the API surface (PR 2 of the
+  /// Radio Controller Polish arc). The raw score lives on the server-side
+  /// record only; the DTO carries only the bucket.
+  /// </summary>
+  public ConfidenceBucket Confidence { get; set; } = ConfidenceBucket.None;
+
   public string? Title { get; set; }
   public string? Artist { get; set; }
   public string? Album { get; set; }

--- a/src/Radio.API/Models/RadioDtos.cs
+++ b/src/Radio.API/Models/RadioDtos.cs
@@ -106,6 +106,17 @@ public class RadioStateDto
   /// of <see cref="RssiDbu"/>. Greenfield project — no back-compat shim.
   /// </summary>
   public double ScanStopThreshold { get; set; }
+
+  /// <summary>
+  /// Gets or sets the <see cref="FingerprintEventDto.MatchId"/> of the
+  /// fingerprint event that is currently playing, when one has been
+  /// identified. The recognition stream in <c>NowPlayingPanel</c> anchors the
+  /// NOW header + amber-left-border on the row whose <c>MatchId</c> equals
+  /// this value. Null when no match is currently anchored (e.g. dead air,
+  /// no-match window, non-radio source). PR 2 of the Radio Controller
+  /// Polish arc.
+  /// </summary>
+  public string? NowPlayingMatchId { get; set; }
 }
 
 /// <summary>

--- a/src/Radio.API/Services/AudioStateUpdateService.cs
+++ b/src/Radio.API/Services/AudioStateUpdateService.cs
@@ -58,6 +58,16 @@ public class AudioStateUpdateService : BackgroundService
   private VolumeDto? _lastVolume;
   private string? _lastActiveSourceType;
 
+  // PR 2 of the Radio Controller Polish arc — caches the MatchId of the
+  // fingerprint event currently anchored as the playing match. The
+  // recognition stream in NowPlayingPanel binds against this to render the
+  // NOW header + amber left border above the correct row. Updated by
+  // OnFingerprintStatusChanged when the snapshot's most-recent match changes;
+  // cleared when the active source changes (OnSourceChanged equivalent) or
+  // when the latest event is not a match. Volatile because reads happen on
+  // the background-polling thread and writes on the SignalR callback thread.
+  private volatile string? _currentMatchId;
+
   /// <summary>
   /// Initializes a new instance of the AudioStateUpdateService.
   /// </summary>
@@ -557,7 +567,11 @@ public class AudioStateUpdateService : BackgroundService
            previous.ScanDirection != current.ScanDirection ||
            previous.IsStereo != current.IsStereo ||
            previous.RdsStationName != current.RdsStationName ||
-           previous.RdsProgramType != current.RdsProgramType;
+           previous.RdsProgramType != current.RdsProgramType ||
+           // PR 2 of the Radio Controller Polish arc — the recognition stream's
+           // NOW row anchors on this. Changes must broadcast so the UI's
+           // amber-border row tracks the actively-playing fingerprint match.
+           previous.NowPlayingMatchId != current.NowPlayingMatchId;
   }
 
   private static bool HasVolumeChanged(VolumeDto? previous, VolumeDto? current)
@@ -681,8 +695,8 @@ public class AudioStateUpdateService : BackgroundService
       : $"{ts.Minutes}:{ts.Seconds:D2}";
   }
 
-  private static RadioStateDto MapToRadioStateDto(IRadioControl radioControls)
-    => RadioStateMapper.MapToRadioStateDto(radioControls);
+  private RadioStateDto MapToRadioStateDto(IRadioControl radioControls)
+    => RadioStateMapper.MapToRadioStateDto(radioControls, _currentMatchId);
 
   private BluetoothStatusDto BuildBluetoothStatusDto()
   {
@@ -807,6 +821,15 @@ public class AudioStateUpdateService : BackgroundService
   {
     try
     {
+      // Update the "currently playing match" anchor on every snapshot — this is
+      // independent of the broadcast throttle below so the RadioState path
+      // (which broadcasts on its own cadence in CheckRadioStateAsync) always
+      // has a fresh value. The anchor is the most-recent matched event; when
+      // the latest event is not a match (no-match window, error, or first
+      // capture) we clear it so the recognition stream falls back to its
+      // "no current match" rendering.
+      UpdateCurrentMatchAnchor(snapshot);
+
       var now = DateTime.UtcNow;
       if (now - _lastFingerprintBroadcast < FingerprintBroadcastThrottle)
       {
@@ -822,6 +845,33 @@ public class AudioStateUpdateService : BackgroundService
     {
       _logger.LogDebug(ex, "Error broadcasting fingerprint status change");
     }
+  }
+
+  /// <summary>
+  /// Maintains the <see cref="_currentMatchId"/> anchor used by the recognition
+  /// stream's NOW row. The anchor is the most-recent matched event in the
+  /// snapshot; when the most-recent event is a no-match (or there are no
+  /// events yet) we clear the anchor so the UI doesn't claim a stale row as
+  /// "now playing".
+  /// </summary>
+  private void UpdateCurrentMatchAnchor(FingerprintStatusSnapshot snapshot)
+  {
+    // Latest-first scan: the most-recent event is at the end of the list per
+    // BackgroundIdentificationService's append semantics. We anchor on the
+    // most-recent MATCHED event so a fresh no-match capture at the tail
+    // doesn't blank the NOW row mid-track. Only when no recent matches
+    // exist at all do we clear.
+    string? latestMatch = null;
+    for (var i = snapshot.RecentEvents.Count - 1; i >= 0; i--)
+    {
+      var evt = snapshot.RecentEvents[i];
+      if (evt.IsMatch && !string.IsNullOrEmpty(evt.MatchId))
+      {
+        latestMatch = evt.MatchId;
+        break;
+      }
+    }
+    _currentMatchId = latestMatch;
   }
 
   public override void Dispose()

--- a/src/Radio.Core/Models/Audio/FingerprintStatus.cs
+++ b/src/Radio.Core/Models/Audio/FingerprintStatus.cs
@@ -20,10 +20,25 @@ public enum FingerprintPhase
 /// </summary>
 public record FingerprintEventRecord
 {
+  /// <summary>
+  /// Stable identifier for this event record, generated once when the record is created.
+  /// Persists across aggregations (Count++ on repeated matches of the same track) so the
+  /// UI has an unambiguous anchor to mark a row as "the now-playing match" via
+  /// <c>RadioStateDto.NowPlayingMatchId</c>. PR 2 of the Radio Controller Polish arc.
+  /// </summary>
+  public string MatchId { get; init; } = Guid.NewGuid().ToString("n");
+
   public string AudioSource { get; init; } = string.Empty;
   public string SourceType { get; set; } = string.Empty;
   public bool IsMatch { get; set; }
   public int Count { get; set; }
+
+  /// <summary>
+  /// Raw AcoustID/Shazam confidence score in the range [0, 1]. Retained on the
+  /// server-side record for diagnostic logging; folded into a coarse
+  /// <c>ConfidenceBucket</c> at the API boundary so the UI never surfaces a
+  /// raw percentage.
+  /// </summary>
   public double? LastConfidence { get; set; }
   public string? Title { get; set; }
   public string? Artist { get; set; }

--- a/src/Radio.Web/Components/Pages/RadioPage.razor
+++ b/src/Radio.Web/Components/Pages/RadioPage.razor
@@ -337,9 +337,11 @@
     }
   }
 
-  private async Task HandleRadioStateChanged()
+  private async Task HandleRadioStateChanged(RadioStateDto dto)
   {
-    await LoadRadioStateAsync();
+    // Use the SignalR payload directly instead of re-fetching via REST.
+    // The hub broadcast carries NowPlayingMatchId; the REST endpoint cannot.
+    _radioState = dto;
     await InvokeAsync(StateHasChanged);
   }
 

--- a/src/Radio.Web/Components/Shared/ConfidencePips.razor
+++ b/src/Radio.Web/Components/Shared/ConfidencePips.razor
@@ -1,0 +1,45 @@
+@*
+  ConfidencePips — 3-pip widget that renders a fingerprint match confidence as a
+  fixed number of lit pips plus a single word ("Strong" / "Likely" / "Possible" /
+  "No match"). Replaces the raw "78%" / "94%" percentage badges that PR 2 of the
+  Radio Controller Polish arc explicitly bans. Driven by the API-side
+  ConfidenceBucket enum so the UI never sees the raw double score.
+
+    Strong   ▌▌▌  green
+    Likely   ▌▌·  light green
+    Possible ▌··  amber
+    None     ···  dim, "No match" label
+
+  CSS lives in design-system.css §U Confidence pips.
+*@
+
+<div class="confidence-pips" data-bucket="@Bucket.ToString().ToLowerInvariant()">
+  <span class="confidence-pip @(LitCount >= 1 ? "is-lit" : null)"></span>
+  <span class="confidence-pip @(LitCount >= 2 ? "is-lit" : null)"></span>
+  <span class="confidence-pip @(LitCount >= 3 ? "is-lit" : null)"></span>
+  <span class="confidence-label">@BucketLabel</span>
+</div>
+
+@code {
+  /// <summary>
+  /// Confidence band to render. Drives both the lit-pip count and the label text.
+  /// </summary>
+  [Parameter, EditorRequired]
+  public ConfidenceBucket Bucket { get; set; }
+
+  private int LitCount => Bucket switch
+  {
+    ConfidenceBucket.Strong => 3,
+    ConfidenceBucket.Likely => 2,
+    ConfidenceBucket.Possible => 1,
+    _ => 0
+  };
+
+  private string BucketLabel => Bucket switch
+  {
+    ConfidenceBucket.Strong => "Strong",
+    ConfidenceBucket.Likely => "Likely",
+    ConfidenceBucket.Possible => "Possible",
+    _ => "No match"
+  };
+}

--- a/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
@@ -60,7 +60,9 @@
               {
                 <div class="np-recognition-header">NOW</div>
                 <div class="np-recognition-row np-recognition-row-current" data-match-id="@nowMatch.MatchId">
-                  <span class="np-recognition-art-placeholder">♪</span>
+                  <span class="np-recognition-art-wrap is-current">
+                    <span class="np-recognition-art-placeholder">♪</span>
+                  </span>
                   @if (string.IsNullOrEmpty(nowMatch.Title))
                   {
                     <span class="np-recognition-title np-recognition-no-match">No match in window</span>
@@ -82,7 +84,9 @@
                 @foreach (var evt in earlierMatches)
                 {
                   <div class="np-recognition-row" data-match-id="@evt.MatchId">
-                    <span class="np-recognition-art-placeholder">♪</span>
+                    <span class="np-recognition-art-wrap">
+                      <span class="np-recognition-art-placeholder">♪</span>
+                    </span>
                     @if (string.IsNullOrEmpty(evt.Title))
                     {
                       <span class="np-recognition-title np-recognition-no-match">No match in window</span>
@@ -428,10 +432,13 @@
     await InvokeAsync(StateHasChanged);
   }
 
-  private async Task OnRadioStateChanged()
+  private async Task OnRadioStateChanged(RadioStateDto dto)
   {
     _lastSignalREventUtc = DateTime.UtcNow;
-    await RefreshRadioStateAsync();
+    // Use the SignalR payload directly — it carries NowPlayingMatchId, which
+    // the REST /api/radio/state endpoint cannot populate (RadioController
+    // has no access to AudioStateUpdateService._currentMatchId).
+    _radioState = dto;
     await InvokeAsync(StateHasChanged);
   }
 

--- a/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
@@ -1,5 +1,6 @@
 @rendermode InteractiveServer
 @inject AudioApiService AudioApi
+@inject RadioApiService RadioApi
 @inject AudioStateHubService HubService
 @inject ConfigurationApiService ConfigApi
 @inject ILogger<NowPlayingPanel> Logger
@@ -29,74 +30,83 @@
   <div style="position: relative; z-index: 1; flex: 1; display: flex; align-items: center; justify-content: center; padding: 12px; min-height: 0;">
     @if (_showFingerprintDetail)
     {
-      <!-- Fingerprint detail panel — replaces album art area when badge is tapped -->
+      @* Recognition stream — replaces the legacy <table>+telemetry-strip block
+         per PR 2 of the Radio Controller Polish arc. NOW/EARLIER headers
+         anchor the active match (_radioState.NowPlayingMatchId) at the top
+         with an amber left-border + dot; older matches list beneath with
+         time-ago labels. Failed lookups render as italic "No match in window"
+         sentences. Confidence reads as <ConfidencePips/>, never as a raw
+         percentage. The telemetry strip (Fingerprints/min · Lookups/min) is
+         removed entirely from the panel header; if it resurfaces it'll live
+         in the DevTray (Arc 1 PR 6) in a future PR. *@
       <div style="width: 100%; height: 100%; display: flex; flex-direction: column; background: rgba(0,0,0,0.75); backdrop-filter: blur(8px); border-radius: 8px; overflow: hidden; border: 1px solid rgba(255,255,255,0.1);">
-        <!-- Header with rates -->
-        <div style="display: flex; justify-content: space-between; align-items: center; padding: 10px 14px; border-bottom: 1px solid rgba(255,255,255,0.1); background: rgba(0,0,0,0.3);">
-          <div style="font-family: var(--font-mono); font-size: 12px; color: var(--text-medium);">
-            Fingerprints: @(_fpStatus?.FingerprintsPerMinute.ToString("F1") ?? "0.0")/min
-            &nbsp;&bull;&nbsp;
-            Lookups: @(_fpStatus?.MetadataCallsPerMinute.ToString("F1") ?? "0.0")/min
-          </div>
+        <div style="display: flex; justify-content: flex-end; align-items: center; padding: 6px 8px; border-bottom: 1px solid rgba(255,255,255,0.1); background: rgba(0,0,0,0.3);">
           <RadzenButton Icon="close" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light"
-                        Variant="Variant.Text" Click="@ToggleFingerprintDetail" Style="padding: 2px;" />
+                        Variant="Variant.Text" Click="@ToggleFingerprintDetail" Style="padding: 2px;"
+                        title="Close recognition stream" />
         </div>
-        <!-- Event log table -->
-        <div style="flex: 1; overflow-y: auto; padding: 0;">
-          <table style="width: 100%; border-collapse: collapse; font-family: var(--font-mono); font-size: 11px;">
-            <thead>
-              <tr style="color: var(--text-low); border-bottom: 1px solid rgba(255,255,255,0.08);">
-                <th style="text-align: center; padding: 6px 4px; font-weight: 500;">Src</th>
-                <th style="text-align: center; padding: 6px 4px; font-weight: 500;">Match</th>
-                <th style="text-align: center; padding: 6px 4px; font-weight: 500;">#</th>
-                <th style="text-align: center; padding: 6px 4px; font-weight: 500;">Conf%</th>
-                <th style="text-align: left; padding: 6px 8px; font-weight: 500;">Track</th>
-                <th style="text-align: center; padding: 6px 4px; font-weight: 500;">Art</th>
-              </tr>
-            </thead>
-            <tbody>
-              @if (_fpEventsReversed != null)
+        <div style="flex: 1; overflow-y: auto;">
+          @if (_fpEventsReversed != null && _fpEventsReversed.Count > 0)
+          {
+            var nowMatchId = _radioState?.NowPlayingMatchId;
+            var nowMatch = !string.IsNullOrEmpty(nowMatchId)
+              ? _fpEventsReversed.FirstOrDefault(e => e.MatchId == nowMatchId)
+              : null;
+            var earlierMatches = nowMatch != null
+              ? _fpEventsReversed.Where(e => e.MatchId != nowMatch.MatchId).ToList()
+              : _fpEventsReversed.ToList();
+            <div class="np-recognition-stream">
+              @if (nowMatch != null)
               {
-                @foreach (var evt in _fpEventsReversed)
+                <div class="np-recognition-header">NOW</div>
+                <div class="np-recognition-row np-recognition-row-current" data-match-id="@nowMatch.MatchId">
+                  <span class="np-recognition-art-placeholder">♪</span>
+                  @if (string.IsNullOrEmpty(nowMatch.Title))
+                  {
+                    <span class="np-recognition-title np-recognition-no-match">No match in window</span>
+                  }
+                  else
+                  {
+                    <div class="np-recognition-text">
+                      <div class="np-recognition-title">@nowMatch.Title</div>
+                      <div class="np-recognition-artist">@(string.IsNullOrEmpty(nowMatch.Artist) ? "—" : nowMatch.Artist)</div>
+                    </div>
+                  }
+                  <ConfidencePips Bucket="@nowMatch.Confidence" />
+                  <span class="np-recognition-now-tag">now</span>
+                </div>
+              }
+              @if (earlierMatches.Count > 0)
+              {
+                <div class="np-recognition-header">EARLIER</div>
+                @foreach (var evt in earlierMatches)
                 {
-                  <tr style="border-bottom: 1px solid rgba(255,255,255,0.04); height: 22px; color: @(GetEventRowColor(evt));">
-                    <td style="text-align: center; padding: 3px 4px;" title="@evt.SourceType">
-                      <RadzenIcon Icon="@GetFpSourceIcon(evt.SourceType)" Style="font-size: 14px;" />
-                    </td>
-                    <td style="text-align: center; padding: 3px 4px;">
-                      @if (evt.IsMatch)
-                      {
-                        <span style="color: #4caf50;">&#x2714;</span>
-                      }
-                      else
-                      {
-                        <span style="color: rgba(255,255,255,0.3);">&#x2718;</span>
-                      }
-                    </td>
-                    <td style="text-align: center; padding: 3px 4px;">@evt.Count</td>
-                    <td style="text-align: center; padding: 3px 4px;">@(evt.LastConfidence.HasValue ? $"{evt.LastConfidence.Value:P0}" : "--")</td>
-                    <td style="padding: 3px 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 160px;">@(FormatEventTrack(evt))</td>
-                    <td style="text-align: center; padding: 3px 4px;">
-                      @if (evt.HasAlbumArt)
-                      {
-                        <span style="color: #4caf50;">&#x2714;</span>
-                      }
-                      else
-                      {
-                        <span style="color: rgba(255,255,255,0.2);">—</span>
-                      }
-                    </td>
-                  </tr>
+                  <div class="np-recognition-row" data-match-id="@evt.MatchId">
+                    <span class="np-recognition-art-placeholder">♪</span>
+                    @if (string.IsNullOrEmpty(evt.Title))
+                    {
+                      <span class="np-recognition-title np-recognition-no-match">No match in window</span>
+                    }
+                    else
+                    {
+                      <div class="np-recognition-text">
+                        <div class="np-recognition-title">@evt.Title</div>
+                        <div class="np-recognition-artist">@(string.IsNullOrEmpty(evt.Artist) ? "—" : evt.Artist)</div>
+                      </div>
+                    }
+                    <ConfidencePips Bucket="@evt.Confidence" />
+                    <span class="np-recognition-time-ago">@FormatTimeAgo(evt.Timestamp)</span>
+                  </div>
                 }
               }
-              else
-              {
-                <tr>
-                  <td colspan="6" style="padding: 16px; text-align: center; color: var(--text-low);">No fingerprint events yet</td>
-                </tr>
-              }
-            </tbody>
-          </table>
+            </div>
+          }
+          else
+          {
+            <div style="padding: 16px; text-align: center; color: var(--text-low); font-family: var(--font-mono); font-size: 11px;">
+              No fingerprint events yet
+            </div>
+          }
         </div>
       </div>
     }
@@ -309,6 +319,11 @@
   private List<FingerprintEventDto>? _fpEventsReversed;
   private bool _showFingerprintDetail;
 
+  // PR 2 of the Radio Controller Polish arc — radio state snapshot for the
+  // recognition stream's NOW-row anchor (binds against NowPlayingMatchId).
+  // Refreshed on RadioStateChanged hub events; null until the first load.
+  private RadioStateDto? _radioState;
+
   // Source gain state
   private float _currentSourceGain = 1.0f;
   private string? _nowPlayingSourceType;
@@ -337,9 +352,11 @@
       HubService.SourceChanged += OnSourceChanged;
       HubService.VolumeChanged += OnVolumeChangedEvent;
       HubService.FingerprintStatusChanged += OnFingerprintStatusChanged;
+      HubService.RadioStateChanged += OnRadioStateChanged;
 
       await RefreshPlaybackStateAsync();
       await RefreshFingerprintStatusAsync();
+      await RefreshRadioStateAsync();
       await LoadSourceGainOffsetsAsync();
 
       // Periodic fallback poll for now playing updates. Catches track identifications
@@ -409,6 +426,28 @@
     _lastSignalREventUtc = DateTime.UtcNow;
     await RefreshFingerprintStatusAsync();
     await InvokeAsync(StateHasChanged);
+  }
+
+  private async Task OnRadioStateChanged()
+  {
+    _lastSignalREventUtc = DateTime.UtcNow;
+    await RefreshRadioStateAsync();
+    await InvokeAsync(StateHasChanged);
+  }
+
+  private async Task RefreshRadioStateAsync()
+  {
+    try
+    {
+      _radioState = await RadioApi.GetStateAsync();
+    }
+    catch (Exception ex)
+    {
+      // Non-radio sources (BT, File) return 400 here; that's fine — the
+      // recognition stream simply renders without the NOW anchor.
+      Logger.LogDebug(ex, "Error refreshing radio state in NowPlayingPanel");
+      _radioState = null;
+    }
   }
 
   private async Task OnNowPlayingPollAsync()
@@ -573,10 +612,26 @@
       "Capturing" => "Listening",
       "Fingerprinting" => "Analyzing",
       "Querying" => "Searching",
-      "Matched" => _fpStatus?.RecentEvents?.LastOrDefault()?.LastConfidence is double c ? $"{c:P0}" : "Match",
+      // PR 2 of the Radio Controller Polish arc — the badge mirrors the
+      // recognition stream and renders a word, never a raw percentage. The
+      // bucket label comes from the most-recent match's coarse Confidence.
+      "Matched" => GetMatchedBadgeLabel(),
       "NoMatch" => "No ID",
       "Error" => "Error",
       _ => "ID"
+    };
+  }
+
+  private string GetMatchedBadgeLabel()
+  {
+    var latestMatch = _fpStatus?.RecentEvents?
+      .LastOrDefault(e => e.IsMatch);
+    return latestMatch?.Confidence switch
+    {
+      ConfidenceBucket.Strong => "Strong",
+      ConfidenceBucket.Likely => "Likely",
+      ConfidenceBucket.Possible => "Possible",
+      _ => "Match"
     };
   }
 
@@ -627,27 +682,23 @@
     };
   }
 
-  private static string GetFpSourceIcon(string sourceType) => SourceTypeHelper.GetIcon(sourceType);
+  /// <summary>
+  /// Short relative-time formatter for recognition rows. Renders "Xs ago" /
+  /// "Xm ago" / "Xh ago" / "Xd ago" — chosen over <c>Timestamps.FormatRelative</c>
+  /// because the recognition stream is anchored on very recent events (most
+  /// matches happen in the last few minutes) and the absolute "Today HH:mm"
+  /// form reads as too rigid in that scale.
+  /// </summary>
+  private static string FormatTimeAgo(DateTime utc) => FormatTimeAgo(utc, DateTime.UtcNow);
 
-  private static string GetEventRowColor(FingerprintEventDto evt)
+  internal static string FormatTimeAgo(DateTime utc, DateTime nowUtc)
   {
-    return evt.Phase switch
-    {
-      "Matched" => "rgba(76,175,80,0.9)",
-      "Error" => "rgba(244,67,54,0.8)",
-      "NoMatch" => "rgba(255,255,255,0.4)",
-      "Capturing" or "Fingerprinting" or "Querying" => "rgba(0,188,212,0.8)",
-      _ => "rgba(255,255,255,0.5)"
-    };
-  }
-
-  private static string FormatEventTrack(FingerprintEventDto evt)
-  {
-    if (string.IsNullOrEmpty(evt.Title)) return "--";
-    var parts = new List<string> { evt.Title };
-    if (!string.IsNullOrEmpty(evt.Artist)) parts.Add(evt.Artist);
-    if (!string.IsNullOrEmpty(evt.Album)) parts.Add(evt.Album);
-    return string.Join(" / ", parts);
+    var delta = nowUtc - utc;
+    if (delta.TotalSeconds < 1) return "just now";
+    if (delta.TotalMinutes < 1) return $"{(int)delta.TotalSeconds}s ago";
+    if (delta.TotalHours < 1) return $"{(int)delta.TotalMinutes}m ago";
+    if (delta.TotalDays < 1) return $"{(int)delta.TotalHours}h ago";
+    return $"{(int)delta.TotalDays}d ago";
   }
 
   // --- Source gain helpers ---
@@ -874,6 +925,7 @@
     HubService.SourceChanged -= OnSourceChanged;
     HubService.VolumeChanged -= OnVolumeChangedEvent;
     HubService.FingerprintStatusChanged -= OnFingerprintStatusChanged;
+    HubService.RadioStateChanged -= OnRadioStateChanged;
     _gainDebounceTimer?.Dispose();
     _nowPlayingPollTimer?.Dispose();
     await Task.CompletedTask;

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -917,9 +917,11 @@
     catch { /* Silently fail */ }
   }
 
-  private async Task HandleRadioStateChanged()
+  private async Task HandleRadioStateChanged(RadioStateDto dto)
   {
-    await LoadRadioStateAsync();
+    // Use the SignalR payload directly instead of re-fetching via REST.
+    // The hub broadcast carries NowPlayingMatchId; the REST endpoint cannot.
+    _radioState = dto;
     await InvokeAsync(StateHasChanged);
   }
 

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -742,6 +742,15 @@ public class AudioEngineConfigDto
 /// Polish arc replaces the raw <c>double?</c> on the wire so the UI renders
 /// a word + pip count instead of a fractional percentage.
 /// </summary>
+/// <remarks>
+/// The API serializes enums as strings via a global <c>JsonStringEnumConverter</c>
+/// registered in <c>Radio.API/Program.cs</c>. The Web's <c>HttpClient</c> calls
+/// (e.g. <c>GetFromJsonAsync</c>) use default <c>JsonSerializerOptions</c> with
+/// no enum converter, so without this attribute deserialization throws
+/// <c>JsonException: The JSON value could not be converted to ConfidenceBucket</c>
+/// on every fingerprint status fetch — silently breaking the recognition UI.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ConfidenceBucket
 {
   None,

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -302,7 +302,11 @@ public record RadioStateDto(
   string? RdsProgramType = null,
   bool Clip = false,
   double RssiDbu = 0.0,
-  double AppliedGain = 0.0
+  double AppliedGain = 0.0,
+  // PR 2 of the Radio Controller Polish arc — anchors the NOW row in the
+  // recognition stream to a specific fingerprint event. Null when no match
+  // is currently anchored (e.g. dead air, no-match window, non-radio source).
+  string? NowPlayingMatchId = null
 );
 
 public record RadioPowerStateDto(
@@ -731,6 +735,21 @@ public class AudioEngineConfigDto
 }
 
 // Fingerprint Status DTOs
+
+/// <summary>
+/// Coarse confidence band for a fingerprint match (mirrors
+/// <c>Radio.API.Models.ConfidenceBucket</c>). PR 2 of the Radio Controller
+/// Polish arc replaces the raw <c>double?</c> on the wire so the UI renders
+/// a word + pip count instead of a fractional percentage.
+/// </summary>
+public enum ConfidenceBucket
+{
+  None,
+  Possible,
+  Likely,
+  Strong
+}
+
 public class FingerprintStatusDto
 {
   public string Phase { get; set; } = "Idle";
@@ -743,11 +762,24 @@ public class FingerprintStatusDto
 
 public class FingerprintEventDto
 {
+  /// <summary>
+  /// Stable identifier for this event record. The UI anchors the
+  /// currently-playing match row when <c>RadioStateDto.NowPlayingMatchId</c>
+  /// equals this value.
+  /// </summary>
+  public string MatchId { get; set; } = string.Empty;
+
   public string AudioSource { get; set; } = string.Empty;
   public string SourceType { get; set; } = string.Empty;
   public bool IsMatch { get; set; }
   public int Count { get; set; }
-  public double? LastConfidence { get; set; }
+
+  /// <summary>
+  /// Coarse confidence band. Replaces the prior raw <c>double? LastConfidence</c>
+  /// field on the API surface (PR 2 of the Radio Controller Polish arc).
+  /// </summary>
+  public ConfidenceBucket Confidence { get; set; } = ConfidenceBucket.None;
+
   public string? Title { get; set; }
   public string? Artist { get; set; }
   public string? Album { get; set; }

--- a/src/Radio.Web/Services/AudioStateStore.cs
+++ b/src/Radio.Web/Services/AudioStateStore.cs
@@ -21,6 +21,10 @@ public class AudioStateStore : IAsyncDisposable
   public float Volume { get; private set; } = 0.75f;
   public bool IsMuted { get; private set; }
   public FingerprintStatusDto? FingerprintStatus { get; private set; }
+  // Most recent RadioStateDto delivered by SignalR. Carries NowPlayingMatchId
+  // which the REST /api/radio/state endpoint cannot populate. Subscribers
+  // can read this directly; null until the first hub broadcast.
+  public RadioStateDto? RadioState { get; private set; }
   public int QueueCount { get; private set; }
   public Dictionary<string, float> SourceGainOffsets { get; private set; } = new();
 
@@ -43,8 +47,9 @@ public class AudioStateStore : IAsyncDisposable
   /// <summary>Raised when fingerprint status changes.</summary>
   public event Func<Task>? FingerprintStatusChanged;
 
-  /// <summary>Raised when radio state changes.</summary>
-  public event Func<Task>? RadioStateChanged;
+  /// <summary>Raised when radio state changes. Carries the typed DTO so
+  /// subscribers can read NowPlayingMatchId directly without a REST refetch.</summary>
+  public event Func<RadioStateDto, Task>? RadioStateChanged;
 
   /// <summary>Raised when sleep state changes.</summary>
   public event Func<bool, Task>? SleepStateChanged;
@@ -182,9 +187,20 @@ public class AudioStateStore : IAsyncDisposable
     await NotifyAsync(FingerprintStatusChanged);
   }
 
-  private async Task OnHubRadioStateChanged()
+  private async Task OnHubRadioStateChanged(RadioStateDto dto)
   {
-    await NotifyAsync(RadioStateChanged);
+    RadioState = dto;
+    if (RadioStateChanged != null)
+    {
+      try
+      {
+        await RadioStateChanged.Invoke(dto);
+      }
+      catch (Exception ex)
+      {
+        _logger.LogWarning(ex, "Error notifying AudioStateStore subscriber");
+      }
+    }
   }
 
   private async Task OnHubSleepStateChanged(bool isSleeping)

--- a/src/Radio.Web/Services/Hub/AudioStateHubService.cs
+++ b/src/Radio.Web/Services/Hub/AudioStateHubService.cs
@@ -25,7 +25,12 @@ public class AudioStateHubService : IAsyncDisposable
   public event Func<Task>? PlaybackStateChanged;
   public event Func<NowPlayingDto?, Task>? NowPlayingChanged;
   public event Func<Task>? QueueChanged;
-  public event Func<Task>? RadioStateChanged;
+  // RadioStateChanged carries the full RadioStateDto payload (including
+  // NowPlayingMatchId) so subscribers don't need to re-fetch via REST.
+  // The REST hop drops NowPlayingMatchId because RadioController has no
+  // access to AudioStateUpdateService._currentMatchId — the broadcast is
+  // the only path that carries it.
+  public event Func<RadioStateDto, Task>? RadioStateChanged;
   public event Func<VolumeDto?, Task>? VolumeChanged;
   public event Func<Task>? SourceChanged;
   public event Func<Task>? FingerprintStatusChanged;
@@ -107,13 +112,16 @@ public class AudioStateHubService : IAsyncDisposable
       });
 
       // Server sends RadioStateChanged with a RadioStateDto payload —
-      // accept and discard it so SignalR dispatches the message.
-      _hubConnection.On<object>("RadioStateChanged", async (_) =>
+      // deserialize and pass through so subscribers can read NowPlayingMatchId
+      // directly. (Previously the payload was discarded and subscribers
+      // re-fetched via REST, which strips NowPlayingMatchId and silently
+      // broke the recognition stream's NOW-row anchor.)
+      _hubConnection.On<RadioStateDto>("RadioStateChanged", async (dto) =>
       {
         _logger.LogDebug("Received RadioStateChanged event");
         if (RadioStateChanged != null)
         {
-          await RadioStateChanged.Invoke();
+          await RadioStateChanged.Invoke(dto);
         }
       });
 

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -3220,9 +3220,26 @@ body {
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.08em;
-  text-transform: lowercase;
+  /* No text-transform — the component emits title-case strings
+     ('Strong', 'Likely', 'Possible', 'No match') matching the spec + mock.
+     Earlier `text-transform: lowercase` was silently mangling them on screen. */
   color: var(--text-medium);
   margin-left: 6px;
+}
+
+/* Per-bucket label color hierarchy matching the pip backgrounds —
+   keeps the word and pips visually coupled so the bucket reads at a glance. */
+.confidence-pips[data-bucket="strong"] .confidence-label {
+  color: var(--signal-green);
+}
+.confidence-pips[data-bucket="likely"] .confidence-label {
+  color: color-mix(in srgb, var(--signal-green) 60%, transparent);
+}
+.confidence-pips[data-bucket="possible"] .confidence-label {
+  color: var(--signal-amber);
+}
+.confidence-pips[data-bucket="none"] .confidence-label {
+  color: var(--text-low);
 }
 
 /* ─── §V  Recognition Stream (Radio Controller Polish PR 2) ────────────────── *
@@ -3260,17 +3277,24 @@ body {
 }
 
 .np-recognition-row-current {
-  position: relative;
   border-left: 2px solid var(--signal-amber);
   background: color-mix(in srgb, var(--signal-amber) 6%, transparent);
 }
 
-/* Small amber dot in the top-right corner of the current row's art square. */
-.np-recognition-row-current::after {
+/* Wraps the art square in a relative-positioned container so the
+   "now playing" amber dot can sit on the art's top-right corner per mock
+   (bleeding slightly into the row gutter), not inside the row body. */
+.np-recognition-art-wrap {
+  position: relative;
+  width: 34px;
+  height: 34px;
+}
+
+.np-recognition-art-wrap.is-current::after {
   content: "";
   position: absolute;
-  top: 6px;
-  left: 36px;
+  top: -3px;
+  right: -3px;
   width: 6px;
   height: 6px;
   border-radius: 50%;

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -3178,3 +3178,162 @@ body {
   color: var(--signal-amber);
   text-shadow: 0 0 6px color-mix(in srgb, var(--signal-amber) 18%, transparent);
 }
+
+/* ─── §U  Confidence Pips (Radio Controller Polish PR 2) ──────────────────── *
+   3-pip widget rendered by Shared/ConfidencePips.razor. Replaces the raw
+   "78%" badges in the recognition stream with a coarse Strong/Likely/Possible
+   word and a fixed pip count, per the handoff's §P0·3 acceptance gate
+   ("No row in the panel contains the literal text 80%").
+
+     Strong   ▌▌▌  --signal-green
+     Likely   ▌▌·  60% --signal-green
+     Possible ▌··  --signal-amber
+     None     ···  unlit, "No match" label
+*/
+.confidence-pips {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.confidence-pip {
+  width: 5px;
+  height: 10px;
+  border-radius: 1px;
+  background: var(--surface-elevated);
+  transition: background 200ms ease;
+}
+
+.confidence-pips[data-bucket="strong"] .confidence-pip.is-lit {
+  background: var(--signal-green);
+}
+
+.confidence-pips[data-bucket="likely"] .confidence-pip.is-lit {
+  background: color-mix(in srgb, var(--signal-green) 60%, transparent);
+}
+
+.confidence-pips[data-bucket="possible"] .confidence-pip.is-lit {
+  background: var(--signal-amber);
+}
+
+.confidence-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  color: var(--text-medium);
+  margin-left: 6px;
+}
+
+/* ─── §V  Recognition Stream (Radio Controller Polish PR 2) ────────────────── *
+   Rewrites the recognition <table> inside NowPlayingPanel.razor into a flex
+   column of rows with NOW/EARLIER headers. The currently-playing match
+   anchors at the top with an amber left border + an amber dot on the art
+   square. Failed lookups render as italic "No match in window" sentences,
+   never as "--". Drops the per-row source-type icon column (the panel-level
+   source bubble already covers it — resolved spec ambiguity #1).
+*/
+.np-recognition-stream {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 0;
+}
+
+.np-recognition-header {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--signal-amber);
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  padding-left: 12px;
+  margin-bottom: 4px;
+}
+
+/* Row: 34px art column · title/artist column · pips column · time-ago column. */
+.np-recognition-row {
+  display: grid;
+  grid-template-columns: 34px 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 6px 12px;
+}
+
+.np-recognition-row-current {
+  position: relative;
+  border-left: 2px solid var(--signal-amber);
+  background: color-mix(in srgb, var(--signal-amber) 6%, transparent);
+}
+
+/* Small amber dot in the top-right corner of the current row's art square. */
+.np-recognition-row-current::after {
+  content: "";
+  position: absolute;
+  top: 6px;
+  left: 36px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--signal-amber);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--signal-amber) 50%, transparent);
+}
+
+.np-recognition-art {
+  width: 34px;
+  height: 34px;
+  border-radius: 4px;
+  object-fit: cover;
+}
+
+.np-recognition-art-placeholder {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  background: var(--surface-elevated);
+  color: var(--text-low);
+  border-radius: 4px;
+  font-size: 18px;
+}
+
+.np-recognition-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.np-recognition-title {
+  color: var(--text-high);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.np-recognition-no-match {
+  color: var(--text-low);
+  font-style: italic;
+}
+
+.np-recognition-artist {
+  color: var(--text-medium);
+  font-size: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.np-recognition-time-ago {
+  color: var(--text-low);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.np-recognition-now-tag {
+  color: var(--signal-amber);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}

--- a/tests/Radio.API.Tests/Mappers/AudioDtoMapperTests.cs
+++ b/tests/Radio.API.Tests/Mappers/AudioDtoMapperTests.cs
@@ -1,0 +1,59 @@
+using Radio.API.Mappers;
+using Radio.API.Models;
+
+namespace Radio.API.Tests.Mappers;
+
+/// <summary>
+/// Locks down the raw-confidence → <see cref="ConfidenceBucket"/> projection
+/// introduced in PR 2 of the Radio Controller Polish arc. The threshold table
+/// is the API surface for fingerprint match strength — drift here would push
+/// raw percentages back through to the UI in disguise.
+///
+/// Thresholds (server-side, applied at the API boundary):
+/// <list type="bullet">
+///   <item><description>Strong   — score ≥ 0.90</description></item>
+///   <item><description>Likely   — 0.80 ≤ score &lt; 0.90</description></item>
+///   <item><description>Possible — 0.60 ≤ score &lt; 0.80</description></item>
+///   <item><description>None     — no match OR score &lt; 0.60</description></item>
+/// </list>
+/// </summary>
+public class AudioDtoMapperTests
+{
+  [Theory]
+  [InlineData(0.95, ConfidenceBucket.Strong)]
+  [InlineData(0.90, ConfidenceBucket.Strong)]
+  [InlineData(0.89999, ConfidenceBucket.Likely)]
+  [InlineData(0.85, ConfidenceBucket.Likely)]
+  [InlineData(0.80, ConfidenceBucket.Likely)]
+  [InlineData(0.79999, ConfidenceBucket.Possible)]
+  [InlineData(0.70, ConfidenceBucket.Possible)]
+  [InlineData(0.60, ConfidenceBucket.Possible)]
+  [InlineData(0.59999, ConfidenceBucket.None)]
+  [InlineData(0.50, ConfidenceBucket.None)]
+  [InlineData(0.0, ConfidenceBucket.None)]
+  public void ToConfidenceBucket_FoldsRawScoreIntoBand(double rawScore, ConfidenceBucket expected)
+  {
+    Assert.Equal(expected, AudioDtoMapper.ToConfidenceBucket(isMatch: true, rawConfidence: rawScore));
+  }
+
+  [Fact]
+  public void ToConfidenceBucket_NoMatch_AlwaysReturnsNone()
+  {
+    // A fingerprint event that produced no match must surface as None on the
+    // wire even when there's a stray legacy confidence value sitting on the
+    // server-side record — the wire shape must mirror the IsMatch flag.
+    Assert.Equal(ConfidenceBucket.None,
+      AudioDtoMapper.ToConfidenceBucket(isMatch: false, rawConfidence: 0.95));
+    Assert.Equal(ConfidenceBucket.None,
+      AudioDtoMapper.ToConfidenceBucket(isMatch: false, rawConfidence: null));
+  }
+
+  [Fact]
+  public void ToConfidenceBucket_NullRawConfidence_ReturnsNone()
+  {
+    // A match flagged true but with no raw score (a pipeline edge case) must
+    // also surface as None — the UI's pip widget needs an unambiguous band.
+    Assert.Equal(ConfidenceBucket.None,
+      AudioDtoMapper.ToConfidenceBucket(isMatch: true, rawConfidence: null));
+  }
+}

--- a/tests/Radio.Web.Tests/Components/Shared/ConfidencePipsTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/ConfidencePipsTests.cs
@@ -1,0 +1,127 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Radzen;
+using Radio.Web.Components.Shared;
+using Radio.Web.Models;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for the <see cref="ConfidencePips"/> widget introduced by PR 2 of
+/// the Radio Controller Polish arc. Asserts the lit-pip count for each
+/// <see cref="ConfidenceBucket"/> value, the word label that replaces the
+/// banned raw percentage ("80%"), and the <c>data-bucket</c> attribute that the
+/// design-system stylesheet hooks into for the per-bucket colour rules.
+/// </summary>
+public class ConfidencePipsTests : TestContext
+{
+  public ConfidencePipsTests()
+  {
+    Services.AddRadzenComponents();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+  }
+
+  [Fact]
+  public void Strong_LightsThreePips()
+  {
+    var cut = RenderComponent<ConfidencePips>(p => p
+      .Add(x => x.Bucket, ConfidenceBucket.Strong));
+
+    var pips = cut.FindAll(".confidence-pip");
+    Assert.Equal(3, pips.Count);
+    var lit = cut.FindAll(".confidence-pip.is-lit");
+    Assert.Equal(3, lit.Count);
+  }
+
+  [Fact]
+  public void Likely_LightsTwoPips()
+  {
+    var cut = RenderComponent<ConfidencePips>(p => p
+      .Add(x => x.Bucket, ConfidenceBucket.Likely));
+
+    var lit = cut.FindAll(".confidence-pip.is-lit");
+    Assert.Equal(2, lit.Count);
+    var unlit = cut.FindAll(".confidence-pip:not(.is-lit)");
+    Assert.Single(unlit);
+  }
+
+  [Fact]
+  public void Possible_LightsOnePip()
+  {
+    var cut = RenderComponent<ConfidencePips>(p => p
+      .Add(x => x.Bucket, ConfidenceBucket.Possible));
+
+    var lit = cut.FindAll(".confidence-pip.is-lit");
+    Assert.Single(lit);
+    var unlit = cut.FindAll(".confidence-pip:not(.is-lit)");
+    Assert.Equal(2, unlit.Count);
+  }
+
+  [Fact]
+  public void None_LightsZeroPips_AndLabelReadsNoMatch()
+  {
+    var cut = RenderComponent<ConfidencePips>(p => p
+      .Add(x => x.Bucket, ConfidenceBucket.None));
+
+    var lit = cut.FindAll(".confidence-pip.is-lit");
+    Assert.Empty(lit);
+    Assert.Equal("No match", cut.Find(".confidence-label").TextContent);
+  }
+
+  [Fact]
+  public void Strong_BucketLabelIsStrong()
+  {
+    var cut = RenderComponent<ConfidencePips>(p => p
+      .Add(x => x.Bucket, ConfidenceBucket.Strong));
+
+    Assert.Equal("Strong", cut.Find(".confidence-label").TextContent);
+  }
+
+  [Fact]
+  public void Likely_BucketLabelIsLikely()
+  {
+    var cut = RenderComponent<ConfidencePips>(p => p
+      .Add(x => x.Bucket, ConfidenceBucket.Likely));
+
+    Assert.Equal("Likely", cut.Find(".confidence-label").TextContent);
+  }
+
+  [Fact]
+  public void Possible_BucketLabelIsPossible()
+  {
+    var cut = RenderComponent<ConfidencePips>(p => p
+      .Add(x => x.Bucket, ConfidenceBucket.Possible));
+
+    Assert.Equal("Possible", cut.Find(".confidence-label").TextContent);
+  }
+
+  [Theory]
+  [InlineData(ConfidenceBucket.Strong, "strong")]
+  [InlineData(ConfidenceBucket.Likely, "likely")]
+  [InlineData(ConfidenceBucket.Possible, "possible")]
+  [InlineData(ConfidenceBucket.None, "none")]
+  public void DataBucketAttribute_PropagatesEnumNameLowercased(ConfidenceBucket bucket, string expected)
+  {
+    var cut = RenderComponent<ConfidencePips>(p => p
+      .Add(x => x.Bucket, bucket));
+
+    var root = cut.Find(".confidence-pips");
+    Assert.Equal(expected, root.GetAttribute("data-bucket"));
+  }
+
+  [Theory]
+  [InlineData(ConfidenceBucket.Strong)]
+  [InlineData(ConfidenceBucket.Likely)]
+  [InlineData(ConfidenceBucket.Possible)]
+  [InlineData(ConfidenceBucket.None)]
+  public void RenderedMarkup_ContainsNoRawPercentage(ConfidenceBucket bucket)
+  {
+    // Regression guard: PR 2's headline acceptance criterion bans the raw
+    // percentage text from the recognition surface. The widget that REPLACES
+    // those percentages must itself never emit one.
+    var cut = RenderComponent<ConfidencePips>(p => p
+      .Add(x => x.Bucket, bucket));
+
+    Assert.DoesNotMatch(@"\b\d{1,3}\s?%", cut.Markup);
+  }
+}

--- a/tests/Radio.Web.Tests/Components/Shared/NowPlayingPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/NowPlayingPanelTests.cs
@@ -354,4 +354,76 @@ public class NowPlayingPanelTests : TestContext
     var result = NowPlayingPanel.FormatTimeAgo(threeMinutesAgo, now);
     Assert.Equal("3m ago", result);
   }
+
+  // ─── Wire-path regression: RadioStateChanged carries the typed DTO ─────────
+  //
+  // Tester surfaced during live-kiosk UAT that the recognition NOW row never
+  // anchored because the SignalR RadioStateChanged handler discarded the
+  // payload and re-fetched via REST. The REST endpoint cannot populate
+  // NowPlayingMatchId (it lives in AudioStateUpdateService._currentMatchId
+  // which RadioController has no access to). After the fix, the handler
+  // accepts a RadioStateDto and the panel anchors immediately on hub push.
+  //
+  // This test proves the wire-path end-to-end: build a real hub service,
+  // mount the panel, invoke the typed event with a payload carrying
+  // NowPlayingMatchId, and assert the NOW row anchors to the matching event.
+
+  [Fact]
+  public async Task Recognition_AnchorsNowRow_WhenRadioStateChangedDtoArrives()
+  {
+    var matches = new List<FingerprintEventDto>
+    {
+      MakeEvent("m-old", "Older Song", "Old Artist", ConfidenceBucket.Likely, DateTime.UtcNow.AddMinutes(-5)),
+      MakeEvent("m-target", "Anchored Track", "Anchor Artist", ConfidenceBucket.Strong, DateTime.UtcNow.AddSeconds(-10))
+    };
+    var status = new FingerprintStatusDto
+    {
+      IsEnabled = true,
+      Phase = "Matched",
+      RecentEvents = matches
+    };
+
+    var cut = RenderComponent<NowPlayingPanel>();
+
+    // Seed the fingerprint events without an anchor — same reflective injection
+    // pattern the rest of the suite uses. _radioState stays null until the
+    // typed hub event fires below.
+    var instance = cut.Instance;
+    var type = typeof(NowPlayingPanel);
+    var flags = BindingFlags.NonPublic | BindingFlags.Instance;
+    type.GetField("_fpStatus", flags)!.SetValue(instance, status);
+    type.GetField("_fpEventsReversed", flags)!
+      .SetValue(instance, Enumerable.Reverse(status.RecentEvents).ToList());
+    type.GetField("_showFingerprintDetail", flags)!.SetValue(instance, true);
+    cut.Render();
+
+    // Sanity: nothing is anchored yet (no NowPlayingMatchId).
+    Assert.Empty(cut.FindAll(".np-recognition-row-current"));
+
+    // Now drive the typed hub event. The hub service is a real instance in DI;
+    // we reach into its compiler-generated backing field and invoke directly,
+    // mirroring what SignalR would do on a live wire push.
+    var hubService = Services.GetRequiredService<AudioStateHubService>();
+    var eventField = typeof(AudioStateHubService).GetField(
+      nameof(AudioStateHubService.RadioStateChanged),
+      BindingFlags.NonPublic | BindingFlags.Instance);
+    Assert.NotNull(eventField);
+    var handler = (Func<RadioStateDto, Task>?)eventField!.GetValue(hubService);
+    Assert.NotNull(handler);
+
+    var dto = new RadioStateDto(
+      Frequency: 92.5e6, Band: "FM", Step: 100e3,
+      SignalStrength: 70, IsScanning: false, ScanDirection: null,
+      ScanStopThreshold: -18.0, Gain: 28, AutoGain: true,
+      Equalizer: "Flat", DeviceVolume: 70,
+      NowPlayingMatchId: "m-target");
+
+    await cut.InvokeAsync(() => handler!.Invoke(dto));
+
+    // The NOW row now anchors to the target match — proving the typed payload
+    // reached the panel without a REST refetch.
+    var currentRows = cut.FindAll(".np-recognition-row-current");
+    Assert.Single(currentRows);
+    Assert.Equal("m-target", currentRows[0].GetAttribute("data-match-id"));
+  }
 }

--- a/tests/Radio.Web.Tests/Components/Shared/NowPlayingPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/NowPlayingPanelTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Bunit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -5,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Radzen;
 using Radio.Web.Components.Shared;
+using Radio.Web.Models;
 using Radio.Web.Services;
 using Radio.Web.Services.ApiClients;
 using Radio.Web.Services.Hub;
@@ -12,10 +14,30 @@ using Radio.Web.Services.Hub;
 namespace Radio.Web.Tests.Components.Shared;
 
 /// <summary>
-/// bUnit tests for <see cref="NowPlayingPanel"/> after PR 3's display-projection rework.
-/// Focuses on the invariant that the panel never emits a raw <see cref="TimeSpan"/>
-/// <c>ToString()</c> artefact (e.g. <c>00:03:00.6628571</c>) anywhere in its markup, even
-/// in the empty/default state — the formatter layer must be the only path to the screen.
+/// bUnit tests for <see cref="NowPlayingPanel"/>.
+///
+/// The first three tests pre-date PR 2 and assert the panel's invariants around
+/// timestamp formatting and the friendly empty-state placeholder. They render
+/// the panel against a no-API-server backdrop and assert against the markup.
+///
+/// The PR 2 tests below add coverage for the recognition-stream rewrite:
+///
+/// <list type="bullet">
+///   <item>NOW + EARLIER headers anchor the active match when
+///         <c>RadioStateDto.NowPlayingMatchId</c> matches an event row.</item>
+///   <item>The active match row carries the <c>np-recognition-row-current</c>
+///         class so the design-system stylesheet can paint the amber border.</item>
+///   <item>A no-match event surfaces the italic "No match in window" sentence,
+///         never the legacy "--" fallback.</item>
+///   <item>No raw percentage character (<c>%</c>) appears anywhere in the
+///         recognition stream — the PR 2 headline acceptance criterion.</item>
+///   <item>The legacy <c>Fingerprints: X/min · Lookups: Y/min</c> telemetry
+///         strip is absent from the panel header.</item>
+/// </list>
+///
+/// The PR 2 tests drive state by reflectively populating the private fields the
+/// component would normally fill from API/hub callbacks — the same approach
+/// <c>NowPlayingDockTests</c> uses for its hub-push regression cases.
 /// </summary>
 public class NowPlayingPanelTests : TestContext
 {
@@ -41,6 +63,7 @@ public class NowPlayingPanelTests : TestContext
 
     Services.AddHttpClient<AudioApiService>();
     Services.AddHttpClient<ConfigurationApiService>();
+    Services.AddHttpClient<RadioApiService>();
 
     Services.AddSingleton(sp =>
       new AudioStateHubService(
@@ -87,5 +110,248 @@ public class NowPlayingPanelTests : TestContext
     var cut = RenderComponent<NowPlayingPanel>();
     // The transport bar exists even on empty state.
     Assert.Contains("transport-group", cut.Markup);
+  }
+
+  // ─── PR 2: Recognition stream ──────────────────────────────────────────────
+
+  /// <summary>
+  /// Reflectively poke the component into "recognition stream open with state X"
+  /// without going through the real API/hub callbacks. The component already has
+  /// fields backing _fpStatus, _fpEventsReversed, _radioState, _showFingerprintDetail
+  /// — we set them and re-render so the recognition branch lights up.
+  /// </summary>
+  private static void SetRecognitionState(
+    IRenderedComponent<NowPlayingPanel> cut,
+    FingerprintStatusDto fpStatus,
+    string? nowPlayingMatchId)
+  {
+    var instance = cut.Instance;
+    var type = typeof(NowPlayingPanel);
+    var flags = BindingFlags.NonPublic | BindingFlags.Instance;
+
+    type.GetField("_fpStatus", flags)!.SetValue(instance, fpStatus);
+    type.GetField("_fpEventsReversed", flags)!
+      .SetValue(instance, Enumerable.Reverse(fpStatus.RecentEvents).ToList());
+    type.GetField("_radioState", flags)!.SetValue(instance,
+      new RadioStateDto(
+        Frequency: 92.5e6, Band: "FM", Step: 100e3,
+        SignalStrength: 70, IsScanning: false, ScanDirection: null,
+        ScanStopThreshold: -18.0, Gain: 28, AutoGain: true,
+        Equalizer: "Flat", DeviceVolume: 70,
+        NowPlayingMatchId: nowPlayingMatchId));
+    type.GetField("_showFingerprintDetail", flags)!.SetValue(instance, true);
+    cut.Render();
+  }
+
+  private static FingerprintEventDto MakeEvent(
+    string matchId,
+    string? title,
+    string? artist = null,
+    ConfidenceBucket confidence = ConfidenceBucket.None,
+    DateTime? timestamp = null)
+  {
+    return new FingerprintEventDto
+    {
+      MatchId = matchId,
+      AudioSource = "SDR Radio",
+      SourceType = "Radio",
+      IsMatch = title != null,
+      Count = 1,
+      Confidence = confidence,
+      Title = title,
+      Artist = artist,
+      Phase = title != null ? "Matched" : "NoMatch",
+      Timestamp = timestamp ?? DateTime.UtcNow.AddMinutes(-1)
+    };
+  }
+
+  [Fact]
+  public void Recognition_RendersNowAndEarlierHeaders_WhenMatchesPresent()
+  {
+    var matches = new List<FingerprintEventDto>
+    {
+      MakeEvent("m-1", "Older Song", "Old Artist", ConfidenceBucket.Likely, DateTime.UtcNow.AddMinutes(-5)),
+      MakeEvent("m-2", "Current Hit", "Active Artist", ConfidenceBucket.Strong, DateTime.UtcNow.AddSeconds(-30))
+    };
+    var status = new FingerprintStatusDto
+    {
+      IsEnabled = true,
+      Phase = "Matched",
+      RecentEvents = matches
+    };
+
+    var cut = RenderComponent<NowPlayingPanel>();
+    SetRecognitionState(cut, status, nowPlayingMatchId: "m-2");
+
+    var headers = cut.FindAll(".np-recognition-header");
+    Assert.Equal(2, headers.Count);
+    Assert.Equal("NOW", headers[0].TextContent);
+    Assert.Equal("EARLIER", headers[1].TextContent);
+  }
+
+  [Fact]
+  public void Recognition_CurrentMatchHasAmberBorderClass()
+  {
+    var matches = new List<FingerprintEventDto>
+    {
+      MakeEvent("m-1", "Older Song", "Old Artist", ConfidenceBucket.Likely, DateTime.UtcNow.AddMinutes(-5)),
+      MakeEvent("m-anchor", "Now Playing", "Anchor Artist", ConfidenceBucket.Strong, DateTime.UtcNow.AddSeconds(-10))
+    };
+    var status = new FingerprintStatusDto
+    {
+      IsEnabled = true,
+      Phase = "Matched",
+      RecentEvents = matches
+    };
+
+    var cut = RenderComponent<NowPlayingPanel>();
+    SetRecognitionState(cut, status, nowPlayingMatchId: "m-anchor");
+
+    var currentRows = cut.FindAll(".np-recognition-row-current");
+    Assert.Single(currentRows);
+    Assert.Equal("m-anchor", currentRows[0].GetAttribute("data-match-id"));
+  }
+
+  [Fact]
+  public void Recognition_NoMatchRow_RendersItalicizedSentence()
+  {
+    var matches = new List<FingerprintEventDto>
+    {
+      MakeEvent("m-nomatch", title: null, confidence: ConfidenceBucket.None)
+    };
+    var status = new FingerprintStatusDto
+    {
+      IsEnabled = true,
+      Phase = "NoMatch",
+      RecentEvents = matches
+    };
+
+    var cut = RenderComponent<NowPlayingPanel>();
+    SetRecognitionState(cut, status, nowPlayingMatchId: null);
+
+    var noMatchSpan = cut.Find(".np-recognition-no-match");
+    Assert.Equal("No match in window", noMatchSpan.TextContent);
+    // The "--" placeholder used by the prior <table> rendering must NOT appear
+    // anywhere inside the recognition stream branch.
+    var stream = cut.Find(".np-recognition-stream");
+    Assert.DoesNotContain("--", stream.InnerHtml);
+  }
+
+  [Fact]
+  public void Recognition_DropsRawConfidencePercentage()
+  {
+    var matches = new List<FingerprintEventDto>
+    {
+      MakeEvent("m-1", "Song A", "Artist A", ConfidenceBucket.Strong, DateTime.UtcNow.AddSeconds(-15)),
+      MakeEvent("m-2", "Song B", "Artist B", ConfidenceBucket.Likely, DateTime.UtcNow.AddMinutes(-3)),
+      MakeEvent("m-3", title: null, confidence: ConfidenceBucket.None, timestamp: DateTime.UtcNow.AddMinutes(-7))
+    };
+    var status = new FingerprintStatusDto
+    {
+      IsEnabled = true,
+      Phase = "Matched",
+      RecentEvents = matches
+    };
+
+    var cut = RenderComponent<NowPlayingPanel>();
+    SetRecognitionState(cut, status, nowPlayingMatchId: "m-1");
+
+    var stream = cut.Find(".np-recognition-stream");
+    // PR 2 acceptance gate: no row in the recognition surface contains the
+    // literal "80%" / "94%" / "0%" / any other raw percentage. Match the
+    // bare-percent pattern AND a few-digit-percent pattern to be safe.
+    Assert.DoesNotMatch(@"\b\d{1,3}\s?%", stream.InnerHtml);
+  }
+
+  [Fact]
+  public void Recognition_TelemetryStripRemoved()
+  {
+    // Even with fingerprint detail open, the panel header no longer carries the
+    // legacy "Fingerprints: X.X/min · Lookups: Y.Y/min" strip — those values
+    // are scoped out of the recognition surface entirely per the plan.
+    var matches = new List<FingerprintEventDto>
+    {
+      MakeEvent("m-1", "Any Song", "Any Artist", ConfidenceBucket.Possible)
+    };
+    var status = new FingerprintStatusDto
+    {
+      IsEnabled = true,
+      Phase = "Matched",
+      FingerprintsPerMinute = 4.5,
+      MetadataCallsPerMinute = 1.2,
+      RecentEvents = matches
+    };
+
+    var cut = RenderComponent<NowPlayingPanel>();
+    SetRecognitionState(cut, status, nowPlayingMatchId: "m-1");
+
+    Assert.DoesNotContain("Fingerprints:", cut.Markup);
+    Assert.DoesNotContain("Lookups:", cut.Markup);
+    Assert.DoesNotContain("/min", cut.Markup);
+  }
+
+  [Fact]
+  public void Recognition_ConfidencePips_RenderedForEachMatch()
+  {
+    var matches = new List<FingerprintEventDto>
+    {
+      MakeEvent("m-1", "Older Song", "Old Artist", ConfidenceBucket.Likely, DateTime.UtcNow.AddMinutes(-5)),
+      MakeEvent("m-anchor", "Now Playing", "Active Artist", ConfidenceBucket.Strong, DateTime.UtcNow.AddSeconds(-10))
+    };
+    var status = new FingerprintStatusDto
+    {
+      IsEnabled = true,
+      Phase = "Matched",
+      RecentEvents = matches
+    };
+
+    var cut = RenderComponent<NowPlayingPanel>();
+    SetRecognitionState(cut, status, nowPlayingMatchId: "m-anchor");
+
+    // One ConfidencePips widget per row (active + earlier).
+    var pips = cut.FindAll(".confidence-pips");
+    Assert.Equal(2, pips.Count);
+  }
+
+  [Fact]
+  public void Recognition_LegacyTableHeader_NotRendered()
+  {
+    // The old recognition surface was a <table> with "Conf%" / "Track" / "Src"
+    // column headers. PR 2 drops the table entirely.
+    var matches = new List<FingerprintEventDto>
+    {
+      MakeEvent("m-1", "Song A", "Artist A", ConfidenceBucket.Strong)
+    };
+    var status = new FingerprintStatusDto
+    {
+      IsEnabled = true,
+      Phase = "Matched",
+      RecentEvents = matches
+    };
+
+    var cut = RenderComponent<NowPlayingPanel>();
+    SetRecognitionState(cut, status, nowPlayingMatchId: "m-1");
+
+    Assert.DoesNotContain("Conf%", cut.Markup);
+    // The recognition surface no longer renders an HTML <table> element.
+    Assert.Empty(cut.FindAll(".np-recognition-stream table"));
+  }
+
+  [Fact]
+  public void FormatTimeAgo_RecentSeconds_RendersSecondsAgo()
+  {
+    var now = new DateTime(2026, 5, 17, 12, 0, 0, DateTimeKind.Utc);
+    var twentySecondsAgo = now.AddSeconds(-20);
+    var result = NowPlayingPanel.FormatTimeAgo(twentySecondsAgo, now);
+    Assert.Equal("20s ago", result);
+  }
+
+  [Fact]
+  public void FormatTimeAgo_Minutes_RendersMinutesAgo()
+  {
+    var now = new DateTime(2026, 5, 17, 12, 0, 0, DateTimeKind.Utc);
+    var threeMinutesAgo = now.AddMinutes(-3);
+    var result = NowPlayingPanel.FormatTimeAgo(threeMinutesAgo, now);
+    Assert.Equal("3m ago", result);
   }
 }

--- a/tests/Radio.Web.Tests/Models/ConfidenceBucketSerializationTests.cs
+++ b/tests/Radio.Web.Tests/Models/ConfidenceBucketSerializationTests.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using Radio.Web.Models;
+
+namespace Radio.Web.Tests.Models;
+
+/// <summary>
+/// Regression tests for the JSON contract between Radio.API (server) and
+/// Radio.Web (client) for the <see cref="ConfidenceBucket"/> enum.
+///
+/// <para>
+/// The API serializes enums as strings via a global
+/// <c>JsonStringEnumConverter</c> registered in <c>Radio.API/Program.cs</c>.
+/// HttpClient calls in <c>AudioApiService</c> (e.g.
+/// <c>GetFromJsonAsync&lt;FingerprintStatusDto&gt;</c>) use default
+/// <c>JsonSerializerOptions</c>, which do <em>not</em> include an enum
+/// converter. Without <c>[JsonConverter(typeof(JsonStringEnumConverter))]</c>
+/// on the enum declaration, every fingerprint status fetch would throw
+/// <c>JsonException</c> and silently leave the recognition UI blank.
+/// </para>
+///
+/// <para>
+/// These tests exercise the deserialization path with <em>default</em>
+/// options on purpose — bUnit tests reflectively-inject DTOs and bypass
+/// the HttpClient pipeline, so without this test the JSON contract is
+/// invisible to the test suite. UAT caught the production bug; this
+/// test ensures the regression never returns.
+/// </para>
+/// </summary>
+public class ConfidenceBucketSerializationTests
+{
+  [Theory]
+  [InlineData("None", ConfidenceBucket.None)]
+  [InlineData("Possible", ConfidenceBucket.Possible)]
+  [InlineData("Likely", ConfidenceBucket.Likely)]
+  [InlineData("Strong", ConfidenceBucket.Strong)]
+  public void FingerprintEventDto_DeserializesConfidenceFromStringEnum_WithDefaultOptions(
+    string serverEnumString,
+    ConfidenceBucket expected)
+  {
+    // Mirrors the JSON shape the API emits — string enum, camelCase property names.
+    // GetFromJsonAsync defaults: PropertyNameCaseInsensitive=true, no enum converter.
+    var json = $$"""
+      {
+        "matchId": "abc-123",
+        "audioSource": "SDR Radio",
+        "sourceType": "Radio",
+        "isMatch": true,
+        "count": 1,
+        "confidence": "{{serverEnumString}}",
+        "title": "Test Track",
+        "artist": "Test Artist",
+        "album": null,
+        "hasAlbumArt": false,
+        "phase": "Matched",
+        "timestamp": "2026-05-17T12:00:00Z"
+      }
+      """;
+
+    var options = new JsonSerializerOptions
+    {
+      // Match what System.Net.Http.Json.HttpClientJsonExtensions uses by default.
+      PropertyNameCaseInsensitive = true
+    };
+
+    var dto = JsonSerializer.Deserialize<FingerprintEventDto>(json, options);
+
+    Assert.NotNull(dto);
+    Assert.Equal(expected, dto!.Confidence);
+    Assert.Equal("abc-123", dto.MatchId);
+  }
+
+  [Fact]
+  public void FingerprintStatusDto_DeserializesNestedConfidenceEnums_WithDefaultOptions()
+  {
+    // The real wire shape: a FingerprintStatusDto containing RecentEvents,
+    // each with a Confidence enum. This is the exact payload that broke on
+    // first contact with a real API in UAT.
+    var json = """
+      {
+        "phase": "Matched",
+        "isEnabled": true,
+        "fingerprintsPerMinute": 4.0,
+        "metadataCallsPerMinute": 1.0,
+        "recentEvents": [
+          {
+            "matchId": "m-1",
+            "audioSource": "SDR Radio",
+            "sourceType": "Radio",
+            "isMatch": true,
+            "count": 1,
+            "confidence": "Strong",
+            "title": "Track One",
+            "phase": "Matched",
+            "timestamp": "2026-05-17T12:00:00Z"
+          },
+          {
+            "matchId": "m-2",
+            "audioSource": "SDR Radio",
+            "sourceType": "Radio",
+            "isMatch": false,
+            "count": 1,
+            "confidence": "None",
+            "phase": "NoMatch",
+            "timestamp": "2026-05-17T12:01:00Z"
+          }
+        ],
+        "lastError": null
+      }
+      """;
+
+    var options = new JsonSerializerOptions
+    {
+      PropertyNameCaseInsensitive = true
+    };
+
+    var dto = JsonSerializer.Deserialize<FingerprintStatusDto>(json, options);
+
+    Assert.NotNull(dto);
+    Assert.Equal(2, dto!.RecentEvents.Count);
+    Assert.Equal(ConfidenceBucket.Strong, dto.RecentEvents[0].Confidence);
+    Assert.Equal(ConfidenceBucket.None, dto.RecentEvents[1].Confidence);
+  }
+
+  [Theory]
+  [InlineData(ConfidenceBucket.None, "\"None\"")]
+  [InlineData(ConfidenceBucket.Possible, "\"Possible\"")]
+  [InlineData(ConfidenceBucket.Likely, "\"Likely\"")]
+  [InlineData(ConfidenceBucket.Strong, "\"Strong\"")]
+  public void ConfidenceBucket_SerializesAsString_WithDefaultOptions(
+    ConfidenceBucket value,
+    string expectedJson)
+  {
+    // Outbound contract sanity check — also confirms the [JsonConverter] is
+    // wired bidirectionally, not just for deserialization.
+    var json = JsonSerializer.Serialize(value);
+    Assert.Equal(expectedJson, json);
+  }
+}

--- a/tests/Radio.Web.Tests/Services/AudioStateHubServiceTests.cs
+++ b/tests/Radio.Web.Tests/Services/AudioStateHubServiceTests.cs
@@ -85,12 +85,15 @@ public class AudioStateHubServiceTests
     Func<Task> handler = () => Task.CompletedTask;
     Func<NowPlayingDto?, Task> nowPlayingHandler = _ => Task.CompletedTask;
     Func<VolumeDto?, Task> volumeHandler = _ => Task.CompletedTask;
+    // RadioStateChanged now carries the typed DTO so subscribers can read
+    // NowPlayingMatchId directly without a REST refetch.
+    Func<RadioStateDto, Task> radioStateHandler = _ => Task.CompletedTask;
 
     // Act - Subscribe to all event types (should not throw)
     _service.PlaybackStateChanged += handler;
     _service.NowPlayingChanged += nowPlayingHandler;
     _service.QueueChanged += handler;
-    _service.RadioStateChanged += handler;
+    _service.RadioStateChanged += radioStateHandler;
     _service.VolumeChanged += volumeHandler;
     _service.SourceChanged += handler;
 
@@ -98,7 +101,7 @@ public class AudioStateHubServiceTests
     _service.PlaybackStateChanged -= handler;
     _service.NowPlayingChanged -= nowPlayingHandler;
     _service.QueueChanged -= handler;
-    _service.RadioStateChanged -= handler;
+    _service.RadioStateChanged -= radioStateHandler;
     _service.VolumeChanged -= volumeHandler;
     _service.SourceChanged -= handler;
 


### PR DESCRIPTION
## Summary

PR 2 of the Radio Controller Polish arc (handoff §P0·3 / plan §PR 2). The
recognition surface inside `NowPlayingPanel` is rewritten from a `<table>`
that surfaced raw confidence percentages (`78%`, `94%`, `0%`, …) into a
flex stream anchored on the currently-playing match. Raw scores stay
server-side; the API folds them into a coarse `ConfidenceBucket` enum
(`None` / `Possible` / `Likely` / `Strong`) and the UI renders pips +
word.

- **DTO + projection** (greenfield rename — no back-compat shim):
  - New `ConfidenceBucket` enum on `Radio.API.Models` (mirrored on
    `Radio.Web.Models`). Threshold map applied at the API mapper:
    `≥0.90 → Strong`, `0.80–0.89 → Likely`, `0.60–0.79 → Possible`,
    everything else (incl. no-match / null score) → `None`.
  - `FingerprintEventDto.LastConfidence` (double?) **removed** —
    replaced with `Confidence: ConfidenceBucket`. Raw score retained on
    the server-side `FingerprintEventRecord` for diagnostic logging.
  - `FingerprintEventRecord` (Core) gains a stable `MatchId` per
    record (`Guid.NewGuid().ToString("n")`) so the UI can anchor the
    NOW row across aggregations.
  - `RadioStateDto` gains `NowPlayingMatchId` (nullable string).
    `AudioStateUpdateService.UpdateCurrentMatchAnchor` tracks the
    most-recent matched event's id on each fingerprint snapshot and
    threads it through `RadioStateMapper`. `HasRadioStateChanged`
    extended so anchor flips broadcast.
- **UI**:
  - New `ConfidencePips.razor` shared widget — 3-pip indicator + label.
    Pip colour swaps via `data-bucket` attribute (CSS in
    design-system.css §U Confidence pips).
  - `NowPlayingPanel` recognition `<table>` deleted. Rewritten as a
    flex column: `NOW` header above the active match (amber-left-border,
    amber dot on art, `now` tag); `EARLIER` header above the rest;
    failed lookups render `"No match in window"` in italics instead of
    `--`.
  - Panel-header telemetry strip (`Fingerprints/min · Lookups/min`)
    removed. If those values resurface they'll live in the DevTray —
    Arc 1 PR 6 — in a future PR, not in scope here.
  - `GetFingerprintBadgeText` for the `Matched` phase now reports the
    bucket word, not a raw percentage.

## Acceptance criteria (from plan §PR 2)

- [x] No row in the panel contains the literal text `80%` (or any other raw percentage).
- [x] The currently-playing match is visually anchored at the top of the stream with a NOW header + amber-left-border.
- [x] A row with no fingerprint match reads as a sentence (`"No match in window"`), not as `--`.
- [x] Confidence reads as a word and a row of pips, never as a percentage.
- [x] No `Fingerprints: X/min` or `Lookups: Y/min` telemetry strip in the panel header.

## Tests

- **`ConfidencePipsTests`** (new, 11 cases) — lit-pip count per bucket,
  label text per bucket, `data-bucket` attribute propagation, no-raw-percent
  regression guard.
- **`NowPlayingPanelTests`** (8 new cases) — NOW/EARLIER headers,
  active-row amber class, italic `No match in window` rendering, no raw
  percent in stream, telemetry strip absent, ConfidencePips widgets one
  per row, legacy `<table>` not rendered, `FormatTimeAgo` s/m boundary.
- **`AudioDtoMapperTests`** (new, 13 cases) — full bucket threshold table
  (Strong/Likely/Possible/None edges, null score, no-match override).

```
Radio.Web.Tests:           373/373 pass
Radio.API.Tests:           264/265 pass (1 pre-existing fail, unrelated — task #10)
Radio.Fingerprinting.Tests: 93/95  (1 network flake to coverartarchive.org, 1 skipped — unrelated)
Build: 0 errors, 0 PR-2 warnings.
```

The pre-existing `AudioEngineInitializationServiceTests.StartAsync_EnumeratesDevices`
failure is unrelated to PR 2 — it's task #10 in the project queue.

## Test plan

Hardware-required UAT (Coordinator will dispatch Tester next):

- [ ] Tune RTL-SDR to an FM station with strong RDS + known content; fingerprinter identifies a track.
- [ ] Open the recognition panel via the badge-tap gesture in the now-playing column.
- [ ] NOW header anchors above the active match with an amber left border + dot in the art square; "now" tag instead of time-ago.
- [ ] EARLIER header lists older matches with time-ago labels (`Xs ago` / `Xm ago`).
- [ ] Tune to dead air; a "No match in window" row appears in italic dim text — no `--`, no `0%`.
- [ ] DevTools search for `%` inside any `.np-recognition-row` returns zero hits.
- [ ] The badge inside the now-playing column reads `Strong` / `Likely` / `Possible`, never a percentage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)