### PR TITLE
chore(deps): bump NuGet packages to non-vulnerable versions

### DIFF
--- a/src/Radio.Configuration/Radio.Configuration.csproj
+++ b/src/Radio.Configuration/Radio.Configuration.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />

--- a/src/Radio.Infrastructure/Radio.Infrastructure.csproj
+++ b/src/Radio.Infrastructure/Radio.Infrastructure.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
   <!-- Linux-only: Tmds.DBus for BlueZ D-Bus interop -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Tmds.DBus" Version="0.90.2" />
+    <PackageReference Include="Tmds.DBus" Version="0.93.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Radio.Configuration\Radio.Configuration.csproj" />

--- a/tests/Radio.Configuration.Tests/Radio.Configuration.Tests.csproj
+++ b/tests/Radio.Configuration.Tests/Radio.Configuration.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/tests/Radio.Infrastructure.Tests/Radio.Infrastructure.Tests.csproj
+++ b/tests/Radio.Infrastructure.Tests/Radio.Infrastructure.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/tools/Radio.Tools.ConfigurationManager/Radio.Tools.ConfigurationManager.csproj
+++ b/tools/Radio.Tools.ConfigurationManager/Radio.Tools.ConfigurationManager.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes Coordinator backlog task #6.

## Summary

CI's `Build and Test` workflow has been failing on every PR since 2026-03-16 because three NuGet packages had active CVEs and `TreatWarningsAsErrors=true` (Directory.Build.props) escalates NuGet audit warnings to build errors. This PR bumps them to non-vulnerable versions.

| Package | Before | After | Severity | Advisory |
|---|---|---|---|---|
| Microsoft.AspNetCore.DataProtection | 10.0.0 | 10.0.8 | CRITICAL | GHSA-9mv3-2cwr-p262 (fixed >= 10.0.7) |
| Microsoft.AspNetCore.DataProtection.Extensions | 10.0.0 | 10.0.8 | (same advisory family) | bumped to match parent |
| Tmds.DBus | 0.90.2 | 0.93.0 | HIGH | GHSA-xrw6-gwf8-vvr9 (fixed >= 0.92.0) |
| System.Security.Cryptography.Xml | 10.0.0 (transitive) | 10.0.8 (transitive) | HIGH (2 advisories) | GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf (fixed >= 10.0.6) |

`System.Security.Cryptography.Xml` is purely transitive (via `Microsoft.AspNetCore.DataProtection`), so bumping the parent pulls in a non-vulnerable transitive — no direct reference added.

### Files touched (5)

- `src/Radio.Configuration/Radio.Configuration.csproj`
- `src/Radio.Infrastructure/Radio.Infrastructure.csproj`
- `tests/Radio.Configuration.Tests/Radio.Configuration.Tests.csproj`
- `tests/Radio.Infrastructure.Tests/Radio.Infrastructure.Tests.csproj`
- `tools/Radio.Tools.ConfigurationManager/Radio.Tools.ConfigurationManager.csproj`

### Note on Tmds.DBus versioning

`Tmds.DBus` uses unusual versioning. The 0.21.x line existed historically and the 0.9x line is the active/current lineage (0.90.x -> 0.91.x -> 0.92.x -> 0.93.x). The handoff prompt suggested "0.21.0 (relaunch)" but the GHSA advisory confirms the fix is in 0.92.0 along the 0.9x line; 0.93.0 is the current latest. The BlueZ D-Bus consumers in `src/Radio.Infrastructure/Platform/Bluetooth/Linux/` (`BluezAgent.cs`, `BluezInterfaces.cs`) use only the stable public surface (`[DBusInterface]`, `IDBusObject`, `ObjectPath`, `Connection`) which has been unchanged across 0.90.x and 0.93.x — no source changes required, full build clean.

## Test plan

- [x] `dotnet restore RadioConsole.sln` succeeds without `-p:NuGetAudit=false`
- [x] `dotnet build --configuration Release --no-restore` succeeds with 0 errors, 42 warnings (all pre-existing IDE0011 style rules whitelisted in `WarningsNotAsErrors`). No `NU190x` audit warnings.
- [x] `dotnet test --configuration Release --no-build --filter "FullyQualifiedName!~Radio.Web.E2ETests&Category!=Integration"` passes 1828/1829. The single failure (`Radio.API.Tests.Services.AudioEngineInitializationServiceTests.StartAsync_EnumeratesDevices`) is a pre-existing flake documented in MEMORY.md, deterministically failing on `main` with the same Moq mock-count signature — unrelated to NuGet bumps (it touches `IAudioDeviceManager` mocks, not DataProtection / SSCXml / Tmds.DBus).
- [ ] CI `Build and Test` workflow passes on this PR (the goal of the change)

## Operator note

After this PR merges, subsequent PRs no longer need `-p:NuGetAudit=false` on local builds — CI should stay green on `main` and on PRs that don't introduce new vulnerable transitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)