### PR TITLE
fix(api): AudioDtoMapper handles duplicate Duration keys without throwing

### DIFF
--- a/src/Radio.API/Controllers/QueueController.cs
+++ b/src/Radio.API/Controllers/QueueController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Radio.API.Extensions;
+using Radio.API.Mappers;
 using Radio.API.Models;
 using Radio.Core.Interfaces.Audio;
 
@@ -383,7 +384,11 @@ public class QueueController : ControllerBase
     if (source is IPrimaryAudioSource primary)
     {
       dto.IsSeekable = primary.IsSeekable;
-      dto.Metadata = primary.Metadata.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+      // Use AudioDtoMapper.CopyMetadataSafe rather than .ToDictionary() — see that
+      // helper's doc for why .ToDictionary() can throw an ArgumentException when
+      // background threads mutate the source's live metadata dictionary during
+      // enumeration.
+      dto.Metadata = AudioDtoMapper.CopyMetadataSafe(primary.Metadata);
     }
 
     return dto;

--- a/src/Radio.API/Mappers/AudioDtoMapper.cs
+++ b/src/Radio.API/Mappers/AudioDtoMapper.cs
@@ -38,7 +38,13 @@ public static class AudioDtoMapper
     if (source is IPrimaryAudioSource primary)
     {
       dto.IsSeekable = primary.IsSeekable;
-      dto.Metadata = primary.Metadata.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+      // Use last-write-wins copy rather than .ToDictionary(): the source's Metadata
+      // is a live, mutable Dictionary shared with background threads (fingerprinting,
+      // AVRCP metadata events, file metadata loading). If a resize/rehash races with
+      // enumeration here, the iterator can yield the same key twice and .ToDictionary
+      // throws ArgumentException ("An item with the same key has already been added.
+      // Key: Duration"). Indexer assignment swallows that race deterministically.
+      dto.Metadata = CopyMetadataSafe(primary.Metadata);
 
       // Bluetooth metadata enrichment
       if (source.Type == AudioSourceType.Bluetooth)
@@ -226,5 +232,24 @@ public static class AudioDtoMapper
       return value.ToString();
     }
     return null;
+  }
+
+  /// <summary>
+  /// Copies a source metadata dictionary into a fresh <see cref="Dictionary{TKey, TValue}"/> using
+  /// last-write-wins semantics for duplicate keys. Audio source <c>Metadata</c> is a live, mutable
+  /// dictionary shared with background threads (fingerprinting, AVRCP, file metadata loaders).
+  /// A raw <see cref="Enumerable.ToDictionary{TSource, TKey, TElement}(IEnumerable{TSource}, Func{TSource, TKey}, Func{TSource, TElement})"/>
+  /// call would throw <see cref="ArgumentException"/> if a concurrent mutation caused the iterator
+  /// to yield the same key (e.g. <c>Duration</c>) twice. Indexer assignment swallows that race
+  /// deterministically — any duplicate observed during enumeration just overwrites the earlier value.
+  /// </summary>
+  public static Dictionary<string, object> CopyMetadataSafe(IReadOnlyDictionary<string, object> source)
+  {
+    var copy = new Dictionary<string, object>(source.Count);
+    foreach (var kvp in source)
+    {
+      copy[kvp.Key] = kvp.Value;
+    }
+    return copy;
   }
 }

--- a/tests/Radio.API.Tests/Mappers/AudioDtoMapperTests.cs
+++ b/tests/Radio.API.Tests/Mappers/AudioDtoMapperTests.cs
@@ -1,5 +1,8 @@
+using Moq;
 using Radio.API.Mappers;
 using Radio.API.Models;
+using Radio.Core.Interfaces.Audio;
+using Radio.Core.Models.Audio;
 
 namespace Radio.API.Tests.Mappers;
 
@@ -55,5 +58,159 @@ public class AudioDtoMapperTests
     // also surface as None — the UI's pip widget needs an unambiguous band.
     Assert.Equal(ConfidenceBucket.None,
       AudioDtoMapper.ToConfidenceBucket(isMatch: true, rawConfidence: null));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Duplicate-key regression coverage for the metadata copy in MapToDto.
+  //
+  // The original bug surfaced as:
+  //   ArgumentException: An item with the same key has already been added.
+  //   Key: Duration
+  // raised from inside AudioDtoMapper.MapToDto when /api/sources serialized an
+  // active source whose live metadata dictionary yielded the same key twice
+  // during enumeration (race with background metadata writers — fingerprinting,
+  // AVRCP, file-tag loader). The fix replaces the LINQ .ToDictionary() call
+  // with an indexer-assignment copy (CopyMetadataSafe) so a duplicate key is
+  // silently coalesced rather than thrown.
+  //
+  // These tests exercise the helper directly and through MapToDto with a fake
+  // dictionary that mimics the race by emitting a duplicate key during
+  // enumeration.
+  // ---------------------------------------------------------------------------
+
+  [Fact]
+  public void CopyMetadataSafe_WithDuplicateKeysDuringEnumeration_DoesNotThrow()
+  {
+    // The fake represents a concurrent-mutation race: the iterator yields the
+    // same key twice. A raw .ToDictionary() would throw ArgumentException here.
+    var racing = new DuplicateKeyEnumerableDictionary
+    {
+      { StandardMetadataKeys.Title, "Test Track" },
+      { StandardMetadataKeys.Duration, TimeSpan.FromSeconds(180) },
+      // Second yield of the same key — last-write-wins should swallow it.
+      { StandardMetadataKeys.Duration, TimeSpan.FromSeconds(999) }
+    };
+
+    var copy = AudioDtoMapper.CopyMetadataSafe(racing);
+
+    Assert.True(copy.ContainsKey(StandardMetadataKeys.Duration));
+    // Last writer wins — this is documented behaviour, not load-bearing in
+    // production (the only realistic source of duplicates is a race during
+    // enumeration, where either value is equally valid).
+    Assert.Equal(TimeSpan.FromSeconds(999), copy[StandardMetadataKeys.Duration]);
+    Assert.Equal("Test Track", copy[StandardMetadataKeys.Title]);
+  }
+
+  [Fact]
+  public void CopyMetadataSafe_PreservesAllUniqueEntries()
+  {
+    var source = new Dictionary<string, object>
+    {
+      [StandardMetadataKeys.Title] = "Be Still My Soul",
+      [StandardMetadataKeys.Artist] = "Steven Sharp Nelson",
+      [StandardMetadataKeys.Album] = "Sacred Cello",
+      [StandardMetadataKeys.Duration] = TimeSpan.FromSeconds(164),
+      ["Source"] = "Bluetooth",
+      ["Device"] = "Pixel 8"
+    };
+
+    var copy = AudioDtoMapper.CopyMetadataSafe(source);
+
+    Assert.Equal(6, copy.Count);
+    foreach (var kvp in source)
+    {
+      Assert.Equal(kvp.Value, copy[kvp.Key]);
+    }
+  }
+
+  [Fact]
+  public void MapToDto_WithDuplicateDurationKeyInLiveMetadata_DoesNotThrow()
+  {
+    // Reproduces the original Tester report: a primary source whose live
+    // metadata dictionary races during enumeration and emits Duration twice.
+    // MapToDto must absorb this without bubbling an ArgumentException to the
+    // /api/sources HTTP response.
+    var racing = new DuplicateKeyEnumerableDictionary
+    {
+      { StandardMetadataKeys.Title, "Be Still My Soul" },
+      { StandardMetadataKeys.Artist, "Steven Sharp Nelson" },
+      { StandardMetadataKeys.Duration, "00:02:44" },
+      // Duplicate yield mid-enumeration — the production bug.
+      { StandardMetadataKeys.Duration, "00:02:44" }
+    };
+
+    var sourceMock = new Mock<IPrimaryAudioSource>();
+    sourceMock.SetupGet(s => s.Id).Returns("bt-1");
+    sourceMock.SetupGet(s => s.Name).Returns("Bluetooth Audio");
+    sourceMock.SetupGet(s => s.Type).Returns(AudioSourceType.Bluetooth);
+    sourceMock.SetupGet(s => s.Category).Returns(AudioSourceCategory.Primary);
+    sourceMock.SetupGet(s => s.State).Returns(AudioSourceState.Playing);
+    sourceMock.SetupGet(s => s.Volume).Returns(0.75f);
+    sourceMock.SetupGet(s => s.IsSeekable).Returns(false);
+    sourceMock.SetupGet(s => s.Metadata).Returns(racing);
+
+    var dto = sourceMock.Object.MapToDto();
+
+    Assert.NotNull(dto);
+    Assert.NotNull(dto.Metadata);
+    Assert.True(dto.Metadata!.ContainsKey(StandardMetadataKeys.Duration));
+    Assert.Equal("Be Still My Soul", dto.Metadata[StandardMetadataKeys.Title]);
+    // Bluetooth enrichment (lines 44-50 of AudioDtoMapper) still runs after
+    // the metadata copy, so Source/Device must be present too.
+    Assert.Equal("Bluetooth", dto.Metadata["Source"]);
+    Assert.True(dto.Metadata.ContainsKey("Device"));
+  }
+
+  /// <summary>
+  /// An <see cref="IReadOnlyDictionary{TKey, TValue}"/> that simulates a
+  /// concurrent-mutation race by emitting each entry exactly as it was added,
+  /// even if the same key is added twice. The real
+  /// <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/> can
+  /// briefly enter this state if a resize/rehash races with enumeration — the
+  /// iterator picks up the key from both the old and new buckets.
+  /// </summary>
+  private sealed class DuplicateKeyEnumerableDictionary : IReadOnlyDictionary<string, object>
+  {
+    private readonly List<KeyValuePair<string, object>> _entries = new();
+
+    public void Add(string key, object value) => _entries.Add(new KeyValuePair<string, object>(key, value));
+
+    public object this[string key]
+    {
+      get
+      {
+        foreach (var kvp in _entries)
+        {
+          if (kvp.Key == key)
+          {
+            return kvp.Value;
+          }
+        }
+        throw new KeyNotFoundException(key);
+      }
+    }
+
+    public IEnumerable<string> Keys => _entries.Select(kvp => kvp.Key);
+    public IEnumerable<object> Values => _entries.Select(kvp => kvp.Value);
+    public int Count => _entries.Count;
+
+    public bool ContainsKey(string key) => _entries.Any(kvp => kvp.Key == key);
+
+    public bool TryGetValue(string key, out object value)
+    {
+      foreach (var kvp in _entries)
+      {
+        if (kvp.Key == key)
+        {
+          value = kvp.Value;
+          return true;
+        }
+      }
+      value = null!;
+      return false;
+    }
+
+    public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => _entries.GetEnumerator();
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _entries.GetEnumerator();
   }
 }


### PR DESCRIPTION
Closes Coordinator backlog task #10.

## Summary

The pre-existing `AudioDtoMapper` duplicate-`Duration`-key bug Tester surfaced during PR 2 UAT — local Windows `/api/sources` returned 500 because the mapper's `MapToDto` called LINQ `.ToDictionary()` on `primary.Metadata`, which can throw `ArgumentException: An item with the same key has already been added. Key: Duration` when the source's live mutable metadata dictionary is being written to concurrently by a background thread (fingerprinting pipeline, AVRCP metadata events, file-tag loader). The .NET `Dictionary<>` iterator can yield an entry from both the old and the new bucket during a concurrent resize/rehash, and the LINQ key-selector callback then sees the same key twice.

## Fix

- New `AudioDtoMapper.CopyMetadataSafe(IReadOnlyDictionary<string, object>)` helper that copies the source via `foreach` + indexer assignment. Last-write-wins absorbs any racy duplicate yield rather than throwing.
- `AudioDtoMapper.MapToDto` now uses the helper.
- `QueueController.MapToAudioSourceDto` had the same `.ToDictionary()` shape and is now routed through the shared helper.

Local Windows API serves `/api/sources` successfully — no more need for the `ApiBaseUrl=radio:5000` workaround Tester used throughout Arc 1 and Arc 2 UATs.

## Root cause (the actual key being added twice)

`Duration`. It's set by:
- `BluetoothAudioSource.OnMetadataChanged` (`MetadataInternal[StandardMetadataKeys.Duration] = e.Duration.ToString()`)
- `FilePlayerAudioSource.LoadFileMetadataAsync` (`_metadata[StandardMetadataKeys.Duration] = _duration`)

Both write to a Dictionary that has no lock around it, so a concurrent `MapToDto` on the HTTP request thread can race their writes during dictionary resize and see the same key emitted twice by the enumerator.

## Approach

Option B/A hybrid: indexer-assignment copy, which is the simplest defensive merge. Last-write-wins is the right semantic here since both yields of `Duration` during an enumeration race are observing the same logical value — the "duplicate" only exists because of the bucket-state race, not because the source ever had two semantically distinct durations.

## Test plan

- [x] New `AudioDtoMapperTests` cases for the duplicate-key scenario:
  - `CopyMetadataSafe_WithDuplicateKeysDuringEnumeration_DoesNotThrow`
  - `CopyMetadataSafe_PreservesAllUniqueEntries`
  - `MapToDto_WithDuplicateDurationKeyInLiveMetadata_DoesNotThrow`
- [x] `dotnet test --filter AudioDtoMapperTests` — 16/16 green (13 prior confidence-bucket + 3 new)
- [x] Full `Radio.API.Tests` suite — 272/273 green; the 1 failure is the pre-existing `AudioEngineInitializationServiceTests.StartAsync_EnumeratesDevices` Moq invocation-count mismatch the task description warned about. Confirmed to fail identically on `main` without this change; not a regression.
- [x] Local `dotnet run --project src/Radio.API` → `curl /api/sources` returns 200 with both FilePlayer and Bluetooth sources serialized (including BT `Duration` metadata).
- [x] Build clean (`-p:NuGetAudit=false` still required until #374 merges; will drop after).

## Notes for reviewer

The duplicate-key test fakes the race deterministically via a custom `IReadOnlyDictionary` impl that emits a duplicate key on enumeration — without it the test would need to race the GC/resize loop, which is flaky. With the old `.ToDictionary()` code restored, this test reproduces the original Tester failure exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)