### PR TITLE
chore(web): UAT data + tester-side improvements (Task #15 PR F)

### DIFF
--- a/deploy/scripts/seed-test-history.sql
+++ b/deploy/scripts/seed-test-history.sql
@@ -1,0 +1,153 @@
+-- seed-test-history.sql
+--
+-- One-shot UAT fixture: inserts a few historical PlayHistory rows so the
+-- /play-history page exercises all three branches of
+-- Radio.Web.Formatting.Timestamps.FormatRelative visually during UAT.
+--
+-- The kiosk runs continuously and PlayHistory rows accrue only when a
+-- track actually plays. In daily UAT every visible row tends to read
+-- "Today HH:mm" because the freshly-played-through-the-day rows
+-- dominate the LIMIT 20 window. This script seeds:
+--
+--   * One row from yesterday      -> exercises "Yesterday HH:mm" branch
+--   * One row from 3 days ago     -> exercises "MMM d · HH:mm" branch
+--   * One row from ~30 days ago   -> exercises "MMM d · HH:mm" branch
+--                                    further back, to verify month rollover
+--
+-- Each row references a seeded TrackMetadata row so the JOIN in
+-- SqlitePlayHistoryRepository.GetRecentAsync surfaces a real title/artist
+-- instead of "Unknown - Unknown".
+--
+-- ## Usage
+--
+-- On the kiosk (Ubuntu x64) or Pi:
+--
+--   sqlite3 /opt/radio-console/data/fingerprints/fingerprints.db \
+--           < deploy/scripts/seed-test-history.sql
+--
+-- Then open /play-history in the kiosk UI. You should see at minimum:
+--
+--   Today HH:mm        (existing rows from normal use, if any)
+--   Yesterday HH:mm    UAT Seed - Yesterday's Broadcast / Tester Fixture
+--   MMM d · HH:mm      UAT Seed - Three Days Back / Tester Fixture
+--   MMM d · HH:mm      UAT Seed - One Month Back / Tester Fixture
+--
+-- ## Idempotency
+--
+-- All inserts use INSERT OR IGNORE keyed on stable Id GUIDs. Re-running
+-- the script is a no-op after the first run. To re-seed with fresh
+-- relative dates (e.g. after several weeks have passed and "yesterday"
+-- is no longer yesterday), DELETE the rows by Id first, then re-run.
+--
+-- ## Cleanup
+--
+-- DELETE FROM PlayHistory  WHERE Id LIKE 'uat-seed-%';
+-- DELETE FROM TrackMetadata WHERE Id LIKE 'uat-seed-%';
+
+BEGIN TRANSACTION;
+
+-- ---------------------------------------------------------------------------
+-- Track metadata for the seeded rows. Realistic-ish titles so the UI doesn't
+-- look like obvious test data on a casual glance, but tagged "UAT Seed -"
+-- so an operator can spot and clean them.
+-- ---------------------------------------------------------------------------
+
+INSERT OR IGNORE INTO TrackMetadata (
+  Id, FingerprintId, Title, Artist, Album, AlbumArtist,
+  TrackNumber, DiscNumber, ReleaseYear, Genre,
+  MusicBrainzArtistId, MusicBrainzReleaseId, MusicBrainzRecordingId, CoverArtUrl,
+  Source, CreatedAt, UpdatedAt
+) VALUES
+  (
+    'uat-seed-meta-yesterday',
+    NULL,
+    'UAT Seed - Yesterday''s Broadcast',
+    'Tester Fixture',
+    'Relative Time Tests',
+    'Tester Fixture',
+    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,
+    'Manual',
+    datetime('now', '-1 day'),
+    datetime('now', '-1 day')
+  ),
+  (
+    'uat-seed-meta-three-days',
+    NULL,
+    'UAT Seed - Three Days Back',
+    'Tester Fixture',
+    'Relative Time Tests',
+    'Tester Fixture',
+    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,
+    'Manual',
+    datetime('now', '-3 days'),
+    datetime('now', '-3 days')
+  ),
+  (
+    'uat-seed-meta-one-month',
+    NULL,
+    'UAT Seed - One Month Back',
+    'Tester Fixture',
+    'Relative Time Tests',
+    'Tester Fixture',
+    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,
+    'Manual',
+    datetime('now', '-30 days'),
+    datetime('now', '-30 days')
+  );
+
+-- ---------------------------------------------------------------------------
+-- Play history rows. Source values must match the PlaySource enum string
+-- form (see src/Radio.Core/Models/Audio/PlayHistoryEntry.cs). PlayedAt is
+-- ISO 8601; strftime emits the form SqlitePlayHistoryRepository expects
+-- (DateTimeOffset.Parse round-trip).
+-- ---------------------------------------------------------------------------
+
+INSERT OR IGNORE INTO PlayHistory (
+  Id, TrackMetadataId, FingerprintId,
+  PlayedAt, EndedAt, Source, MetadataSource, SourceDetails,
+  Duration, IdentificationConfidence, WasIdentified
+) VALUES
+  (
+    'uat-seed-hist-yesterday',
+    'uat-seed-meta-yesterday',
+    NULL,
+    strftime('%Y-%m-%dT%H:%M:%S.000+00:00', 'now', '-1 day'),
+    strftime('%Y-%m-%dT%H:%M:%S.000+00:00', 'now', '-1 day', '+3 minutes'),
+    'Radio',
+    'Manual',
+    'UAT seed (yesterday)',
+    180,
+    NULL,
+    0
+  ),
+  (
+    'uat-seed-hist-three-days',
+    'uat-seed-meta-three-days',
+    NULL,
+    strftime('%Y-%m-%dT%H:%M:%S.000+00:00', 'now', '-3 days'),
+    strftime('%Y-%m-%dT%H:%M:%S.000+00:00', 'now', '-3 days', '+3 minutes'),
+    'File',
+    'Manual',
+    'UAT seed (three days ago)',
+    195,
+    NULL,
+    0
+  ),
+  (
+    'uat-seed-hist-one-month',
+    'uat-seed-meta-one-month',
+    NULL,
+    strftime('%Y-%m-%dT%H:%M:%S.000+00:00', 'now', '-30 days'),
+    strftime('%Y-%m-%dT%H:%M:%S.000+00:00', 'now', '-30 days', '+3 minutes'),
+    'File',
+    'Manual',
+    'UAT seed (one month ago)',
+    210,
+    NULL,
+    0
+  );
+
+COMMIT;

--- a/src/Radio.Web/Components/Shared/VisualizerPanel.razor
+++ b/src/Radio.Web/Components/Shared/VisualizerPanel.razor
@@ -76,6 +76,27 @@
 
   <!-- Full-bleed canvas -->
   <div class="visualizer-canvas-wrap">
+    @*
+      Canvas is rendered UNCONDITIONALLY here, not inside the @if branch
+      below. visualizer.js's init call in OnAfterRenderAsync targets the
+      canvas by element id (WebConstants.ElementIds.VisualizerCanvas), so
+      the element must already exist in the DOM on the first render pass —
+      we can't gate it on _isInitialized without creating a chicken-and-egg
+      between "init runs after canvas mounts" and "canvas mounts after
+      init succeeds".
+
+      The Skeleton in the !_isInitialized branch therefore overlays the
+      already-mounted-but-not-yet-drawn-to canvas for the brief window
+      between first render and the successful return of visualizer.init.
+      This produces a visible "skeleton sitting on top of blank canvas"
+      flash for ~1 frame on slow connections. That is INTENTIONAL — it
+      bridges the gap so users don't see a blank black rectangle. Don't
+      "fix" the overlap by hiding the canvas behind _isInitialized; that
+      would break visualizer.init's element lookup. The visualizer-canvas
+      and skeleton both fill the wrap via position: absolute / inset: 0,
+      and the skeleton's z-index sits above the canvas until the @if
+      flips and the skeleton unmounts.
+    *@
     <canvas id="@WebConstants.ElementIds.VisualizerCanvas" class="visualizer-canvas"></canvas>
 
     @if (_isInitialized && !_hasReceivedData)


### PR DESCRIPTION
Sixth and smallest of the task #15 follow-up nit bundle PRs.

## Summary

- #4: PlayHistory seed script under `deploy/scripts/seed-test-history.sql` so `Timestamps.FormatRelative`'s `Yesterday` + `MMM d · HH:mm` branches are exercised visually during UAT. Idempotent (`INSERT OR IGNORE` keyed on stable `uat-seed-*` Ids), cleanup queries documented in the script header.
- #10: VisualizerPanel inline `@* … *@` comment explaining the intentional skeleton-atop-canvas flash (canvas must be unconditionally mounted for `visualizer.init` to target it via element id; skeleton overlays until `OnAfterRenderAsync` flips `_isInitialized`).

No production code-behavior changes; pure docs + ops fixture.

## Plan reference

`docs/superpowers/plans/2026-05-17-arc-followup-nits.md` §PR F.

## Implementation notes

- No in-tree seeder exists for `PlayHistory` (only the table-creation DDL in `FingerprintDbContext.CreateTablesAsync`), so per plan §PR F option (b) the fix lands as a one-shot SQL script for operators rather than a code-side seeder. This keeps the change profile to "ops tooling, no runtime behavior" and lets the operator opt in (the script is *not* run by `Deploy-ToLinux.ps1`).
- The script seeds 3 `PlayHistory` rows + 3 matching `TrackMetadata` rows: yesterday, 3 days ago, ~30 days ago. The 3-day row exercises the same `MMM d · HH:mm` branch as the 30-day row but with a different month-rollover risk profile.
- `Source` enum values (`Radio`, `File`) match `PlaySource.ToString()` in `src/Radio.Core/Models/Audio/PlayHistoryEntry.cs`, mirroring what `SqlitePlayHistoryRepository.RecordPlayAsync` emits.
- `PlayedAt` uses `strftime('%Y-%m-%dT%H:%M:%S.000+00:00', 'now', '-N day')` so the value round-trips through `DateTimeOffset.Parse` in `SqlitePlayHistoryRepository.MapFromReader` cleanly.
- VisualizerPanel comment placed inside the `<div class=\"visualizer-canvas-wrap\">` block, immediately before the `<canvas>` element so it's the first thing a future reader sees when investigating the skeleton flash.

## Verify

```powershell
dotnet build src/Radio.Web/Radio.Web.csproj --configuration Release  # clean (0 warn / 0 err)
dotnet test  tests/Radio.Web.Tests/Radio.Web.Tests.csproj --configuration Release --nologo  # 494 / 494 pass
```

No test changes; behavior is unchanged.

## Operator note

To seed UAT data on the live kiosk after deploy:

```bash
sqlite3 /opt/radio-console/data/fingerprints/fingerprints.db \
        < deploy/scripts/seed-test-history.sql
```

Then open `/play-history` to confirm all three FormatRelative branches render. Cleanup queries are documented in the script's header comment.

## Test plan

- [x] Build clean (0 warnings, 0 errors).
- [x] Existing tests green (494/494 Web tests pass).
- [ ] Operator runs the seed script against the kiosk db; `/play-history` shows seeded "Yesterday" and "MMM d · HH:mm" rows alongside organic "Today" rows. (Manual UAT, not gated by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)