### PR TITLE
fix(web): LED font swap + freq -20% + band pill fit + show-all presets + rename/delete affordances

### DIFF
--- a/src/Radio.API/Controllers/RadioController.cs
+++ b/src/Radio.API/Controllers/RadioController.cs
@@ -699,6 +699,59 @@ public class RadioController : ControllerBase
   }
 
   /// <summary>
+  /// Renames an existing radio preset. Band and frequency are immutable on a
+  /// saved preset; only the display name is updated.
+  /// </summary>
+  /// <param name="id">The preset ID to rename.</param>
+  /// <param name="request">The new name payload.</param>
+  /// <returns>The renamed preset DTO, or 404 if the ID does not exist.</returns>
+  /// <response code="200">Returns the updated preset.</response>
+  /// <response code="400">If the new name is empty or whitespace.</response>
+  /// <response code="404">If the preset was not found.</response>
+  [HttpPut("presets/{id}")]
+  [ProducesResponseType(typeof(RadioPresetDto), StatusCodes.Status200OK)]
+  [ProducesResponseType(StatusCodes.Status400BadRequest)]
+  [ProducesResponseType(StatusCodes.Status404NotFound)]
+  public async Task<ActionResult<RadioPresetDto>> RenamePreset(string id, [FromBody] RenameRadioPresetRequest request)
+  {
+    if (request == null || string.IsNullOrWhiteSpace(request.Name))
+    {
+      return BadRequest(new { error = "Preset name must not be empty or whitespace." });
+    }
+
+    try
+    {
+      var renamed = await _presetService.RenamePresetAsync(id, request.Name);
+      if (renamed == null)
+      {
+        return NotFound(new { error = $"Preset with ID '{id}' not found" });
+      }
+
+      // Compute the slot number against the band's current set so the response
+      // carries the same SlotNumber GetPresets() would surface. Mirrors the
+      // logic in CreatePreset above.
+      var bandPresets = await _presetService.GetAllPresetsAsync();
+      var slot = bandPresets
+        .Where(p => p.Band == renamed.Band)
+        .OrderBy(p => p.CreatedAt)
+        .Select((p, idx) => new { p.Id, Slot = idx + 1 })
+        .FirstOrDefault(t => t.Id == renamed.Id)?.Slot ?? 0;
+
+      return Ok(RadioPresetDto.FromModel(renamed, slot));
+    }
+    catch (ArgumentException ex)
+    {
+      _logger.LogWarning(ex, "Invalid rename payload for preset {Id}", id);
+      return BadRequest(new { error = ex.Message });
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Error renaming radio preset {Id}", id);
+      return StatusCode(500, new { error = "Failed to rename radio preset" });
+    }
+  }
+
+  /// <summary>
   /// Loads a radio preset — sets the band and tunes to the saved frequency.
   /// </summary>
   /// <param name="id">The preset ID to load.</param>

--- a/src/Radio.API/Models/RadioPresetDto.cs
+++ b/src/Radio.API/Models/RadioPresetDto.cs
@@ -100,3 +100,20 @@ public sealed record CreateRadioPresetRequest
   /// </summary>
   public required double Frequency { get; init; }
 }
+
+/// <summary>
+/// Request DTO for renaming an existing radio preset. Carries only the new
+/// name — band and frequency are immutable on a saved preset (changing those
+/// would create a different station; the user should delete + re-save).
+/// Added by the LED-font + preset-affordances hot-fix off PR #371 so the
+/// kebab-menu Rename action has a server endpoint to call.
+/// </summary>
+public sealed record RenameRadioPresetRequest
+{
+  /// <summary>
+  /// The new display name for the preset. Empty / whitespace is rejected
+  /// at the controller layer (400 Bad Request); the preset always retains
+  /// a usable label.
+  /// </summary>
+  public required string Name { get; init; }
+}

--- a/src/Radio.Core/Interfaces/Audio/IRadioPresetRepository.cs
+++ b/src/Radio.Core/Interfaces/Audio/IRadioPresetRepository.cs
@@ -47,6 +47,19 @@ public interface IRadioPresetRepository
   Task<bool> DeleteAsync(string id, CancellationToken ct = default);
 
   /// <summary>
+  /// Updates the display name on an existing preset, refreshing
+  /// <see cref="RadioPreset.LastModifiedAt"/>. Band and frequency are
+  /// intentionally immutable here — the kebab-menu rename action off the
+  /// PR #371 hot-fix only renames; reassigning a band/frequency would be a
+  /// new preset.
+  /// </summary>
+  /// <param name="id">The preset ID to rename.</param>
+  /// <param name="newName">The new display name.</param>
+  /// <param name="ct">Cancellation token.</param>
+  /// <returns>True if the row was updated, false if the ID was not found.</returns>
+  Task<bool> UpdateNameAsync(string id, string newName, CancellationToken ct = default);
+
+  /// <summary>
   /// Gets the count of saved presets.
   /// </summary>
   /// <param name="ct">Cancellation token.</param>

--- a/src/Radio.Core/Interfaces/Audio/IRadioPresetService.cs
+++ b/src/Radio.Core/Interfaces/Audio/IRadioPresetService.cs
@@ -46,6 +46,17 @@ public interface IRadioPresetService
   Task<bool> DeletePresetAsync(string id, CancellationToken cancellationToken = default);
 
   /// <summary>
+  /// Renames an existing preset. Band and frequency are immutable; only the
+  /// display name is updated. Empty or whitespace-only names are rejected
+  /// (the caller — the controller layer — must validate first).
+  /// </summary>
+  /// <param name="id">The preset ID to rename.</param>
+  /// <param name="newName">The new display name (already trimmed/validated).</param>
+  /// <param name="cancellationToken">Cancellation token.</param>
+  /// <returns>The renamed preset if found, or null if no preset matches the ID.</returns>
+  Task<RadioPreset?> RenamePresetAsync(string id, string newName, CancellationToken cancellationToken = default);
+
+  /// <summary>
   /// Checks if a preset with the given band and frequency already exists.
   /// </summary>
   /// <param name="band">The radio band.</param>

--- a/src/Radio.Infrastructure/Audio/Fingerprinting/Data/SqliteRadioPresetRepository.cs
+++ b/src/Radio.Infrastructure/Audio/Fingerprinting/Data/SqliteRadioPresetRepository.cs
@@ -156,6 +156,43 @@ public sealed class SqliteRadioPresetRepository : IRadioPresetRepository
   }
 
   /// <inheritdoc/>
+  public async Task<bool> UpdateNameAsync(string id, string newName, CancellationToken ct = default)
+  {
+    // Added by the LED-font + preset-affordances hot-fix off PR #371 so the
+    // kebab-menu Rename action has somewhere to land. Band/Frequency stay
+    // immutable — only Name + LastModifiedAt are touched. ROWS_AFFECTED
+    // disambiguates "not found" (0) from "renamed" (1) without an extra
+    // SELECT round-trip.
+    var conn = await _dbContext.GetConnectionAsync(ct);
+
+    var sql = """
+      UPDATE RadioPresets
+      SET Name = @Name, LastModifiedAt = @LastModifiedAt
+      WHERE Id = @Id
+      """;
+
+    await using var cmd = conn.CreateCommand();
+    cmd.CommandText = sql;
+    cmd.Parameters.AddWithValue("@Id", id);
+    cmd.Parameters.AddWithValue("@Name", newName);
+    cmd.Parameters.AddWithValue("@LastModifiedAt", DateTimeOffset.UtcNow.ToString("O"));
+
+    var rowsAffected = await cmd.ExecuteNonQueryAsync(ct);
+    var updated = rowsAffected > 0;
+
+    if (updated)
+    {
+      _logger.LogDebug("Renamed radio preset {Id} to {Name}", id, newName);
+    }
+    else
+    {
+      _logger.LogDebug("Radio preset {Id} not found for rename", id);
+    }
+
+    return updated;
+  }
+
+  /// <inheritdoc/>
   public async Task<int> GetCountAsync(CancellationToken ct = default)
   {
     var conn = await _dbContext.GetConnectionAsync(ct);

--- a/src/Radio.Infrastructure/Audio/Services/RadioPresetService.cs
+++ b/src/Radio.Infrastructure/Audio/Services/RadioPresetService.cs
@@ -107,6 +107,32 @@ public sealed class RadioPresetService : IRadioPresetService
   }
 
   /// <inheritdoc/>
+  public async Task<RadioPreset?> RenamePresetAsync(string id, string newName, CancellationToken cancellationToken = default)
+  {
+    // Added by the LED-font + preset-affordances hot-fix off PR #371. Empty
+    // / whitespace names are rejected up-front — the API controller does the
+    // same check but defending here keeps callers (tests, future internal
+    // callers) from sneaking through a blank rename via a direct service
+    // call.
+    if (string.IsNullOrWhiteSpace(newName))
+    {
+      throw new ArgumentException("Preset name must not be empty or whitespace.", nameof(newName));
+    }
+
+    var trimmed = newName.Trim();
+    var updated = await _repository.UpdateNameAsync(id, trimmed, cancellationToken);
+    if (!updated)
+    {
+      _logger.LogWarning("Radio preset {Id} not found for rename", id);
+      return null;
+    }
+
+    var renamed = await _repository.GetByIdAsync(id, cancellationToken);
+    _logger.LogInformation("Renamed radio preset {Id} → {Name}", id, trimmed);
+    return renamed;
+  }
+
+  /// <inheritdoc/>
   public async Task<bool> PresetExistsAsync(RadioBand band, double frequency, CancellationToken cancellationToken = default)
   {
     var preset = await _repository.GetByBandAndFrequencyAsync(band, frequency, cancellationToken);

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -299,16 +299,28 @@
 
     @* Preset action menu — anchored by absolute positioning when open. Only
        one menu is open at a time; clicking the overlay or hitting Esc closes
-       it. Actions call into RenamePresetAsync / DeletePresetAsync below. *@
+       it. Actions call into RenamePresetAsync / DeletePresetAsync below.
+       A11y: the popover surface carries role="menu" + aria-label so screen
+       readers announce it as a menu; items carry role="menuitem". Esc
+       dismissal is wired on the overlay (tabindex=0 so it can receive
+       keydown) and bubbles from the focused menu items. *@
     @if (!string.IsNullOrEmpty(_actionMenuPresetId))
     {
-      <div class="rcp-preset-menu-overlay" @onclick="CloseActionMenu">
-        <div class="rcp-preset-menu" @onclick:stopPropagation="true">
+      <div class="rcp-preset-menu-overlay"
+           tabindex="0"
+           @onclick="CloseActionMenu"
+           @onkeydown="HandleActionMenuKeyDown">
+        <div class="rcp-preset-menu"
+             role="menu"
+             aria-label="Preset actions"
+             @onclick:stopPropagation="true">
           <button type="button" class="rcp-preset-menu-item"
+                  role="menuitem"
                   @onclick="@(() => OpenRenameDialog(_actionMenuPresetId!))">
             <span class="rzi rzi-edit" aria-hidden="true"></span> Rename
           </button>
           <button type="button" class="rcp-preset-menu-item rcp-preset-menu-danger"
+                  role="menuitem"
                   @onclick="@(() => ConfirmDeleteAsync(_actionMenuPresetId!))">
             <span class="rzi rzi-delete" aria-hidden="true"></span> Delete
           </button>
@@ -1252,19 +1264,74 @@
     }
   }
 
+  // Holds the most-recently deleted preset so the toast Click handler can
+  // re-create it (Undo affordance). Cleared on next delete or on successful
+  // undo. Only the wire-shape fields (Name / Band / Frequency) are restored —
+  // the server assigns a fresh Id + SlotNumber, which matches in-tree
+  // create-preset semantics.
+  private RadioPresetDto? _lastDeletedPreset;
+
   private async Task DeletePresetAsync(string id)
   {
+    var preset = _presets?.FirstOrDefault(p => p.Id == id);
     try
     {
       if (await RadioApi.DeletePresetAsync(id))
       {
+        _lastDeletedPreset = preset;
         await LoadPresetsAsync();
-        NotificationService.Notify(NotificationSeverity.Info, "Deleted", "Preset deleted");
+
+        // PR plan called for a toast with name + Undo. The Click handler on
+        // the NotificationMessage fires when the toast itself is clicked; the
+        // user gets ~5s to undo before the toast auto-dismisses.
+        var detail = preset != null
+          ? $"\"{preset.Name}\" removed — click to undo"
+          : "Preset deleted";
+        NotificationService.Notify(new NotificationMessage
+        {
+          Severity = NotificationSeverity.Info,
+          Summary = "Preset deleted",
+          Detail = detail,
+          Duration = 5000,
+          Click = async _ => await UndoDeletePresetAsync(),
+        });
       }
     }
     catch (Exception ex)
     {
       Logger.LogError(ex, "Error deleting preset {Id}", id);
+    }
+  }
+
+  /// <summary>
+  /// Re-creates the most-recently deleted preset via the existing save path.
+  /// Note: the server assigns a fresh Id and SlotNumber — the visual slot
+  /// number may differ from the original. Wire-shape fidelity (Name / Band /
+  /// Frequency) is preserved.
+  /// </summary>
+  private async Task UndoDeletePresetAsync()
+  {
+    if (_lastDeletedPreset == null) return;
+    var preset = _lastDeletedPreset;
+    _lastDeletedPreset = null;
+
+    try
+    {
+      if (await RadioApi.SavePresetAsync(preset.Name, preset.Frequency, preset.Band))
+      {
+        await LoadPresetsAsync();
+        NotificationService.Notify(NotificationSeverity.Success, "Restored", $"\"{preset.Name}\" restored");
+        await InvokeAsync(StateHasChanged);
+      }
+      else
+      {
+        NotificationService.Notify(NotificationSeverity.Error, "Error", "Failed to restore preset — check API logs");
+      }
+    }
+    catch (Exception ex)
+    {
+      Logger.LogError(ex, "Error undoing delete of preset {Name}", preset.Name);
+      NotificationService.Notify(NotificationSeverity.Error, "Error", $"Error restoring preset: {ex.Message}");
     }
   }
 
@@ -1354,6 +1421,20 @@
   private void CloseActionMenu()
   {
     _actionMenuPresetId = null;
+  }
+
+  /// <summary>
+  /// Keydown handler on the action-menu overlay. Esc dismisses the menu
+  /// (matches the inline-CSS comment that promises Esc + overlay-tap close).
+  /// The overlay carries tabindex=0 so it can receive keyboard events; Esc
+  /// from a focused menu-item button also bubbles up to this handler.
+  /// </summary>
+  private void HandleActionMenuKeyDown(KeyboardEventArgs e)
+  {
+    if (e.Key == "Escape")
+    {
+      CloseActionMenu();
+    }
   }
 
   /// <summary>

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -212,14 +212,24 @@
       }
     </div>
 
-    <!-- Presets Memory Bank — handoff §P1·2: slot · name+band · freq grid.
-         Save action is a long-press on the active band pill (above) per the
-         resolved spec default; the icon button is replaced by a discoverable
-         hint. -->
+    <!-- Presets Memory Bank — handoff §P1·2 (slot · name+band · freq grid),
+         updated by the hot-fix off PR #371 (user feedback) so:
+           1. ALL presets across ALL bands are shown (not just the current
+              band) — the user couldn't find their saved WB station while
+              tuned to FM. The .rcp-preset-band sub-line on each row already
+              communicates the band context, so cross-band visibility is
+              navigable.
+           2. The header counter shows total saved across all bands rather
+              than "N of CAP" (mixing band capacities would be confusing).
+           3. Each row gains a trailing kebab opening a Rename + Delete
+              popover. Long-press on the row also opens the same popover
+              (matches the band-pill long-press-to-save gesture from PR 3).
+           4. The single empty-slot placeholder still scopes to the
+              current band so saving stays in-band. -->
     <div class="rcp-presets">
       <div class="rcp-presets-header">
         <span class="rcp-presets-count">
-          MEMORY · @presetCount of @activeBandCapacity
+          MEMORY · @presetCount saved
         </span>
         @if (bandSavable)
         {
@@ -240,31 +250,71 @@
           @foreach (var preset in _presets)
           {
             var isActivePreset = IsActivePreset(preset);
-            <button type="button"
-                    class="rcp-preset-item @(isActivePreset ? "is-active" : "")"
-                    @onclick="@(() => LoadPresetAsync(preset.Id))">
+            var presetId = preset.Id;
+            <div class="rcp-preset-item @(isActivePreset ? "is-active" : "")"
+                 data-preset-id="@presetId"
+                 @onclick="@(() => HandlePresetRowClickAsync(presetId))"
+                 @onpointerdown="@(e => HandlePresetPointerDown(presetId))"
+                 @onpointerup="@(e => HandlePresetPointerUp(presetId))"
+                 @onpointerleave="@(e => HandlePresetPointerCancel())"
+                 @onpointercancel="@(e => HandlePresetPointerCancel())"
+                 role="button"
+                 tabindex="0"
+                 title="Click to tune; long-press or use ⋮ for rename / delete">
               <span class="rcp-preset-slot">@(preset.SlotNumber > 0 ? preset.SlotNumber.ToString("00") : "")</span>
               <span class="rcp-preset-text">
                 <span class="rcp-preset-name">@preset.Name</span>
                 <span class="rcp-preset-band">@preset.Band</span>
               </span>
               <span class="rcp-preset-freq">@FormatFrequency(preset.Frequency, preset.Band)</span>
-            </button>
+              <button type="button"
+                      class="rcp-preset-kebab"
+                      aria-label="Rename or delete preset @preset.Name"
+                      title="Rename / delete"
+                      @onclick="@(e => HandleKebabClickAsync(presetId))"
+                      @onclick:stopPropagation="true">⋮</button>
+            </div>
           }
         }
 
         @* Render exactly ONE dashed-border placeholder for the next empty
-           slot when the band has capacity left (handoff §P1·2 step 3). *@
-        @if (activeBandCapacity > 0 && presetCount < activeBandCapacity)
+           slot when the CURRENT band has capacity left. Slot numbering is
+           per-band, so this counts the active-band presets only — keeps the
+           "long-press to save" affordance scoped to where a new save will
+           actually land. *@
+        @if (activeBandCapacity > 0 && _presets != null)
         {
-          var nextSlot = presetCount + 1;
-          <div class="rcp-preset-item rcp-preset-empty">
-            <span class="rcp-preset-slot">@nextSlot.ToString("00")</span>
-            <span class="rcp-preset-empty-hint">EMPTY · long-press to save</span>
-          </div>
+          var activeBandCount = _presets.Count(p => string.Equals(p.Band, _radioState.Band, StringComparison.OrdinalIgnoreCase));
+          if (activeBandCount < activeBandCapacity)
+          {
+            var nextSlot = activeBandCount + 1;
+            <div class="rcp-preset-item rcp-preset-empty">
+              <span class="rcp-preset-slot">@nextSlot.ToString("00")</span>
+              <span class="rcp-preset-empty-hint">EMPTY · long-press @(_radioState.Band) to save</span>
+            </div>
+          }
         }
       </div>
     </div>
+
+    @* Preset action menu — anchored by absolute positioning when open. Only
+       one menu is open at a time; clicking the overlay or hitting Esc closes
+       it. Actions call into RenamePresetAsync / DeletePresetAsync below. *@
+    @if (!string.IsNullOrEmpty(_actionMenuPresetId))
+    {
+      <div class="rcp-preset-menu-overlay" @onclick="CloseActionMenu">
+        <div class="rcp-preset-menu" @onclick:stopPropagation="true">
+          <button type="button" class="rcp-preset-menu-item"
+                  @onclick="@(() => OpenRenameDialog(_actionMenuPresetId!))">
+            <span class="rzi rzi-edit" aria-hidden="true"></span> Rename
+          </button>
+          <button type="button" class="rcp-preset-menu-item rcp-preset-menu-danger"
+                  @onclick="@(() => ConfirmDeleteAsync(_actionMenuPresetId!))">
+            <span class="rzi rzi-delete" aria-hidden="true"></span> Delete
+          </button>
+        </div>
+      </div>
+    }
   }
 </div>
 
@@ -297,6 +347,22 @@
         <RadzenButton Variant="Variant.Text" Click="CloseSavePresetDialog" Text="Cancel" />
         <RadzenButton ButtonStyle="ButtonStyle.Warning" Variant="Variant.Filled"
                       Click="SavePresetAsync" Text="Save" />
+      </div>
+    </div>
+  </div>
+}
+
+@if (_isRenamePresetDialogOpen)
+{
+  <div class="overlay" style="display:flex; position:fixed; inset:0; background:rgba(0,0,0,0.5); z-index:9999; justify-content:center; align-items:center;" @onclick="CloseRenamePresetDialog">
+    <div class="rcp-preset-rename-card" style="min-width: 320px; background: var(--rz-base-background-color, #1e1e2e); border-radius: 8px; padding: 24px; box-shadow: 0 8px 32px rgba(0,0,0,0.6);" @onclick:stopPropagation="true">
+      <h6 style="margin-bottom: 12px;">Rename Preset</h6>
+      <RadzenTextBox @bind-Value="_renamePresetName"
+                     Placeholder="Preset Name" Style="width: 100%;" />
+      <div style="display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px;">
+        <RadzenButton Variant="Variant.Text" Click="CloseRenamePresetDialog" Text="Cancel" />
+        <RadzenButton ButtonStyle="ButtonStyle.Primary" Variant="Variant.Filled"
+                      Click="RenamePresetAsync" Text="Save" />
       </div>
     </div>
   </div>
@@ -375,8 +441,17 @@
   /* ── Band Selector — Console Push-Buttons ── */
 
   .rcp-band-group {
+    /* Hot-fix off PR #371 (user feedback): even with flex-wrap, the AM
+       + VHF labels were clipping at 1920×720 because the group was
+       sized to its content and overflowed its parent before wrap could
+       fire. width: 100% pins the row to the parent column so wrap has
+       a real boundary to pivot against. Combined with the min-width
+       reduction in .rcp-band-btn (design-system.css §W: 64 → 56) and
+       the smaller sub-range font, six pills now fit cleanly or wrap
+       to 3+3 on narrower containers. */
     display: flex;
     flex-wrap: wrap;
+    width: 100%;
     justify-content: center;
     gap: 2px;
     row-gap: 4px;
@@ -466,9 +541,12 @@
     opacity: 0.6;
   }
 
-  /* Frequency display sizing override for the well context */
+  /* Frequency display sizing override for the well context.
+     Hot-fix off PR #371: user asked for the radio frequency to be 20%
+     smaller. 54px × 0.8 = 43.2 → 43px keeps a clean pixel boundary and
+     leaves more headroom for the well's bezel + scan/step row below. */
   .rcp-freq-well .display-frequency {
-    font-size: 54px;
+    font-size: 43px;
     position: relative;
     z-index: 1;
     cursor: pointer;
@@ -816,6 +894,24 @@
   private string? _bandPointerDownBand;
   private bool _suppressNextBandClick;
 
+  // ── Hot-fix off PR #371: preset row gestures + action menu ──
+  // Long-press on a preset row opens the same Rename / Delete popover the
+  // kebab opens. Mirrors the band-pill gesture above. _suppressNextPresetClick
+  // makes sure the synthesised click after a long-press doesn't also fire
+  // LoadPresetAsync (which would re-tune to the preset the user was about to
+  // rename/delete).
+  private DateTime _presetPointerDownAt;
+  private string? _presetPointerDownId;
+  private bool _suppressNextPresetClick;
+
+  // Action menu state — single popover at a time. Null when closed; the
+  // preset ID when open. Rename dialog has its own dedicated open flag
+  // because it transitions out of the action menu into a text-entry surface.
+  private string? _actionMenuPresetId;
+  private bool _isRenamePresetDialogOpen;
+  private string? _renamePresetId;
+  private string _renamePresetName = "";
+
   protected override async Task OnInitializedAsync()
   {
     // Radio state must load BEFORE presets so LoadPresetsAsync can band-filter
@@ -847,14 +943,16 @@
     try
     {
       var presets = await RadioApi.GetPresetsAsync();
-      // Filter to the currently-active band so the memory bank reflects what
-      // the user is tuning. Per-band slot numbering (SlotNumber) is already
-      // assigned server-side (PR 3 of the Radio Controller Polish arc);
-      // ordering by slot makes the list deterministic across reloads.
-      var bandFilter = _radioState?.Band;
+      // Hot-fix off PR #371: the user couldn't find their saved WB preset
+      // while on FM because the previous filter scoped the list to the
+      // currently-tuned band. Removed the band filter so ALL saved presets
+      // render here; the .rcp-preset-band sub-line on each row already
+      // carries the band context. Sort by Band first (alphabetical) then by
+      // server-assigned per-band SlotNumber — visually groups bands without
+      // breaking the per-band slot numbering the API surfaces.
       _presets = presets?
-        .Where(p => string.IsNullOrEmpty(bandFilter) || string.Equals(p.Band, bandFilter, StringComparison.OrdinalIgnoreCase))
-        .OrderBy(p => p.SlotNumber)
+        .OrderBy(p => p.Band, StringComparer.OrdinalIgnoreCase)
+        .ThenBy(p => p.SlotNumber)
         .ThenBy(p => p.CreatedAt)
         .ToList();
     }
@@ -881,17 +979,10 @@
   {
     // Use the SignalR payload directly instead of re-fetching via REST.
     // The hub broadcast carries NowPlayingMatchId; the REST endpoint cannot.
-    var previousBand = _radioState?.Band;
+    // Hot-fix off PR #371: presets are no longer band-filtered, so a band
+    // change doesn't require a re-fetch — the empty-slot placeholder
+    // re-evaluates against the new band's count on the next render.
     _radioState = dto;
-
-    // PR 3 of the Radio Controller Polish arc — presets are band-filtered;
-    // when the band changes via remote control (SignalR push) we need to
-    // re-pull the preset list so the memory bank reflects the new band.
-    if (!string.Equals(previousBand, dto.Band, StringComparison.OrdinalIgnoreCase))
-    {
-      await LoadPresetsAsync();
-    }
-
     await InvokeAsync(StateHasChanged);
   }
 
@@ -929,9 +1020,10 @@
       if (await RadioApi.SetBandAsync(newBand))
       {
         await LoadRadioStateAsync();
-        // Presets are band-filtered — re-pull so the memory bank stays in
-        // sync after the band switch.
-        await LoadPresetsAsync();
+        // Hot-fix off PR #371: presets are no longer band-filtered, so we
+        // skip the re-fetch the previous implementation did on band change.
+        // The empty-slot placeholder re-evaluates against the new band's
+        // count on the next render via _presets.Count(p => p.Band == ...).
         await InvokeAsync(StateHasChanged);
       }
     }
@@ -1174,6 +1266,166 @@
     {
       Logger.LogError(ex, "Error deleting preset {Id}", id);
     }
+  }
+
+  // ─── Preset row gestures + action menu — hot-fix off PR #371 ──────────────
+  // The user asked for a way to rename / delete saved presets. Each row now
+  // carries a trailing kebab and supports a long-press; both open the same
+  // small popover with Rename + Delete actions. The Rename action transitions
+  // into a dedicated text-entry dialog (mirrors the Save dialog pattern).
+
+  /// <summary>
+  /// Handles a normal click on a preset row — falls through to LoadPresetAsync
+  /// unless the preceding gesture was a long-press (in which case we swallow
+  /// the synthesised click so the row's tune-to-preset action doesn't fire
+  /// alongside the action menu open).
+  /// </summary>
+  private async Task HandlePresetRowClickAsync(string presetId)
+  {
+    if (_suppressNextPresetClick)
+    {
+      _suppressNextPresetClick = false;
+      return;
+    }
+
+    await LoadPresetAsync(presetId);
+  }
+
+  /// <summary>
+  /// Starts the long-press timer when the user puts a finger / mouse on a
+  /// preset row. Stored ID lets us correlate the eventual pointerup with the
+  /// originating row so a press that drifts onto another row doesn't fire.
+  /// </summary>
+  private void HandlePresetPointerDown(string presetId)
+  {
+    _presetPointerDownAt = DateTime.UtcNow;
+    _presetPointerDownId = presetId;
+  }
+
+  /// <summary>
+  /// Resolves the long-press: if the press exceeded
+  /// <see cref="LongPressThresholdMs"/>, open the action menu (and suppress
+  /// the synthesised click so the row doesn't also tune the preset). Shorter
+  /// presses fall through to the click handler which loads the preset.
+  /// </summary>
+  private void HandlePresetPointerUp(string presetId)
+  {
+    if (_presetPointerDownId != presetId)
+    {
+      _presetPointerDownId = null;
+      return;
+    }
+
+    var heldMs = (DateTime.UtcNow - _presetPointerDownAt).TotalMilliseconds;
+    _presetPointerDownId = null;
+
+    if (heldMs >= LongPressThresholdMs)
+    {
+      _suppressNextPresetClick = true;
+      _actionMenuPresetId = presetId;
+    }
+  }
+
+  /// <summary>
+  /// Cancels the long-press timer when the pointer leaves the row or the
+  /// gesture is interrupted.
+  /// </summary>
+  private void HandlePresetPointerCancel()
+  {
+    _presetPointerDownId = null;
+  }
+
+  /// <summary>
+  /// Kebab click — opens the action menu for the given preset without firing
+  /// the row's load-preset handler (markup stops propagation, this method is
+  /// the menu open).
+  /// </summary>
+  private Task HandleKebabClickAsync(string presetId)
+  {
+    _actionMenuPresetId = presetId;
+    return Task.CompletedTask;
+  }
+
+  /// <summary>
+  /// Closes the action menu — called by the overlay click handler and after
+  /// each action that transitions to another surface (rename dialog) or
+  /// completes terminally (delete).
+  /// </summary>
+  private void CloseActionMenu()
+  {
+    _actionMenuPresetId = null;
+  }
+
+  /// <summary>
+  /// Transitions from the action menu into the rename text-entry dialog.
+  /// Pre-fills the input with the preset's current name so a small edit is
+  /// a single keystroke + Save.
+  /// </summary>
+  private void OpenRenameDialog(string presetId)
+  {
+    var preset = _presets?.FirstOrDefault(p => p.Id == presetId);
+    if (preset == null)
+    {
+      _actionMenuPresetId = null;
+      return;
+    }
+
+    _renamePresetId = presetId;
+    _renamePresetName = preset.Name;
+    _isRenamePresetDialogOpen = true;
+    _actionMenuPresetId = null;
+  }
+
+  private void CloseRenamePresetDialog()
+  {
+    _isRenamePresetDialogOpen = false;
+    _renamePresetId = null;
+    _renamePresetName = "";
+  }
+
+  /// <summary>
+  /// Commits the rename via the API and re-loads the preset list so the new
+  /// name surfaces immediately. The dialog stays open if the API call fails
+  /// so the user can retry without re-typing.
+  /// </summary>
+  private async Task RenamePresetAsync()
+  {
+    if (string.IsNullOrEmpty(_renamePresetId) || string.IsNullOrWhiteSpace(_renamePresetName))
+    {
+      return;
+    }
+
+    try
+    {
+      var success = await RadioApi.RenamePresetAsync(_renamePresetId, _renamePresetName);
+      if (success)
+      {
+        await LoadPresetsAsync();
+        NotificationService.Notify(NotificationSeverity.Success, "Renamed", $"Preset renamed to {_renamePresetName.Trim()}");
+        CloseRenamePresetDialog();
+      }
+      else
+      {
+        NotificationService.Notify(NotificationSeverity.Error, "Error", "Failed to rename preset — check API logs");
+      }
+    }
+    catch (Exception ex)
+    {
+      Logger.LogError(ex, "Error renaming preset {Id}", _renamePresetId);
+      NotificationService.Notify(NotificationSeverity.Error, "Error", $"Error renaming preset: {ex.Message}");
+    }
+  }
+
+  /// <summary>
+  /// Delete action from the kebab menu. Calls the existing DeletePresetAsync
+  /// which already toasts on success. No two-step confirm — the action is
+  /// reversible (the user can re-save the same band/frequency from the
+  /// long-press-band gesture).
+  /// </summary>
+  private async Task ConfirmDeleteAsync(string presetId)
+  {
+    _actionMenuPresetId = null;
+    await DeletePresetAsync(presetId);
   }
 
   private async Task CycleStepSizeAsync()

--- a/src/Radio.Web/Services/ApiClients/RadioApiService.cs
+++ b/src/Radio.Web/Services/ApiClients/RadioApiService.cs
@@ -318,6 +318,31 @@ public class RadioApiService
     }
   }
 
+  /// <summary>
+  /// Renames an existing preset. Added by the LED-font + preset-affordances
+  /// hot-fix off PR #371 so the kebab-menu Rename action can call PUT
+  /// /api/radio/presets/{id} with the new name. Returns the new name on
+  /// success so the caller can echo it into a toast without re-fetching.
+  /// </summary>
+  public async Task<bool> RenamePresetAsync(string id, string newName, CancellationToken cancellationToken = default)
+  {
+    if (string.IsNullOrWhiteSpace(newName))
+    {
+      return false;
+    }
+
+    try
+    {
+      var response = await _httpClient.PutAsJsonAsync($"/api/radio/presets/{id}", new { name = newName.Trim() }, cancellationToken);
+      return response.IsSuccessStatusCode;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to rename preset {Id}", id);
+      return false;
+    }
+  }
+
   public async Task<List<RadioDeviceDto>?> GetAvailableDevicesAsync(CancellationToken cancellationToken = default)
   {
     try

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -87,8 +87,19 @@
   --surface-hover:          rgba(255, 255, 255, 0.05);
 
   /* ── Typography Stacks ── */
-  --font-led:       'DSEG14Classic-Bold', 'JetBrains Mono', 'Consolas', monospace;
-  --font-led-light: 'DSEG14Classic-Regular', 'JetBrains Mono', 'Consolas', monospace;
+  /* Hot-fix (user feedback off PR #371): the DSEG14 "calculator LCD" font
+     read as cheap/toy-like on the live kiosk. The user asked for the LED
+     surfaces (clocks, frequency well, preset frequency column, queue total
+     tile, history led-value) to use the same display font as the radio
+     main frequency — that's Orbitron via --font-display. We point
+     --font-led at the same stack so every LED consumer migrates with a
+     single token swap. Bold weight is applied at each consumer site
+     (font-weight: 700) so the new font reads as "display chrome", not
+     body copy. --font-led-light retains DSEG-Regular for the rare
+     consumer that wanted the lighter LCD glyph weight; we keep the font
+     face available but no consumer references it after this fix. */
+  --font-led:       'Orbitron', 'JetBrains Mono', 'Consolas', monospace;
+  --font-led-light: 'Orbitron', 'JetBrains Mono', 'Consolas', monospace;
   --font-display:   'Orbitron', 'JetBrains Mono', 'Consolas', monospace;
   --font-mono:      'JetBrains Mono', 'SF Mono', 'Consolas', monospace;
   --font-body:      'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -196,7 +207,12 @@ html, body {
 
 .topbar-clock {
   font-family: var(--font-led);
-  font-size: 28px;
+  /* Hot-fix off PR #371: Orbitron at the previous DSEG14 size reads too
+     thick for the topbar; nudge slightly smaller while keeping the bold
+     weight that gives the clock its "display chrome" presence. */
+  font-size: 26px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
   color: var(--signal-amber);
   text-shadow: 0 0 8px var(--signal-amber-glow);
   min-width: 100px;
@@ -267,6 +283,8 @@ html, body {
 
 .cluster-value .font-led {
   font-family: var(--font-led);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
   color: var(--signal-amber);
   text-shadow: 0 0 6px var(--signal-amber-glow);
   letter-spacing: 2px;
@@ -669,17 +687,26 @@ html, body {
 
 .display-frequency {
   font-family: var(--font-display);
-  font-size: 52px;
+  /* Hot-fix off PR #371: user asked for the radio main frequency to be
+     20% smaller so it sits proportionally in the tuner column. Base
+     size dropped from 52px to 42px (52 × 0.8 = 41.6, rounded up to 42
+     for clean pixel alignment). Letter-spacing scaled in proportion
+     (4px → 3px) so the kerning still reads as "display chrome". */
+  font-size: 42px;
   font-weight: 600;
   color: var(--signal-amber);
   text-shadow:
     0 0 12px var(--signal-amber-glow),
     0 0 40px rgba(240, 168, 48, 0.10);
-  letter-spacing: 4px;
+  letter-spacing: 3px;
   line-height: 1;
 }
 
-/* Ghosted "all segments on" background — DSEG stays for authentic LCD look */
+/* Ghosted "all segments on" background — was DSEG14's "888.88 MHz" all-on
+   look. After the PR #371 hot-fix the LED stack is Orbitron, so the ghost
+   becomes a faint Orbitron silhouette of the same magnitude — still
+   reads as "set the display dimensions before the real value paints"
+   without the calculator-LCD vibe the user vetoed. */
 .display-frequency-ghost {
   position: relative;
 }
@@ -688,6 +715,8 @@ html, body {
   position: absolute;
   inset: 0;
   font-family: var(--font-led);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
   font-size: inherit;
   letter-spacing: inherit;
   color: rgba(240, 168, 48, 0.06);
@@ -2578,6 +2607,8 @@ body {
 
 .queue-total-tile-value {
   font-family: var(--font-led);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
   font-size: 30px;
   color: var(--signal-amber);
   letter-spacing: 0.02em;
@@ -2755,6 +2786,8 @@ body {
 
 .history-stats-value-led {
   font-family: var(--font-led);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
   font-size: 22px;
   color: var(--signal-amber);
   letter-spacing: 0.02em;
@@ -2813,12 +2846,16 @@ body {
 
 .sleep-screen-clock {
   font-family: var(--font-led);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
   font-size: 96px;
   color: var(--signal-amber);
   text-shadow: 0 0 24px color-mix(in srgb, var(--signal-amber) 50%, transparent);
   letter-spacing: 0.02em;
-  /* Block-level so the radial glow doesn't clip the descenders on the colon
-     glyph in DSEG14. */
+  /* Block-level so the radial glow doesn't clip descenders on the colon
+     glyph. (Was a DSEG14 quirk before the PR #371 hot-fix; Orbitron has
+     no descenders, but the rule remains harmless and keeps the layout
+     stable if the font swaps again.) */
   position: relative;
   line-height: 1;
 }
@@ -3410,12 +3447,21 @@ body {
 
 /* Tall band pills — override §RCP base .rcp-band-btn into a two-line column.
    The base rule already sets background/hover/active states; we layer on the
-   sizing and inner layout so the dual-line label fits comfortably. */
+   sizing and inner layout so the dual-line label fits comfortably.
+
+   Hot-fix off PR #371: min-width dropped 64 → 56 and sub-range font 8 → 7.5px
+   to free ~50px of horizontal budget across the six-pill row at 1920×720.
+   The user was still seeing AM + VHF labels clipped after the PR 3 fixer
+   added flex-wrap; combined with `width: 100%` on .rcp-band-group (set in
+   the component's inline style block), the row now fits cleanly or wraps
+   to 3+3 if the container narrows further. Inner padding also dropped
+   slightly (14px → 10px horizontal) so each pill is tighter without
+   crowding the dual-line label. */
 .rcp-band-btn {
-  min-width: 64px;
+  min-width: 56px;
   height: auto;
   min-height: 56px;
-  padding: 8px 14px 6px;
+  padding: 8px 10px 6px;
   flex-direction: column;
   justify-content: center;
   gap: 2px;
@@ -3431,8 +3477,8 @@ body {
 
 .rcp-band-sub {
   font-family: var(--font-mono);
-  font-size: 8px;
-  letter-spacing: 0.14em;
+  font-size: 7.5px;
+  letter-spacing: 0.12em;
   color: var(--text-low);
   line-height: 1;
   text-transform: uppercase;
@@ -3551,14 +3597,14 @@ body {
   border: 1px solid color-mix(in srgb, var(--signal-amber) 25%, transparent);
 }
 
-/* Preset row — grid layout: slot (22px) | name+band stack (1fr) | freq (64px).
-   This overrides the legacy `.rcp-preset-item` (defined in the RadioControlPanel
-   inline <style>) — both selectors will load, but our grid template + flex
-   children win because the row markup no longer uses .rcp-preset-name as a
-   block child; the row's own grid takes precedence for layout. */
+/* Preset row — grid layout: slot (22px) | name+band stack (1fr) | freq (64px) | kebab (24px).
+   Kebab column added by the LED-font + preset-affordances hot-fix off PR #371
+   so each row exposes a Rename / Delete affordance without consuming the
+   row's tap target. Long-press on the row also opens the kebab menu —
+   mirrors the band-pill long-press-to-save gesture from PR 3. */
 .rcp-preset-item {
   display: grid;
-  grid-template-columns: 22px 1fr 64px;
+  grid-template-columns: 22px 1fr 64px 24px;
   gap: 8px;
   align-items: center;
   padding: 6px 8px;
@@ -3629,10 +3675,15 @@ body {
 }
 
 /* Override legacy `.rcp-preset-freq` (which was a block sibling). Under the
-   grid it's the right-most cell, DSEG amber, right-aligned, with glow when
-   the row is the active preset. */
+   grid it's the right-most cell, amber, right-aligned, with glow when
+   the row is the active preset. Hot-fix off PR #371 swapped DSEG14 for
+   Orbitron via --font-led — bold + tabular-nums keeps the column
+   visually a "display chrome" cell and stops the kHz/MHz numerals from
+   jittering between rows. */
 .rcp-preset-item .rcp-preset-freq {
   font-family: var(--font-led);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
   font-size: 13px;
   text-align: right;
   color: var(--signal-amber);
@@ -3660,12 +3711,101 @@ body {
 }
 
 .rcp-preset-empty-hint {
-  grid-column: 2 / 4;
+  /* Spans from column 2 through the kebab cell — the empty placeholder has
+     no kebab affordance so this lets the hint fill the row. The grid is
+     now 4-column (slot | text | freq | kebab) after the PR #371 hot-fix
+     added the kebab cell. */
+  grid-column: 2 / 5;
   font-family: var(--font-mono);
   font-size: 9px;
   letter-spacing: 0.10em;
   text-transform: uppercase;
   color: var(--text-low);
+}
+
+/* Kebab affordance — small text-low ⋮ button that opens the Rename / Delete
+   popover. Lives in the 4th grid column on .rcp-preset-item. Click bubbles
+   are stopped at the markup level so tapping the kebab opens the menu
+   without also firing the row's "load preset" handler. Added by the
+   LED-font + preset-affordances hot-fix off PR #371. */
+.rcp-preset-kebab {
+  background: transparent;
+  border: none;
+  color: var(--text-low);
+  font-size: 18px;
+  line-height: 1;
+  padding: 2px 4px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 80ms ease, color 80ms ease;
+  -webkit-tap-highlight-color: transparent;
+  /* Right-align inside the column; the column itself is fixed-width so the
+     kebab sits flush with the row's right edge. */
+  justify-self: end;
+}
+
+.rcp-preset-kebab:hover {
+  background: color-mix(in srgb, var(--signal-amber) 12%, transparent);
+  color: var(--text-high);
+}
+
+.rcp-preset-kebab:focus-visible {
+  outline: 1px solid var(--signal-amber);
+  outline-offset: 1px;
+}
+
+/* Preset menu overlay — full-viewport dim with a centered card carrying
+   Rename and Delete actions. Esc / overlay tap closes. The danger variant
+   (.rcp-preset-menu-danger) wears a red text accent so Delete reads as
+   destructive without an extra confirm dialog (the action is undoable via
+   re-save). */
+.rcp-preset-menu-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rcp-preset-menu {
+  min-width: 200px;
+  background: var(--surface-elevated, #1e1e2e);
+  border: 1px solid var(--surface-separator);
+  border-radius: 8px;
+  padding: 6px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.rcp-preset-menu-item {
+  background: transparent;
+  border: none;
+  color: var(--text-high);
+  font-size: 14px;
+  padding: 10px 14px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: background 80ms ease;
+}
+
+.rcp-preset-menu-item:hover {
+  background: color-mix(in srgb, var(--signal-amber) 12%, transparent);
+}
+
+.rcp-preset-menu-danger {
+  color: #ff6b6b;
+}
+
+.rcp-preset-menu-danger:hover {
+  background: rgba(255, 107, 107, 0.12);
 }
 
 /* Suppress the legacy `::before` counter badge that the inline <style> defines

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -3801,11 +3801,11 @@ body {
 }
 
 .rcp-preset-menu-danger {
-  color: #ff6b6b;
+  color: var(--rz-danger);
 }
 
 .rcp-preset-menu-danger:hover {
-  background: rgba(255, 107, 107, 0.12);
+  background: color-mix(in srgb, var(--rz-danger) 12%, transparent);
 }
 
 /* Suppress the legacy `::before` counter badge that the inline <style> defines

--- a/tests/Radio.API.Tests/Controllers/RadioControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/RadioControllerTests.cs
@@ -556,6 +556,67 @@ public class RadioControllerTests : IClassFixture<CustomWebApplicationFactory<Pr
     Assert.DoesNotContain(presets, p => p.Id == createdPreset.Id);
   }
 
+  [Fact]
+  public async Task RenamePreset_WithValidData_UpdatesNameOnly()
+  {
+    // Hot-fix off PR #371 added PUT /api/radio/presets/{id} so the kebab
+    // Rename action has a server endpoint. Band/Frequency stay immutable —
+    // only Name + LastModifiedAt are touched.
+    var uniqueFreq = 96.7 + (Random.Shared.NextDouble() * 0.5);
+    var originalName = $"Rename Original {Guid.NewGuid():N}";
+    var createRequest = new CreateRadioPresetRequest
+    {
+      Name = originalName,
+      Band = "FM",
+      Frequency = uniqueFreq
+    };
+    var createResponse = await _client.PostAsJsonAsync("/api/radio/presets", createRequest);
+    if (createResponse.StatusCode == HttpStatusCode.Conflict)
+    {
+      uniqueFreq = 105.1 + (Random.Shared.NextDouble() * 0.5);
+      createRequest = createRequest with { Frequency = uniqueFreq };
+      createResponse = await _client.PostAsJsonAsync("/api/radio/presets", createRequest);
+    }
+    Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+    var createdPreset = await createResponse.Content.ReadFromJsonAsync<RadioPresetDto>();
+    Assert.NotNull(createdPreset);
+
+    var newName = $"Renamed {Guid.NewGuid():N}";
+    var renameResponse = await _client.PutAsJsonAsync(
+      $"/api/radio/presets/{createdPreset.Id}",
+      new RenameRadioPresetRequest { Name = newName });
+    Assert.Equal(HttpStatusCode.OK, renameResponse.StatusCode);
+    var renamed = await renameResponse.Content.ReadFromJsonAsync<RadioPresetDto>();
+    Assert.NotNull(renamed);
+    Assert.Equal(newName, renamed.Name);
+    Assert.Equal(createdPreset.Band, renamed.Band);
+    Assert.Equal(createdPreset.Frequency, renamed.Frequency);
+    Assert.Equal(createdPreset.Id, renamed.Id);
+
+    // Cleanup
+    await _client.DeleteAsync($"/api/radio/presets/{createdPreset.Id}");
+  }
+
+  [Fact]
+  public async Task RenamePreset_WithNonexistentId_ReturnsNotFound()
+  {
+    var response = await _client.PutAsJsonAsync(
+      "/api/radio/presets/nonexistent-id",
+      new RenameRadioPresetRequest { Name = "Anything" });
+    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+  }
+
+  [Fact]
+  public async Task RenamePreset_WithEmptyName_ReturnsBadRequest()
+  {
+    // The controller rejects empty / whitespace-only names up-front so
+    // the preset always carries a usable label.
+    var response = await _client.PutAsJsonAsync(
+      "/api/radio/presets/anything",
+      new RenameRadioPresetRequest { Name = "   " });
+    Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+  }
+
   #region Device Factory Endpoint Tests
 
   [Fact]

--- a/tests/Radio.Infrastructure.Tests/Audio/Services/RadioPresetServiceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Services/RadioPresetServiceTests.cs
@@ -286,6 +286,57 @@ public class RadioPresetServiceTests
     Assert.False(result);
   }
 
+  // ── Hot-fix off PR #371: rename endpoint coverage ──
+
+  [Fact]
+  public async Task RenamePresetAsync_TrimWhitespaceAndReturnsUpdatedPreset()
+  {
+    // The service trims the new name before passing to the repository, then
+    // re-fetches the updated row so the controller can echo it back to the
+    // client without an extra round-trip.
+    var renamed = new RadioPreset
+    {
+      Id = "1", Name = "KQED", Band = RadioBand.FM, Frequency = 88_500_000
+    };
+    _repositoryMock
+      .Setup(r => r.UpdateNameAsync("1", "KQED", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(true);
+    _repositoryMock
+      .Setup(r => r.GetByIdAsync("1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(renamed);
+
+    var service = CreateService();
+    var result = await service.RenamePresetAsync("1", "  KQED  ");
+
+    Assert.NotNull(result);
+    Assert.Equal("KQED", result!.Name);
+    _repositoryMock.Verify(r => r.UpdateNameAsync("1", "KQED", It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task RenamePresetAsync_ReturnsNullWhenIdNotFound()
+  {
+    _repositoryMock
+      .Setup(r => r.UpdateNameAsync("missing", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(false);
+
+    var service = CreateService();
+    var result = await service.RenamePresetAsync("missing", "Anything");
+
+    Assert.Null(result);
+  }
+
+  [Theory]
+  [InlineData("")]
+  [InlineData("   ")]
+  [InlineData(null)]
+  public async Task RenamePresetAsync_ThrowsOnEmptyOrWhitespaceName(string? name)
+  {
+    var service = CreateService();
+    await Assert.ThrowsAsync<ArgumentException>(
+      () => service.RenamePresetAsync("1", name!));
+  }
+
   [Fact]
   public async Task PresetExistsAsync_ReturnsTrueWhenExists()
   {

--- a/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using AngleSharp.Dom;
 using Bunit;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -636,6 +637,58 @@ public class RadioControlPanelTests : TestContext
     Assert.Single(cut.FindAll(".rcp-preset-menu"));
 
     cut.Find(".rcp-preset-menu-overlay").Click();
+    Assert.Empty(cut.FindAll(".rcp-preset-menu"));
+  }
+
+  [Fact]
+  public void PresetActionMenu_HasMenuRole()
+  {
+    // Polisher pass on PR #373: a11y. The popover surface must announce as a
+    // menu (role=menu + aria-label), and each item must carry role=menuitem
+    // so screen readers traverse the actions correctly. The kebab button
+    // itself is already an accessible <button> with aria-label.
+    var state = BuildState();
+    var presets = new[]
+    {
+      BuildPreset("p1", "KQED", 88_500_000, "FM", 1),
+    };
+    var cut = RenderPanel(state, presets: presets, bands: new[] { BuildFmBand(16) });
+
+    cut.Find(".rcp-preset-kebab").Click();
+
+    var menu = cut.Find(".rcp-preset-menu");
+    Assert.Equal("menu", menu.GetAttribute("role"));
+    Assert.False(string.IsNullOrWhiteSpace(menu.GetAttribute("aria-label")));
+
+    var items = cut.FindAll(".rcp-preset-menu-item");
+    Assert.Equal(2, items.Count);
+    foreach (var item in items)
+    {
+      Assert.Equal("menuitem", item.GetAttribute("role"));
+    }
+  }
+
+  [Fact]
+  public void PresetActionMenu_EscKey_ClosesMenu()
+  {
+    // Polisher pass on PR #373: the inline-CSS comment at design-system.css
+    // promises "Esc / overlay tap closes" — overlay tap was wired but Esc
+    // wasn't. After this fix, a keydown of "Escape" on the overlay dismisses
+    // the menu (the overlay is tabindex=0 so it can receive keyboard events,
+    // and Esc from focused menu items bubbles up).
+    var state = BuildState();
+    var presets = new[]
+    {
+      BuildPreset("p1", "KQED", 88_500_000, "FM", 1),
+    };
+    var cut = RenderPanel(state, presets: presets, bands: new[] { BuildFmBand(16) });
+
+    cut.Find(".rcp-preset-kebab").Click();
+    Assert.Single(cut.FindAll(".rcp-preset-menu"));
+
+    var overlay = cut.Find(".rcp-preset-menu-overlay");
+    overlay.KeyDown(new KeyboardEventArgs { Key = "Escape" });
+
     Assert.Empty(cut.FindAll(".rcp-preset-menu"));
   }
 

--- a/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
@@ -406,8 +406,13 @@ public class RadioControlPanelTests : TestContext
   }
 
   [Fact]
-  public void PresetsHeader_ShowsCountAndCapacity()
+  public void PresetsHeader_ShowsTotalSavedCount()
   {
+    // Hot-fix off PR #371: the header counter dropped the per-band "N of CAP"
+    // form (which was confusing once the list itself stopped filtering by
+    // band) and now shows the total saved count across all bands. The empty
+    // placeholder remains scoped to the current band's capacity — tested
+    // separately.
     var state = BuildState();
     var presets = new[]
     {
@@ -418,7 +423,9 @@ public class RadioControlPanelTests : TestContext
 
     var count = cut.Find(".rcp-presets-count");
     Assert.Contains("MEMORY", count.TextContent);
-    Assert.Contains("2 of 16", count.TextContent);
+    Assert.Contains("2 saved", count.TextContent);
+    // The old "of CAP" form must be gone — defends against a regression.
+    Assert.DoesNotContain(" of ", count.TextContent);
   }
 
   [Fact]
@@ -519,22 +526,171 @@ public class RadioControlPanelTests : TestContext
   }
 
   [Fact]
-  public void Presets_FilteredToCurrentBand()
+  public void Presets_ShowAllBands_NotFilteredByCurrentBand()
   {
-    // FM tuned; presets include one AM. The AM preset should not render in
-    // the FM memory bank — the filter runs client-side in LoadPresetsAsync.
+    // Hot-fix off PR #371: user couldn't find their saved WB preset while
+    // tuned to FM. The list now shows ALL saved presets across all bands;
+    // the per-row .rcp-preset-band sub-line carries the band context so
+    // cross-band visibility is navigable.
     var state = BuildState(band: "FM");
     var presets = new[]
     {
       BuildPreset("p1", "KQED", 88_500_000, "FM", 1),
       BuildPreset("p2", "KCBS-AM", 740_000, "AM", 1),
+      BuildPreset("p3", "WX-Sierra", 162_550_000, "WB", 1),
     };
     var cut = RenderPanel(state, presets: presets, bands: new[] { BuildFmBand(), BuildAmBand() });
 
     var names = cut.FindAll(".rcp-preset-item:not(.rcp-preset-empty) .rcp-preset-name")
       .Select(e => e.TextContent.Trim()).ToList();
     Assert.Contains("KQED", names);
-    Assert.DoesNotContain("KCBS-AM", names);
+    Assert.Contains("KCBS-AM", names);
+    Assert.Contains("WX-Sierra", names);
+  }
+
+  [Fact]
+  public void EmptyPlaceholder_ScopedToCurrentBand_WhenOtherBandSavedPresetsExist()
+  {
+    // Hot-fix off PR #371: even though the list shows all bands, the empty
+    // placeholder still scopes to the CURRENT band so saving stays in-band.
+    // FM is current; one FM preset saved (capacity 16); AM has its own
+    // preset that should NOT count toward the empty slot calculation.
+    var state = BuildState(band: "FM");
+    var presets = new[]
+    {
+      BuildPreset("p1", "KQED", 88_500_000, "FM", 1),
+      BuildPreset("p2", "KCBS-AM", 740_000, "AM", 1),
+    };
+    var cut = RenderPanel(state, presets: presets, bands: new[] { BuildFmBand(16), BuildAmBand(16) });
+
+    var empties = cut.FindAll(".rcp-preset-empty");
+    Assert.Single(empties);
+    // Slot 2 — second FM preset, NOT the third row in the (mixed-band) list.
+    Assert.Equal("02", empties[0].QuerySelector(".rcp-preset-slot")!.TextContent.Trim());
+    Assert.Contains("FM", empties[0].QuerySelector(".rcp-preset-empty-hint")!.TextContent);
+  }
+
+  [Fact]
+  public void PresetRow_RendersKebabButton()
+  {
+    // Hot-fix off PR #371: each row carries a trailing ⋮ button that opens
+    // the Rename / Delete menu. Verifies the kebab is on EVERY real preset
+    // row (the empty placeholder has no kebab — it isn't actionable).
+    var state = BuildState();
+    var presets = new[]
+    {
+      BuildPreset("p1", "KQED", 88_500_000, "FM", 1),
+      BuildPreset("p2", "KCBS", 99_700_000, "FM", 2),
+    };
+    var cut = RenderPanel(state, presets: presets, bands: new[] { BuildFmBand(16) });
+
+    var realRows = cut.FindAll(".rcp-preset-item:not(.rcp-preset-empty)");
+    Assert.Equal(2, realRows.Count);
+    foreach (var row in realRows)
+    {
+      var kebab = row.QuerySelector(".rcp-preset-kebab");
+      Assert.NotNull(kebab);
+      Assert.Equal("⋮", kebab!.TextContent.Trim());
+    }
+  }
+
+  [Fact]
+  public void PresetKebabClick_OpensActionMenu()
+  {
+    // Hot-fix off PR #371: clicking the kebab opens the action popover with
+    // Rename + Delete options. The popover is rendered via @if on the
+    // _actionMenuPresetId field so it materialises after the click.
+    var state = BuildState();
+    var presets = new[]
+    {
+      BuildPreset("p1", "KQED", 88_500_000, "FM", 1),
+    };
+    var cut = RenderPanel(state, presets: presets, bands: new[] { BuildFmBand(16) });
+
+    Assert.Empty(cut.FindAll(".rcp-preset-menu"));
+
+    var kebab = cut.Find(".rcp-preset-kebab");
+    kebab.Click();
+
+    var menu = cut.Find(".rcp-preset-menu");
+    Assert.NotNull(menu);
+    var items = cut.FindAll(".rcp-preset-menu-item");
+    Assert.Equal(2, items.Count);
+    Assert.Contains("Rename", items[0].TextContent);
+    Assert.Contains("Delete", items[1].TextContent);
+  }
+
+  [Fact]
+  public void PresetMenuOverlayClick_ClosesActionMenu()
+  {
+    // Clicking the overlay (background of the menu) closes the menu — same
+    // dismiss pattern as the save/rename dialogs.
+    var state = BuildState();
+    var presets = new[]
+    {
+      BuildPreset("p1", "KQED", 88_500_000, "FM", 1),
+    };
+    var cut = RenderPanel(state, presets: presets, bands: new[] { BuildFmBand(16) });
+
+    cut.Find(".rcp-preset-kebab").Click();
+    Assert.Single(cut.FindAll(".rcp-preset-menu"));
+
+    cut.Find(".rcp-preset-menu-overlay").Click();
+    Assert.Empty(cut.FindAll(".rcp-preset-menu"));
+  }
+
+  [Fact]
+  public void PresetMenuRenameClick_OpensRenameDialogPrefilled()
+  {
+    // The Rename action transitions from the popover into a text-entry
+    // dialog pre-filled with the preset's current name (one-keystroke
+    // small-edit UX).
+    var state = BuildState();
+    var presets = new[]
+    {
+      BuildPreset("p1", "KQED", 88_500_000, "FM", 1),
+    };
+    var cut = RenderPanel(state, presets: presets, bands: new[] { BuildFmBand(16) });
+
+    cut.Find(".rcp-preset-kebab").Click();
+    var renameItem = cut.FindAll(".rcp-preset-menu-item")[0];
+    renameItem.Click();
+
+    // Menu closes, rename dialog opens.
+    Assert.Empty(cut.FindAll(".rcp-preset-menu"));
+    Assert.Single(cut.FindAll(".rcp-preset-rename-card"));
+  }
+
+  [Fact]
+  public void RadioPresetDto_DtoFieldShapeIsStable()
+  {
+    // The hot-fix introduced a new API client method (RenamePresetAsync)
+    // and a new server-side endpoint (PUT /api/radio/presets/{id}). The
+    // wire-shape DTO is unchanged — verify by asserting on the fields the
+    // Web side serialises/deserialises.
+    var t = typeof(RadioPresetDto);
+    Assert.NotNull(t.GetProperty(nameof(RadioPresetDto.Id), BindingFlags.Public | BindingFlags.Instance));
+    Assert.NotNull(t.GetProperty(nameof(RadioPresetDto.Name), BindingFlags.Public | BindingFlags.Instance));
+    Assert.NotNull(t.GetProperty(nameof(RadioPresetDto.Band), BindingFlags.Public | BindingFlags.Instance));
+    Assert.NotNull(t.GetProperty(nameof(RadioPresetDto.Frequency), BindingFlags.Public | BindingFlags.Instance));
+    Assert.NotNull(t.GetProperty(nameof(RadioPresetDto.SlotNumber), BindingFlags.Public | BindingFlags.Instance));
+  }
+
+  [Fact]
+  public void RadioApiService_ExposesRenamePresetAsync()
+  {
+    // Hot-fix off PR #371: the kebab Rename action calls PUT
+    // /api/radio/presets/{id}. Verify via reflection that the Web client
+    // exposes the new method with the expected signature (id, newName, ct).
+    var method = typeof(RadioApiService).GetMethod(
+      "RenamePresetAsync",
+      BindingFlags.Public | BindingFlags.Instance);
+    Assert.NotNull(method);
+    var parameters = method!.GetParameters();
+    Assert.Equal(3, parameters.Length);
+    Assert.Equal(typeof(string), parameters[0].ParameterType);
+    Assert.Equal(typeof(string), parameters[1].ParameterType);
+    Assert.Equal(typeof(CancellationToken), parameters[2].ParameterType);
   }
 
   [Fact]


### PR DESCRIPTION
User feedback hot-fix off main after the Arc 2 PR 3 merge (#371), parallel to PR #372 still under review.

## Summary

Six issues raised by the user on the live kiosk:

1. **LED font replaced.** `--font-led` was DSEG14Classic-Bold (calculator LCD). User asked for the LED surfaces to use the same font as the radio main frequency. Swapped the token to Orbitron (the radio frequency's font via `--font-display`) and added `font-weight: 700` + `font-variant-numeric: tabular-nums` at each consumer site so the surfaces read as display chrome. Affects topbar clock, sleep clock, freq ghost, preset frequency column, queue total tile, history led-value.
2. **Radio main frequency 20% smaller.** `.display-frequency` 52 → 42px, `.rcp-freq-well` override 54 → 43px, letter-spacing scaled in proportion.
3. **Band pill row no longer clips at 1920×720.** Belt-and-suspenders fix on top of the PR 3 wrap: `width: 100%` on `.rcp-band-group`, `min-width 64 → 56` on `.rcp-band-btn`, horizontal padding 14 → 10, sub-range font 8 → 7.5px. Six pills fit cleanly or wrap to 3+3.
4. **Preset list shows all bands.** Removed the per-band client filter so the user's saved WB preset is visible while tuned to FM. Sorted by Band then per-band slot. Memory counter shows total saved across all bands; the single empty-slot placeholder still scopes to the current band so saving stays in-band.
5. **Preset rename/delete affordances.** Each row gained a trailing `⋮` kebab opening a popover with Rename + Delete. Long-press on the row opens the same menu (mirrors the PR 3 band-pill long-press save pattern). Server-side: added `PUT /api/radio/presets/{id}` with full repository → service → controller → Web client wiring.
6. **Clock font** — covered by #1 (clock consumed `var(--font-led)`, picked up Orbitron automatically).

## Server-side API additions

- `IRadioPresetRepository.UpdateNameAsync(id, newName, ct)` — \`UPDATE\` only the Name + LastModifiedAt; Band + Frequency immutable.
- `IRadioPresetService.RenamePresetAsync(id, newName, ct)` — trims, rejects empty/whitespace, refetches the row to echo back.
- `RadioController.RenamePreset(id, RenameRadioPresetRequest)` — `PUT /api/radio/presets/{id}`. Returns the renamed DTO (200), 400 on empty name, 404 on unknown ID.
- `RadioApiService.RenamePresetAsync(id, newName, ct)` — Web client helper used by the kebab menu.

## Test plan

- [x] \`dotnet build src/Radio.Web/Radio.Web.csproj\` — clean (0 errors).
- [x] \`dotnet build src/Radio.API/Radio.API.csproj\` — clean (0 errors).
- [x] \`dotnet test tests/Radio.Web.Tests/Radio.Web.Tests.csproj\` — 423/423 pass (7 new tests, 2 updated for new header text + show-all-bands semantics).
- [x] \`dotnet test tests/Radio.API.Tests/Radio.API.Tests.csproj\` — 269/270 pass (1 pre-existing flake in `AudioEngineInitializationServiceTests.StartAsync_EnumeratesDevices`, unrelated to this PR — confirmed via `git stash + test on main`).
- [x] \`dotnet test tests/Radio.Infrastructure.Tests/Radio.Infrastructure.Tests.csproj --filter \"~RadioPresetService\"\` — 21/21 pass (4 new tests for rename happy path, not-found, empty/whitespace rejection).
- [ ] **Tester UAT at 1920×720** — required gate, see below.

## Tester UAT checklist

This PR ships visual and gesture changes that bUnit can only validate structurally. Live kiosk verification:

- [ ] Topbar clock renders in Orbitron Bold (not DSEG14 calculator-LCD glyphs) and is legible.
- [ ] Radio main frequency in the tuner well is visibly ~20% smaller than the PR #371 version, still amber-glowing, still tabular.
- [ ] Sleep screen clock (route `/sleep`) is Orbitron Bold at 96px, no descenders cut off.
- [ ] Six band pills (AM / FM / WB / VHF / SW / HF or whatever the kiosk has) fit in one row at 1920×720 without clipping any labels; if any narrower viewport, they wrap to 3+3 instead of overflowing.
- [ ] With at least one FM preset and one WB preset saved, the FM-tuned home page shows BOTH in the memory bank.
- [ ] Memory counter reads \"MEMORY · N saved\" (not the old \"of CAP\" form).
- [ ] Empty placeholder row shows \"EMPTY · long-press FM to save\" (current band) and disappears once the current band hits its capacity.
- [ ] Tapping the ⋮ kebab opens the action menu without also tuning the preset; menu shows Rename + Delete.
- [ ] Long-pressing a preset row (≥600ms) opens the same menu and does NOT also tune the preset on release.
- [ ] Rename → dialog opens pre-filled with current name → typing + Save → toast \"Preset renamed to <NEW>\" → row name updates.
- [ ] Delete → toast \"Preset deleted\" → row gone.
- [ ] Menu overlay (background dim) tap closes the menu.

## Operator note

Schema unchanged — the rename endpoint reuses the existing `RadioPresets` table (only `Name` + `LastModifiedAt` columns are updated). No migration required; deploy and restart `radio-api.service` + `radio-web.service` on the kiosk.

## Spec ambiguity surfaced

The handoff said \"replace LED fonts with same large font we use for the radio frequency\" but the spec writer suggested JetBrains Mono. The radio frequency uses Orbitron via `--font-display`. I went with the user's literal words (Orbitron) since unifying with the actual radio frequency font matches the stated intent. If the user prefers JetBrains Mono Bold instead, swap the `--font-led` token value and `--font-led-light` to the JetBrains Mono stack — every consumer site picks up the change automatically (the `font-weight: 700` + `tabular-nums` rules are font-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)