### PR TITLE
fix(web): PlayHistory left filter panel fits without scrollbar

### DIFF
--- a/src/Radio.Web/Components/Pages/PlayHistoryPage.razor
+++ b/src/Radio.Web/Components/Pages/PlayHistoryPage.razor
@@ -12,8 +12,8 @@
 
 <div style="height: 100%; display: flex; gap: 2px; overflow: hidden;">
   <!-- Left: Filters & Statistics -->
-  <div class="panel surface-raised" style="width: 360px; flex-shrink: 0; overflow: hidden; padding: 16px; display: flex; flex-direction: column;">
-    <div style="display:flex; flex-direction:column; gap:12px; overflow-y: auto; overflow-x: hidden; flex: 1; min-height: 0;">
+  <div class="panel surface-raised" style="width: 360px; flex-shrink: 0; overflow: hidden; padding: 12px; display: flex; flex-direction: column;">
+    <div class="history-filter-scroll" style="display:flex; flex-direction:column; gap:8px; overflow-y: auto; overflow-x: hidden; flex: 1; min-height: 0;">
       <h6>Play History</h6>
 
       <RadzenDatePicker TValue="DateTime?" @bind-Value="_selectedDate" AllowClear="true" Placeholder="Filter by Date" />
@@ -31,22 +31,24 @@
                      Placeholder="Search title, artist, album..."
                      @onkeyup="@OnSearchKeyUp" />
 
-      <RadzenButton Text="Filter"
-                    Icon="filter_list"
-                    ButtonStyle="ButtonStyle.Primary"
-                    Variant="Variant.Filled"
-                    Click="@ApplyFilters"
-                    Style="width:100%" />
-      <RadzenButton Text="Clear Filters"
-                    Icon="filter_list_off"
-                    ButtonStyle="ButtonStyle.Secondary"
-                    Variant="Variant.Outlined"
-                    Click="@ClearAllFilters"
-                    Style="width:100%" />
+      <div style="display:flex; gap:6px;">
+        <RadzenButton Text="Filter"
+                      Icon="filter_list"
+                      ButtonStyle="ButtonStyle.Primary"
+                      Variant="Variant.Filled"
+                      Click="@ApplyFilters"
+                      Style="flex:1" />
+        <RadzenButton Text="Clear"
+                      Icon="filter_list_off"
+                      ButtonStyle="ButtonStyle.Secondary"
+                      Variant="Variant.Outlined"
+                      Click="@ClearAllFilters"
+                      Style="flex:1" />
+      </div>
 
       @if (_stats != null)
       {
-        <hr style="border-color:var(--surface-separator); margin:8px 0" />
+        <hr style="border-color:var(--surface-separator); margin:4px 0" />
         <span style="font-size:0.875rem; font-weight:500; color: var(--text-medium); text-transform: uppercase; letter-spacing: 0.05em;">Statistics</span>
         <RadzenRow Gap="4px">
           <RadzenColumn Size="6">

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -1130,29 +1130,34 @@ body::-webkit-scrollbar,
 .scrollable,
 #queue-scroll-container,
 .rz-tabview-panels,
-.rz-data-grid-data {
+.rz-data-grid-data,
+.history-filter-scroll {
   scrollbar-width: thin;
   scrollbar-color: var(--text-low) transparent;
 }
 .scrollable::-webkit-scrollbar,
 #queue-scroll-container::-webkit-scrollbar,
 .rz-tabview-panels::-webkit-scrollbar,
-.rz-data-grid-data::-webkit-scrollbar { display: block; width: 3px; }
+.rz-data-grid-data::-webkit-scrollbar,
+.history-filter-scroll::-webkit-scrollbar { display: block; width: 3px; }
 .scrollable::-webkit-scrollbar-track,
 #queue-scroll-container::-webkit-scrollbar-track,
 .rz-tabview-panels::-webkit-scrollbar-track,
-.rz-data-grid-data::-webkit-scrollbar-track { background: transparent; }
+.rz-data-grid-data::-webkit-scrollbar-track,
+.history-filter-scroll::-webkit-scrollbar-track { background: transparent; }
 .scrollable::-webkit-scrollbar-thumb,
 #queue-scroll-container::-webkit-scrollbar-thumb,
 .rz-tabview-panels::-webkit-scrollbar-thumb,
-.rz-data-grid-data::-webkit-scrollbar-thumb {
+.rz-data-grid-data::-webkit-scrollbar-thumb,
+.history-filter-scroll::-webkit-scrollbar-thumb {
   background: var(--text-low);
   border-radius: 2px;
 }
 .scrollable::-webkit-scrollbar-thumb:hover,
 #queue-scroll-container::-webkit-scrollbar-thumb:hover,
 .rz-tabview-panels::-webkit-scrollbar-thumb:hover,
-.rz-data-grid-data::-webkit-scrollbar-thumb:hover { background: var(--text-medium); }
+.rz-data-grid-data::-webkit-scrollbar-thumb:hover,
+.history-filter-scroll::-webkit-scrollbar-thumb:hover { background: var(--text-medium); }
 
 
 /* ─── §20  Bottom-Sheet Dialogs ───────────────────────────────────────────── */

--- a/tests/Radio.Web.E2ETests/PlayHistoryPageE2ETests.cs
+++ b/tests/Radio.Web.E2ETests/PlayHistoryPageE2ETests.cs
@@ -31,7 +31,9 @@ public class PlayHistoryPageE2ETests
     var filterButton = _fixture.Page.Locator("button:has-text('Filter')");
     await Expect(filterButton).ToBeVisibleAsync();
 
-    var clearButton = _fixture.Page.Locator("button:has-text('Clear Filters')");
+    // Button text shortened from "Clear Filters" -> "Clear" in
+    // fix/web-history-filter-panel-fit to fit a half-width cell.
+    var clearButton = _fixture.Page.Locator("button:has-text('Clear')");
     await Expect(clearButton).ToBeVisibleAsync();
   }
 

--- a/tests/Radio.Web.Tests/Components/Pages/PlayHistoryPageTests.cs
+++ b/tests/Radio.Web.Tests/Components/Pages/PlayHistoryPageTests.cs
@@ -135,7 +135,9 @@ public class PlayHistoryPageTests : TestContext
     // Act
     var cut = RenderPlayHistoryPage();
 
-    // Assert - Check for clear filters button
-    Assert.Contains("Clear Filters", cut.Markup);
+    // Assert - Check for clear filters button (icon class identifies the action;
+    // visible text was shortened to "Clear" in fix/web-history-filter-panel-fit
+    // to fit a half-width side-by-side button cell).
+    Assert.Contains("filter_list_off", cut.Markup);
   }
 }


### PR DESCRIPTION
Eliminates the ugly default scrollbar on the History page's left filter panel.

## Summary

- Arc 1 PR 2 + PR 5 reduced the effective content area on `/history` from 640px to ~504px (topbar bumped to 120px + NowPlayingDock subtracts 64px). The PlayHistory left filter panel was designed for the old layout and overflowed the new container.
- Fix: tighten spacing (padding 16→12, gap 12→8, hr margin 8→4) + put Filter / Clear Filters side-by-side (saves ~48px). Now fits comfortably.
- Defensive: add `.history-filter-scroll` to the thin-scrollbar selector list so any future content additions degrade to the 3px thin scrollbar instead of the default thick one.

## Test plan

- [x] `dotnet build` clean (0 errors)
- [x] `dotnet test` green (Radio.Web.Tests: 383/383)
- [ ] Visual UAT at 1920x720 on `/history`: left panel renders Filter card + Statistics + Top Track + Top Artist + source badges with no scrollbar visible.

## Test updates

- `PlayHistoryPageTests.PlayHistoryPage_Contains_Clear_Filters_Button` now asserts the `filter_list_off` icon class (button text was shortened from "Clear Filters" to "Clear" to fit the half-width cell; the icon still uniquely identifies the clear-filters action).
- `PlayHistoryPageE2ETests.HistoryPage_HasFilterButtons` locator updated to `has-text('Clear')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)