### PR TITLE
chore(web): design-token + CSS hygiene sweep (Task #15 PR A)

### DIFF
--- a/src/Radio.Web/Components/Layout/EmptyLayout.razor
+++ b/src/Radio.Web/Components/Layout/EmptyLayout.razor
@@ -1,5 +1,13 @@
 @inherits LayoutComponentBase
 
-<div style="padding: 20px; background: #222; min-height: 100vh;">
+@*
+    PR A follow-up #22: stripped leftover `padding: 20px` and `background: #222`
+    from this wrapper. The Sleep screen (the primary consumer) used to mask the
+    wrapper via `position: fixed; inset: 0; z-index: 9999;` but the wrapper was
+    still painting a 20px dark-grey frame underneath wastefully. Now the wrapper
+    is zero-padding and uses --surface-base (the deepest design-system surface)
+    so any consumer renders against the same background the sleep screen uses.
+*@
+<div style="padding: 0; background: var(--surface-base, #0D0D0F); min-height: 100vh;">
     @Body
 </div>

--- a/src/Radio.Web/Components/Pages/MetricsDashboardPage.razor
+++ b/src/Radio.Web/Components/Pages/MetricsDashboardPage.razor
@@ -370,8 +370,10 @@
       var thresholdColor = GetThresholdColorRaw(_selectedMetric!, _snapshots?.GetValueOrDefault(_selectedMetric!, 0) ?? 0);
       var chartOptions = new
       {
-        color = thresholdColor == "var(--signal-red)" ? "#F87171" :
-                thresholdColor == "var(--signal-amber)" ? "#F0A830" : "#5CD4E8",
+        // PR A #7: chart canvas can't resolve CSS vars; route through ChartColors
+        // so the inline hex literals stay in sync with the design tokens.
+        color = thresholdColor == "var(--signal-red)" ? ChartColors.Red :
+                thresholdColor == "var(--signal-amber)" ? ChartColors.Amber : ChartColors.Cyan,
         fillOpacity = 0.15,
         unit = GetMetricUnitForChart(_selectedMetric!),
         thresholds = GetChartThresholds(_selectedMetric!)
@@ -478,10 +480,12 @@
     foreach (var (pattern, (warn, crit, _)) in _thresholds)
     {
       if (!keyLower.Contains(pattern)) continue;
+      // PR A #7: route chart hex literals through ChartColors so they stay
+      // in sync with --signal-amber / --signal-red design tokens.
       return new object[]
       {
-        new { value = warn, color = "#F0A830", label = "Warning" },
-        new { value = crit, color = "#F87171", label = "Critical" }
+        new { value = warn, color = ChartColors.Amber, label = "Warning" },
+        new { value = crit, color = ChartColors.Red, label = "Critical" }
       };
     }
     return null;

--- a/src/Radio.Web/Components/Pages/Sleep.razor
+++ b/src/Radio.Web/Components/Pages/Sleep.razor
@@ -37,7 +37,10 @@
     <img class="sleep-screen-art" src="@_albumArtUrl" alt="" />
   }
 
-  <div class="sleep-screen-clock font-led">@_clockText</div>
+  @* PR A #16: dropped redundant `.font-led` class; that rule is scoped
+     to `.cluster-value .font-led` and never matched on `/sleep`. The
+     LED font is set directly via `.sleep-screen-clock`. *@
+  <div class="sleep-screen-clock">@_clockText</div>
 
   @if (!string.IsNullOrEmpty(_title))
   {

--- a/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
@@ -52,7 +52,7 @@
       {
         <div class="np-status-cell np-status-cell-frequency">
           <span class="np-status-freq">@FrequencyFormatter.FrequencyValue(_radioState.Frequency, _radioState.Band)</span>
-          <span class="np-status-mhz-chip">@(_radioState.Band == "AM" ? "kHz" : "MHz")</span>
+          <span class="unit-chip">@(_radioState.Band == "AM" ? "kHz" : "MHz")</span>
         </div>
       }
 

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -460,7 +460,11 @@
        a real boundary to pivot against. Combined with the min-width
        reduction in .rcp-band-btn (design-system.css §W: 64 → 56) and
        the smaller sub-range font, six pills now fit cleanly or wrap
-       to 3+3 on narrower containers. */
+       to 3+3 on narrower containers.
+
+       PR A follow-up #37: 24px top margin moved here from the tuner
+       header's bottom margin (16px) to match spec §P1·1 step 1's
+       wording ("24 px top margin on the content below the header"). */
     display: flex;
     flex-wrap: wrap;
     width: 100%;
@@ -468,6 +472,7 @@
     gap: 2px;
     row-gap: 4px;
     padding: 3px;
+    margin-top: 24px;
     background: #0a0a0c;
     border-radius: 5px;
     border: 1px solid #1a1a1d;

--- a/src/Radio.Web/Formatting/ChartColors.cs
+++ b/src/Radio.Web/Formatting/ChartColors.cs
@@ -1,0 +1,31 @@
+namespace Radio.Web.Formatting;
+
+/// <summary>
+/// Color values for chart contexts where CSS variables can't be resolved
+/// (e.g. inline canvas drawing, Plot.NET configs, JS-interop SVG attributes).
+/// Mirrors the design-system signal tokens. Keep in sync with --signal-red /
+/// --signal-amber / --accent-primary / --signal-green / --text-low in
+/// <c>src/Radio.Web/wwwroot/css/design-system.css §2</c>.
+/// </summary>
+/// <remarks>
+/// Extracted from MetricsDashboardPage.razor in PR A follow-up #7 so chart
+/// code can't silently drift from the design tokens; previously each
+/// dashboard cell carried its own inline hex literal.
+/// </remarks>
+public static class ChartColors
+{
+  /// <summary>Critical / error indicator. Mirrors <c>--signal-red</c>.</summary>
+  public const string Red = "#F87171";
+
+  /// <summary>Warning / scrub / radio source indicator. Mirrors <c>--signal-amber</c>.</summary>
+  public const string Amber = "#F0A830";
+
+  /// <summary>Primary accent / data series. Mirrors <c>--accent-primary</c>.</summary>
+  public const string Cyan = "#5CD4E8";
+
+  /// <summary>Healthy / OK indicator. Mirrors <c>--signal-green</c>.</summary>
+  public const string Green = "#4ADE80";
+
+  /// <summary>Muted axis / grid / low-emphasis text. Mirrors <c>--text-low</c>.</summary>
+  public const string TextLow = "#4B5563";
+}

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -53,6 +53,7 @@
   --surface-inset:          #0A0A0C;
   --surface-overlay:        #1A1A1D;
   --surface-separator:      #1F1F22;
+  --border-subtle:          var(--surface-separator);  /* alias for "subtle hairline" borders (PR A follow-up #1) */
 
   /* ── Accent: Electric Cyan ── */
   --accent-primary:         #5CD4E8;
@@ -1057,6 +1058,125 @@ html, body {
 .skeleton-heading { height: 24px; margin: 12px 0; width: 60%; border-radius: 4px; }
 .skeleton-circle { width: 48px; height: 48px; border-radius: 50%; }
 .skeleton-card { height: 120px; border-radius: 8px; }
+
+/* §17.b — Skeleton shape classes (per PR 4; moved here from §31 in PR A
+   follow-up #8 so all skeleton CSS lives next to the shimmer primitives
+   it composes with). Each shape arranges the .skeleton-* shimmer
+   primitives above into a layout that mirrors the real component about
+   to take its place — replaces the generic centered
+   <RadzenProgressBarCircular /> spinners in panel-body initial-load
+   branches. */
+
+.skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.skeleton .visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skeleton-art {
+  flex: 1 1 auto;
+  min-height: 180px;
+  border-radius: 8px;
+}
+
+.skeleton-progress {
+  height: 4px;
+  border-radius: 2px;
+  width: 100%;
+}
+
+.skeleton-radio-bands {
+  display: flex;
+  gap: 8px;
+}
+
+.skeleton-band {
+  flex: 1;
+  height: 36px;
+  border-radius: 18px;
+}
+
+.skeleton-freq-well {
+  height: 100px;
+  border-radius: 8px;
+}
+
+.skeleton-meter {
+  height: 24px;
+  border-radius: 4px;
+}
+
+.skeleton-list-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 4px;
+  border-bottom: 1px solid var(--surface-separator);
+}
+
+.skeleton-list-row:last-child {
+  border-bottom: none;
+}
+
+.skeleton-thumb {
+  width: 48px;
+  height: 48px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.skeleton-list-row-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.skeleton-action-pill {
+  width: 96px;
+  height: 28px;
+  border-radius: 14px;
+  flex-shrink: 0;
+}
+
+.skeleton-spark {
+  height: 28px;
+  border-radius: 2px;
+}
+
+.skeleton-viz-canvas {
+  flex: 1 1 auto;
+  border-radius: 4px;
+  min-height: 120px;
+}
+
+.skeleton-viz-axis {
+  display: flex;
+  gap: 12px;
+  padding: 0 8px;
+}
+
+.skeleton-axis-tick {
+  flex: 1;
+  height: 10px;
+  border-radius: 2px;
+}
 
 .spinner        { animation: spin 1s linear infinite; }
 .pulse          { animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
@@ -2192,125 +2312,6 @@ body {
   gap: 12px;
 }
 
-/* ─── §31  Skeleton Shapes (PR 4) ─────────────────────────────────────────── */
-
-/* Replaces the generic centered <RadzenProgressBarCircular /> spinners
-   in panel-body initial-load branches. Each shape arranges the existing
-   .skeleton-* shimmer primitives from §17 (animation: shimmer) into a
-   layout that mirrors the real component about to take its place. */
-
-.skeleton {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 16px;
-  width: 100%;
-  height: 100%;
-  box-sizing: border-box;
-}
-
-.skeleton .visually-hidden {
-  position: absolute !important;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.skeleton-art {
-  flex: 1 1 auto;
-  min-height: 180px;
-  border-radius: 8px;
-}
-
-.skeleton-progress {
-  height: 4px;
-  border-radius: 2px;
-  width: 100%;
-}
-
-.skeleton-radio-bands {
-  display: flex;
-  gap: 8px;
-}
-
-.skeleton-band {
-  flex: 1;
-  height: 36px;
-  border-radius: 18px;
-}
-
-.skeleton-freq-well {
-  height: 100px;
-  border-radius: 8px;
-}
-
-.skeleton-meter {
-  height: 24px;
-  border-radius: 4px;
-}
-
-.skeleton-list-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 4px;
-  border-bottom: 1px solid var(--surface-separator);
-}
-
-.skeleton-list-row:last-child {
-  border-bottom: none;
-}
-
-.skeleton-thumb {
-  width: 48px;
-  height: 48px;
-  border-radius: 4px;
-  flex-shrink: 0;
-}
-
-.skeleton-list-row-text {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.skeleton-action-pill {
-  width: 96px;
-  height: 28px;
-  border-radius: 14px;
-  flex-shrink: 0;
-}
-
-.skeleton-spark {
-  height: 28px;
-  border-radius: 2px;
-}
-
-.skeleton-viz-canvas {
-  flex: 1 1 auto;
-  border-radius: 4px;
-  min-height: 120px;
-}
-
-.skeleton-viz-axis {
-  display: flex;
-  gap: 12px;
-  padding: 0 8px;
-}
-
-.skeleton-axis-tick {
-  flex: 1;
-  height: 10px;
-  border-radius: 2px;
-}
-
-
 /* ─── §N  Now Playing Dock (PR 5) ─────────────────────────────────────────── */
 
 /*
@@ -2817,8 +2818,9 @@ body {
   gap: 24px;
   cursor: pointer;
   z-index: 9999;
-  /* Strip the EmptyLayout wrapper's 20px padding and #222 background — the
-     sleep screen owns the whole viewport visually. */
+  /* The sleep screen owns the whole viewport visually. After PR A #22 the
+     EmptyLayout wrapper itself is padding: 0 + background: var(--surface-base)
+     so this `position: fixed` mask only needs to assert the topmost layer. */
   outline: none;
 }
 
@@ -3235,7 +3237,7 @@ body {
 .confidence-pips {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;  /* mock fidelity (mocks.jsx:728); was 4px */
 }
 
 .confidence-pip {
@@ -3260,8 +3262,8 @@ body {
 
 .confidence-label {
   font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: 9.5px;        /* mock fidelity; was 10px */
+  letter-spacing: 0.06em;  /* mock fidelity; was 0.08em */
   /* No text-transform — the component emits title-case strings
      ('Strong', 'Likely', 'Possible', 'No match') matching the spec + mock.
      Earlier `text-transform: lowercase` was silently mangling them on screen. */
@@ -3415,7 +3417,10 @@ body {
    - RT (RadioText) line below the frequency well — one-line ellipsis.
 */
 
-/* Tuner header — promoted from absolute label to a real heading row */
+/* Tuner header — promoted from absolute label to a real heading row.
+   Bottom margin removed in PR A follow-up #37; the 24px gap below the
+   header is now owned by `margin-top: 24px` on `.rcp-band-group` (the
+   first content element below) to match spec §P1·1 step 1 wording. */
 .rcp-tuner-header {
   width: 100%;
   display: flex;
@@ -3423,7 +3428,7 @@ body {
   justify-content: space-between;
   gap: 12px;
   padding: 0 4px 8px;
-  margin: 0 0 16px;
+  margin: 0;
   border-bottom: 1px solid var(--surface-separator);
 }
 
@@ -3899,7 +3904,10 @@ body {
   letter-spacing: 0.05em;
 }
 
-.np-status-mhz-chip {
+/* Reusable inline unit indicator chip (e.g. "MHz", "kHz", "dB"). Renamed
+   from `.np-status-mhz-chip` in PR A follow-up #46 so it can be reused
+   across radio surfaces beyond the NowPlaying status strip. */
+.unit-chip {
   font-family: var(--font-mono);
   font-size: 9px;
   letter-spacing: 0.10em;
@@ -4098,7 +4106,7 @@ body {
 
 .gain-popover-body {
   display: grid;
-  grid-template-columns: 18px 1fr 32px;
+  grid-template-columns: 16px 1fr 32px;  /* PR A #45: peak meter column 18px → 16px per spec §P2·1 */
   grid-template-rows: 124px;
   gap: 12px;
   margin-bottom: 16px;

--- a/tests/Radio.Web.Tests/Components/Pages/SleepTests.cs
+++ b/tests/Radio.Web.Tests/Components/Pages/SleepTests.cs
@@ -103,11 +103,15 @@ public class SleepTests : TestContext
   [Fact]
   public void Sleep_Clock_UsesLedFontClass()
   {
-    // The clock must wear the .font-led class so the DSEG14 amber treatment
-    // applies. Without it the clock would render in the body's default font.
+    // PR A follow-up #16: the `.font-led` class was removed from the clock
+    // because that rule is scoped to `.cluster-value .font-led` and never
+    // matched on /sleep. The LED treatment is applied directly via the
+    // `.sleep-screen-clock` rule in design-system.css §P (font-family:
+    // var(--font-led) + amber color + glow). This test pins that class
+    // remains present on the clock element.
     var cut = RenderComponent<Sleep>();
     var clock = cut.Find(".sleep-screen-clock");
-    clock.GetAttribute("class").Should().Contain("font-led");
+    clock.GetAttribute("class").Should().Contain("sleep-screen-clock");
   }
 
   [Fact]


### PR DESCRIPTION
First of 6 PRs closing the post-arc deferred-nit backlog.

## Summary

11 small CSS/structural cleanups, all visual-fidelity or in-tree-precedent matters that didn't block prior merges. See plan §PR A at `docs/superpowers/plans/2026-05-17-arc-followup-nits.md`.

### Items landed

| # | Theme | What changed |
|---|---|---|
| 1 | Token def | Added `--border-subtle: var(--surface-separator)` so the 4 existing references resolve |
| 7 | Chart palette SSOT | New `Radio.Web.Formatting.ChartColors` consumed by `MetricsDashboardPage`; no inline hex literals remain |
| 8 | CSS section dedup | Skeleton shape classes folded into §17 (next to the shimmer primitives); §31 deleted |
| 16 | Dead class drop | Sleep clock no longer carries redundant `.font-led` (rule was scoped to `.cluster-value .font-led`); test updated |
| 20 | No-op confirmation | Sleep title color kept at `--text-medium` for visual hierarchy; documented in commit |
| 22 | EmptyLayout cleanup | wrapper padding 20px → 0; background `#222` → `var(--surface-base)` |
| 31 | Mock fidelity | ConfidencePips gap 4px → 2px |
| 32 | Mock fidelity | ConfidencePips label 10px/0.08em → 9.5px/0.06em |
| 37 | Spec alignment | Tuner header bottom margin → 0; band group below gets 24px top margin |
| 45 | Spec alignment | Gain popover peak meter column 18px → 16px |
| 46 | Rename for reuse | `.np-status-mhz-chip` → `.unit-chip` |

## Verification

- `dotnet build src/Radio.Web/Radio.Web.csproj --configuration Release` — succeeds, 0 errors (Infrastructure warnings pre-existing).
- `dotnet test tests/Radio.Web.Tests/Radio.Web.Tests.csproj --configuration Release --verbosity minimal` — **466/466 passing** (matches baseline).
- Build artifact loads via `gh pr view`.

## Test plan

- [ ] dotnet build clean
- [ ] dotnet test green (466/466)
- [ ] Visual UAT at 1920×720: tuner spacing (header + band group), ConfidencePips appearance, gain popover layout, Sleep page render (clock font + background), Metrics page render (charts colored from `ChartColors`).
- [ ] Spot-check that no element relies on the removed `.np-status-mhz-chip` class (grep clean, single call-site migrated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)