### PR TITLE
fix(infrastructure): FilePlayer populates QueueItem.AlbumArtUrl (Task #81)

### DIFF
--- a/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/FilePlayerAudioSource.cs
@@ -1598,6 +1598,11 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
       Logger.LogDebug(ex, "Failed to read metadata for {File}, using defaults", filePath);
     }
 
+    // Populate album art from embedded picture tags so Up Next tiles render real art
+    // instead of falling back to the music_note placeholder. Content-addressed cache
+    // makes repeated reads idempotent.
+    var albumArtUrl = TryGetEmbeddedAlbumArtUrl(filePath);
+
     return new QueueItem
     {
       Id = filePath,
@@ -1605,6 +1610,7 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
       Artist = artist,
       Album = album,
       Duration = duration,
+      AlbumArtUrl = albumArtUrl,
       Index = index,
       IsCurrent = isCurrent,
       State = isCurrent ? QueueItemState.Current : QueueItemState.Upcoming,
@@ -1657,6 +1663,11 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
       Logger.LogDebug(ex, "Failed to read metadata for {File}, using defaults", filePath);
     }
 
+    // Populate album art from embedded picture tags so Up Next / Recent tiles render real
+    // art instead of falling back to the music_note placeholder. Content-addressed cache
+    // makes repeated reads idempotent.
+    var albumArtUrl = TryGetEmbeddedAlbumArtUrl(filePath);
+
     return new QueueItem
     {
       Id = filePath,
@@ -1664,6 +1675,7 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
       Artist = artist,
       Album = album,
       Duration = duration,
+      AlbumArtUrl = albumArtUrl,
       Index = fullPlaylistIndex, // For operational compatibility
       IsCurrent = state == QueueItemState.Current,
       State = state,
@@ -1987,13 +1999,30 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
 
   /// <summary>
   /// Extracts embedded album art from audio file metadata using TagLib.
-  /// Saves to the album art cache and sets AlbumArtUrl if found.
+  /// Saves to the album art cache and sets AlbumArtUrl on the current-track metadata if found.
   /// </summary>
   private void ExtractEmbeddedAlbumArt(string filePath)
   {
+    var cachedUrl = TryGetEmbeddedAlbumArtUrl(filePath);
+    if (cachedUrl != null)
+    {
+      _metadata[StandardMetadataKeys.AlbumArtUrl] = cachedUrl;
+    }
+  }
+
+  /// <summary>
+  /// Reads embedded album art from <paramref name="filePath"/> via TagLib, writes it to the
+  /// content-addressed album-art cache, and returns the resulting proxy URL
+  /// (e.g. <c>/api/albumart/&lt;hash&gt;.jpg</c>). Returns <c>null</c> when no cache service
+  /// is configured, no embedded picture exists, or any error occurs.
+  /// Safe to call from both the current-track metadata path and the queue-item enqueue path:
+  /// the cache is content-addressed so repeated calls for the same file are idempotent.
+  /// </summary>
+  private string? TryGetEmbeddedAlbumArtUrl(string filePath)
+  {
     if (_albumArtCache == null)
     {
-      return;
+      return null;
     }
 
     try
@@ -2002,7 +2031,7 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
       var pictures = tagFile.Tag.Pictures;
       if (pictures == null || pictures.Length == 0)
       {
-        return;
+        return null;
       }
 
       // Prefer FrontCover, fall back to first picture
@@ -2012,19 +2041,21 @@ public class FilePlayerAudioSource : PrimaryAudioSourceBase, IPlayQueue
       var data = picture.Data?.Data;
       if (data == null || data.Length == 0)
       {
-        return;
+        return null;
       }
 
       var mime = !string.IsNullOrEmpty(picture.MimeType) ? picture.MimeType : "image/jpeg";
       var cachedUrl = _albumArtCache.Save(data, mime);
-      _metadata[StandardMetadataKeys.AlbumArtUrl] = cachedUrl;
 
       Logger.LogDebug("Extracted embedded album art from {File}: {Url} ({Bytes} bytes)",
         Path.GetFileName(filePath), cachedUrl, data.Length);
+
+      return cachedUrl;
     }
     catch (Exception ex)
     {
       Logger.LogDebug(ex, "Failed to extract embedded album art from {File}", filePath);
+      return null;
     }
   }
 

--- a/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/FilePlayerAudioSourceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Sources/Primary/FilePlayerAudioSourceTests.cs
@@ -5,6 +5,7 @@ using Radio.Core.Configuration;
 using Radio.Core.Interfaces.Audio;
 using Radio.Fingerprinting;
 using Radio.Core.Models.Audio;
+using Radio.Infrastructure.Audio;
 using Radio.Infrastructure.Audio.Sources.Primary;
 
 namespace Radio.Infrastructure.Tests.Audio.Sources.Primary;
@@ -837,12 +838,233 @@ public class FilePlayerAudioSourceTests : IDisposable
     // Assert
     Assert.NotNull(queue);
     Assert.Equal(2, queue.Count);
-    
+
     // Check metadata fields are populated (using defaults since test files don't have tags)
     Assert.NotNull(queue[0].Title);
     Assert.NotNull(queue[0].Artist);
     Assert.NotNull(queue[0].Album);
     Assert.NotNull(queue[0].Id);
+  }
+
+  // -- Album-art-on-enqueue tests (Task #81) ------------------------------------
+  //
+  // PR D added AlbumArtUrl to QueueItemDto and Up Next reads it with music_note fallback.
+  // FilePlayerAudioSource is the producer; CreateQueueItem / CreateQueueItemWithState
+  // must surface the URL so Up Next renders real art instead of placeholder icons.
+
+  [Fact]
+  public async Task GetQueueAsync_WithoutAlbumArtCache_ReturnsNullAlbumArtUrl()
+  {
+    // Arrange: source with no AlbumArtCacheService — TryGetEmbeddedAlbumArtUrl
+    // returns null on the cache==null guard, regardless of file content.
+    var source = CreateSource();
+    CreateTestFile("song1.mp3");
+    await source.LoadDirectoryAsync("");
+
+    // Act
+    var queue = await source.GetQueueAsync();
+
+    // Assert
+    Assert.Single(queue);
+    Assert.Null(queue[0].AlbumArtUrl);
+  }
+
+  [Fact]
+  public async Task GetQueueAsync_WithCacheButInvalidFile_ReturnsNullAlbumArtUrl()
+  {
+    // Arrange: cache wired but file content is "test" — TagLib throws and we
+    // log+swallow, returning null. Up Next falls back to music_note.
+    var cache = CreateAlbumArtCacheService();
+    var source = CreateSourceWithAlbumArtCache(cache);
+    CreateTestFile("song1.mp3");
+    await source.LoadDirectoryAsync("");
+
+    // Act
+    var queue = await source.GetQueueAsync();
+
+    // Assert
+    Assert.Single(queue);
+    Assert.Null(queue[0].AlbumArtUrl);
+  }
+
+  [Fact]
+  public async Task GetQueueAsync_WithCacheAndEmbeddedArt_PopulatesAlbumArtUrl()
+  {
+    // Arrange: real MP3 fixture with an APIC frame injected via TagLib#.
+    // Producer must surface the cached /api/albumart/<hash>.<ext> URL.
+    var cache = CreateAlbumArtCacheService();
+    var source = CreateSourceWithAlbumArtCache(cache);
+    var mp3WithArt = CreateMp3WithEmbeddedArt("song-with-art.mp3");
+    try
+    {
+      await source.LoadDirectoryAsync("");
+
+      // Act
+      var queue = await source.GetQueueAsync();
+
+      // Assert: art-bearing track has a real proxy URL.
+      var item = queue.Single(q => q.Id == mp3WithArt);
+      Assert.NotNull(item.AlbumArtUrl);
+      Assert.StartsWith("/api/albumart/", item.AlbumArtUrl);
+    }
+    finally
+    {
+      await source.DisposeAsync();
+    }
+  }
+
+  [Fact]
+  public async Task GetQueueAsync_WithCacheAndNoArt_ReturnsNullAlbumArtUrl()
+  {
+    // Arrange: real MP3 fixture WITHOUT any embedded picture.
+    // TryGetEmbeddedAlbumArtUrl returns null on the pictures==empty guard.
+    var cache = CreateAlbumArtCacheService();
+    var source = CreateSourceWithAlbumArtCache(cache);
+    var mp3NoArt = CreateMp3WithoutEmbeddedArt("song-no-art.mp3");
+    try
+    {
+      await source.LoadDirectoryAsync("");
+
+      // Act
+      var queue = await source.GetQueueAsync();
+
+      // Assert
+      var item = queue.Single(q => q.Id == mp3NoArt);
+      Assert.Null(item.AlbumArtUrl);
+    }
+    finally
+    {
+      await source.DisposeAsync();
+    }
+  }
+
+  [Fact]
+  public async Task GetFullPlaylistAsync_WithEmbeddedArt_PopulatesAlbumArtUrl()
+  {
+    // Arrange: same as above but exercises the CreateQueueItemWithState path used by
+    // GetFullPlaylistAsync (the path that backs /api/queue/full — the endpoint the
+    // Up Next tile reads).
+    var cache = CreateAlbumArtCacheService();
+    var source = CreateSourceWithAlbumArtCache(cache);
+    var mp3WithArt = CreateMp3WithEmbeddedArt("full-playlist-art.mp3");
+    try
+    {
+      await source.LoadFileAsync(Path.GetFileName(mp3WithArt));
+
+      // Act
+      var fullPlaylist = await source.GetFullPlaylistAsync();
+
+      // Assert: the loaded (current) track surfaces the album-art URL through the
+      // CreateQueueItemWithState path used by full-playlist projection.
+      var item = fullPlaylist.Single(q => q.Id == mp3WithArt);
+      Assert.NotNull(item.AlbumArtUrl);
+      Assert.StartsWith("/api/albumart/", item.AlbumArtUrl);
+    }
+    finally
+    {
+      await source.DisposeAsync();
+    }
+  }
+
+  // -- Album-art test helpers ---------------------------------------------------
+
+  // The album-art cache writes to ./data/albumart by design (content-addressed,
+  // shared cache). We let it write there and rely on the SHA-256 dedup to keep
+  // the on-disk footprint minimal across test runs.
+  private static AlbumArtCacheService CreateAlbumArtCacheService()
+  {
+    var logger = new Mock<ILogger<AlbumArtCacheService>>().Object;
+    return new AlbumArtCacheService(logger);
+  }
+
+  private FilePlayerAudioSource CreateSourceWithAlbumArtCache(AlbumArtCacheService cache)
+  {
+    return new FilePlayerAudioSource(
+      _loggerMock.Object,
+      _optionsMock.Object,
+      _preferencesMock.Object,
+      _testDir,
+      albumArtCache: cache);
+  }
+
+  // Path to a real MP3 already in the repo. Used as the "base" of fixture files
+  // because constructing a valid MP3 from scratch is non-trivial and TagLib needs
+  // a real audio container to write tags to.
+  private static readonly string SampleMp3 =
+    Path.GetFullPath(Path.Combine(
+      AppContext.BaseDirectory,
+      "..", "..", "..", "..", "..", "src", "Radio.API", "media", "audio", "alarm",
+      "PD - Alert.mp3"));
+
+  // A tiny synthetic PNG payload (8x8 transparent) used as the embedded picture.
+  // Generated once via System.Drawing-equivalent magic-byte construction. PNG
+  // header + IHDR + IDAT + IEND chunks for an 8x8 RGBA image. TagLib treats this
+  // as opaque bytes — it never decodes the image.
+  private static readonly byte[] TinyPng = new byte[]
+  {
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+    0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR length + type
+    0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x08, // 8x8
+    0x08, 0x06, 0x00, 0x00, 0x00, 0xC4, 0x0F, 0xBE, // 8-bit RGBA + CRC
+    0x8B,
+    0x00, 0x00, 0x00, 0x13, 0x49, 0x44, 0x41, 0x54, // IDAT length + type
+    0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0xF0, 0x1F, // zlib-compressed solid
+    0x09, 0x00, 0x80, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, // (placeholder; CRC may be off
+    0x00, 0x00, 0x00, 0xFF,                         // but TagLib doesn't validate)
+    0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, // IEND length + type
+    0xAE, 0x42, 0x60, 0x82                          // IEND CRC
+  };
+
+  // Copies the sample MP3 into the test dir under the given name, then injects a
+  // FrontCover APIC frame. Returns the absolute path to the resulting file.
+  private string CreateMp3WithEmbeddedArt(string relativePath)
+  {
+    var dest = CopySampleMp3(relativePath);
+    using (var tag = TagLib.File.Create(dest))
+    {
+      tag.Tag.Pictures = new TagLib.IPicture[]
+      {
+        new TagLib.Picture(new TagLib.ByteVector(TinyPng))
+        {
+          Type = TagLib.PictureType.FrontCover,
+          MimeType = "image/png",
+          Description = "Cover"
+        }
+      };
+      tag.Save();
+    }
+    return dest;
+  }
+
+  // Copies the sample MP3 into the test dir under the given name and ensures no
+  // pictures are present (TagLib defaults strip embedded art on Save when the
+  // pictures collection is empty).
+  private string CreateMp3WithoutEmbeddedArt(string relativePath)
+  {
+    var dest = CopySampleMp3(relativePath);
+    using (var tag = TagLib.File.Create(dest))
+    {
+      tag.Tag.Pictures = Array.Empty<TagLib.IPicture>();
+      tag.Save();
+    }
+    return dest;
+  }
+
+  private string CopySampleMp3(string relativePath)
+  {
+    if (!System.IO.File.Exists(SampleMp3))
+    {
+      throw new InvalidOperationException(
+        $"Sample MP3 fixture not found at expected repo path: {SampleMp3}");
+    }
+    var dest = Path.Combine(_testDir, relativePath);
+    var destDir = Path.GetDirectoryName(dest);
+    if (!string.IsNullOrEmpty(destDir) && !Directory.Exists(destDir))
+    {
+      Directory.CreateDirectory(destDir);
+    }
+    System.IO.File.Copy(SampleMp3, dest, overwrite: true);
+    return dest;
   }
 
   [Fact]


### PR DESCRIPTION
Closes task #81 from the post-arc backlog.

## Summary

PR D's `AlbumArtUrl` DTO contract change shipped correctly through to Up Next; producer-side population on the file-player path was missing. Every queue item returned `albumArtUrl: null` from `/api/queue/full`, so Up Next tiles fell back to `music_note` for every entry — even when the current-source's metadata correctly resolved an `/api/albumart/<hash>.jpg` URL.

This PR closes that gap so queue thumbs render real album art instead of the placeholder icon.

### What changed

- Extracted the existing TagLib# + `AlbumArtCacheService` path into `TryGetEmbeddedAlbumArtUrl(filePath)` (the current-track `ExtractEmbeddedAlbumArt` now calls it too).
- Invoked it from both `CreateQueueItem` and `CreateQueueItemWithState`.
- Approach A (same source as current). The cache is content-addressed (SHA-256) so repeated reads for the same file are idempotent — a TagLib read + SHA-256 hash + cache-hit-no-op (or a single file write on first sight). Acceptable at enqueue time.

### Tests (5 new)

In `FilePlayerAudioSourceTests`:
- `GetQueueAsync_WithoutAlbumArtCache_ReturnsNullAlbumArtUrl` — `cache==null` guard
- `GetQueueAsync_WithCacheButInvalidFile_ReturnsNullAlbumArtUrl` — TagLib throws, swallowed
- `GetQueueAsync_WithCacheAndEmbeddedArt_PopulatesAlbumArtUrl` — real `/api/albumart/<hash>.png` URL
- `GetQueueAsync_WithCacheAndNoArt_ReturnsNullAlbumArtUrl` — pictures==empty guard
- `GetFullPlaylistAsync_WithEmbeddedArt_PopulatesAlbumArtUrl` — covers `CreateQueueItemWithState` path (backs `/api/queue/full`)

Real-MP3 fixtures copy a PD-licensed alarm clip from the repo's `src/Radio.API/media/audio/alarm/` directory; TagLib# injects / strips an APIC frame at test time.

## Test plan

- [x] `dotnet build src/Radio.Infrastructure/Radio.Infrastructure.csproj --configuration Release` clean (0 errors)
- [x] `dotnet build src/Radio.API/Radio.API.csproj --configuration Release` clean (0 errors)
- [x] `dotnet test --configuration Release` green across the full suite (Infrastructure 811/811, API 295/295, Web 528/528, Fingerprinting 94/94, RTLSDRCore 157/157, IntegrationTests 30/30, Web E2E 28/28 — all passing, no regressions)
- [ ] Live kiosk UAT: enqueue files with embedded album art → Up Next tiles render real art (not `music_note`) — known gap, user to verify in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)