### PR TITLE
feat(web/api): server-side follow-ups (Task #15 PR D)

### DIFF
--- a/src/Radio.API/Controllers/AudioDebugController.cs
+++ b/src/Radio.API/Controllers/AudioDebugController.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Radio.API.Controllers;
+
+/// <summary>
+/// Debug-only audio endpoints surfaced to the DevTray. Today the only
+/// route is a stubbed audio-frame dump that returns 501 with a clear
+/// message — the SoundFlow output pipeline does not yet expose a way to
+/// retain the last N seconds of mixed PCM in a re-readable buffer (PR D
+/// #23 of the Arc follow-up backlog).
+/// <para>
+/// When the underlying buffer becomes available, replace the stub with
+/// a real WAV serializer: grab the last 5 s from the tap, prefix a WAV
+/// header, return as <c>application/octet-stream</c>. The DevTray opens
+/// the URL in a new tab, so any 200/file download will trigger the
+/// browser's save-as dialog.
+/// </para>
+/// <para>
+/// <b>Authorization:</b> no auth policy exists in this project today
+/// (no <c>[Authorize]</c> usages anywhere in <c>Radio.API</c>). Until a
+/// kiosk-auth policy is wired the endpoint is reachable from the local
+/// network. For the stub this is acceptable — the payload is a 501
+/// description, not real audio. When the real endpoint lands the
+/// follow-up PR must add an authorization gate.
+/// </para>
+/// </summary>
+[ApiController]
+[Route("api/audio/debug")]
+[Produces("application/json")]
+public class AudioDebugController : ControllerBase
+{
+  private readonly ILogger<AudioDebugController> _logger;
+
+  public AudioDebugController(ILogger<AudioDebugController> logger)
+  {
+    _logger = logger;
+  }
+
+  /// <summary>
+  /// Dumps the last 5 seconds of mixed audio as a WAV download. Currently
+  /// returns <c>501 Not Implemented</c> — see class summary for why and
+  /// what the real implementation needs from the SoundFlow pipeline.
+  /// </summary>
+  [HttpGet("dump-frame")]
+  [ProducesResponseType(typeof(object), StatusCodes.Status501NotImplemented)]
+  public IActionResult DumpAudioFrame()
+  {
+    _logger.LogInformation("Audio-frame dump requested via DevTray; returning 501 stub");
+    return StatusCode(StatusCodes.Status501NotImplemented, new
+    {
+      error = "Audio-frame dump not yet implemented.",
+      reason = "The SoundFlow output stage does not currently retain a re-readable buffer of the last N seconds of mixed PCM. A follow-up PR will add a circular buffer tap that the dump endpoint can serialize to WAV.",
+      tracked = "Arc follow-up #23"
+    });
+  }
+}

--- a/src/Radio.API/Controllers/ConfigurationController.cs
+++ b/src/Radio.API/Controllers/ConfigurationController.cs
@@ -336,6 +336,15 @@ public class ConfigurationController : ControllerBase
       }
     }
 
+    // PR D #30 — section-specific value validation. RadioOptions.ScanStopThreshold
+    // is clamped silently by RadioStateMapper.PercentToDbu; explicit validation
+    // is friendlier to API consumers than silent saturation.
+    var sectionValidation = ValidateSectionValues(section, data);
+    if (sectionValidation != null)
+    {
+      return sectionValidation;
+    }
+
     try
     {
       // Use the main configuration store (determined by CurrentStoreType)
@@ -382,6 +391,72 @@ public class ConfigurationController : ControllerBase
     {
       _logger.LogError(ex, "Error updating configuration section {Section}", section);
       return StatusCode(500, new { error = "Failed to update configuration" });
+    }
+  }
+
+  /// <summary>
+  /// Section-specific validation. Called after the generic shape checks pass.
+  /// Returns a <see cref="BadRequestObjectResult"/> on validation failure, or
+  /// <c>null</c> if the values are acceptable. Today this only enforces the
+  /// radio-section threshold range (PR D #30); add additional sections as
+  /// they accumulate hard-bound fields.
+  /// </summary>
+  private static ActionResult? ValidateSectionValues(string section, IDictionary<string, object> data)
+  {
+    if (string.Equals(section, "radio", StringComparison.OrdinalIgnoreCase))
+    {
+      if (data.TryGetValue("ScanStopThreshold", out var rawValue))
+      {
+        if (TryReadInt(rawValue, out var pct))
+        {
+          if (pct < 0 || pct > 100)
+          {
+            return new BadRequestObjectResult(new
+            {
+              error = "ScanStopThreshold must be between 0 and 100 (percent).",
+              field = "ScanStopThreshold",
+              value = pct
+            });
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  /// <summary>
+  /// Reads an int out of a raw JSON value or boxed CLR value. Returns false
+  /// when the source cannot be coerced to an int (e.g. nested object, array,
+  /// or non-numeric string).
+  /// </summary>
+  private static bool TryReadInt(object? value, out int result)
+  {
+    result = 0;
+    if (value is System.Text.Json.JsonElement el)
+    {
+      if (el.ValueKind == System.Text.Json.JsonValueKind.Number)
+      {
+        return el.TryGetInt32(out result);
+      }
+      if (el.ValueKind == System.Text.Json.JsonValueKind.String)
+      {
+        return int.TryParse(el.GetString(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out result);
+      }
+      return false;
+    }
+    return value switch
+    {
+      int i => SetAndReturn(i, out result),
+      long l when l >= int.MinValue && l <= int.MaxValue => SetAndReturn((int)l, out result),
+      double d when d >= int.MinValue && d <= int.MaxValue && Math.Truncate(d) == d => SetAndReturn((int)d, out result),
+      string s when int.TryParse(s, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed) => SetAndReturn(parsed, out result),
+      _ => false,
+    };
+
+    static bool SetAndReturn(int value, out int target)
+    {
+      target = value;
+      return true;
     }
   }
 

--- a/src/Radio.API/Controllers/MetricsController.cs
+++ b/src/Radio.API/Controllers/MetricsController.cs
@@ -15,6 +15,7 @@ public class MetricsController : ControllerBase
   private readonly ILogger<MetricsController> _logger;
   private readonly IMetricsReader _metricsReader;
   private readonly IMetricsCollector? _metricsCollector;
+  private readonly IMetricDescriptorRegistry? _descriptorRegistry;
 
   /// <summary>
   /// Initializes a new instance of the MetricsController.
@@ -22,11 +23,32 @@ public class MetricsController : ControllerBase
   public MetricsController(
     ILogger<MetricsController> logger,
     IMetricsReader metricsReader,
-    IMetricsCollector? metricsCollector = null)
+    IMetricsCollector? metricsCollector = null,
+    IMetricDescriptorRegistry? descriptorRegistry = null)
   {
     _logger = logger;
     _metricsReader = metricsReader;
     _metricsCollector = metricsCollector;
+    _descriptorRegistry = descriptorRegistry;
+  }
+
+  /// <summary>
+  /// Lists all registered metric descriptors (key, unit, category, thresholds).
+  /// Dashboards consume this surface to render unit-aware tiles without
+  /// resorting to key-pattern heuristics. PR D #11 of the Arc follow-up
+  /// backlog.
+  /// </summary>
+  /// <param name="ct">Cancellation token</param>
+  /// <returns>The list of registered descriptors; empty when no descriptors are registered.</returns>
+  [HttpGet("descriptors")]
+  [ProducesResponseType(typeof(IReadOnlyList<MetricDescriptor>), StatusCodes.Status200OK)]
+  public ActionResult<IReadOnlyList<MetricDescriptor>> GetDescriptors(CancellationToken ct = default)
+  {
+    if (_descriptorRegistry == null)
+    {
+      return Ok(Array.Empty<MetricDescriptor>());
+    }
+    return Ok(_descriptorRegistry.All);
   }
 
   /// <summary>

--- a/src/Radio.API/Controllers/SystemLogsController.cs
+++ b/src/Radio.API/Controllers/SystemLogsController.cs
@@ -1,0 +1,129 @@
+using System.IO.Compression;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Radio.API.Controllers;
+
+/// <summary>
+/// System-level log-download endpoint surfaced to the DevTray
+/// (PR D #24 of the Arc follow-up backlog). Reads Serilog log files from
+/// the local logs directory (same path the existing
+/// <see cref="SystemController.GetSystemLogs"/> endpoint scans), bundles
+/// the ones whose last-write timestamp falls within the requested window
+/// into a zip, and streams it as a download.
+/// <para>
+/// <b>Authorization:</b> no auth policy exists in this project today.
+/// Log archives can leak sensitive runtime state (file paths, IP
+/// addresses, partial stack traces). Until a kiosk-auth policy is wired
+/// this endpoint is reachable from the local network — the DevTray is
+/// itself the access gate at the UI layer. A follow-up PR must add
+/// server-side authorization.
+/// </para>
+/// </summary>
+[ApiController]
+[Route("api/system/logs")]
+public class SystemLogsController : ControllerBase
+{
+  private readonly ILogger<SystemLogsController> _logger;
+
+  // Mirrors SystemController.MaxLogFileSizeBytes — skip any file larger than
+  // this to avoid pinning the process working set on a runaway log.
+  private const long MaxLogFileSizeBytes = 50L * 1024L * 1024L;
+
+  // The DevTray accepts these strings; any other period falls back to "1h".
+  // Keep the set small so the UI and server never disagree on what's legal.
+  private static readonly Dictionary<string, TimeSpan> _periodWindows = new(StringComparer.OrdinalIgnoreCase)
+  {
+    ["5m"] = TimeSpan.FromMinutes(5),
+    ["1h"] = TimeSpan.FromHours(1),
+    ["24h"] = TimeSpan.FromHours(24),
+    ["7d"] = TimeSpan.FromDays(7),
+  };
+
+  // Tests inject an explicit logs directory so the file-system dependency
+  // is hermetic. Production wiring leaves this null; the endpoint then
+  // falls back to <c>{cwd}/logs</c>, matching SystemController's existing
+  // log scanner.
+  internal string? OverrideLogsDirectory { get; set; }
+
+  public SystemLogsController(ILogger<SystemLogsController> logger)
+  {
+    _logger = logger;
+  }
+
+  /// <summary>
+  /// Returns a zip archive containing all Serilog log files
+  /// (<c>radio-*.txt</c>) modified within the requested window. Default
+  /// window is <c>1h</c>. Accepts <c>5m</c> / <c>1h</c> / <c>24h</c> /
+  /// <c>7d</c>; anything else is treated as <c>1h</c>.
+  /// </summary>
+  [HttpGet("download")]
+  [Produces("application/zip")]
+  [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+  [ProducesResponseType(StatusCodes.Status404NotFound)]
+  public IActionResult DownloadLogs([FromQuery] string period = "1h")
+  {
+    var window = _periodWindows.TryGetValue(period, out var w) ? w : TimeSpan.FromHours(1);
+    var resolvedPeriod = _periodWindows.ContainsKey(period) ? period.ToLowerInvariant() : "1h";
+
+    var logsDir = OverrideLogsDirectory ?? Path.Combine(Directory.GetCurrentDirectory(), "logs");
+    if (!Directory.Exists(logsDir))
+    {
+      _logger.LogWarning("Logs directory does not exist: {LogsDir}", logsDir);
+      return NotFound(new { error = "Logs directory not found", path = logsDir });
+    }
+
+    var since = DateTime.UtcNow - window;
+    var candidates = Directory.GetFiles(logsDir, "radio-*.txt")
+      .Select(p => new FileInfo(p))
+      .Where(fi => fi.LastWriteTimeUtc >= since && fi.Length <= MaxLogFileSizeBytes)
+      .OrderByDescending(fi => fi.LastWriteTimeUtc)
+      .ToList();
+
+    if (candidates.Count == 0)
+    {
+      _logger.LogInformation(
+        "Log download: no files within {Period} window (since {Since:o}); returning 404",
+        resolvedPeriod, since);
+      return NotFound(new
+      {
+        error = "No log files found within the requested window.",
+        period = resolvedPeriod,
+        since = since.ToString("o")
+      });
+    }
+
+    // Build the zip in memory. Log files are bounded by MaxLogFileSizeBytes
+    // and we cap to candidates whose last-write is recent; the total fits
+    // comfortably in a single response on any reasonable kiosk.
+    var ms = new MemoryStream();
+    using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+    {
+      foreach (var fi in candidates)
+      {
+        try
+        {
+          var entry = zip.CreateEntry(fi.Name, CompressionLevel.Optimal);
+          using var entryStream = entry.Open();
+          // Open with shared read so Serilog can keep writing.
+          using var fs = new FileStream(fi.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+          fs.CopyTo(entryStream);
+        }
+        catch (Exception ex)
+        {
+          // Don't abort the whole zip for one bad file — log and continue.
+          _logger.LogWarning(ex, "Failed to include log file {LogFile} in download zip", fi.FullName);
+        }
+      }
+    }
+    ms.Position = 0;
+
+    var ts = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
+    var filename = $"radio-logs-{resolvedPeriod}-{ts}.zip";
+
+    _logger.LogInformation(
+      "Log download served: period={Period}, files={Count}, bytes={Bytes}",
+      resolvedPeriod, candidates.Count, ms.Length);
+
+    return File(ms.ToArray(), "application/zip", filename);
+  }
+}

--- a/src/Radio.API/Mappers/RadioStateMapper.cs
+++ b/src/Radio.API/Mappers/RadioStateMapper.cs
@@ -66,6 +66,7 @@ public static class RadioStateMapper
       Gain = (int?)radioSource.Gain,
       IsStereo = radioSource.IsStereo,
       RdsStationName = radioSource.RdsStationName,
+      RdsStationNameStable = radioSource.RdsStationNameStable,
       RdsProgramType = radioSource.RdsProgramType,
       RdsRadioText = radioSource.RdsRadioText,
       NowPlayingMatchId = nowPlayingMatchId,

--- a/src/Radio.API/Models/RadioDtos.cs
+++ b/src/Radio.API/Models/RadioDtos.cs
@@ -89,9 +89,21 @@ public class RadioStateDto
 
   /// <summary>
   /// Gets or sets the RDS Program Service station name (up to 8 characters),
-  /// or null if RDS is not available.
+  /// or null if RDS is not available. This is the <em>live</em> value — for
+  /// rolling-PS stations it cycles every few seconds. Use
+  /// <see cref="RdsStationNameStable"/> for save-seed scenarios where a
+  /// transient rolling frame would be the wrong value to capture.
   /// </summary>
   public string? RdsStationName { get; set; }
+
+  /// <summary>
+  /// Gets or sets the last <em>stable</em> RDS Program Service station name —
+  /// the consensus value after several consecutive identical PS frames.
+  /// Used by the save-preset dialog and history records so rolling-PS
+  /// stations (e.g. "Rock 92" cycling 8 chars at a time) don't end up
+  /// seeded with mid-roll fragments like "anoidRoc". PR D #40.
+  /// </summary>
+  public string? RdsStationNameStable { get; set; }
 
   /// <summary>
   /// Gets or sets the RDS Program Type name (e.g., "Rock", "News"),

--- a/src/Radio.API/Program.cs
+++ b/src/Radio.API/Program.cs
@@ -84,6 +84,10 @@ builder.Services.AddHealthChecks()
 
 builder.Services.AddManagedConfiguration(builder.Configuration);
 builder.Services.AddMetrics(builder.Configuration);
+// Register authoritative MetricDescriptor entries for API-tier metrics
+// (PR D #11). Replaces the client-side MapKeyToUnit heuristic for these
+// keys; dashboards fall back to the heuristic for any key not described.
+builder.Services.AddHostedService<Radio.API.Services.ApiMetricDescriptorRegistration>();
 builder.Services.AddFingerprinting(builder.Configuration);
 builder.Services.AddSoundFlowAudio(builder.Configuration);
 builder.Services.AddRadioServices();

--- a/src/Radio.API/Services/ApiMetricDescriptorRegistration.cs
+++ b/src/Radio.API/Services/ApiMetricDescriptorRegistration.cs
@@ -1,0 +1,158 @@
+using Microsoft.Extensions.Hosting;
+using Radio.Metrics;
+
+namespace Radio.API.Services;
+
+/// <summary>
+/// One-shot hosted service that registers authoritative
+/// <see cref="MetricDescriptor"/> entries for the API-tier metric keys
+/// emitted by middleware, audio outputs, and infrastructure services.
+/// <para>
+/// PR D #11 of the Arc follow-up backlog. Replaces the client-side
+/// <c>MapKeyToUnit</c> key-pattern heuristic with a server-registered
+/// unit table for representative metrics. The dashboard falls back to
+/// the heuristic for any key not described here, so this list is a
+/// migration surface, not a hard contract — adding/removing entries
+/// is safe across deploys.
+/// </para>
+/// </summary>
+public sealed class ApiMetricDescriptorRegistration : IHostedService
+{
+  private readonly IMetricDescriptorRegistry _registry;
+
+  public ApiMetricDescriptorRegistration(IMetricDescriptorRegistry registry)
+  {
+    _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+  }
+
+  public Task StartAsync(CancellationToken cancellationToken)
+  {
+    // API middleware metrics (see ApiMetricsMiddleware).
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "api.requests_total",
+      Unit = MetricUnit.Count,
+      Category = "API",
+      DisplayName = "Requests",
+    });
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "api.request_duration_ms",
+      Unit = MetricUnit.Milliseconds,
+      Category = "API",
+      DisplayName = "Request Duration",
+      Warn = 500,
+      Critical = 2000,
+    });
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "api.errors.unhandled",
+      Unit = MetricUnit.Count,
+      Category = "API",
+      DisplayName = "Unhandled Errors",
+    });
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "api.errors.client",
+      Unit = MetricUnit.Count,
+      Category = "API",
+      DisplayName = "Client Errors (4xx)",
+    });
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "api.errors.server",
+      Unit = MetricUnit.Count,
+      Category = "API",
+      DisplayName = "Server Errors (5xx)",
+    });
+
+    // SignalR websocket metrics (see AudioStateHub).
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "websocket.connected_clients",
+      Unit = MetricUnit.Count,
+      Category = "WebSocket",
+      DisplayName = "Connected Clients",
+    });
+
+    // Audio buffer health (see BufferedSoundGenerator).
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "audio.buffer.fill_percent",
+      Unit = MetricUnit.Percent,
+      Category = "Audio | Buffer",
+      DisplayName = "Buffer Fill",
+      // Inverted: low fill is bad. Dashboard uses InvertThresholds for
+      // patterns matching "buffer_fill" / "fill" — descriptor reflects
+      // the raw band; UI flips the colour.
+      Warn = 50,
+      Critical = 20,
+    });
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "audio.buffer.underruns",
+      Unit = MetricUnit.Count,
+      Category = "Audio | Buffer",
+      DisplayName = "Buffer Underruns",
+      Warn = 1,
+      Critical = 10,
+    });
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "audio.buffer.samples_dropped",
+      Unit = MetricUnit.Count,
+      Category = "Audio | Buffer",
+      DisplayName = "Samples Dropped",
+    });
+
+    // Audio callback timing.
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "audio.callback.max_interval_ms",
+      Unit = MetricUnit.Milliseconds,
+      Category = "Audio | Callback",
+      DisplayName = "Max Callback Interval",
+    });
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "audio.callback.max_execution_ms",
+      Unit = MetricUnit.Milliseconds,
+      Category = "Audio | Callback",
+      DisplayName = "Max Callback Execution",
+    });
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "audio.callback.missed_deadlines",
+      Unit = MetricUnit.Count,
+      Category = "Audio | Callback",
+      DisplayName = "Missed Deadlines",
+    });
+
+    // Cast streaming metrics (see DirectCastStreamingService).
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "audio.cast.direct.chunks_sent",
+      Unit = MetricUnit.Count,
+      Category = "Audio | Cast",
+      DisplayName = "Chunks Sent",
+    });
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "audio.cast.direct.bytes_sent_mb",
+      Unit = MetricUnit.Megabytes,
+      Category = "Audio | Cast",
+      DisplayName = "Bytes Sent",
+    });
+    _registry.Register(new MetricDescriptor
+    {
+      Key = "audio.cast.direct.silence_percent",
+      Unit = MetricUnit.Percent,
+      Category = "Audio | Cast",
+      DisplayName = "Silence",
+    });
+
+    return Task.CompletedTask;
+  }
+
+  public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Radio.API/Services/AudioStateUpdateService.cs
+++ b/src/Radio.API/Services/AudioStateUpdateService.cs
@@ -567,6 +567,7 @@ public class AudioStateUpdateService : BackgroundService
            previous.ScanDirection != current.ScanDirection ||
            previous.IsStereo != current.IsStereo ||
            previous.RdsStationName != current.RdsStationName ||
+           previous.RdsStationNameStable != current.RdsStationNameStable ||
            previous.RdsProgramType != current.RdsProgramType ||
            // PR 3 of the Radio Controller Polish arc — the RT line below the
            // frequency well binds to this. RDS RadioText updates roughly once

--- a/src/Radio.Core/Interfaces/Audio/IRadioControl.cs
+++ b/src/Radio.Core/Interfaces/Audio/IRadioControl.cs
@@ -223,6 +223,25 @@ public interface IRadioControl
   string? RdsStationName { get; }
 
   /// <summary>
+  /// Gets the last <em>stable</em> RDS Program Service station name — the value
+  /// that has been observed unchanged for several consecutive PS updates.
+  /// Mid-rolling stations (e.g. "Rock 92" cycling through "anoidRoc", "k92 PaR",
+  /// etc. as the PS rotates 8 chars at a time) frequently have a transient PS
+  /// at the moment a user long-presses to save a preset; the stable variant
+  /// is the consensus value that's safe to seed save dialogs and history
+  /// records with. Null while no station has yet produced N consecutive
+  /// identical PS frames. PR D #40 of the Arc follow-up backlog.
+  /// </summary>
+  /// <remarks>
+  /// Default implementation simply mirrors <see cref="RdsStationName"/>. The
+  /// SDR-based <c>SDRRadioAudioSource</c> overrides this with a ring-buffer
+  /// tracker that emits the consensus value after 3 consecutive identical
+  /// updates. Other implementations (e.g. the RF320 stub) may leave it
+  /// equal to the live name.
+  /// </remarks>
+  string? RdsStationNameStable => RdsStationName;
+
+  /// <summary>
   /// Gets the RDS Program Type name (e.g., "Rock", "News", "Classical"), or null if not available.
   /// Derived from the PTY code broadcast via RDS.
   /// </summary>

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/RdsStationNameStabilityTracker.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/RdsStationNameStabilityTracker.cs
@@ -1,0 +1,128 @@
+namespace Radio.Infrastructure.Audio.Sources.Primary;
+
+/// <summary>
+/// Tracks an RDS Program-Service (PS) signal and emits a "stable" value
+/// after <c>N</c> consecutive identical samples. Used by the SDR radio
+/// source to filter rolling-PS artifacts before exposing
+/// <c>IRadioControl.RdsStationNameStable</c> on the wire.
+/// <para>
+/// Implementation: a tiny FIFO sized to <c>WindowSize</c>. The stable
+/// value is the most recent value that has been seen at least
+/// <c>WindowSize</c> times in a row. When the buffer hasn't filled (or
+/// the latest <c>WindowSize</c> samples are not all identical) the
+/// previously emitted stable value is held until a new consensus
+/// emerges.
+/// </para>
+/// <para>
+/// Null / empty / whitespace samples reset the candidate run — a
+/// momentary RDS dropout doesn't poison the consensus, but also
+/// doesn't promote a transient null to "stable". The previously
+/// observed stable value is retained until a real, stable PS appears.
+/// PR D #40 of the Arc follow-up backlog.
+/// </para>
+/// </summary>
+public sealed class RdsStationNameStabilityTracker
+{
+  /// <summary>
+  /// Number of consecutive identical PS samples required to promote a
+  /// candidate to "stable". Default of 3 is a balance between capturing
+  /// fast-changing-but-real PS updates (a quick band change should
+  /// promote within a few seconds) and rejecting mid-roll fragments
+  /// (typical rolling PS cycles every 1-2 seconds).
+  /// </summary>
+  public int WindowSize { get; }
+
+  private readonly Queue<string?> _window;
+  private string? _stable;
+  private readonly object _lock = new();
+
+  public RdsStationNameStabilityTracker(int windowSize = 3)
+  {
+    if (windowSize < 1)
+    {
+      throw new ArgumentOutOfRangeException(nameof(windowSize), "WindowSize must be ≥ 1");
+    }
+    WindowSize = windowSize;
+    _window = new Queue<string?>(windowSize);
+  }
+
+  /// <summary>
+  /// Pushes a new PS sample into the tracker. After enough consecutive
+  /// identical samples, <see cref="Stable"/> updates. Returns the
+  /// current stable value (after this sample is observed). Null when
+  /// no stable value has yet been emitted.
+  /// </summary>
+  public string? Observe(string? sample)
+  {
+    lock (_lock)
+    {
+      // Normalize null/empty/whitespace to null so an RDS-dropped frame
+      // doesn't get treated as a distinct value alongside the real PS.
+      var normalized = string.IsNullOrWhiteSpace(sample) ? null : sample;
+
+      if (_window.Count == WindowSize)
+      {
+        _window.Dequeue();
+      }
+      _window.Enqueue(normalized);
+
+      // Only promote a candidate when the window is full and every entry
+      // is identical and non-null. A null-only window doesn't promote a
+      // null stable — the previously emitted value is held.
+      if (_window.Count == WindowSize)
+      {
+        string? first = null;
+        var firstSet = false;
+        var allSame = true;
+        foreach (var entry in _window)
+        {
+          if (!firstSet)
+          {
+            first = entry;
+            firstSet = true;
+          }
+          else if (!string.Equals(first, entry, StringComparison.Ordinal))
+          {
+            allSame = false;
+            break;
+          }
+        }
+
+        if (allSame && first != null)
+        {
+          _stable = first;
+        }
+      }
+
+      return _stable;
+    }
+  }
+
+  /// <summary>
+  /// Current stable PS value, or <c>null</c> when no consensus has yet
+  /// been reached. Safe to read concurrently with <see cref="Observe"/>.
+  /// </summary>
+  public string? Stable
+  {
+    get
+    {
+      lock (_lock)
+      {
+        return _stable;
+      }
+    }
+  }
+
+  /// <summary>
+  /// Clears the stability tracker. Use after a frequency/band change so
+  /// the previous station's stable name doesn't leak across tunes.
+  /// </summary>
+  public void Reset()
+  {
+    lock (_lock)
+    {
+      _window.Clear();
+      _stable = null;
+    }
+  }
+}

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/SDRRadioAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/SDRRadioAudioSource.cs
@@ -38,6 +38,14 @@ public class SDRRadioAudioSource : PrimaryAudioSourceBase, Radio.Core.Interfaces
   private string? _playbackId;
   private bool _hasRestoredPreferences;
 
+  // PR D #40 — tracks the last-stable RDS Program-Service (PS) value so the
+  // save-preset dialog and history records don't seed with mid-roll fragments.
+  // Observe() is called inside the RdsStationNameStable getter — each poll
+  // of the property pushes the current live PS into the tracker, and after
+  // WindowSize identical samples the consensus value is emitted.
+  private readonly RdsStationNameStabilityTracker _rdsStationNameStabilityTracker
+    = new RdsStationNameStabilityTracker(windowSize: 3);
+
   /// <summary>
   /// Initializes a new instance of the <see cref="SDRRadioAudioSource"/> class.
   /// </summary>
@@ -480,6 +488,22 @@ public class SDRRadioAudioSource : PrimaryAudioSourceBase, Radio.Core.Interfaces
   public string? RdsStationName => _radioReceiver.RdsStationName;
 
   /// <inheritdoc/>
+  /// <remarks>
+  /// Each read pushes the current live PS into the stability tracker so the
+  /// broadcast loop (AudioStateUpdateService at ~1 Hz) naturally drives the
+  /// 3-consecutive-identical-samples window. The property returns the
+  /// consensus value, or null until consensus is reached.
+  /// </remarks>
+  public string? RdsStationNameStable
+  {
+    get
+    {
+      _rdsStationNameStabilityTracker.Observe(_radioReceiver.RdsStationName);
+      return _rdsStationNameStabilityTracker.Stable;
+    }
+  }
+
+  /// <inheritdoc/>
   public string? RdsProgramType => _radioReceiver.RdsProgramTypeName;
 
   /// <inheritdoc/>
@@ -533,10 +557,15 @@ public class SDRRadioAudioSource : PrimaryAudioSourceBase, Radio.Core.Interfaces
   {
     var oldFreq = new Frequency(e.OldFrequency);
     var newFreq = new Frequency(e.NewFrequency);
-    
+
     // Track frequency change metric
     MetricsCollector?.Increment("radio.frequency_changes");
-    
+
+    // PR D #40 — the previous station's stable PS is no longer meaningful
+    // after a re-tune. Reset so the next station has to earn its own
+    // consensus from scratch.
+    _rdsStationNameStabilityTracker.Reset();
+
     FrequencyChanged?.Invoke(this, new RadioControlFrequencyChangedEventArgs(oldFreq, newFreq));
   }
 

--- a/src/Radio.Metrics/IMetricDescriptorRegistry.cs
+++ b/src/Radio.Metrics/IMetricDescriptorRegistry.cs
@@ -1,0 +1,41 @@
+namespace Radio.Metrics;
+
+/// <summary>
+/// Read-only registry of <see cref="MetricDescriptor"/> entries. Dashboards
+/// consume this surface to render unit-aware tiles without resorting to
+/// key-pattern heuristics (e.g. <c>"system.memory_usage_mb"</c> → MB,
+/// <c>"audio.latency_ms"</c> → ms).
+/// <para>
+/// Producers register their authoritative units via
+/// <see cref="IMetricDescriptorRegistry.Register"/>; consumers look up units
+/// via <see cref="IMetricDescriptorRegistry.GetByKey"/>. When a key has no
+/// descriptor, dashboards fall back to whatever default the consumer chooses
+/// (typically <see cref="MetricUnit.Bare"/> or a residual heuristic for keys
+/// that haven't been migrated yet).
+/// </para>
+/// </summary>
+public interface IMetricDescriptorRegistry
+{
+  /// <summary>
+  /// All registered descriptors, in insertion order. Multiple registrations
+  /// for the same <see cref="MetricDescriptor.Key"/> are deduplicated — the
+  /// most recent registration wins. Returns an empty list when no producer
+  /// has registered any descriptors yet.
+  /// </summary>
+  IReadOnlyList<MetricDescriptor> All { get; }
+
+  /// <summary>
+  /// Returns the descriptor for <paramref name="key"/> if one is registered,
+  /// otherwise <c>null</c>. Lookup is case-sensitive and does not consult
+  /// the underlying key-pattern heuristic — callers must decide their own
+  /// fallback behavior.
+  /// </summary>
+  /// <param name="key">The metric key (e.g. <c>"system.memory_usage_mb"</c>).</param>
+  MetricDescriptor? GetByKey(string key);
+
+  /// <summary>
+  /// Adds or replaces the descriptor for <see cref="MetricDescriptor.Key"/>.
+  /// </summary>
+  /// <param name="descriptor">The descriptor to register.</param>
+  void Register(MetricDescriptor descriptor);
+}

--- a/src/Radio.Metrics/MetricDescriptorRegistry.cs
+++ b/src/Radio.Metrics/MetricDescriptorRegistry.cs
@@ -1,0 +1,78 @@
+namespace Radio.Metrics;
+
+using System.Collections.Concurrent;
+
+/// <summary>
+/// In-memory <see cref="IMetricDescriptorRegistry"/> implementation. Registered
+/// once at startup and consulted by the metrics API for the lifetime of the
+/// process. Thread-safe so producers can register from <c>BackgroundService</c>
+/// constructors / hosted-service start hooks concurrently.
+/// </summary>
+public sealed class MetricDescriptorRegistry : IMetricDescriptorRegistry
+{
+  // ConcurrentDictionary for atomic Register; a separate List for insertion
+  // order is rebuilt on every Register so All is stable across enumeration.
+  // The All count is bounded by the number of distinct metric keys (~dozens
+  // in practice) — rebuilding is cheap and avoids ordering surprises during
+  // a re-registration.
+  private readonly ConcurrentDictionary<string, MetricDescriptor> _byKey = new();
+  private readonly object _orderLock = new();
+  private List<MetricDescriptor> _ordered = new();
+
+  /// <inheritdoc />
+  public IReadOnlyList<MetricDescriptor> All
+  {
+    get
+    {
+      lock (_orderLock)
+      {
+        // Snapshot to keep the returned list immune to mid-enumeration writes.
+        return _ordered.ToArray();
+      }
+    }
+  }
+
+  /// <inheritdoc />
+  public MetricDescriptor? GetByKey(string key)
+  {
+    if (string.IsNullOrEmpty(key))
+    {
+      return null;
+    }
+    return _byKey.TryGetValue(key, out var d) ? d : null;
+  }
+
+  /// <inheritdoc />
+  public void Register(MetricDescriptor descriptor)
+  {
+    if (descriptor == null)
+    {
+      throw new ArgumentNullException(nameof(descriptor));
+    }
+    if (string.IsNullOrEmpty(descriptor.Key))
+    {
+      throw new ArgumentException("Descriptor.Key is required", nameof(descriptor));
+    }
+
+    var isNew = !_byKey.ContainsKey(descriptor.Key);
+    _byKey[descriptor.Key] = descriptor;
+
+    lock (_orderLock)
+    {
+      if (isNew)
+      {
+        _ordered = new List<MetricDescriptor>(_ordered) { descriptor };
+      }
+      else
+      {
+        // Replace in-place; preserve insertion order.
+        var copy = new List<MetricDescriptor>(_ordered.Count);
+        foreach (var d in _ordered)
+        {
+          copy.Add(d.Key == descriptor.Key ? descriptor : d);
+        }
+        _ordered = copy;
+      }
+    }
+  }
+}

--- a/src/Radio.Metrics/MetricsServiceExtensions.cs
+++ b/src/Radio.Metrics/MetricsServiceExtensions.cs
@@ -37,6 +37,13 @@ public static class MetricsServiceExtensions
     // Register reader
     services.AddSingleton<IMetricsReader>(sp => sp.GetRequiredService<SqliteMetricsRepository>());
 
+    // Register descriptor registry (PR D #11 — replaces the client-side
+    // MapKeyToUnit heuristic with an authoritative server-registered unit
+    // table). Singleton so producers (background services, controllers) and
+    // consumers (dashboards via the API) share the same map for the
+    // process lifetime.
+    services.AddSingleton<IMetricDescriptorRegistry, MetricDescriptorRegistry>();
+
     // Register background services
     services.AddHostedService<MetricsRollupService>();
     services.AddHostedService<SystemMonitorService>();

--- a/src/Radio.Metrics/Radio.Metrics.csproj
+++ b/src/Radio.Metrics/Radio.Metrics.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <!-- NuGet package metadata -->
     <PackageId>Radio.Metrics</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Description>Lightweight metrics collection and time-series storage library with SQLite backend. Supports counters and gauges, buffered writes, multi-resolution rollup (minute/hour/day), configurable retention, and system monitoring. Zero external service dependencies.</Description>
     <PackageTags>metrics;telemetry;time-series;sqlite;counters;gauges;monitoring;rollup</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Radio.Metrics/Services/SystemMonitorService.cs
+++ b/src/Radio.Metrics/Services/SystemMonitorService.cs
@@ -15,16 +15,73 @@ public sealed class SystemMonitorService : BackgroundService
   private readonly ILogger<SystemMonitorService> _logger;
   private readonly MetricsOptions _options;
   private readonly IMetricsCollector _metricsCollector;
+  private readonly IMetricDescriptorRegistry? _descriptorRegistry;
   private readonly TimeSpan _collectInterval = TimeSpan.FromMinutes(5);
 
   public SystemMonitorService(
     ILogger<SystemMonitorService> logger,
     IOptions<MetricsOptions> options,
-    IMetricsCollector metricsCollector)
+    IMetricsCollector metricsCollector,
+    IMetricDescriptorRegistry? descriptorRegistry = null)
   {
     _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
     _metricsCollector = metricsCollector ?? throw new ArgumentNullException(nameof(metricsCollector));
+    _descriptorRegistry = descriptorRegistry;
+
+    // Register authoritative descriptors for the system metrics this service
+    // produces. PR D #11 — replaces the client-side MapKeyToUnit heuristic
+    // for these keys with server-side ground truth. Registration happens in
+    // the constructor (not ExecuteAsync) so the descriptors are available
+    // immediately at service startup, before any sample is collected.
+    if (_descriptorRegistry != null)
+    {
+      _descriptorRegistry.Register(new MetricDescriptor
+      {
+        Key = "system.memory_usage_mb",
+        Unit = MetricUnit.Megabytes,
+        Category = "System",
+        DisplayName = "Memory Usage",
+      });
+      _descriptorRegistry.Register(new MetricDescriptor
+      {
+        Key = "system.disk_usage_percent",
+        Unit = MetricUnit.Percent,
+        Category = "System",
+        DisplayName = "Disk Usage",
+        Warn = 80,
+        Critical = 95,
+      });
+      _descriptorRegistry.Register(new MetricDescriptor
+      {
+        Key = "system.cpu_usage_percent",
+        Unit = MetricUnit.Percent,
+        Category = "System",
+        DisplayName = "CPU Usage",
+        Warn = 80,
+        Critical = 95,
+      });
+      // CPU temperature has no matching MetricUnit (no Celsius/Fahrenheit
+      // entry today). Register it as Bare so dashboards don't accidentally
+      // tag it with the wrong suffix; the dashboard's residual heuristic
+      // pulls "°C" from the key suffix when present.
+      _descriptorRegistry.Register(new MetricDescriptor
+      {
+        Key = "system.cpu_temp_celsius",
+        Unit = MetricUnit.Bare,
+        Category = "System",
+        DisplayName = "CPU Temperature",
+        Warn = 70,
+        Critical = 85,
+      });
+      _descriptorRegistry.Register(new MetricDescriptor
+      {
+        Key = "db.file_size_mb",
+        Unit = MetricUnit.Megabytes,
+        Category = "Database",
+        DisplayName = "DB File Size",
+      });
+    }
   }
 
   protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/Radio.Web/Components/Pages/MetricsDashboardPage.razor
+++ b/src/Radio.Web/Components/Pages/MetricsDashboardPage.razor
@@ -84,7 +84,7 @@
               @foreach (var metric in catMetrics)
               {
                 var key = metric.Key;
-                var unit = MapKeyToUnit(key);
+                var unit = GetUnitForKey(key);
                 var (warn, critical, invert) = GetThresholds(key);
                 _sparklineData.TryGetValue(key, out var series);
                 <div @onclick="@(async () => await SelectMetricAsync(key))" style="cursor: pointer;">
@@ -129,6 +129,10 @@
   private List<string> _categories = new();
   private Dictionary<string, List<double>> _sparklineData = new();
   private Dictionary<string, List<MetricHistoryDto>> _sparklineHistory = new();
+  // PR D #11 — descriptor map populated from /api/metrics/descriptors.
+  // GetUnitForKey consults this first; MapKeyToUnit is the residual fallback
+  // for keys that no producer has registered yet.
+  private Dictionary<string, MetricDescriptorDto> _descriptors = new(StringComparer.Ordinal);
 
   // Threshold definitions: (warning, critical) by metric name fragment.
   // invertAbove == true → high is bad (cpu, memory).
@@ -214,12 +218,35 @@
     try
     {
       await LoadAvailableMetricsAsync();
+      await LoadDescriptorsAsync();
       await LoadSnapshotsAsync();
       UpdateCategories();
       await LoadSparklineDataAsync();
       UpdateCardValuesFromSparklines();
     }
     finally { _loading = false; }
+  }
+
+  /// <summary>
+  /// Loads server-registered metric descriptors (PR D #11). Failures are
+  /// non-fatal — the dashboard falls back to the residual MapKeyToUnit
+  /// heuristic for any key without a descriptor.
+  /// </summary>
+  private async Task LoadDescriptorsAsync()
+  {
+    try
+    {
+      var descriptors = await MetricsApi.GetMetricDescriptorsAsync();
+      _descriptors.Clear();
+      if (descriptors != null)
+      {
+        foreach (var d in descriptors)
+        {
+          _descriptors[d.Key] = d;
+        }
+      }
+    }
+    catch (Exception ex) { Logger.LogWarning(ex, "Failed to load metric descriptors"); }
   }
 
   private async Task LoadAvailableMetricsAsync()
@@ -403,10 +430,31 @@
   }
 
   /// <summary>
+  /// Returns the Unit for the given metric key. Consults the server-registered
+  /// descriptor map first (PR D #11) and falls back to the key-pattern
+  /// heuristic <see cref="MapKeyToUnit"/> for keys without a registered
+  /// descriptor.
+  /// </summary>
+  private Units GetUnitForKey(string metricKey)
+  {
+    if (_descriptors.TryGetValue(metricKey, out var descriptor)
+        && Enum.TryParse<Units>(descriptor.Unit, ignoreCase: true, out var parsed))
+    {
+      return parsed;
+    }
+    return MapKeyToUnit(metricKey);
+  }
+
+  /// <summary>
   /// Maps a metric key to a display Unit by pattern matching the suffix
   /// and well-known fragments. This is what fixes the "Memory Usage Mb
   /// = 850.4%" bug — the key ends in <c>_mb</c> and ought to render
   /// with the MB suffix.
+  /// <para>
+  /// PR D #11 — retained as a residual fallback for any key that does not
+  /// have a server-registered descriptor. <see cref="GetUnitForKey"/> is
+  /// the preferred entry point; consult descriptors first.
+  /// </para>
   /// </summary>
   internal static Units MapKeyToUnit(string metricKey)
   {
@@ -563,9 +611,9 @@
     return metricKey;
   }
 
-  private static string GetMetricUnitForChart(string metricKey)
+  private string GetMetricUnitForChart(string metricKey)
   {
-    var unit = MapKeyToUnit(metricKey);
+    var unit = GetUnitForKey(metricKey);
     return unit switch
     {
       Units.Percent => "%",
@@ -594,8 +642,8 @@
   }
 
   // Used by the chart stats footer. Mirrors MetricTile's unit-aware formatting.
-  private static string FormatMetricValue(double value, string metricKey)
-    => UnitsFormatter.Format(value, MapKeyToUnit(metricKey));
+  private string FormatMetricValue(double value, string metricKey)
+    => UnitsFormatter.Format(value, GetUnitForKey(metricKey));
 
   public async ValueTask DisposeAsync()
   {

--- a/src/Radio.Web/Components/Pages/MetricsDashboardPage.razor
+++ b/src/Radio.Web/Components/Pages/MetricsDashboardPage.razor
@@ -599,8 +599,16 @@
     return System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(s.Replace('_', ' '));
   }
 
-  internal static string GetMetricLabel(string metricKey)
+  internal string GetMetricLabel(string metricKey)
   {
+    // Prefer the server-registered descriptor's DisplayName when present
+    // (PR D #11) — that's the authoritative human label and avoids the
+    // "Memory Usage Mb" artifact from suffix-aware humanization.
+    if (_descriptors.TryGetValue(metricKey, out var descriptor)
+        && !string.IsNullOrWhiteSpace(descriptor.DisplayName))
+    {
+      return descriptor.DisplayName!;
+    }
     if (string.IsNullOrEmpty(metricKey)) return metricKey;
     var parts = metricKey.Split('.');
     if (parts.Length > 1)

--- a/src/Radio.Web/Components/Pages/SystemConfigPage.razor
+++ b/src/Radio.Web/Components/Pages/SystemConfigPage.razor
@@ -387,7 +387,7 @@
                 <RadzenNumeric TValue="double" @bind-Value="_radioConfig.MaxAMFrequencyKHz" Min="100" Max="2000" Step="(decimal)10.0" Placeholder="Max AM (kHz)" Style="width:100%" />
               </RadzenColumn>
               <RadzenColumn Size="12" SizeMD="3">
-                <RadzenNumeric TValue="int" @bind-Value="_radioConfig.ScanStopThreshold" Min="0" Max="200" Placeholder="Scan Stop Threshold" Style="width:100%" />
+                <RadzenNumeric TValue="int" @bind-Value="_radioConfig.ScanStopThreshold" Min="0" Max="100" Placeholder="Scan Stop Threshold" Style="width:100%" />
                 <small>Signal strength to stop scan</small>
               </RadzenColumn>
               <RadzenColumn Size="12" SizeMD="3">

--- a/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
+++ b/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
@@ -498,8 +498,9 @@
   /// <summary>
   /// Picks the next <paramref name="count"/> queue rows whose state is "Upcoming",
   /// projected into a small UI record so the markup doesn't reach into <see cref="QueueItemDto"/>.
-  /// CoverArtUrl is best-effort — most QueueItemDto rows don't carry album art today,
-  /// so the tile falls back to a music_note icon if the URL is missing.
+  /// Album art is sourced from <see cref="QueueItemDto.AlbumArtUrl"/> (PR D #15) —
+  /// populated server-side from file ID3 tags / album-art proxy. Tile falls back
+  /// to a music_note icon when the URL is null or the default placeholder.
   /// </summary>
   private List<UpNextEntry> GetUpNext(int count)
   {
@@ -510,8 +511,7 @@
       result.Add(new UpNextEntry(
         item.Title ?? "Unknown",
         item.Artist ?? "—",
-        // QueueItemDto doesn't currently carry CoverArtUrl; placeholder for future wiring.
-        null));
+        item.AlbumArtUrl));
       if (result.Count >= count) break;
     }
     return result;

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -1212,8 +1212,21 @@
       // formatted frequency ONLY when RDS is unavailable. Never seed with
       // the raw frequency. Acceptance gate: "The save flow defaults to the
       // RDS station name when one is present."
-      _presetName = !string.IsNullOrEmpty(_radioState.RdsStationName)
-        ? _radioState.RdsStationName!
+      //
+      // PR D #40 — prefer the server-tracked stable PS (RdsStationNameStable)
+      // over the live RdsStationName. Rolling-PS stations like "Rock 92"
+      // cycle 8 chars at a time; the live name often catches a mid-roll
+      // fragment ("anoidRoc") at the instant the user long-presses. The
+      // stable variant emits only after 3 consecutive identical samples.
+      // Fall back to the live name when the stable tracker hasn't yet
+      // reached consensus (new station, RDS dropout, etc.).
+      var stable = _radioState.RdsStationNameStable;
+      var live = _radioState.RdsStationName;
+      var seed = !string.IsNullOrEmpty(stable) ? stable
+               : !string.IsNullOrEmpty(live) ? live
+               : null;
+      _presetName = !string.IsNullOrEmpty(seed)
+        ? seed!
         : $"{_radioState.Band} {FormatFrequency(_radioState.Frequency, _radioState.Band)}";
     }
     _isSavePresetDialogOpen = true;

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -59,6 +59,11 @@ public record UpdatePlaybackRequest(
 );
 
 // Queue API DTOs
+//
+// AlbumArtUrl mirrors the API surface (Radio.API.Models.QueueItemDto.AlbumArtUrl)
+// — populated by the server-side projection from the QueueItem source data
+// (file ID3 / MusicBrainz proxy / fingerprint payload). When null, Up Next
+// thumbs render the music_note placeholder glyph (PR D #15).
 public record QueueItemDto(
   int Index,
   string? Title,
@@ -67,7 +72,8 @@ public record QueueItemDto(
   string? Duration,
   bool IsCurrent,
   string State = "Upcoming",
-  int FullPlaylistIndex = 0
+  int FullPlaylistIndex = 0,
+  string? AlbumArtUrl = null
 );
 
 // Sources API DTOs
@@ -198,6 +204,22 @@ public record MetricEventResponse(
   string Metric
 );
 
+/// <summary>
+/// Mirror of <c>Radio.Metrics.MetricDescriptor</c> on the Web side. The
+/// dashboard fetches a list of these from <c>/api/metrics/descriptors</c>
+/// and uses them to resolve units, categories, and threshold bands without
+/// resorting to client-side key-pattern heuristics (PR D #11 of the Arc
+/// follow-up backlog).
+/// </summary>
+public record MetricDescriptorDto(
+  string Key,
+  string Unit,
+  string? Category,
+  double? Warn,
+  double? Critical,
+  string? DisplayName
+);
+
 // File API DTOs
 public record FileListDto(
   string CurrentPath,
@@ -309,7 +331,12 @@ public record RadioStateDto(
   string? NowPlayingMatchId = null,
   // PR 3 of the Radio Controller Polish arc — RDS RadioText (RT) line
   // below the frequency well. Null/empty hides the RT row entirely.
-  string? RdsRadioText = null
+  string? RdsRadioText = null,
+  // PR D #40 of the Arc follow-up backlog — last-stable RDS PS value
+  // (consensus after 3+ identical samples). Save-preset dialog seeds
+  // from this rather than RdsStationName so rolling-PS stations don't
+  // capture mid-roll fragments like "anoidRoc".
+  string? RdsStationNameStable = null
 );
 
 public record RadioPowerStateDto(
@@ -679,7 +706,17 @@ public class RadioConfigDto
   public double MaxFMFrequencyMHz { get; set; } = 108.0;
   public double MinAMFrequencyKHz { get; set; } = 520.0;
   public double MaxAMFrequencyKHz { get; set; } = 1710.0;
+
+  /// <summary>
+  /// Signal-strength percentage at which the scan stops on a station.
+  /// Server-side <c>RadioStateMapper.PercentToDbu</c> clamps to <c>[0, 100]</c>;
+  /// the API validation layer rejects values outside that range with a
+  /// 400 so silent saturation isn't a footgun (PR D #30).
+  /// </summary>
+  [System.ComponentModel.DataAnnotations.Range(0, 100,
+    ErrorMessage = "ScanStopThreshold must be between 0 and 100 (percent).")]
   public int ScanStopThreshold { get; set; } = 50;
+
   public int ScanStepDelayMs { get; set; } = 100;
   public int DefaultDeviceVolume { get; set; } = 50;
 }

--- a/src/Radio.Web/Services/ApiClients/MetricsApiService.cs
+++ b/src/Radio.Web/Services/ApiClients/MetricsApiService.cs
@@ -109,6 +109,25 @@ public class MetricsApiService
   }
 
   /// <summary>
+  /// GET /api/metrics/descriptors - Gets all registered metric descriptors
+  /// (key, unit, category, threshold bands). PR D #11. Empty list when no
+  /// producer has registered any descriptors yet — caller falls back to
+  /// the residual MapKeyToUnit heuristic.
+  /// </summary>
+  public async Task<List<MetricDescriptorDto>?> GetMetricDescriptorsAsync(CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      return await _httpClient.GetFromJsonAsync<List<MetricDescriptorDto>>("/api/metrics/descriptors", cancellationToken);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to get metric descriptors");
+      return null;
+    }
+  }
+
+  /// <summary>
   /// POST /api/metrics/event - Records a UI event metric from the frontend
   /// </summary>
   public async Task<MetricEventResponse?> RecordUIEventAsync(

--- a/tests/Radio.API.Tests/Controllers/AudioDebugControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/AudioDebugControllerTests.cs
@@ -1,0 +1,42 @@
+namespace Radio.API.Tests.Controllers;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Radio.API.Controllers;
+using Xunit;
+
+/// <summary>
+/// Tests for the AudioDebugController stub (PR D #23). The endpoint currently
+/// returns 501 — when the SoundFlow tap exposes a retained buffer, replace
+/// the stub with a real WAV serializer and update these tests.
+/// </summary>
+public class AudioDebugControllerTests
+{
+  [Fact]
+  public void DumpAudioFrame_ReturnsNotImplemented()
+  {
+    var controller = new AudioDebugController(NullLogger<AudioDebugController>.Instance);
+
+    var result = controller.DumpAudioFrame();
+
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    Assert.Equal(StatusCodes.Status501NotImplemented, objectResult.StatusCode);
+  }
+
+  [Fact]
+  public void DumpAudioFrame_BodyExplainsStubAndTracking()
+  {
+    var controller = new AudioDebugController(NullLogger<AudioDebugController>.Instance);
+
+    var result = controller.DumpAudioFrame();
+
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var body = objectResult.Value;
+    Assert.NotNull(body);
+    // Body shape: { error, reason, tracked }
+    var json = System.Text.Json.JsonSerializer.Serialize(body);
+    Assert.Contains("tracked", json);
+    Assert.Contains("#23", json);
+  }
+}

--- a/tests/Radio.API.Tests/Controllers/ConfigurationControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/ConfigurationControllerTests.cs
@@ -131,11 +131,58 @@ public class ConfigurationControllerTests : IClassFixture<CustomWebApplicationFa
     // Act
     var response = await _client.PostAsJsonAsync("/api/configuration", request);
 
-    // Assert - Should return 200 OK if ConfigurationManager is available, 
+    // Assert - Should return 200 OK if ConfigurationManager is available,
     // or 501 if not yet integrated
     Assert.True(
       response.StatusCode == System.Net.HttpStatusCode.OK ||
       response.StatusCode == System.Net.HttpStatusCode.NotImplemented,
       $"Expected OK or NotImplemented, got {response.StatusCode}");
+  }
+
+  // PR D #30 — ScanStopThreshold range validation.
+  [Fact]
+  public async Task UpdateRadioSection_ScanStopThresholdAbove100_ReturnsBadRequest()
+  {
+    // Arrange — POST /api/configuration/radio with ScanStopThreshold = 150
+    var sectionPayload = new Dictionary<string, object>
+    {
+      ["ScanStopThreshold"] = 150,
+    };
+
+    // Act
+    var response = await _client.PostAsJsonAsync("/api/configuration/radio", sectionPayload);
+
+    // Assert
+    Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+    var body = await response.Content.ReadAsStringAsync();
+    Assert.Contains("ScanStopThreshold", body);
+  }
+
+  [Fact]
+  public async Task UpdateRadioSection_ScanStopThresholdNegative_ReturnsBadRequest()
+  {
+    var sectionPayload = new Dictionary<string, object>
+    {
+      ["ScanStopThreshold"] = -5,
+    };
+
+    var response = await _client.PostAsJsonAsync("/api/configuration/radio", sectionPayload);
+
+    Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+  }
+
+  [Fact]
+  public async Task UpdateRadioSection_ScanStopThresholdInRange_DoesNotReturn400()
+  {
+    var sectionPayload = new Dictionary<string, object>
+    {
+      ["ScanStopThreshold"] = 75,
+    };
+
+    var response = await _client.PostAsJsonAsync("/api/configuration/radio", sectionPayload);
+
+    // Acceptable: 200 OK (write succeeded) or 5xx (configuration manager
+    // unavailable in this test host). The case we MUST NOT see is 400.
+    Assert.NotEqual(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
   }
 }

--- a/tests/Radio.API.Tests/Controllers/MetricsControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/MetricsControllerTests.cs
@@ -298,4 +298,62 @@ public class MetricsControllerTests
       x => x.Increment("ui.play_button_clicked_", 1.0, null),
       Times.Once);
   }
+
+  // PR D #11 — descriptor endpoint contract tests.
+
+  [Fact]
+  public void GetDescriptors_NoRegistry_ReturnsEmptyOk()
+  {
+    // Arrange — controller built without an injected IMetricDescriptorRegistry.
+    var controller = new MetricsController(
+      NullLogger<MetricsController>.Instance,
+      _mockMetricsReader.Object,
+      _mockMetricsCollector.Object,
+      descriptorRegistry: null);
+
+    // Act
+    var result = controller.GetDescriptors();
+
+    // Assert
+    var okResult = Assert.IsType<OkObjectResult>(result.Result);
+    var list = Assert.IsAssignableFrom<IReadOnlyList<MetricDescriptor>>(okResult.Value);
+    Assert.Empty(list);
+  }
+
+  [Fact]
+  public void GetDescriptors_PopulatedRegistry_ReturnsRegisteredEntries()
+  {
+    // Arrange
+    var registry = new MetricDescriptorRegistry();
+    registry.Register(new MetricDescriptor
+    {
+      Key = "system.memory_usage_mb",
+      Unit = MetricUnit.Megabytes,
+      Category = "System",
+      DisplayName = "Memory Usage",
+    });
+    registry.Register(new MetricDescriptor
+    {
+      Key = "audio.buffer.underruns",
+      Unit = MetricUnit.Count,
+      Category = "Audio | Buffer",
+    });
+
+    var controller = new MetricsController(
+      NullLogger<MetricsController>.Instance,
+      _mockMetricsReader.Object,
+      _mockMetricsCollector.Object,
+      descriptorRegistry: registry);
+
+    // Act
+    var result = controller.GetDescriptors();
+
+    // Assert
+    var okResult = Assert.IsType<OkObjectResult>(result.Result);
+    var list = Assert.IsAssignableFrom<IReadOnlyList<MetricDescriptor>>(okResult.Value);
+    Assert.Equal(2, list.Count);
+    var memory = list.FirstOrDefault(d => d.Key == "system.memory_usage_mb");
+    Assert.NotNull(memory);
+    Assert.Equal(MetricUnit.Megabytes, memory!.Unit);
+  }
 }

--- a/tests/Radio.API.Tests/Controllers/SystemLogsControllerTests.cs
+++ b/tests/Radio.API.Tests/Controllers/SystemLogsControllerTests.cs
@@ -1,0 +1,134 @@
+namespace Radio.API.Tests.Controllers;
+
+using System.IO.Compression;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Radio.API.Controllers;
+using Xunit;
+
+/// <summary>
+/// Tests for the SystemLogsController logs/download endpoint (PR D #24).
+/// Uses a hermetic per-test logs directory (set via the
+/// <c>OverrideLogsDirectory</c> seam) so concurrent test execution doesn't
+/// share a global current-directory mutation.
+/// </summary>
+public class SystemLogsControllerTests : IDisposable
+{
+  private readonly string _logsDir;
+
+  public SystemLogsControllerTests()
+  {
+    _logsDir = Path.Combine(Path.GetTempPath(), $"radio-logs-test-{Guid.NewGuid():N}");
+    Directory.CreateDirectory(_logsDir);
+  }
+
+  public void Dispose()
+  {
+    try
+    {
+      if (Directory.Exists(_logsDir))
+      {
+        Directory.Delete(_logsDir, recursive: true);
+      }
+    }
+    catch
+    {
+      // best-effort cleanup; some files may be locked by the test runner.
+    }
+  }
+
+  private SystemLogsController CreateController(bool clearLogsDir = false)
+  {
+    var controller = new SystemLogsController(NullLogger<SystemLogsController>.Instance);
+    if (clearLogsDir)
+    {
+      // Point at a sibling path that does NOT exist — for the "no logs
+      // directory" scenario. The override gets us hermetic regardless.
+      controller.OverrideLogsDirectory = Path.Combine(_logsDir, "missing-subdir");
+    }
+    else
+    {
+      controller.OverrideLogsDirectory = _logsDir;
+    }
+    return controller;
+  }
+
+  [Fact]
+  public void DownloadLogs_NoLogsDirectory_ReturnsNotFound()
+  {
+    var controller = CreateController(clearLogsDir: true);
+
+    var result = controller.DownloadLogs(period: "1h");
+
+    Assert.IsType<NotFoundObjectResult>(result);
+  }
+
+  [Fact]
+  public void DownloadLogs_NoRecentFiles_ReturnsNotFound()
+  {
+    // Write a log file but backdate it well outside the 1h window.
+    var stale = Path.Combine(_logsDir, "radio-stale.txt");
+    File.WriteAllText(stale, "stale line");
+    File.SetLastWriteTimeUtc(stale, DateTime.UtcNow.AddDays(-30));
+
+    var controller = CreateController();
+
+    var result = controller.DownloadLogs(period: "1h");
+
+    Assert.IsType<NotFoundObjectResult>(result);
+  }
+
+  [Fact]
+  public void DownloadLogs_RecentFile_ReturnsZip()
+  {
+    var recent = Path.Combine(_logsDir, "radio-20260518.txt");
+    File.WriteAllText(recent, "2026-05-18 12:00:00.000 +00:00 [INF] [Test] Hello");
+
+    var controller = CreateController();
+
+    var result = controller.DownloadLogs(period: "1h");
+
+    var file = Assert.IsType<FileContentResult>(result);
+    Assert.Equal("application/zip", file.ContentType);
+    Assert.NotEmpty(file.FileContents);
+
+    // Verify the zip contains the original filename.
+    using var ms = new MemoryStream(file.FileContents);
+    using var zip = new ZipArchive(ms, ZipArchiveMode.Read);
+    Assert.Contains(zip.Entries, e => e.Name == "radio-20260518.txt");
+  }
+
+  [Theory]
+  [InlineData("5m")]
+  [InlineData("1h")]
+  [InlineData("24h")]
+  [InlineData("7d")]
+  public void DownloadLogs_AcceptsKnownPeriods(string period)
+  {
+    var recent = Path.Combine(_logsDir, "radio-test.txt");
+    File.WriteAllText(recent, "line");
+
+    var controller = CreateController();
+
+    var result = controller.DownloadLogs(period);
+
+    // Either 200 with zip, or 404 if the LastWriteTime ends up outside the
+    // window for the smaller periods due to filesystem timestamp granularity.
+    // Never a 400 or 5xx — period is always accepted.
+    Assert.True(result is FileContentResult or NotFoundObjectResult,
+      $"Expected file or not-found for period={period}, got {result.GetType().Name}");
+  }
+
+  [Fact]
+  public void DownloadLogs_UnknownPeriod_FallsBackTo1h()
+  {
+    var recent = Path.Combine(_logsDir, "radio-test.txt");
+    File.WriteAllText(recent, "line");
+
+    var controller = CreateController();
+
+    var result = controller.DownloadLogs(period: "garbage-period");
+
+    Assert.True(result is FileContentResult or NotFoundObjectResult);
+  }
+}

--- a/tests/Radio.API.Tests/Services/SleepServiceTests.cs
+++ b/tests/Radio.API.Tests/Services/SleepServiceTests.cs
@@ -1,0 +1,123 @@
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Radio.API.Hubs;
+using Radio.API.Services;
+
+namespace Radio.API.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="SleepService"/>'s SignalR broadcast contract.
+/// PR D #25 of the Arc follow-up backlog — verifies the server broadcasts
+/// <c>SleepStateChanged</c> with the correct <c>bool</c> payload when sleep
+/// state changes. The Web's <c>AudioStateHubService</c> already subscribes
+/// to this event (Arc 1 PR 6), so confirming the server side fires it
+/// closes the round-trip.
+/// </summary>
+public class SleepServiceTests
+{
+  private static (SleepService service, Mock<IClientProxy> allClients) CreateService()
+  {
+    var hubContextMock = new Mock<IHubContext<AudioStateHub>>();
+    var clientsMock = new Mock<IHubClients>();
+    var allClientsMock = new Mock<IClientProxy>();
+    clientsMock.SetupGet(c => c.All).Returns(allClientsMock.Object);
+    hubContextMock.SetupGet(h => h.Clients).Returns(clientsMock.Object);
+
+    var service = new SleepService(
+      NullLogger<SleepService>.Instance,
+      hubContextMock.Object,
+      audioManager: null);
+
+    return (service, allClientsMock);
+  }
+
+  [Fact]
+  public async Task EnterSleepAsync_BroadcastsSleepStateChangedTrue()
+  {
+    var (service, allClients) = CreateService();
+
+    await service.EnterSleepAsync();
+
+    allClients.Verify(
+      c => c.SendCoreAsync(
+        "SleepStateChanged",
+        It.Is<object?[]>(args => MatchesBool(args, true)),
+        It.IsAny<CancellationToken>()),
+      Times.Once);
+
+    Assert.True(service.IsSleeping);
+  }
+
+  [Fact]
+  public async Task WakeAsync_BroadcastsSleepStateChangedFalse()
+  {
+    var (service, allClients) = CreateService();
+
+    // Pre-condition: must be sleeping before wake fires.
+    await service.EnterSleepAsync();
+    allClients.Invocations.Clear();
+
+    await service.WakeAsync("test");
+
+    allClients.Verify(
+      c => c.SendCoreAsync(
+        "SleepStateChanged",
+        It.Is<object?[]>(args => MatchesBool(args, false)),
+        It.IsAny<CancellationToken>()),
+      Times.Once);
+
+    Assert.False(service.IsSleeping);
+  }
+
+  // Helper — Moq expression trees can't contain pattern-matching, so the
+  // predicate body lives in a regular static method.
+  private static bool MatchesBool(object?[] args, bool expected)
+  {
+    if (args == null || args.Length != 1)
+    {
+      return false;
+    }
+    var first = args[0];
+    if (first is bool b)
+    {
+      return b == expected;
+    }
+    return false;
+  }
+
+  [Fact]
+  public async Task EnterSleepAsync_AlreadySleeping_DoesNotRebroadcast()
+  {
+    var (service, allClients) = CreateService();
+
+    await service.EnterSleepAsync();
+    allClients.Invocations.Clear();
+
+    // Second call should no-op.
+    await service.EnterSleepAsync();
+
+    allClients.Verify(
+      c => c.SendCoreAsync(
+        "SleepStateChanged",
+        It.IsAny<object?[]>(),
+        It.IsAny<CancellationToken>()),
+      Times.Never);
+  }
+
+  [Fact]
+  public async Task WakeAsync_NotSleeping_DoesNotRebroadcast()
+  {
+    var (service, allClients) = CreateService();
+
+    // Not sleeping — wake should no-op.
+    await service.WakeAsync("test");
+
+    allClients.Verify(
+      c => c.SendCoreAsync(
+        "SleepStateChanged",
+        It.IsAny<object?[]>(),
+        It.IsAny<CancellationToken>()),
+      Times.Never);
+  }
+}

--- a/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/RdsStationNameStabilityTrackerTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/RdsStationNameStabilityTrackerTests.cs
@@ -1,0 +1,132 @@
+using Radio.Infrastructure.Audio.Sources.Primary;
+
+namespace Radio.Infrastructure.Tests.Audio.Sources.Primary;
+
+/// <summary>
+/// Tests for <see cref="RdsStationNameStabilityTracker"/> — the helper that
+/// filters rolling-PS artifacts before exposing a "stable" station name
+/// (PR D #40 of the Arc follow-up backlog).
+/// </summary>
+public class RdsStationNameStabilityTrackerTests
+{
+  [Fact]
+  public void Stable_StartsNull()
+  {
+    var tracker = new RdsStationNameStabilityTracker();
+
+    Assert.Null(tracker.Stable);
+  }
+
+  [Fact]
+  public void Observe_BelowWindow_DoesNotEmitStable()
+  {
+    var tracker = new RdsStationNameStabilityTracker(windowSize: 3);
+
+    var first = tracker.Observe("Rock 92");
+    var second = tracker.Observe("Rock 92");
+
+    Assert.Null(first);
+    Assert.Null(second);
+  }
+
+  [Fact]
+  public void Observe_WindowOfIdenticalSamples_PromotesToStable()
+  {
+    var tracker = new RdsStationNameStabilityTracker(windowSize: 3);
+
+    tracker.Observe("Rock 92");
+    tracker.Observe("Rock 92");
+    var stable = tracker.Observe("Rock 92");
+
+    Assert.Equal("Rock 92", stable);
+    Assert.Equal("Rock 92", tracker.Stable);
+  }
+
+  [Fact]
+  public void Observe_MidRollFragments_NeverPromote_UntilConsensus()
+  {
+    var tracker = new RdsStationNameStabilityTracker(windowSize: 3);
+
+    // Rolling PS cycles: each frame is a different fragment.
+    tracker.Observe("Rock 92 ");
+    tracker.Observe("anoidRoc");
+    tracker.Observe("k92 PaR");
+
+    Assert.Null(tracker.Stable);
+
+    // Now three identical frames in a row — consensus emerges.
+    tracker.Observe("Rock 92");
+    tracker.Observe("Rock 92");
+    tracker.Observe("Rock 92");
+
+    Assert.Equal("Rock 92", tracker.Stable);
+  }
+
+  [Fact]
+  public void Observe_BreakingConsensus_KeepsPreviousStableUntilNewConsensus()
+  {
+    var tracker = new RdsStationNameStabilityTracker(windowSize: 3);
+
+    // Reach consensus on first station.
+    tracker.Observe("WCPE");
+    tracker.Observe("WCPE");
+    tracker.Observe("WCPE");
+    Assert.Equal("WCPE", tracker.Stable);
+
+    // Now a couple of transient frames — stable should hold.
+    tracker.Observe("WUNC");
+    tracker.Observe("transient");
+    Assert.Equal("WCPE", tracker.Stable);
+
+    // New consensus takes over once 3-in-a-row of "WUNC" arrives.
+    tracker.Observe("WUNC");
+    tracker.Observe("WUNC");
+    tracker.Observe("WUNC");
+    Assert.Equal("WUNC", tracker.Stable);
+  }
+
+  [Theory]
+  [InlineData(null)]
+  [InlineData("")]
+  [InlineData("   ")]
+  public void Observe_NullOrWhitespace_DoesNotPromoteStableNull(string? value)
+  {
+    var tracker = new RdsStationNameStabilityTracker(windowSize: 3);
+
+    // First reach a stable value.
+    tracker.Observe("Rock 92");
+    tracker.Observe("Rock 92");
+    tracker.Observe("Rock 92");
+    Assert.Equal("Rock 92", tracker.Stable);
+
+    // Now flood with null/empty — stable should hold the previous consensus
+    // rather than transitioning to null.
+    tracker.Observe(value);
+    tracker.Observe(value);
+    tracker.Observe(value);
+
+    Assert.Equal("Rock 92", tracker.Stable);
+  }
+
+  [Fact]
+  public void Reset_ClearsStable()
+  {
+    var tracker = new RdsStationNameStabilityTracker(windowSize: 3);
+
+    tracker.Observe("Rock 92");
+    tracker.Observe("Rock 92");
+    tracker.Observe("Rock 92");
+    Assert.Equal("Rock 92", tracker.Stable);
+
+    tracker.Reset();
+
+    Assert.Null(tracker.Stable);
+  }
+
+  [Fact]
+  public void Constructor_NonPositiveWindowSize_Throws()
+  {
+    Assert.Throws<ArgumentOutOfRangeException>(() => new RdsStationNameStabilityTracker(windowSize: 0));
+    Assert.Throws<ArgumentOutOfRangeException>(() => new RdsStationNameStabilityTracker(windowSize: -1));
+  }
+}

--- a/tests/Radio.Metrics.Tests/MetricDescriptorRegistryTests.cs
+++ b/tests/Radio.Metrics.Tests/MetricDescriptorRegistryTests.cs
@@ -1,0 +1,105 @@
+namespace Radio.Metrics.Tests;
+
+using Radio.Metrics;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="MetricDescriptorRegistry"/>. Covers register/lookup
+/// behavior, insertion-order stability, and re-registration overwrite (PR D
+/// #11 of the Arc follow-up backlog).
+/// </summary>
+public class MetricDescriptorRegistryTests
+{
+  [Fact]
+  public void Register_StoresDescriptor_LookupReturnsIt()
+  {
+    var registry = new MetricDescriptorRegistry();
+    var descriptor = new MetricDescriptor
+    {
+      Key = "system.memory_usage_mb",
+      Unit = MetricUnit.Megabytes,
+      Category = "System",
+      DisplayName = "Memory Usage",
+    };
+
+    registry.Register(descriptor);
+
+    var result = registry.GetByKey("system.memory_usage_mb");
+    Assert.NotNull(result);
+    Assert.Equal(MetricUnit.Megabytes, result!.Unit);
+    Assert.Equal("System", result.Category);
+  }
+
+  [Fact]
+  public void GetByKey_UnknownKey_ReturnsNull()
+  {
+    var registry = new MetricDescriptorRegistry();
+
+    var result = registry.GetByKey("does.not.exist");
+
+    Assert.Null(result);
+  }
+
+  [Fact]
+  public void GetByKey_EmptyOrNullKey_ReturnsNull()
+  {
+    var registry = new MetricDescriptorRegistry();
+
+    Assert.Null(registry.GetByKey(""));
+    Assert.Null(registry.GetByKey(null!));
+  }
+
+  [Fact]
+  public void All_PreservesInsertionOrder()
+  {
+    var registry = new MetricDescriptorRegistry();
+    registry.Register(new MetricDescriptor { Key = "a", Unit = MetricUnit.Bare });
+    registry.Register(new MetricDescriptor { Key = "b", Unit = MetricUnit.Percent });
+    registry.Register(new MetricDescriptor { Key = "c", Unit = MetricUnit.Count });
+
+    var keys = registry.All.Select(d => d.Key).ToArray();
+
+    Assert.Equal(new[] { "a", "b", "c" }, keys);
+  }
+
+  [Fact]
+  public void Register_DuplicateKey_OverwritesAndPreservesOrder()
+  {
+    var registry = new MetricDescriptorRegistry();
+    registry.Register(new MetricDescriptor { Key = "a", Unit = MetricUnit.Bare });
+    registry.Register(new MetricDescriptor { Key = "b", Unit = MetricUnit.Percent });
+    registry.Register(new MetricDescriptor { Key = "c", Unit = MetricUnit.Count });
+
+    // Replace "b" with a different unit; "b" should remain in position 2.
+    registry.Register(new MetricDescriptor { Key = "b", Unit = MetricUnit.Megabytes });
+
+    var keys = registry.All.Select(d => d.Key).ToArray();
+    Assert.Equal(new[] { "a", "b", "c" }, keys);
+    Assert.Equal(MetricUnit.Megabytes, registry.GetByKey("b")!.Unit);
+  }
+
+  [Fact]
+  public void Register_NullDescriptor_Throws()
+  {
+    var registry = new MetricDescriptorRegistry();
+
+    Assert.Throws<ArgumentNullException>(() => registry.Register(null!));
+  }
+
+  [Fact]
+  public void Register_EmptyKey_Throws()
+  {
+    var registry = new MetricDescriptorRegistry();
+
+    Assert.Throws<ArgumentException>(() =>
+      registry.Register(new MetricDescriptor { Key = "", Unit = MetricUnit.Bare }));
+  }
+
+  [Fact]
+  public void All_EmptyRegistry_ReturnsEmpty()
+  {
+    var registry = new MetricDescriptorRegistry();
+
+    Assert.Empty(registry.All);
+  }
+}


### PR DESCRIPTION
Fourth of 6 PRs closing the post-arc deferred-nit backlog.

## Summary

7 server-side items deferred across both arcs (Plan §PR D):

- **#11 Wire MetricDescriptor descriptors end-to-end.** New `IMetricDescriptorRegistry` lives in `Radio.Metrics` (bumped 1.1.0 → 1.2.0, re-packed via `pack-local.ps1`). API serves `GET /api/metrics/descriptors` from the registry. `MetricsDashboardPage` consults descriptors first and falls back to `MapKeyToUnit` for keys without one. ~17 representative metric keys registered (system/API/audio/cast); the registry is a migration surface, not a hard contract — adding/removing entries across deploys is safe.
- **#15 `QueueItemDto.AlbumArtUrl` on the Web side.** API DTO already had the field; the Web mirror was missing it. Up Next thumbs now render from `item.AlbumArtUrl` with the existing `music_note` placeholder when null.
- **#23 `GET /api/audio/debug/dump-frame`.** Ships as a 501 stub with a descriptive body — the SoundFlow output stage doesn't currently retain a re-readable buffer. DevTray no longer 404s; clicking the card now shows a clear \"not yet implemented\" response.
- **#24 `GET /api/system/logs/download?period=5m|1h|24h|7d`.** Real implementation. Bundles `radio-*.txt` files whose `LastWriteTimeUtc` falls within the requested window into a zip and streams it as `application/zip`. Unknown periods fall back to `1h`. Default is `1h`. Uses the same `logs/` directory `SystemController.GetSystemLogs` already scans, with an internal `OverrideLogsDirectory` seam for hermetic tests.
- **#25 `SleepStateChanged` hub event.** Already wired in `SleepService` (Arc 1 PR 6). New `SleepServiceTests` covers the broadcast contract: `EnterSleepAsync` / `WakeAsync` each broadcast `bool` exactly once and no-op on repeated calls.
- **#30 `RadioConfigDto.ScanStopThreshold` validation.** Added `[Range(0,100)]` on the Web mirror DTO, dropped UI `Max` from 200 to 100, and added section-aware validation in `ConfigurationController` that returns 400 with a field-level error when `ScanStopThreshold` is outside the [0,100] range. POSTing 150 now returns 400 instead of silently saturating at 100 via `RadioStateMapper.PercentToDbu`.
- **#40 Server-side RDS PS stability tracker.** New `RdsStationNameStabilityTracker` (3-sample window) lives in `Radio.Infrastructure`. `IRadioControl` gains a default `RdsStationNameStable` that mirrors `RdsStationName`; `SDRRadioAudioSource` overrides with a tracker that observes the live PS on each property read and resets on frequency change. New `RadioStateDto.RdsStationNameStable` rides the wire. `RadioControlPanel.OpenSavePresetDialog` seeds from the stable variant with fallback to the live name → rolling-PS stations no longer seed save dialogs with mid-roll fragments like \"anoidRoc\".

## Auth note

`#23` and `#24` ship **without** an auth gate because no `[Authorize]` policy exists anywhere in `Radio.API` today. The DevTray is the UI access gate (3-tap on an invisible corner). A follow-up PR should add server-side authorization once the project's auth strategy lands.

## UAT performed

- `dotnet build --configuration Release` clean (Web + API + Metrics + Core + Infrastructure).
- `dotnet test --configuration Release` green except the known pre-existing `AudioEngineInitializationServiceTests.StartAsync_EnumeratesDevices` Moq flake (Task #72).
- Started `Radio.API` on `localhost:5000` and hit the new endpoints:
  - `GET /api/metrics/descriptors` → 200 with the 17 registered descriptors (verified Memory `Megabytes`, CPU `Percent`, Buffer Fill `Percent` w/ thresholds, etc.).
  - `GET /api/audio/debug/dump-frame` → 501 with the stub body including `tracked: \"Arc follow-up #23\"`.
  - `GET /api/system/logs/download?period=1h` → 200 with a valid 5 KB zip (`Content-Type: application/zip`) containing the day's `radio-*.txt`.
  - `POST /api/configuration/radio {ScanStopThreshold: 150}` → 400 with `{ error: \"ScanStopThreshold must be between 0 and 100 (percent).\", field: \"ScanStopThreshold\", value: 150 }`.
- `Radio.Metrics` 1.2.0 packed into `./packages/` via `pack-local.ps1`.

Live-kiosk visual UAT (Up Next thumbs from real album art, Sleep page reacts to server-pushed wake, Save dialog stable seed) is **deferred to live deploy** — none of those flows are exercisable on the Windows dev box without the actual hardware. Flagged below as the open UAT item.

## Test plan

- [x] `dotnet build` clean (Web + API + Metrics).
- [x] `dotnet test` green (only known pre-existing Moq flake remains red).
- [x] `/api/metrics/descriptors` returns the registered list.
- [x] `/api/audio/debug/dump-frame` returns 501 + descriptive body.
- [x] `/api/system/logs/download?period=1h` returns a valid zip.
- [x] `POST /api/configuration/radio {ScanStopThreshold:150}` returns 400.
- [ ] **Kiosk UAT (deferred to deploy):** Metrics page shows units via descriptors. Up Next tiles show real album art (when a file with embedded art is queued). Save dialog on a rolling-PS station seeds from the stable name. SystemConfig page rejects threshold > 100 in the UI before POSTing. DevTray cards open the new endpoints without 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)