### PR TITLE
fix(web): restore 6 visualizer modes regressed in Arc 1 PR 4

### DIFF
--- a/src/Radio.Web/Components/Shared/VisualizerPanel.razor
+++ b/src/Radio.Web/Components/Shared/VisualizerPanel.razor
@@ -7,13 +7,12 @@
 @implements IAsyncDisposable
 
 @*
-  VisualizerPanel — full-bleed visualizer with promoted 3-segment mode picker.
+  VisualizerPanel — full-bleed visualizer with promoted 6-segment mode picker.
 
   PR 4 rework (handoff §P1·3):
-    • Replaced the floating chip group with a full-width 3-segment header
-      (VU / WAVE / SPECTRUM) — 44px tall, mono 12px uppercase 0.10em
-      letter-spacing, active segment tinted with --accent-dim + accent
-      underline.
+    • Replaced the floating chip group with a full-width header — 44px tall,
+      mono 12px uppercase 0.10em letter-spacing, active segment tinted with
+      --accent-dim + accent underline.
     • Canvas now fills the remaining vertical space — no inset padding.
     • "Connected" pill collapsed to an 8px dot at top-right.
     • The "Updates: NN/sec" overlay moves out of the canvas into
@@ -21,35 +20,54 @@
     • Frequency-band axis labels live in a 16px strip under the canvas
       (mono 10px, low-contrast).
 
-  The underlying VisualizationMode enum still has six entries because the
-  visualizer.js module supports waveform/phase/spectrogram/circular. The
-  promoted header only exposes the three primary modes; the secondary
-  modes remain reachable from the dev tray (PR 6) and from saved
-  preferences.
+  Hot-fix (post-PR 4): the picker exposes all six modes the underlying
+  visualizer.js module supports — VU / Wave / Spectrum / Fall (Spectrogram)
+  / Ring (Circular) / Phase (PhaseScope). The handoff spec referenced only
+  three modes because the spec author worked from a 3-mode screenshot, but
+  the enum, JS draw calls, and SignalR subscribe paths were always wired
+  for all six.
 *@
 
 <div class="viz-panel">
-  <!-- 3-segment mode picker header -->
+  <!-- 6-segment mode picker header -->
   <div class="visualizer-header">
     <div class="visualizer-mode-picker" role="tablist" aria-label="Visualizer mode">
-      <button class="visualizer-mode @(IsVuMode ? "is-active" : "")"
+      <button class="visualizer-mode @(_currentMode == VisualizationMode.VUMeter ? "is-active" : "")"
               type="button"
               @onclick="@(() => SelectMode(VisualizationMode.VUMeter))"
               role="tab"
-              aria-selected="@(IsVuMode ? "true" : "false")"
+              aria-selected="@(_currentMode == VisualizationMode.VUMeter ? "true" : "false")"
               aria-label="VU meter mode">VU</button>
-      <button class="visualizer-mode @(IsWaveMode ? "is-active" : "")"
+      <button class="visualizer-mode @(_currentMode == VisualizationMode.Waveform ? "is-active" : "")"
               type="button"
               @onclick="@(() => SelectMode(VisualizationMode.Waveform))"
               role="tab"
-              aria-selected="@(IsWaveMode ? "true" : "false")"
+              aria-selected="@(_currentMode == VisualizationMode.Waveform ? "true" : "false")"
               aria-label="Waveform mode">Wave</button>
-      <button class="visualizer-mode @(IsSpectrumMode ? "is-active" : "")"
+      <button class="visualizer-mode @(_currentMode == VisualizationMode.Spectrum ? "is-active" : "")"
               type="button"
               @onclick="@(() => SelectMode(VisualizationMode.Spectrum))"
               role="tab"
-              aria-selected="@(IsSpectrumMode ? "true" : "false")"
+              aria-selected="@(_currentMode == VisualizationMode.Spectrum ? "true" : "false")"
               aria-label="Spectrum mode">Spectrum</button>
+      <button class="visualizer-mode @(_currentMode == VisualizationMode.Spectrogram ? "is-active" : "")"
+              type="button"
+              @onclick="@(() => SelectMode(VisualizationMode.Spectrogram))"
+              role="tab"
+              aria-selected="@(_currentMode == VisualizationMode.Spectrogram ? "true" : "false")"
+              aria-label="Spectrogram (falling spectrum) mode">Fall</button>
+      <button class="visualizer-mode @(_currentMode == VisualizationMode.Circular ? "is-active" : "")"
+              type="button"
+              @onclick="@(() => SelectMode(VisualizationMode.Circular))"
+              role="tab"
+              aria-selected="@(_currentMode == VisualizationMode.Circular ? "true" : "false")"
+              aria-label="Circular spectrum mode">Ring</button>
+      <button class="visualizer-mode @(_currentMode == VisualizationMode.PhaseScope ? "is-active" : "")"
+              type="button"
+              @onclick="@(() => SelectMode(VisualizationMode.PhaseScope))"
+              role="tab"
+              aria-selected="@(_currentMode == VisualizationMode.PhaseScope ? "true" : "false")"
+              aria-label="Phase scope mode">Phase</button>
     </div>
     <span class="visualizer-conn-dot @(VisualizationHub.IsConnected ? "is-connected" : "")"
           aria-label="@(VisualizationHub.IsConnected ? "Connected" : "Disconnected")"
@@ -107,11 +125,8 @@
   private int _frameCountSinceLastSample;
   private System.Threading.Timer? _telemetryTimer;
 
-  // Map the six-mode enum to the three primary buckets the header exposes.
-  private bool IsVuMode => _currentMode == VisualizationMode.VUMeter;
-  private bool IsWaveMode =>
-    _currentMode == VisualizationMode.Waveform ||
-    _currentMode == VisualizationMode.PhaseScope;
+  // Spectrum-family modes share the freq-band axis strip beneath the canvas.
+  // Picker buttons compare _currentMode directly — no per-button helper needed.
   private bool IsSpectrumMode =>
     _currentMode == VisualizationMode.Spectrum ||
     _currentMode == VisualizationMode.Spectrogram ||

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -1971,7 +1971,7 @@ body {
 .visualizer-mode-picker {
   flex: 1;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(6, 1fr);
   height: 44px;
 }
 

--- a/tests/Radio.Web.Tests/Components/Shared/VisualizerPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/VisualizerPanelTests.cs
@@ -1,0 +1,204 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Radzen;
+using Radio.Web.Components.Shared;
+using Radio.Web.Services;
+using Radio.Web.Services.ApiClients;
+using Radio.Web.Services.Hub;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for the <see cref="VisualizerPanel"/> mode picker.
+///
+/// PR 4 of the design tightening arc (handoff §P1·3) promoted the mode
+/// picker from a floating chip group into a full-width header. The
+/// original spec referenced only three modes (VU / Wave / Spectrum)
+/// because the spec author worked from a 3-mode screenshot, but the
+/// underlying <c>VisualizationMode</c> enum, the JS visualizer module,
+/// and the SignalR subscribe / unsubscribe paths were always wired for
+/// six modes:
+///
+/// <list type="bullet">
+///   <item>VU (VUMeter)</item>
+///   <item>Wave (Waveform)</item>
+///   <item>Spectrum (Spectrum)</item>
+///   <item>Fall (Spectrogram)</item>
+///   <item>Ring (Circular)</item>
+///   <item>Phase (PhaseScope)</item>
+/// </list>
+///
+/// These tests lock the contract that all six segments render in the
+/// header and that clicking each segment activates that segment.
+/// </summary>
+public class VisualizerPanelTests : TestContext
+{
+  private readonly ILoggerFactory _loggerFactory;
+
+  public VisualizerPanelTests()
+  {
+    _loggerFactory = new NullLoggerFactory();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+
+    var configuration = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>
+      {
+        { "ApiBaseUrl", "http://localhost:5000" }
+      })
+      .Build();
+
+    Services.AddSingleton<IConfiguration>(configuration);
+    Services.AddSingleton(_loggerFactory);
+    Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+    Services.AddRadzenComponents();
+
+    // ConfigurationApiService needs an HttpClient; it'll fail to connect
+    // (no server running in the test rig) which is fine — the panel
+    // swallows preference-load exceptions and stays at its default mode.
+    Services.AddHttpClient<ConfigurationApiService>();
+
+    // The hub services connect lazily; without a server they stay
+    // disconnected. The panel handles that path (IsConnected=false → dot
+    // stays red, no data callbacks fire).
+    Services.AddSingleton(sp =>
+      new AudioVisualizationHubService(
+        NullLogger<AudioVisualizationHubService>.Instance,
+        sp.GetRequiredService<IConfiguration>()
+      )
+    );
+
+    Services.AddSingleton<VisualizerTelemetryService>();
+  }
+
+  protected override void Dispose(bool disposing)
+  {
+    if (disposing)
+    {
+      _loggerFactory?.Dispose();
+    }
+    base.Dispose(disposing);
+  }
+
+  [Fact]
+  public void ModePicker_RendersExactlySixModeButtons()
+  {
+    // The picker exposes every mode the visualizer.js module supports.
+    // A regression in PR 4 dropped Fall / Ring / Phase from the UI even
+    // though the wiring (enum, JS calls, subscribe paths) was intact —
+    // this test locks against that regression returning.
+    var cut = RenderComponent<VisualizerPanel>();
+    cut.FindAll(".visualizer-mode").Count.Should().Be(6);
+  }
+
+  [Fact]
+  public void ModePicker_RendersAllSixLabelsInOrder()
+  {
+    // Visual order matches the handoff sequence (primary → secondary):
+    // VU, Wave, Spectrum, Fall, Ring, Phase.
+    var cut = RenderComponent<VisualizerPanel>();
+    var labels = cut.FindAll(".visualizer-mode")
+      .Select(e => e.TextContent.Trim())
+      .ToList();
+    labels.Should().Equal("VU", "Wave", "Spectrum", "Fall", "Ring", "Phase");
+  }
+
+  [Fact]
+  public void ModePicker_DefaultsToVuModeActive()
+  {
+    // _currentMode defaults to VUMeter when no saved preference loads
+    // (the config call fails in the test rig and is swallowed).
+    var cut = RenderComponent<VisualizerPanel>();
+    var buttons = cut.FindAll(".visualizer-mode").ToList();
+    (buttons[0].GetAttribute("class") ?? string.Empty).Should().Contain("is-active");
+    buttons[0].GetAttribute("aria-selected").Should().Be("true");
+
+    foreach (var b in buttons.Skip(1))
+    {
+      (b.GetAttribute("class") ?? string.Empty).Should().NotContain("is-active");
+      b.GetAttribute("aria-selected").Should().Be("false");
+    }
+  }
+
+  [Fact]
+  public void ModePicker_FallButton_HasSpectrogramAriaLabel()
+  {
+    // Fall is the user-facing label for VisualizationMode.Spectrogram.
+    var cut = RenderComponent<VisualizerPanel>();
+    var fall = cut.FindAll(".visualizer-mode").First(b => b.TextContent.Trim() == "Fall");
+    (fall.GetAttribute("aria-label") ?? string.Empty).Should().ContainAll("Spectrogram", "mode");
+  }
+
+  [Fact]
+  public void ModePicker_RingButton_HasCircularAriaLabel()
+  {
+    // Ring is the user-facing label for VisualizationMode.Circular.
+    var cut = RenderComponent<VisualizerPanel>();
+    var ring = cut.FindAll(".visualizer-mode").First(b => b.TextContent.Trim() == "Ring");
+    (ring.GetAttribute("aria-label") ?? string.Empty).Should().ContainAll("Circular", "mode");
+  }
+
+  [Fact]
+  public void ModePicker_PhaseButton_HasPhaseScopeAriaLabel()
+  {
+    // Phase is the user-facing label for VisualizationMode.PhaseScope.
+    var cut = RenderComponent<VisualizerPanel>();
+    var phase = cut.FindAll(".visualizer-mode").First(b => b.TextContent.Trim() == "Phase");
+    (phase.GetAttribute("aria-label") ?? string.Empty).Should().ContainAll("Phase", "mode");
+  }
+
+  [Fact]
+  public void ModePicker_ClickingFall_ActivatesFallSegment()
+  {
+    // Clicking Fall flips _currentMode to Spectrogram. The is-active class
+    // and aria-selected attribute should move from VU to Fall.
+    var cut = RenderComponent<VisualizerPanel>();
+    var fall = cut.FindAll(".visualizer-mode").First(b => b.TextContent.Trim() == "Fall");
+    fall.Click();
+
+    var fallAfter = cut.FindAll(".visualizer-mode").First(b => b.TextContent.Trim() == "Fall");
+    (fallAfter.GetAttribute("class") ?? string.Empty).Should().Contain("is-active");
+    fallAfter.GetAttribute("aria-selected").Should().Be("true");
+
+    var vuAfter = cut.FindAll(".visualizer-mode").First(b => b.TextContent.Trim() == "VU");
+    (vuAfter.GetAttribute("class") ?? string.Empty).Should().NotContain("is-active");
+    vuAfter.GetAttribute("aria-selected").Should().Be("false");
+  }
+
+  [Fact]
+  public void ModePicker_ClickingRing_ActivatesRingSegment()
+  {
+    var cut = RenderComponent<VisualizerPanel>();
+    var ring = cut.FindAll(".visualizer-mode").First(b => b.TextContent.Trim() == "Ring");
+    ring.Click();
+
+    var ringAfter = cut.FindAll(".visualizer-mode").First(b => b.TextContent.Trim() == "Ring");
+    (ringAfter.GetAttribute("class") ?? string.Empty).Should().Contain("is-active");
+    ringAfter.GetAttribute("aria-selected").Should().Be("true");
+  }
+
+  [Fact]
+  public void ModePicker_ClickingPhase_ActivatesPhaseSegment()
+  {
+    var cut = RenderComponent<VisualizerPanel>();
+    var phase = cut.FindAll(".visualizer-mode").First(b => b.TextContent.Trim() == "Phase");
+    phase.Click();
+
+    var phaseAfter = cut.FindAll(".visualizer-mode").First(b => b.TextContent.Trim() == "Phase");
+    (phaseAfter.GetAttribute("class") ?? string.Empty).Should().Contain("is-active");
+    phaseAfter.GetAttribute("aria-selected").Should().Be("true");
+  }
+
+  [Fact]
+  public void ModePicker_RoleTablistAndAriaLabel_AreDeclared()
+  {
+    // ARIA contract for the picker container — preserved from PR 4.
+    var cut = RenderComponent<VisualizerPanel>();
+    var picker = cut.Find(".visualizer-mode-picker");
+    picker.GetAttribute("role").Should().Be("tablist");
+    picker.GetAttribute("aria-label").Should().Be("Visualizer mode");
+  }
+}


### PR DESCRIPTION
Restores Fall / Ring / Phase visualizer modes to the picker.

## Summary

- Arc 1 PR 4 (commit `2d12cc0`) replaced the 6-mode floating `.route-toggle` picker with a 3-segment `.visualizer-mode-picker`. Only VU / Wave / Spectrum got buttons. Fall (Spectrogram), Ring (Circular), and Phase (PhaseScope) were dropped from the UI but still wired in code (enum values, `visualizer.drawSpectrogram` / `drawCircularSpectrum` / `drawPhaseScope` JS interop, SignalR subscribe/unsubscribe paths).
- Handoff spec defect (`IMPLEMENTATION.md` P1-3): the spec author worked from a 3-mode screenshot and named only "VU / WAVE / SPECTRUM" as the corner chip group. The actual code had six modes.
- Fix: extend `.visualizer-mode-picker` grid from 3 to 6 columns; add button entries for Spectrogram / Circular / PhaseScope with the same `is-active` + accent-underline treatment as the original three. Replace the `IsVuMode` / `IsWaveMode` helpers (which conflated PhaseScope into Wave and Circular/Spectrogram into Spectrum to fit the 3-button layout) with direct `_currentMode == X` comparisons so each button activates exactly one mode. `IsSpectrumMode` is retained because it correctly drives the freq-band axis strip for all three spectrum-family modes.

## Test Plan

- [x] `dotnet build src/Radio.Web` — 0 errors, only pre-existing IDE0011 warnings unrelated to this change.
- [x] `dotnet test tests/Radio.Web.Tests` — 359/359 pass, including 10 new `VisualizerPanelTests` cases covering button count, label order, default activation, per-mode `aria-label`, click → activate flow for Fall / Ring / Phase, and the `role=tablist` + `aria-label="Visualizer mode"` ARIA contract.
- [ ] Visual UAT on kiosk (1920x720): all 6 mode buttons render in order `[VU, Wave, Spectrum, Fall, Ring, Phase]`; clicking each switches the canvas to its dedicated draw call; active-state cycles to the clicked button only.

## Operator note

No deploy-side change. UI-only fix; restart `radio-web.service` after deploy to pick up the new component markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)