### PR TITLE
docs(plans): Cast/BT research Phase 1 + Phase 2 implementation plans

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,9 +39,28 @@ Research arcs explore a problem space deeply enough that *if* the team decides t
 
 ## Planning queue (scoped, ready for implementation)
 
-*Empty.*
+### Cast/BT research — Phase 1 + Phase 2 (selected 2026-05-22)
 
-When a plan lands in [`docs/plans/`](plans/), reference it here with its target acceptance criteria, dependencies, and rough scope.
+Consumed from the cast/BT research arc per embedded-audio-engineering prioritization (transcript record). Sequenced and scoped in [`docs/plans/2026-05-22-cast-bt-phase-1-2-arc.md`](plans/2026-05-22-cast-bt-phase-1-2-arc.md).
+
+**Phase 1 — stop the bleeding** (3 plans, ~280 LOC; can run in any order or parallel):
+
+| Plan | Idea | Addresses | Branch |
+|---|---|---|---|
+| [`2026-05-22-bt-capture-watchdog.md`](plans/2026-05-22-bt-capture-watchdog.md) | #12 Watchdog on `OnProcess` interval | FM-BT-3 (known long-uptime quiescence bug) | `feat/bt-capture-watchdog` |
+| [`2026-05-22-bt-autoswitch-gate.md`](plans/2026-05-22-bt-autoswitch-gate.md) | #13 Gate `autoSwitchOnConnect` on PW node existence | FM-BT-1 (autoSwitch retries on missing PW node) | `feat/bt-autoswitch-gate` |
+| [`2026-05-22-bt-codec-observability.md`](plans/2026-05-22-bt-codec-observability.md) | #15 Surface negotiated codec + bitpool as observable metric | FM-BT-6 (codec quality degradation currently invisible) | `feat/bt-codec-observability` |
+
+**Phase 2 — isolate the audio path** (2 plans, ~165 LOC; ships immediately after Phase 1 completes; CPU affinity before PW event subscription):
+
+| Order | Plan | Idea | Addresses | Branch |
+|---|---|---|---|---|
+| 1 | [`2026-05-22-audio-thread-isolation.md`](plans/2026-05-22-audio-thread-isolation.md) | #9 Pin radio-api to dedicated CPU cores + SCHED_FIFO | FM2 + FM8 + FM-BT-11 (load contention) | `feat/audio-thread-isolation` |
+| 2 | [`2026-05-22-pw-event-subscription.md`](plans/2026-05-22-pw-event-subscription.md) | #14 Replace pw-cli scraping with PipeWire event subscription | FM-BT-1 + FM-BT-2 (eliminates scrape race) | `feat/pw-event-subscription` |
+
+**Shared scaffolding** (research-tier code in `scripts/research/`, declared per-plan in Task 0): `sysload_capture.sh`, `sysload_correlate.py`, `bt_stall_detect.py`, `bt_autoswitch_audit.py`, `bt_codec_observability_probe.sh`, `heavy_load_harness.sh`, `bt_pair_cycle_harness.sh`, plus the per-plan `*_compare.py` PASS/FAIL gates.
+
+**Phase 3+ ideas remain in research** until Phase 1+2 measurement points the finger.
 
 ---
 

--- a/docs/plans/2026-05-22-audio-thread-isolation.md
+++ b/docs/plans/2026-05-22-audio-thread-isolation.md
@@ -1,0 +1,406 @@
+# Audio Thread Isolation Implementation Plan (Phase 2 / Plan D)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Apply standard Linux embedded-audio isolation practice (CPU affinity, scheduling priority, IO niceness, RT-priority limits) to `radio-api` and `radio-web` systemd units. Optionally bump the PipeWire native capture thread and Cast/HTTP audio threads to `SCHED_FIFO` priority via P/Invoke `pthread_setschedparam`. Validates the MEMORY-documented "audio distortion correlates with SSH activity" gap closes under the two-scenario protocol.
+
+**Architecture:**
+
+- systemd unit changes are the *primary* win — `CPUAffinity=2,3` on `radio-api`, `CPUAffinity=0,1` on `radio-web`; `Nice=-5`; `IOSchedulingClass=2 IOSchedulingPriority=2` (best-effort, near-realtime); `LimitNICE=-5:0` + `LimitRTPRIO=99` to allow the process to actually use the requested priorities.
+- The P/Invoke `pthread_setschedparam` bumps for the BT capture thread + HTTP/Cast encode threads are *optional* and ship in a separate task with explicit opt-in flag (`BluetoothOptions.UseRealtimeCaptureThread`, default `false`). They need testing on both Ubuntu and Pi before becoming default.
+
+This plan ships *immediately after Phase 1 merges*; it does not depend on Phase 1 code changes but does benefit from Phase 1's `PROBE-SYS-LOAD` infrastructure already being established.
+
+**Tech Stack:** systemd directives, `pthread_setschedparam` via P/Invoke (Linux only, `#if !WINDOWS_TARGET`), existing `BluetoothCaptureWatchdog` from Plan A for one of the success criteria.
+
+**Addresses**: FM2 (Cast sender pipeline jitter — load-amplified), FM8 (Cast host resource contention), FM-BT-11 (BT host resource contention) from both research docs.
+
+---
+
+## Task 0: Author probe scripts (research deliverable)
+
+**Files:**
+- Create: `scripts/research/heavy_load_harness.sh`
+- Create: `scripts/research/cast_load_compare.py`
+
+**Step 1: `heavy_load_harness.sh`** — generates the "heavy load" scenario the §3 two-scenario protocol requires. Composed of three concurrent SSH-launched loops:
+- `journalctl -f > /dev/null` (continuous log streaming)
+- `while true; do sqlite3 /opt/radio-console/data/metrics/metrics.db 'SELECT COUNT(*) FROM gauges'; sleep 0.5; done` (DB busy-loop)
+- A Playwright/curl loop hitting `radio-web` endpoints to simulate UI traffic
+
+Takes positional arg: duration in seconds. Cleanly terminates all child loops on SIGINT.
+
+**Step 2: `cast_load_compare.py`** — given pairs of `(baseline_light, baseline_heavy, after_light, after_heavy)` artifacts (each containing PROBE-CAST-BUFFER + PROBE-CAST-AUDIO + PROBE-SYS-LOAD), computes:
+- Per-scenario `silence_events/h` and `bufferAhead_p5` deltas
+- Cross-scenario gap (heavy − light) before and after
+- `radio-api` CPU-on-cores-2,3 and `radio-web` CPU-on-cores-0,1 (post-change) — verifies pinning is taking effect
+- PASS/FAIL against the §7 Idea #9 success criterion in the cast doc.
+
+Reuses `bt_stall_compare.py`-style format.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/research/heavy_load_harness.sh scripts/research/cast_load_compare.py
+git commit -m "scripts(research): heavy-load harness + cast load-compare script"
+```
+
+---
+
+## Task 1: systemd unit — `radio-api.service`
+
+**Files:**
+- Modify: `deploy/common/radio-api.service`
+
+**Step 1: Find the `[Service]` section.** Add the resource-isolation directives. Place them logically after `Group=` / `WorkingDirectory=` and before `Environment=`:
+
+```ini
+# === Audio-thread isolation (added 2026-05-22, plan D) ===
+# Pin to cores 2,3 (leave 0,1 for OS + journald + sshd + radio-web).
+# Verify against `nproc` on each deployment target — radio (N100) has 4 cores;
+# Pi 5 has 4 cores; both layouts identical.
+CPUAffinity=2 3
+
+# Boost scheduling priority. Requires LimitNICE below to be actually grant-able.
+Nice=-5
+LimitNICE=-5:0
+
+# IO best-effort near-realtime (class 2, priority 2). Class 1 (realtime) is
+# usually overkill for application audio; class 2 + low prio matches CCRMA/JACK
+# guidance.
+IOSchedulingClass=2
+IOSchedulingPriority=2
+
+# Allow process to use SCHED_FIFO up to priority 99 if it requests it via
+# pthread_setschedparam (Task 4 below — feature-flagged). Without this limit
+# the call would fail with EPERM.
+LimitRTPRIO=99
+
+# Allow mlock for any future low-latency pages (not used today; cheap to allow).
+LimitMEMLOCK=infinity
+# === end audio-thread isolation ===
+```
+
+**Step 2: Verify systemd unit parses**
+
+After deployment, on the target host:
+```bash
+ssh mmack@radio "sudo systemd-analyze verify /opt/radio-console/radio-api.service"
+```
+Expected: no errors.
+
+**Step 3: Commit**
+
+```bash
+git add deploy/common/radio-api.service
+git commit -m "feat(deploy): pin radio-api to cores 2,3 with Nice=-5 + RT-prio limits"
+```
+
+---
+
+## Task 2: systemd unit — `radio-web.service`
+
+**Files:**
+- Modify: `deploy/common/radio-web.service` (or whatever the project's web service file is named)
+
+**Step 1: Find the `[Service]` section.** Add the complementary affinity:
+
+```ini
+# === Complement to radio-api's pin to cores 2,3 (plan D, 2026-05-22) ===
+# Keep radio-web on cores 0,1 so it doesn't crowd the audio cores.
+CPUAffinity=0 1
+# Web is not audio-critical — default scheduling priority.
+# === end ===
+```
+
+**Step 2: Commit**
+
+```bash
+git add deploy/common/radio-web.service
+git commit -m "feat(deploy): pin radio-web to cores 0,1 (complement to api pin)"
+```
+
+---
+
+## Task 3: Deploy + verify systemd-level changes (no code)
+
+**Step 1: Deploy**
+
+```bash
+./deploy/Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64
+```
+
+**Step 2: Verify directives are honored**
+
+```bash
+ssh mmack@radio "sudo systemctl daemon-reload && sudo systemctl restart radio-api radio-web"
+
+# Verify CPU affinity:
+ssh mmack@radio "taskset -p \$(pgrep radio-api)"   # expect mask 0xC (cores 2,3)
+ssh mmack@radio "taskset -p \$(pgrep radio-web)"   # expect mask 0x3 (cores 0,1)
+
+# Verify nice:
+ssh mmack@radio "ps -o pid,nice,comm \$(pgrep radio-api)"   # expect NI=-5
+
+# Verify IO sched:
+ssh mmack@radio "sudo ionice -p \$(pgrep radio-api)"   # expect: best-effort: prio 2
+
+# Verify RT-prio limit:
+ssh mmack@radio "cat /proc/\$(pgrep radio-api)/limits | grep RTPRIO"   # expect Max=99
+```
+
+Expected: all directives are reflected on the running process. If any fail, the systemd unit didn't reload — repeat `daemon-reload`.
+
+**Step 3:** **No commit at this task** — this is a deployment-verification task.
+
+---
+
+## Task 4: (optional, feature-flagged) SCHED_FIFO bump on the PipeWire native capture thread
+
+**Files:**
+- Modify: `src/Radio.Core/Configuration/BluetoothOptions.cs`
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs`
+
+**Step 1: Add config flag**
+
+```csharp
+/// <summary>
+/// When true, the PipeWire capture thread is bumped to SCHED_FIFO priority 50
+/// via pthread_setschedparam. Requires systemd LimitRTPRIO ≥ 50. Linux-only.
+/// Default false — turn on after measurement confirms the systemd-level isolation
+/// in Plan D's Tasks 1-3 is insufficient.
+/// </summary>
+public bool UseRealtimeCaptureThread { get; set; } = false;
+
+/// <summary>
+/// SCHED_FIFO priority to apply when UseRealtimeCaptureThread is true.
+/// Values 50-70 are typical for audio (above default kernel IRQ threads at ~50,
+/// below kernel critical threads at 99). Default 50.
+/// </summary>
+public int RealtimeCaptureThreadPriority { get; set; } = 50;
+```
+
+**Step 2: P/Invoke for `pthread_setschedparam`**
+
+Add to `PipeWireNative.cs` (or a small new `LinuxPosixThread.cs`):
+
+```csharp
+#if !WINDOWS_TARGET
+[StructLayout(LayoutKind.Sequential)]
+internal struct SchedParam
+{
+  public int sched_priority;
+}
+
+internal const int SCHED_FIFO = 1;
+
+[DllImport("libpthread.so.0", EntryPoint = "pthread_self")]
+internal static extern IntPtr pthread_self();
+
+[DllImport("libpthread.so.0", EntryPoint = "pthread_setschedparam", SetLastError = true)]
+internal static extern int pthread_setschedparam(IntPtr thread, int policy, ref SchedParam param);
+#endif
+```
+
+**Step 3: Apply inside `OnProcess` on first call**
+
+In `PipeWireNativeStream.OnProcess`, gate the priority bump behind a once-only flag + the options check:
+
+```csharp
+private bool _rtPriorityApplied;
+
+private static void OnProcess(IntPtr userData)
+{
+  // ... existing GCHandle resolution ...
+
+  if (!self._rtPriorityApplied && self._useRealtime)
+  {
+    self._rtPriorityApplied = true;
+    var param = new SchedParam { sched_priority = self._rtPriority };
+    var result = pthread_setschedparam(pthread_self(), SCHED_FIFO, ref param);
+    if (result != 0)
+    {
+      self._logger.LogWarning("pthread_setschedparam(SCHED_FIFO, {Prio}) failed with errno {Errno}",
+        self._rtPriority, Marshal.GetLastPInvokeError());
+    }
+    else
+    {
+      self._logger.LogInformation("PipeWire capture thread bumped to SCHED_FIFO priority {Prio}", self._rtPriority);
+    }
+  }
+
+  // ... existing OnProcess body ...
+}
+```
+
+Constructor takes new args `bool useRealtime, int rtPriority` from `BluetoothOptions`.
+
+**Step 4: Build + commit**
+
+```bash
+git add src/Radio.Core/Configuration/BluetoothOptions.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNative.cs
+git commit -m "feat(bt): optional SCHED_FIFO bump on PW capture thread (feature-flagged)"
+```
+
+---
+
+## Task 5: Documentation — deploy README + boundary doc
+
+**Files:**
+- Modify: `deploy/README.md` (or wherever deploy steps are documented)
+- Modify: `D:\prj\RotaryPhone\docs\prompts\RADIO-CONSOLE-BT-AUDIO-BOUNDARY.md` if cores 2,3 are crossing into RotaryPhone's space
+
+**Step 1: Document the affinity layout** in `deploy/README.md`:
+
+```markdown
+### CPU affinity layout (added 2026-05-22)
+
+Both production deployment targets have 4 cores. We split:
+  - cores 0,1: OS + journald + sshd + radio-web
+  - cores 2,3: radio-api (BT capture, Cast encode, all audio paths)
+
+If RotaryPhone is co-located on `radio` (it is not currently), document
+RotaryPhone's affinity layout in `docs/prompts/RADIO-CONSOLE-BT-AUDIO-BOUNDARY.md`
+to avoid double-pinning.
+```
+
+**Step 2:** Check the boundary doc — does RotaryPhone run on the same host? Per MEMORY: "RotaryPhone is UI-only" and accessed via REST — so no co-location. No boundary doc update needed.
+
+**Step 3: Commit**
+
+```bash
+git add deploy/README.md
+git commit -m "docs(deploy): document CPU affinity layout"
+```
+
+---
+
+## Task 6: Full build + test
+
+```bash
+dotnet build --configuration Release
+dotnet test --configuration Release --verbosity normal
+```
+Expected: 0 warnings; all tests pass. (The optional SCHED_FIFO code path is feature-flagged off by default — no test coverage required for now; the systemd changes have no unit-test surface.)
+
+---
+
+## Task 7: Deploy + integration test on Ubuntu (the load-isolation win)
+
+```bash
+./deploy/Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64
+ssh mmack@radio "sudo systemctl daemon-reload && sudo systemctl restart radio-api radio-web"
+```
+
+Re-verify Task 3 checks. All directives should still take effect.
+
+---
+
+## Task 8: Verify acceptance criteria — the two-scenario protocol
+
+**This is the load-validation moment.** Run the same probe under both light and heavy scenarios, on baseline (`main`) and post-change (this branch).
+
+**Baseline — light load** (`main` deploy, no heavy harness running):
+```bash
+./deploy/Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64  # against main
+# Start Cast DC playback of reference playlist
+arecord -D plughw:CARD=USB_Audio -d 3600 -f cd /tmp/cast_baseline_light.wav &
+ssh mmack@radio "/opt/radio-console/scripts/research/sysload_capture.sh 3600" > baseline_sysload_light.txt
+# Wait 1 h
+python3 scripts/research/cast_audio_glitch.py /tmp/cast_baseline_light.wav --silence-min-ms 50 > baseline_audio_light.txt
+ssh mmack@radio "sqlite3 /opt/radio-console/data/metrics/metrics.db 'SELECT * FROM gauges WHERE metric=\"cast.dc.buffer_ahead_s\" AND ts > strftime(\"%s\",\"now\",\"-1 hour\")*1000'" | python3 scripts/research/cast_dc_buffer_summarize.py > baseline_buffer_light.txt
+```
+
+**Baseline — heavy load**:
+```bash
+# Same playlist, but with the heavy harness running concurrently
+ssh mmack@radio "/opt/radio-console/scripts/research/heavy_load_harness.sh 3600" &
+# Repeat the audio capture + sysload + buffer-summarize, save as baseline_*_heavy.txt
+```
+
+**Post-change — light + heavy**: deploy the feature branch and repeat both scenarios. Save as `after_*_light.txt` and `after_*_heavy.txt`.
+
+**Success criterion** (must hold across both scenarios):
+
+- **Light load**: `silence_events/h` from PROBE-CAST-AUDIO does not regress (≤ baseline-light +1 event); `bufferAhead` p5 does not regress (≥ baseline-light p5 −0.5 s)
+- **Heavy load**: `silence_events/h` drops by `≥ 80 %` vs baseline-heavy; `bufferAhead` p5 stays within `1.0 s` of light-load p5
+- **Cross-scenario gap** (heavy − light): on baseline, expect e.g. `+8` silence events/h of degradation; post-change, this gap drops to `≤ +2` events/h
+- PROBE-SYS-LOAD post-change shows `radio-api` CPU% on cores 2,3 (taskset -p mask reads as `0xc`) and `radio-web` CPU% on cores 0,1 (mask `0x3`)
+- **Negative check**: no new failure modes — RDS station-name decode, Spotify playback, file playback all work as before (smoke test on the 5 most-used features)
+
+**Debug-agent verification**:
+
+```bash
+python3 scripts/research/cast_load_compare.py \
+  baseline_audio_light.txt baseline_audio_heavy.txt \
+  after_audio_light.txt after_audio_heavy.txt
+```
+
+Expected: `PASS` plus deltas.
+
+**If FAIL**: diagnose whether the affinity is being honored (`taskset -p`) or whether the cross-scenario gap is bigger than expected and Task 4 (SCHED_FIFO bump) needs to be enabled.
+
+---
+
+## Task 9: Verify on Pi as well
+
+```bash
+./deploy/Deploy-ToPi.ps1 -PiHost piradio -PiUser radio
+ssh radio@piradio "sudo systemctl daemon-reload && sudo systemctl restart radio-api radio-web"
+ssh radio@piradio "taskset -p \$(pgrep radio-api)"   # expect 0xC
+```
+
+Run a shorter (15 min) audio-capture validation on Pi — confirm no regression. Pi has 4 cores; same layout applies.
+
+---
+
+## Task 10: Open PR + merge
+
+```bash
+git push -u origin feat/audio-thread-isolation
+
+gh pr create --title "feat(deploy): isolate audio-pipeline threads via CPU affinity + scheduling priority" --body "$(cat <<'EOF'
+## Summary
+
+Implements [Plan D from the Cast/BT research arc](../docs/plans/2026-05-22-cast-bt-phase-1-2-arc.md). Applies standard Linux embedded-audio isolation practice — `radio-api` pinned to cores 2,3 with `Nice=-5` + `LimitRTPRIO=99` + IO best-effort near-realtime; `radio-web` pinned to cores 0,1.
+
+Closes the MEMORY-documented load gap ("audio distortion correlates with SSH activity") by structurally separating audio-critical scheduling from journald + sshd + web traffic.
+
+Optional SCHED_FIFO bump on the PipeWire capture thread is included but feature-flagged off (`BluetoothOptions.UseRealtimeCaptureThread = false`); turn it on later if measurement shows the systemd-level isolation is insufficient.
+
+## Acceptance criteria (verified)
+
+- Heavy-load `silence_events/h` drops by ≥80 % vs baseline-heavy
+- Light-load: no regression
+- Cross-scenario gap drops from baseline ~+8/h to ≤+2/h
+- `taskset -p` confirms pinning on both Ubuntu (radio) and Pi (piradio)
+- See attached `cast_load_compare.py` PASS artifact
+
+## Test plan
+
+- [x] systemd-analyze verify
+- [x] Affinity / nice / IO-sched / RT-prio verified via `taskset`, `ps`, `ionice`, `/proc/.../limits` on radio
+- [x] Same verifications on piradio
+- [x] Two-scenario probe runs (light + heavy) on radio
+- [x] 15-min smoke test on piradio
+- [x] Negative-check: RDS, Spotify, file-playback all work as before
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Merge once Mark approves.
+
+---
+
+## Out of scope
+
+- **CPU isolation via `isolcpus=` kernel boot param**: a stricter form of isolation that removes cores from the kernel's normal scheduler entirely. Not needed for this round — `CPUAffinity=` is enough.
+- **PREEMPT_RT kernel**: real-time kernel patches. Would help further but a kernel-swap is a heavy operation; defer to Phase 4+.
+- **Per-thread affinity inside radio-api** (e.g. binding the BT capture thread to a specific core within 2,3): the kernel scheduler within the affinity mask is usually fine; per-thread pinning is a Phase 4 micro-optimization.
+- **Windows path**: no equivalent on Windows (the dev environment is on Windows but production is Linux). NOPs on Windows.
+- **Logging-path audit (idea #10)**: addresses load contribution from synchronous flushes; this plan addresses load contention from external processes. They're complementary — if Plan D's verification shows residual gap, Plan #10 is the next move.
+- **Background-op gating (idea #11)**: same reasoning — complementary, not redundant.

--- a/docs/plans/2026-05-22-bt-autoswitch-gate.md
+++ b/docs/plans/2026-05-22-bt-autoswitch-gate.md
@@ -1,0 +1,550 @@
+# BT AutoSwitch Gate Implementation Plan (Phase 1 / Plan B)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Stop `BluetoothAutoSwitchService` from forcing a source-switch when the BlueZ `Connected` event fires before the PipeWire capture node is ready (FM-BT-1). Instead, probe for node presence first; if absent, register a one-shot subscriber so the switch fires when the node *does* appear — bounded by a max-wait timeout.
+
+**Architecture:**
+
+- New method `IBluetoothService.IsCaptureNodeAvailableAsync(string deviceAddress, CancellationToken ct)` — returns true if a `bluez_input.<MAC>.a2dp-source` PW node currently exists.
+- New event `IBluetoothService.CaptureNodeAvailable` — fires when `LinuxBluetoothService`'s periodic re-scan detects a previously-absent node has appeared.
+- `BluetoothAutoSwitchService.OnBluetoothDeviceConnected` is rewritten as follows: short-bounded probe (≤ 5 s with 500 ms polls) for node presence. If present → switch as today. If still absent → log + subscribe to `CaptureNodeAvailable` with a `BluetoothOptions.AutoSwitchMaxWaitMs` timeout (default 60 s). Switch fires when the event hits, or the subscription is torn down on timeout.
+
+This plan leaves `LinuxBluetoothService.GetAudioCaptureDeviceAsync`'s existing `pw-cli`-scrape implementation in place; the periodic re-scan that raises `CaptureNodeAvailable` re-uses the same `ParsePwCliOutputForBtNode` parser. Plan E (PW event subscription) replaces the scrape with a real event API, at which point this plan's periodic re-scan is replaced with a direct event subscription — but this plan ships independently of Plan E.
+
+**Tech Stack:** existing `LinuxBluetoothService` + `ParsePwCliOutputForBtNode`, existing `BluetoothAutoSwitchService` orchestration, new periodic re-scan loop, Radio.Metrics counter for visibility.
+
+**Addresses**: FM-BT-1 from [`docs/research/2026-05-22-bt-audio-stabilization.md`](../research/2026-05-22-bt-audio-stabilization.md) §4 (its contribution to FM-BT-3 long-uptime degradation is addressed indirectly).
+
+---
+
+## Task 0: Author probe scripts (research deliverable)
+
+**Files:**
+- Create: `scripts/research/bt_autoswitch_audit.py`
+- Create: `scripts/research/bt_autoswitch_compare.py`
+- Create: `scripts/research/bt_pair_unpair_harness.sh`
+
+(`sysload_capture.sh` + `sysload_correlate.py` were authored in Plan A's Task 0; reuse.)
+
+**Step 1: `bt_autoswitch_audit.py`** — reads stdin (journalctl text); counts: (a) `GetOrCreateSourceAsync(Bluetooth` invocations, (b) `GetAudioCaptureDeviceAsync` retries, (c) `waiting for PW node` log lines (existing log message at [LinuxBluetoothService.cs:L1131-L1141](../../src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs)), (d) wall-clock duration spent in retry loops (computed from first-to-last waiting-line timestamps per session). Outputs:
+```
+switches=<N>
+getcapture_invocations=<M>
+waiting_log_lines=<L>
+retry_loop_hours=<T>
+```
+
+**Step 2: `bt_pair_unpair_harness.sh`** — scripted pair/unpair cycle harness. Drives the test phone via either:
+- `adb shell svc bluetooth disable && svc bluetooth enable` (Android), or
+- AppleScript via SSH to a macOS host with `blueutil` (iPhone via USB)
+
+Takes args: `--cycles N --period-sec X --simulate-no-audio` (if `--simulate-no-audio` is set, the phone is paired but doesn't start playing audio — the FM-BT-1 trigger condition).
+
+**Step 3: `bt_autoswitch_compare.py`** — reads two audit artifacts; produces PASS/FAIL against the success criteria; outputs per-metric deltas.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/research/bt_autoswitch_audit.py \
+        scripts/research/bt_autoswitch_compare.py \
+        scripts/research/bt_pair_unpair_harness.sh
+git commit -m "scripts(research): add probe scripts for BT autoswitch gate measurement"
+```
+
+---
+
+## Task 1: BluetoothOptions — add gate config
+
+**Files:**
+- Modify: `src/Radio.Core/Configuration/BluetoothOptions.cs`
+- Modify: `src/Radio.API/appsettings.json`
+
+**Step 1:** Add three properties:
+
+```csharp
+/// <summary>
+/// How long the auto-switch probes for the PipeWire capture node before falling back
+/// to event-driven wait (milliseconds). The probe interval is fixed at 500 ms.
+/// </summary>
+public int AutoSwitchProbeWindowMs { get; set; } = 5000;
+
+/// <summary>
+/// Maximum time the auto-switch waits for a CaptureNodeAvailable event before giving up
+/// (milliseconds). Default 60 s — typical phone-attaches-A2DP delay is well under that.
+/// </summary>
+public int AutoSwitchMaxWaitMs { get; set; } = 60000;
+
+/// <summary>
+/// Interval at which LinuxBluetoothService re-scans for newly-appeared PW BT nodes
+/// (milliseconds). The re-scan raises CaptureNodeAvailable for any node not present in
+/// the previous scan.
+/// </summary>
+public int CaptureNodeRescanIntervalMs { get; set; } = 1000;
+```
+
+**Step 2: Update appsettings.json defaults** in the `Bluetooth` section.
+
+**Step 3: Build + commit**
+
+```bash
+git add src/Radio.Core/Configuration/BluetoothOptions.cs src/Radio.API/appsettings.json
+git commit -m "feat(bt): add auto-switch gate config options"
+```
+
+---
+
+## Task 2: `CaptureNodeAvailable` event + probe method on `IBluetoothService`
+
+**Files:**
+- Modify: `src/Radio.Core/Interfaces/Audio/IBluetoothService.cs`
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs`
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs`
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs`
+
+**Step 1: Add to interface**
+
+```csharp
+/// <summary>
+/// Raised when a previously-absent PipeWire BT capture node has appeared for the
+/// connected device. Fires once per appearance; subscribers wishing to act repeatedly
+/// must re-subscribe.
+/// </summary>
+event EventHandler<CaptureNodeAvailableEventArgs>? CaptureNodeAvailable;
+
+/// <summary>
+/// Probes whether a PipeWire BT capture node currently exists for the given device.
+/// On non-Linux platforms returns true (audio routing is platform-managed).
+/// </summary>
+Task<bool> IsCaptureNodeAvailableAsync(string deviceAddress, CancellationToken ct = default);
+```
+
+Plus event args class:
+
+```csharp
+public class CaptureNodeAvailableEventArgs : EventArgs
+{
+  public required string DeviceAddress { get; init; }
+  public required int PipeWireSerial { get; init; }
+}
+```
+
+**Step 2: Implement `IsCaptureNodeAvailableAsync` in `LinuxBluetoothService`**
+
+Wrap the existing `pw-cli ls Node` + `ParsePwCliOutputForBtNode` pipeline; return true if a matching node is found. *Does not acquire* — pure probe.
+
+```csharp
+public async Task<bool> IsCaptureNodeAvailableAsync(string deviceAddress, CancellationToken ct = default)
+{
+  var prefix = $"bluez_input.{deviceAddress.Replace(':', '_').ToLowerInvariant()}";
+  try
+  {
+    var output = await RunPwCliListNodesAsync(ct);  // extract this from existing GetAudioCaptureDeviceAsync
+    var (nodeName, _, _) = ParsePwCliOutputForBtNode(output, prefix);
+    return nodeName != null;
+  }
+  catch (OperationCanceledException) { throw; }
+  catch (Exception ex)
+  {
+    _logger.LogDebug(ex, "IsCaptureNodeAvailableAsync probe failed (treating as not-available)");
+    return false;
+  }
+}
+```
+
+Extract `RunPwCliListNodesAsync(ct)` as a private helper from the existing scrape code at [L1247](../../src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs) — share between probe and full acquisition.
+
+**Step 3: Implement `CaptureNodeAvailable` raising** — see Task 3.
+
+**Step 4: Stub on Windows + Mock** — `IsCaptureNodeAvailableAsync` returns `Task.FromResult(true)` (the platform manages routing); `CaptureNodeAvailable` event declared but never fires.
+
+**Step 5: Build + commit**
+
+```bash
+git add src/Radio.Core/Interfaces/Audio/IBluetoothService.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
+git commit -m "feat(bt): add CaptureNodeAvailable event + IsCaptureNodeAvailableAsync probe"
+```
+
+---
+
+## Task 3: Periodic node re-scan loop in `LinuxBluetoothService`
+
+**Files:**
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs`
+
+**Step 1: Add private state**
+
+```csharp
+private CancellationTokenSource? _rescanCts;
+private Task? _rescanTask;
+private readonly HashSet<string> _knownNodeAddresses = new(StringComparer.OrdinalIgnoreCase);
+private readonly object _knownNodesLock = new();
+```
+
+**Step 2: Start the re-scan loop on first `DeviceConnected`**
+
+In the existing device-connected handler, start `_rescanTask` if not already running:
+
+```csharp
+private void EnsureRescanLoopRunning()
+{
+  if (_rescanTask != null && !_rescanTask.IsCompleted) return;
+  _rescanCts = new CancellationTokenSource();
+  var token = _rescanCts.Token;
+  _rescanTask = Task.Run(() => RescanLoopAsync(token), token);
+}
+
+private async Task RescanLoopAsync(CancellationToken ct)
+{
+  var interval = _options.CurrentValue.CaptureNodeRescanIntervalMs;
+  while (!ct.IsCancellationRequested)
+  {
+    try
+    {
+      var connectedAddress = ConnectedDevice?.Address;
+      if (connectedAddress != null)
+      {
+        var available = await IsCaptureNodeAvailableAsync(connectedAddress, ct);
+        bool wasKnown;
+        lock (_knownNodesLock)
+        {
+          wasKnown = _knownNodeAddresses.Contains(connectedAddress);
+          if (available) _knownNodeAddresses.Add(connectedAddress);
+          else _knownNodeAddresses.Remove(connectedAddress);
+        }
+        if (available && !wasKnown)
+        {
+          _logger.LogInformation("PW capture node appeared for {Address}", connectedAddress);
+          _metricsCollector?.Increment("bluetooth.capture_node_appeared_total");
+          CaptureNodeAvailable?.Invoke(this, new CaptureNodeAvailableEventArgs
+          {
+            DeviceAddress = connectedAddress,
+            PipeWireSerial = 0  // serial is filled by full acquisition path; not needed here
+          });
+        }
+      }
+    }
+    catch (OperationCanceledException) { break; }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Rescan loop iteration failed");
+    }
+
+    try { await Task.Delay(interval, ct); }
+    catch (OperationCanceledException) { break; }
+  }
+}
+```
+
+**Step 3: Stop the re-scan loop on disconnect / dispose**
+
+In disconnect handler + `Dispose`:
+
+```csharp
+_rescanCts?.Cancel();
+_rescanCts?.Dispose();
+_rescanCts = null;
+_rescanTask = null;
+lock (_knownNodesLock) _knownNodeAddresses.Clear();
+```
+
+**Step 4: Build + commit**
+
+```bash
+git add src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+git commit -m "feat(bt): periodic PW node re-scan loop raising CaptureNodeAvailable"
+```
+
+---
+
+## Task 4: Gate `BluetoothAutoSwitchService.OnBluetoothDeviceConnected`
+
+**Files:**
+- Modify: `src/Radio.Infrastructure/Audio/Services/BluetoothAutoSwitchService.cs`
+
+**Step 1:** Rewrite the handler. Replace the existing `OnBluetoothDeviceConnected` at [L56-L83](../../src/Radio.Infrastructure/Audio/Services/BluetoothAutoSwitchService.cs) with:
+
+```csharp
+private async void OnBluetoothDeviceConnected(object? sender, BluetoothDeviceConnectedEventArgs e)
+{
+  try
+  {
+    var opts = _bluetoothOptions.CurrentValue;
+    if (!opts.AutoSwitchOnConnect) return;
+    if (!_bluetoothService.IsAvailable)
+    {
+      _logger.LogWarning("Bluetooth auto-switch skipped; adapter not available");
+      return;
+    }
+
+    var audioManager = _getAudioManager();
+    if (audioManager.ActiveSource?.Type == AudioSourceType.Bluetooth)
+    {
+      _logger.LogDebug("BT device connected but BT is already active source; skipping switch");
+      return;
+    }
+
+    // Short-bounded probe for PW capture node presence — typical happy path
+    using var probeCts = new CancellationTokenSource(opts.AutoSwitchProbeWindowMs);
+    var nodeReady = await ProbeForNodeAsync(e.Device.Address, probeCts.Token);
+    if (nodeReady)
+    {
+      _logger.LogInformation("BT auto-switch: PW node ready, switching immediately for {Address}", e.Device.Address);
+      await audioManager.GetOrCreateSourceAsync(AudioSourceType.Bluetooth, switchToSource: true);
+      return;
+    }
+
+    // Node not ready inside probe window → defer to event subscription
+    _logger.LogInformation(
+      "BT auto-switch: PW node not ready for {Address} after {Probe}ms; subscribing to CaptureNodeAvailable (max wait {Max}ms)",
+      e.Device.Address, opts.AutoSwitchProbeWindowMs, opts.AutoSwitchMaxWaitMs);
+    _bluetoothService.MetricsCollector?.Increment("bluetooth.autoswitch_deferred_total");
+    await WaitForNodeOrTimeoutAsync(e.Device.Address, opts.AutoSwitchMaxWaitMs);
+  }
+  catch (Exception ex)
+  {
+    _logger.LogError(ex, "Failed to auto-switch to Bluetooth after device connect {Device}", e.Device.Address);
+  }
+}
+
+private async Task<bool> ProbeForNodeAsync(string address, CancellationToken ct)
+{
+  while (!ct.IsCancellationRequested)
+  {
+    if (await _bluetoothService.IsCaptureNodeAvailableAsync(address, ct)) return true;
+    try { await Task.Delay(500, ct); } catch (OperationCanceledException) { return false; }
+  }
+  return false;
+}
+
+private async Task WaitForNodeOrTimeoutAsync(string address, int timeoutMs)
+{
+  var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+  EventHandler<CaptureNodeAvailableEventArgs>? handler = null;
+  handler = (_, e) =>
+  {
+    if (string.Equals(e.DeviceAddress, address, StringComparison.OrdinalIgnoreCase))
+      tcs.TrySetResult(true);
+  };
+  _bluetoothService.CaptureNodeAvailable += handler;
+  try
+  {
+    var timeoutTask = Task.Delay(timeoutMs);
+    var winner = await Task.WhenAny(tcs.Task, timeoutTask);
+    if (winner == tcs.Task)
+    {
+      _logger.LogInformation("BT auto-switch: PW node arrived for {Address}, switching", address);
+      var audioManager = _getAudioManager();
+      if (audioManager.ActiveSource?.Type != AudioSourceType.Bluetooth)
+        await audioManager.GetOrCreateSourceAsync(AudioSourceType.Bluetooth, switchToSource: true);
+    }
+    else
+    {
+      _logger.LogWarning("BT auto-switch: PW node did not appear within {Max}ms for {Address}; abandoning switch", timeoutMs, address);
+      _bluetoothService.MetricsCollector?.Increment("bluetooth.autoswitch_abandoned_total");
+    }
+  }
+  finally
+  {
+    _bluetoothService.CaptureNodeAvailable -= handler;
+  }
+}
+```
+
+Note: `_bluetoothService.MetricsCollector` may not exist as a public property — if not, accept `IMetricsCollector?` in the `BluetoothAutoSwitchService` constructor and use that.
+
+**Step 2: Build + commit**
+
+```bash
+git add src/Radio.Infrastructure/Audio/Services/BluetoothAutoSwitchService.cs
+git commit -m "feat(bt): gate autoSwitchOnConnect on PW capture-node availability"
+```
+
+---
+
+## Task 5: Unit tests
+
+**Files:**
+- Create: `tests/Radio.Infrastructure.Tests/Audio/Services/BluetoothAutoSwitchServiceTests.cs`
+
+**Step 1: Mockable interfaces** — the test needs to drive `IBluetoothService.IsCaptureNodeAvailableAsync` + `CaptureNodeAvailable` event. Use Moq or a hand-rolled `FakeBluetoothService`.
+
+**Step 2: Write tests for the three execution paths**
+
+```csharp
+[Fact]
+public async Task NodeReadyInsideProbeWindow_SwitchesImmediately()
+{
+  var fakeBt = new FakeBluetoothService { IsCaptureNodeAvailable = true };
+  var fakeAudio = new FakeAudioManager();
+  var svc = CreateService(fakeBt, fakeAudio, probeMs: 1000, maxWaitMs: 30000);
+  await svc.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
+  Assert.True(fakeAudio.SwitchedToBluetooth);
+  Assert.Equal(0, fakeBt.CaptureNodeAvailableSubscriberCount);
+}
+
+[Fact]
+public async Task NodeArrivesAfterProbe_SwitchesViaEvent()
+{
+  var fakeBt = new FakeBluetoothService { IsCaptureNodeAvailable = false };
+  var fakeAudio = new FakeAudioManager();
+  var svc = CreateService(fakeBt, fakeAudio, probeMs: 200, maxWaitMs: 5000);
+  var connectTask = svc.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
+  await Task.Delay(400);  // probe window expires; subscription active
+  Assert.False(fakeAudio.SwitchedToBluetooth);
+  fakeBt.RaiseCaptureNodeAvailable("AA:BB:CC:DD:EE:FF");
+  await connectTask;
+  Assert.True(fakeAudio.SwitchedToBluetooth);
+}
+
+[Fact]
+public async Task NodeNeverArrives_TimesOutWithoutSwitch()
+{
+  var fakeBt = new FakeBluetoothService { IsCaptureNodeAvailable = false };
+  var fakeAudio = new FakeAudioManager();
+  var svc = CreateService(fakeBt, fakeAudio, probeMs: 100, maxWaitMs: 300);
+  await svc.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
+  Assert.False(fakeAudio.SwitchedToBluetooth);
+  Assert.Equal(1, fakeBt.AbandonedSwitchCount);
+}
+
+[Fact]
+public async Task AlreadyActiveBluetoothSource_SkipsSwitch()
+{
+  var fakeBt = new FakeBluetoothService { IsCaptureNodeAvailable = true };
+  var fakeAudio = new FakeAudioManager { ActiveSourceType = AudioSourceType.Bluetooth };
+  var svc = CreateService(fakeBt, fakeAudio, probeMs: 1000, maxWaitMs: 30000);
+  await svc.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
+  Assert.False(fakeAudio.GetOrCreateCalled);
+}
+
+[Fact]
+public async Task AutoSwitchDisabled_SkipsEntirely()
+{
+  var fakeBt = new FakeBluetoothService { IsCaptureNodeAvailable = true };
+  var fakeAudio = new FakeAudioManager();
+  var svc = CreateService(fakeBt, fakeAudio, probeMs: 1000, maxWaitMs: 30000, autoSwitchEnabled: false);
+  await svc.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
+  Assert.False(fakeAudio.GetOrCreateCalled);
+}
+```
+
+**Step 3: Run tests**
+
+```bash
+dotnet test tests/Radio.Infrastructure.Tests --filter "BluetoothAutoSwitchServiceTests" --configuration Release -v n
+```
+Expected: 5 PASS.
+
+**Step 4: Commit**
+
+```bash
+git add tests/Radio.Infrastructure.Tests/Audio/Services/BluetoothAutoSwitchServiceTests.cs
+git commit -m "test(bt): unit tests for BluetoothAutoSwitchService gating"
+```
+
+---
+
+## Task 6: Full build + test
+
+```bash
+dotnet build --configuration Release
+dotnet test --configuration Release --verbosity normal
+```
+Expected: 0 warnings; all tests pass.
+
+---
+
+## Task 7: Deploy to Ubuntu
+
+```bash
+./deploy/Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64
+```
+
+Verify re-scan loop running:
+```bash
+ssh mmack@radio "journalctl -u radio-api --since '1 minute ago' | grep -E 'PW capture node|autoswitch'"
+```
+
+---
+
+## Task 8: Verify acceptance criteria
+
+**Baseline probe** (against `main`, 24 h scripted pair/unpair):
+
+```bash
+ssh mmack@radio "/opt/radio-console/scripts/research/bt_pair_unpair_harness.sh --cycles 48 --period-sec 1800 --simulate-no-audio" &
+
+# Concurrent sysload capture:
+ssh mmack@radio "/opt/radio-console/scripts/research/sysload_capture.sh 86400" > baseline_autoswitch_sysload.txt
+
+# After 24 h:
+ssh mmack@radio "journalctl -u radio-api --since '24 hours ago' -o cat" \
+  | python3 scripts/research/bt_autoswitch_audit.py \
+  > baseline_autoswitch.txt
+```
+
+**Post-change probe** (same 24 h with new branch deployed): produce `after_autoswitch.txt`.
+
+**Success criterion**:
+
+- `waiting_log_lines` per pair-without-audio cycle drops to `≤5` (vs current observed unbounded)
+- `retry_loop_hours` drops to `0` (no auto-switch occurring without a node present)
+- On healthy pair-with-node-ready cycles (control): `getcapture_invocations ≤ 2` (no regression for the happy path)
+- New counter `bluetooth.autoswitch_deferred_total` matches the expected ~50 % of cycles (those that simulated no audio)
+- New counter `bluetooth.autoswitch_abandoned_total` is `0` for cycles where the phone *eventually* plays audio (within the 60 s window)
+
+**Debug-agent verification**:
+
+```bash
+python3 scripts/research/bt_autoswitch_compare.py baseline_autoswitch.txt after_autoswitch.txt
+```
+
+Expected: `PASS`.
+
+---
+
+## Task 9: Open PR + merge
+
+```bash
+git push -u origin feat/bt-autoswitch-gate
+
+gh pr create --title "feat(bt): gate autoSwitchOnConnect on PW capture-node availability" --body "$(cat <<'EOF'
+## Summary
+
+Implements [Plan B from the Cast/BT research arc](../docs/plans/2026-05-22-cast-bt-phase-1-2-arc.md) — stops `BluetoothAutoSwitchService` from forcing source-switch + retry-loop when the BlueZ `Connected` event fires before the PipeWire capture node has materialized (FM-BT-1).
+
+Two-phase wait: short-bounded probe (5 s) → event-driven subscription (60 s timeout). Contributes to reducing FM-BT-3 long-uptime degradation by eliminating the hours-of-retry-loop pathology documented in MEMORY.
+
+## Acceptance criteria (verified)
+
+- `waiting_log_lines` per cycle ≤ 5 (was unbounded)
+- `retry_loop_hours` = 0
+- Happy-path `getcapture_invocations ≤ 2`
+- See attached `bt_autoswitch_compare.py` PASS artifact
+
+## Test plan
+
+- [x] Unit tests for 5 execution paths
+- [x] 24 h scripted pair/unpair harness on `radio` (with `--simulate-no-audio`)
+- [x] Concurrent PROBE-SYS-LOAD captured
+- [x] Verified counters: `autoswitch_deferred_total`, `autoswitch_abandoned_total`, `capture_node_appeared_total`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Merge once Mark approves.
+
+---
+
+## Out of scope
+
+- **Replacing `pw-cli` scrape with PW events**: that's Plan E. This plan ships the periodic re-scan version; Plan E later replaces it cleanly.
+- **Recovery from a stuck `autoswitch_abandoned_total`**: once we abandon, the user must trigger source switch manually. Re-attempting after Nth failure is Phase 3+.
+- **Cast-side equivalent**: no equivalent failure mode on the cast side (Cast is push-driven; no analogous race).
+- **Windows BT path**: stub only.

--- a/docs/plans/2026-05-22-bt-capture-watchdog.md
+++ b/docs/plans/2026-05-22-bt-capture-watchdog.md
@@ -1,0 +1,581 @@
+# BT Capture Watchdog Implementation Plan (Phase 1 / Plan A)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Detect FM-BT-3 (the known long-uptime PipeWire OnProcess quiescence bug) by polling `_lastOnProcessTimestamp` from the active `PipeWireNativeStream`; raise a `CaptureStreamStalled` event when the callback has been silent past threshold; wire into the existing `OnGeneratorStalled` recovery path with interlock-guarded dedup.
+
+**Architecture:** New `BluetoothCaptureWatchdog` `BackgroundService`. Polls a public `LastOnProcessTimestamp` property exposed on `PipeWireNativeStream` (currently private). When wall-clock now minus the timestamp exceeds `BluetoothOptions.OnProcessStallThresholdMs` for `ConsecutiveStalledChecks` checks while the BT source is active, raises `CaptureStreamStalled`. `LinuxBluetoothService` re-raises this on `IBluetoothService` so `BluetoothAudioSource` can subscribe alongside its existing `CaptureStreamRecovered` and `OnGeneratorStalled` handlers — recovery flows through the *same* `_recoveryInProgress` interlock at [BluetoothAudioSource.cs:L363](../../src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs), reusing the existing recovery path.
+
+**Tech Stack:** .NET 10 `BackgroundService`, existing `PipeWireNativeStream` instrumentation, existing `BluetoothAudioSource` recovery interlock, Radio.Metrics counter for visibility.
+
+**Addresses**: FM-BT-3 from [`docs/research/2026-05-22-bt-audio-stabilization.md`](../research/2026-05-22-bt-audio-stabilization.md) §4.
+
+---
+
+## Task 0: Author probe scripts (research deliverable)
+
+**Files:**
+- Create: `scripts/research/sysload_capture.sh`
+- Create: `scripts/research/sysload_correlate.py`
+- Create: `scripts/research/bt_stall_detect.py`
+- Create: `scripts/research/bt_stall_compare.py`
+
+These are *test instrumentation* used by the acceptance-criteria verification in Task 10. They live in `scripts/research/` (not shipped to production).
+
+**Step 1: `sysload_capture.sh`** — runs `vmstat 1`, `iostat -x 1`, `pidstat -p $(pgrep -d, radio-api,radio-web,journald,sqlite3,sshd) 1`, and per-second `journalctl --since "1 second ago" -o cat | wc -l` + `pgrep sshd | wc -l` snapshots concurrently; all timestamped with monotonic clock; merged into a single tab-separated `sysload_<timestamp>.tsv` artifact. Takes one positional arg: duration in seconds. Used by every Phase 1+2 plan.
+
+**Step 2: `sysload_correlate.py`** — takes two args: an audio-event-list artifact and a sysload tsv. For each audio event timestamp, computes the 5-second-pre-event median CPU%, total IO MB/s, log line rate, and active SSH session count. Outputs a classified event list: `event_ts, audio_metric_value, cpu_5s_median, io_5s_total, log_rate_5s_median, ssh_sessions_5s_max, classification`. Classification: `quiet_host` if CPU < 70 % AND log_rate < 100/s AND ssh_sessions == 0; else `load_correlated`.
+
+**Step 3: `bt_stall_detect.py`** — reads stdin (journalctl text); detects windows where the `🔬 PipeWire OnProcess` log line has been absent for `>= --window` seconds despite the most recent `BluetoothAudioSource: state == Playing` log. Outputs events as one-per-line: `start_ts, end_ts, gap_seconds`. Accepts `--window N` (default 60s).
+
+**Step 4: `bt_stall_compare.py`** — reads two classified-event artifacts (baseline + after); produces PASS/FAIL against the success criteria from Task 10; outputs per-metric deltas.
+
+**Step 5: Build verification (sanity)**
+
+Run: `bash scripts/research/sysload_capture.sh 10 && ls -la sysload_*.tsv`
+Expected: a TSV file is produced with non-zero size.
+
+**Step 6: Commit**
+
+```bash
+git add scripts/research/
+git commit -m "scripts(research): add probe scripts for BT capture watchdog measurement"
+```
+
+---
+
+## Task 1: Expose `LastOnProcessTimestamp` from `PipeWireNativeStream`
+
+**Files:**
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs:L44-L50` (existing instrumentation fields)
+
+**Step 1:** Add a public read-only property mirroring the existing `_lastOnProcessTimestamp` field (currently private). Use `Volatile.Read` since `OnProcess` runs on the PipeWire thread loop.
+
+```csharp
+/// <summary>
+/// Wall-clock-equivalent stopwatch timestamp of the most recent OnProcess callback.
+/// Zero if OnProcess has not fired yet. Used by BluetoothCaptureWatchdog to detect
+/// FM-BT-3 silent quiescence. Safe to read from any thread.
+/// </summary>
+public long LastOnProcessTimestamp => Volatile.Read(ref _lastOnProcessTimestamp);
+
+/// <summary>
+/// Returns the elapsed milliseconds since the last OnProcess callback, or
+/// long.MaxValue if no callback has fired yet.
+/// </summary>
+public long MillisecondsSinceLastOnProcess()
+{
+  var last = LastOnProcessTimestamp;
+  if (last == 0) return long.MaxValue;
+  return (long)((Stopwatch.GetTimestamp() - last) / (double)Stopwatch.Frequency * 1000.0);
+}
+```
+
+**Step 2: Build to verify**
+
+Run: `dotnet build src/Radio.Infrastructure --configuration Release`
+Expected: 0 warnings, 0 errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs
+git commit -m "feat(bt): expose LastOnProcessTimestamp on PipeWireNativeStream"
+```
+
+---
+
+## Task 2: BluetoothOptions — add watchdog config
+
+**Files:**
+- Modify: `src/Radio.Core/Configuration/BluetoothOptions.cs`
+
+**Step 1:** Add three properties to `BluetoothOptions`:
+
+```csharp
+/// <summary>
+/// Threshold in milliseconds for the OnProcess-interval watchdog (FM-BT-3 detection).
+/// When wall-clock now minus the last OnProcess timestamp exceeds this for
+/// <see cref="ConsecutiveStalledChecks"/> consecutive watchdog ticks, the watchdog
+/// raises CaptureStreamStalled. Set to 0 to disable the watchdog entirely.
+/// </summary>
+public int OnProcessStallThresholdMs { get; set; } = 5000;
+
+/// <summary>
+/// How often the watchdog checks the OnProcess timestamp (milliseconds).
+/// </summary>
+public int WatchdogTickIntervalMs { get; set; } = 2000;
+
+/// <summary>
+/// Number of consecutive watchdog ticks past <see cref="OnProcessStallThresholdMs"/>
+/// required before the watchdog raises the stall event. Default 3 (~6 s @ 2 s tick)
+/// to suppress single transient hiccups.
+/// </summary>
+public int ConsecutiveStalledChecks { get; set; } = 3;
+```
+
+**Step 2: Update `appsettings.json` defaults**
+
+In `src/Radio.API/appsettings.json` under `Bluetooth`:
+
+```json
+"OnProcessStallThresholdMs": 5000,
+"WatchdogTickIntervalMs": 2000,
+"ConsecutiveStalledChecks": 3
+```
+
+**Step 3: Build + commit**
+
+Run: `dotnet build src/Radio.Core --configuration Release`
+Expected: 0 warnings.
+
+```bash
+git add src/Radio.Core/Configuration/BluetoothOptions.cs src/Radio.API/appsettings.json
+git commit -m "feat(bt): add OnProcess watchdog config options"
+```
+
+---
+
+## Task 3: `CaptureStreamStalled` event on `IBluetoothService`
+
+**Files:**
+- Modify: `src/Radio.Core/Interfaces/Audio/IBluetoothService.cs`
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs`
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs` (stub)
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs` (stub)
+
+**Step 1: Add event to interface**
+
+```csharp
+/// <summary>
+/// Raised when the watchdog detects that the BT capture stream's OnProcess callback
+/// has been silent past the configured threshold (FM-BT-3 detection).
+/// Subscribers should attempt recovery via the same path used for OnGeneratorStalled.
+/// </summary>
+event EventHandler<CaptureStreamStalledEventArgs>? CaptureStreamStalled;
+```
+
+Plus the event-args class in the same file:
+
+```csharp
+public class CaptureStreamStalledEventArgs : EventArgs
+{
+  public required string DeviceAddress { get; init; }
+  public required long ElapsedMsSinceLastCallback { get; init; }
+  public required int ConsecutiveStalledChecks { get; init; }
+}
+```
+
+**Step 2: Implement in `LinuxBluetoothService`** — declare the event field; the raise call comes from Task 5's watchdog wiring.
+
+**Step 3: Stub in Windows + Mock implementations** — just `public event EventHandler<CaptureStreamStalledEventArgs>? CaptureStreamStalled;` with no raise calls.
+
+**Step 4: Build + commit**
+
+```bash
+git add src/Radio.Core/Interfaces/Audio/IBluetoothService.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
+git commit -m "feat(bt): add CaptureStreamStalled event on IBluetoothService"
+```
+
+---
+
+## Task 4: `BluetoothCaptureWatchdog` background service
+
+**Files:**
+- Create: `src/Radio.Infrastructure/Audio/Services/BluetoothCaptureWatchdog.cs`
+- Modify: `src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs`
+
+**Step 1: Implement the watchdog**
+
+The watchdog needs to read `LastOnProcessTimestamp` from the *currently active* `PipeWireNativeStream`. The cleanest approach is to introduce a small accessor on `LinuxBluetoothService` (Linux-only path) that returns the current stream's timestamp + the connected device's address, or null if no stream is active.
+
+Add to `LinuxBluetoothService`:
+
+```csharp
+/// <summary>
+/// Snapshot for the watchdog: address + elapsed ms since last OnProcess.
+/// Returns null if no native capture stream is active.
+/// </summary>
+internal (string Address, long ElapsedMs)? GetCaptureStreamSnapshot()
+{
+  var stream = _nativeStream;
+  var device = ConnectedDevice;
+  if (stream == null || device == null) return null;
+  return (device.Address, stream.MillisecondsSinceLastOnProcess());
+}
+
+/// <summary>
+/// Invoked by the watchdog when a stall is confirmed. Raises CaptureStreamStalled.
+/// </summary>
+internal void RaiseCaptureStreamStalled(string address, long elapsedMs, int consecutive)
+{
+  _metricsCollector?.Increment("bluetooth.capture_stall_detected_total");
+  _logger.LogWarning(
+    "BluetoothCaptureWatchdog: stall detected for {Address}, elapsed {Elapsed}ms after {N} consecutive checks",
+    address, elapsedMs, consecutive);
+  CaptureStreamStalled?.Invoke(this, new CaptureStreamStalledEventArgs
+  {
+    DeviceAddress = address,
+    ElapsedMsSinceLastCallback = elapsedMs,
+    ConsecutiveStalledChecks = consecutive
+  });
+}
+```
+
+Now create `BluetoothCaptureWatchdog`:
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Radio.Core.Configuration;
+using Radio.Infrastructure.Platform.Bluetooth;
+
+namespace Radio.Infrastructure.Audio.Services;
+
+/// <summary>
+/// Periodic watchdog that detects FM-BT-3 (silent OnProcess quiescence on a long-running
+/// PipeWire capture stream). When the active stream's MillisecondsSinceLastOnProcess
+/// exceeds BluetoothOptions.OnProcessStallThresholdMs for ConsecutiveStalledChecks ticks,
+/// raises CaptureStreamStalled on IBluetoothService.
+/// </summary>
+public sealed class BluetoothCaptureWatchdog : BackgroundService
+{
+  private readonly ILogger<BluetoothCaptureWatchdog> _logger;
+  private readonly IOptionsMonitor<BluetoothOptions> _options;
+  private readonly LinuxBluetoothService? _linuxService;
+  private int _consecutiveStalledChecks;
+
+  public BluetoothCaptureWatchdog(
+    ILogger<BluetoothCaptureWatchdog> logger,
+    IOptionsMonitor<BluetoothOptions> options,
+    LinuxBluetoothService? linuxService = null)  // null on Windows / Mock
+  {
+    _logger = logger;
+    _options = options;
+    _linuxService = linuxService;
+  }
+
+  protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    if (_linuxService == null)
+    {
+      _logger.LogInformation("BluetoothCaptureWatchdog: no Linux BT service, watchdog disabled");
+      return;
+    }
+
+    _logger.LogInformation("BluetoothCaptureWatchdog: starting (threshold={Threshold}ms, tick={Tick}ms, consecutive={N})",
+      _options.CurrentValue.OnProcessStallThresholdMs,
+      _options.CurrentValue.WatchdogTickIntervalMs,
+      _options.CurrentValue.ConsecutiveStalledChecks);
+
+    while (!stoppingToken.IsCancellationRequested)
+    {
+      var opts = _options.CurrentValue;
+      if (opts.OnProcessStallThresholdMs <= 0)
+      {
+        // watchdog disabled
+        await Task.Delay(opts.WatchdogTickIntervalMs, stoppingToken);
+        continue;
+      }
+
+      var snapshot = _linuxService.GetCaptureStreamSnapshot();
+      if (snapshot == null)
+      {
+        // no active stream; reset consecutive counter
+        _consecutiveStalledChecks = 0;
+      }
+      else if (snapshot.Value.ElapsedMs >= opts.OnProcessStallThresholdMs)
+      {
+        _consecutiveStalledChecks++;
+        if (_consecutiveStalledChecks >= opts.ConsecutiveStalledChecks)
+        {
+          _linuxService.RaiseCaptureStreamStalled(
+            snapshot.Value.Address, snapshot.Value.ElapsedMs, _consecutiveStalledChecks);
+          _consecutiveStalledChecks = 0; // reset so we don't fire every tick after the first detection
+        }
+      }
+      else
+      {
+        _consecutiveStalledChecks = 0;
+      }
+
+      await Task.Delay(opts.WatchdogTickIntervalMs, stoppingToken);
+    }
+  }
+}
+```
+
+**Step 2: DI registration**
+
+In `AudioServiceExtensions.cs`, after the existing BT registrations:
+
+```csharp
+// FM-BT-3 watchdog (Linux-only; depends on LinuxBluetoothService having been registered as concrete type)
+services.AddSingleton<BluetoothCaptureWatchdog>();
+services.AddHostedService(sp => sp.GetRequiredService<BluetoothCaptureWatchdog>());
+```
+
+Use the `AddSingleton + AddHostedService(factory)` pattern (see MEMORY: "DI / Hosted Service Gotchas").
+
+**Step 3: Build + commit**
+
+```bash
+git add src/Radio.Infrastructure/Audio/Services/BluetoothCaptureWatchdog.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs \
+        src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
+git commit -m "feat(bt): add BluetoothCaptureWatchdog to detect FM-BT-3 quiescence"
+```
+
+---
+
+## Task 5: Wire into `BluetoothAudioSource` recovery path
+
+**Files:**
+- Modify: `src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs`
+
+**Step 1: Subscribe to the new event** in the constructor (alongside the existing subscriptions at L79-L84):
+
+```csharp
+_bluetoothService.CaptureStreamStalled += OnCaptureStreamStalled;
+```
+
+**Step 2: Implement handler** — funnel to the existing `OnGeneratorStalled` path so the same `_recoveryInProgress` interlock dedups both stall sources:
+
+```csharp
+private void OnCaptureStreamStalled(object? sender, CaptureStreamStalledEventArgs e)
+{
+  Logger.LogWarning(
+    "BluetoothAudioSource: capture stream stall detected via watchdog ({Address}, elapsed={Elapsed}ms); triggering recovery",
+    e.DeviceAddress, e.ElapsedMsSinceLastCallback);
+  // Reuse the existing recovery path; the interlock guards against double-fire.
+  OnGeneratorStalled(BluetoothSourceId);  // or whatever the existing sourceId constant is — verify in code
+}
+```
+
+(Use whatever identifier `OnGeneratorStalled` already receives — verify by reading the existing method signature at L360.)
+
+**Step 3: Unsubscribe in `DisposeCore`** (alongside L297-L301):
+
+```csharp
+_bluetoothService.CaptureStreamStalled -= OnCaptureStreamStalled;
+```
+
+**Step 4: Build + commit**
+
+```bash
+git add src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+git commit -m "feat(bt): route CaptureStreamStalled through existing recovery interlock"
+```
+
+---
+
+## Task 6: Unit tests for watchdog logic
+
+**Files:**
+- Create: `tests/Radio.Infrastructure.Tests/Audio/Services/BluetoothCaptureWatchdogTests.cs`
+
+**Step 1:** Mock `LinuxBluetoothService` is impractical (concrete class with heavy dependencies). Instead, refactor `BluetoothCaptureWatchdog` to depend on a thin interface `ICaptureStreamSnapshotSource` exposing `GetCaptureStreamSnapshot()` + `RaiseCaptureStreamStalled()`. `LinuxBluetoothService` implements this internal interface.
+
+Re-do the constructor in `BluetoothCaptureWatchdog` to take `ICaptureStreamSnapshotSource?` instead of `LinuxBluetoothService?`. The DI registration becomes:
+
+```csharp
+services.AddSingleton<ICaptureStreamSnapshotSource>(sp =>
+  sp.GetService<LinuxBluetoothService>() ?? NullSnapshotSource.Instance);
+```
+
+**Step 2: Write tests**
+
+```csharp
+public class BluetoothCaptureWatchdogTests
+{
+  [Fact]
+  public async Task NoActiveStream_DoesNotRaise()
+  {
+    var source = new FakeSnapshotSource(snapshot: null);
+    var watchdog = CreateWatchdog(source, threshold: 1000, tick: 50, consecutive: 2);
+    await RunForMs(watchdog, 250);
+    Assert.Equal(0, source.RaiseCount);
+  }
+
+  [Fact]
+  public async Task BelowThreshold_DoesNotRaise()
+  {
+    var source = new FakeSnapshotSource(("AA:BB:CC:DD:EE:FF", elapsedMs: 500));
+    var watchdog = CreateWatchdog(source, threshold: 1000, tick: 50, consecutive: 2);
+    await RunForMs(watchdog, 250);
+    Assert.Equal(0, source.RaiseCount);
+  }
+
+  [Fact]
+  public async Task AboveThreshold_RaisesAfterConsecutiveChecks()
+  {
+    var source = new FakeSnapshotSource(("AA:BB:CC:DD:EE:FF", elapsedMs: 6000));
+    var watchdog = CreateWatchdog(source, threshold: 5000, tick: 50, consecutive: 3);
+    await RunForMs(watchdog, 250); // ~5 ticks
+    Assert.Equal(1, source.RaiseCount);
+  }
+
+  [Fact]
+  public async Task DisabledByZeroThreshold_DoesNotRaise()
+  {
+    var source = new FakeSnapshotSource(("AA:BB:CC:DD:EE:FF", elapsedMs: 99999));
+    var watchdog = CreateWatchdog(source, threshold: 0, tick: 50, consecutive: 1);
+    await RunForMs(watchdog, 250);
+    Assert.Equal(0, source.RaiseCount);
+  }
+
+  [Fact]
+  public async Task IntermittentStall_ResetsCounter()
+  {
+    var source = new FakeSnapshotSource();
+    var watchdog = CreateWatchdog(source, threshold: 5000, tick: 50, consecutive: 3);
+    var task = Task.Run(() => watchdog.StartAsync(CancellationToken.None));
+    await Task.Delay(100);
+    source.Set(("AA:BB:CC:DD:EE:FF", elapsedMs: 6000));
+    await Task.Delay(100); // ~2 ticks above threshold
+    source.Set(("AA:BB:CC:DD:EE:FF", elapsedMs: 100));   // recovery
+    await Task.Delay(100); // ~2 ticks healthy
+    source.Set(("AA:BB:CC:DD:EE:FF", elapsedMs: 6000));
+    await Task.Delay(100); // ~2 ticks above threshold again
+    await watchdog.StopAsync(CancellationToken.None);
+    // Never reached 3 consecutive above-threshold → no raise
+    Assert.Equal(0, source.RaiseCount);
+  }
+}
+```
+
+Plus a `FakeSnapshotSource` test helper + `CreateWatchdog`/`RunForMs` builders.
+
+**Step 3: Run tests**
+
+```bash
+dotnet test tests/Radio.Infrastructure.Tests --filter "BluetoothCaptureWatchdogTests" --configuration Release -v n
+```
+Expected: 5 tests PASS.
+
+**Step 4: Commit**
+
+```bash
+git add tests/Radio.Infrastructure.Tests/Audio/Services/BluetoothCaptureWatchdogTests.cs \
+        src/Radio.Infrastructure/Audio/Services/BluetoothCaptureWatchdog.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs \
+        src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
+git commit -m "test(bt): unit tests for BluetoothCaptureWatchdog + interface refactor"
+```
+
+---
+
+## Task 7: Full build + test verification
+
+**Step 1:**
+```bash
+dotnet build --configuration Release
+dotnet test --configuration Release --verbosity normal
+```
+Expected: 0 warnings; all ~1,697+ tests pass.
+
+---
+
+## Task 8: Deploy to Ubuntu
+
+```bash
+./deploy/Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64
+```
+
+Verify watchdog started:
+```bash
+ssh mmack@radio "journalctl -u radio-api -p info --since '1 minute ago' | grep -i 'BluetoothCaptureWatchdog'"
+```
+Expected: `BluetoothCaptureWatchdog: starting (threshold=5000ms, tick=2000ms, consecutive=3)`.
+
+---
+
+## Task 9: Verify acceptance criteria (the measurement-discipline contract)
+
+These are the success criteria from the research's 5-block measurement structure ([`docs/research/2026-05-22-bt-audio-stabilization.md`](../research/2026-05-22-bt-audio-stabilization.md) §7 Idea #1). A debug agent runs this Task as the merge gate.
+
+**Baseline probe** (run against `main` BEFORE this branch ships):
+
+```bash
+ssh mmack@radio "journalctl -u radio-api --since '72 hours ago' -o cat" \
+  | python3 scripts/research/bt_stall_detect.py --window 60s \
+  > baseline_bt_stall.txt
+
+ssh mmack@radio "/opt/radio-console/scripts/research/sysload_capture.sh 259200" \
+  > baseline_bt_sysload.txt
+
+python3 scripts/research/sysload_correlate.py \
+  baseline_bt_stall.txt baseline_bt_sysload.txt \
+  > baseline_bt_stall_classified.txt
+```
+
+**Post-change probe** (run after this branch deploys, same 72 h soak):
+
+```bash
+# same commands, produce after_*.txt
+```
+
+**Success criterion** — all must hold:
+
+- `events_quiet_host` (stalls without concurrent host load) drops to `≤1` over a 72 h soak (vs current observed multiple per week)
+- For any event that still occurs: a `CaptureStreamStalled` log line fires within `≤15 s` of the stall (verified by log-timestamp correlation)
+- `events_load_correlated` is *expected to be unchanged or reduced only as side effect* — this plan does not claim to fix FM-BT-11; that's Phase 2 / Plan D
+- No false positives during legitimate idle periods (verified by `0` stall events in a 1 h soak with the BT source paused on the phone side)
+
+**Debug-agent verification**:
+
+```bash
+python3 scripts/research/bt_stall_compare.py baseline_bt_stall_classified.txt after_bt_stall_classified.txt
+```
+
+Expected output: `PASS` plus per-metric deltas.
+
+**If FAIL: do not merge.** Diagnose: is the watchdog firing too aggressively (false positives), or not firing on the known-bug case (false negatives)?
+
+---
+
+## Task 10: Open PR + merge
+
+```bash
+git push -u origin feat/bt-capture-watchdog
+
+gh pr create --title "feat(bt): capture watchdog for FM-BT-3 long-uptime quiescence" --body "$(cat <<'EOF'
+## Summary
+
+Implements [Plan A from the Cast/BT research arc](../docs/plans/2026-05-22-cast-bt-phase-1-2-arc.md) — a periodic watchdog that detects FM-BT-3 (silent PipeWire OnProcess callback cessation on a long-running BT capture stream), addressing the production bug documented in MEMORY ("Long-running capture device lifecycle bug").
+
+Reuses the existing `_recoveryInProgress` interlock in BluetoothAudioSource so watchdog-driven recovery and downstream-stall recovery share the same dedup path.
+
+## Acceptance criteria (verified)
+
+- See attached `bt_stall_compare.py` PASS artifact in PR conversation
+- 72 h soak baseline vs post-change with two-scenario PROBE-SYS-LOAD
+
+## Test plan
+
+- [x] Unit tests for watchdog logic (5 cases incl. threshold, consecutive, disabled, intermittent)
+- [x] Build clean across Linux + Windows TFMs
+- [x] Deploy to `radio` (Ubuntu N100) + 72 h soak
+- [x] Verify `events_quiet_host ≤ 1` over 72 h
+- [x] Verify `events_load_correlated` not regressed
+- [x] Verify no false positives in 1 h paused-phone soak
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Merge via `gh pr merge --squash --delete-branch` once Mark approves.
+
+---
+
+## Out of scope
+
+- **Load-correlated stalls (FM-BT-11)**: this plan does not claim to fix them; that's Plan D (CPU affinity).
+- **Recovery quality**: this plan triggers the existing recovery path; whether recovery itself works as well as it could is a separate question.
+- **Cast-side watchdogs**: Cast's HM mode has `LoadMediaWithRecoveryAsync`; DC mode would need its own watchdog (Cast research §7 Idea #8, deferred to Phase 3+).
+- **Windows BT path**: stub only; the watchdog is Linux-only.

--- a/docs/plans/2026-05-22-bt-codec-observability.md
+++ b/docs/plans/2026-05-22-bt-codec-observability.md
@@ -1,0 +1,607 @@
+# BT Codec Observability Implementation Plan (Phase 1 / Plan C)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Surface the currently-negotiated A2DP codec name (and SBC bitpool / sample rate when available) as an observable metric + log entry + UI display, so "audio sounds bad today" can be diagnosed against actual codec data instead of memory.
+
+**Architecture:**
+
+- New method `IBluetoothService.GetA2dpCodecInfoAsync(string deviceAddress, CancellationToken ct)` returning `A2dpCodecInfo` (record with `CodecName`, `SampleRateHz`, `BitpoolOrNull`).
+- Linux implementation reads BlueZ D-Bus `org.bluez.MediaTransport1` properties (`Codec`, `Configuration`) from the existing `_mediaTransport` reference that `LinuxBluetoothService.AttachMediaTransportAsync` already holds.
+  - `Codec` is a `byte` (0x00 = SBC, 0x02 = AAC, 0xFF = vendor-specific i.e. aptX/LDAC/aptX-HD).
+  - `Configuration` is a byte-array whose layout depends on codec — for SBC, a 4-byte LC3-style cap blob from which bitpool can be extracted (byte 3 low nibble = max bitpool, high nibble = min bitpool). For AAC/vendor, codec-specific.
+- Emit `bluetooth.a2dp.codec` (gauge — codec ID as integer) + `bluetooth.a2dp.bitpool` (gauge — bitpool for SBC, or `-1` for non-SBC) + `bluetooth.a2dp.sample_rate_hz` (gauge) on connect + on `TransportPropertiesChanged` for `Codec`/`Configuration`.
+- Surface in `BluetoothStatusDto` + render in `BluetoothPage.razor`.
+
+This plan ships codec *visibility* only — no codec pinning, no negotiation forcing, no behavior change.
+
+**Tech Stack:** existing BlueZ D-Bus client (Tmds.DBus.Protocol per existing usage in `LinuxBluetoothService`), Radio.Metrics, Radzen Blazor UI.
+
+**Addresses**: FM-BT-6 from [`docs/research/2026-05-22-bt-audio-stabilization.md`](../research/2026-05-22-bt-audio-stabilization.md) §4 ("Y but invisible" — failure mode exists but cannot be diagnosed from logs).
+
+---
+
+## Task 0: Author probe scripts (research deliverable)
+
+**Files:**
+- Create: `scripts/research/bt_codec_observability_probe.sh`
+- Create: `scripts/research/bt_codec_observability_compare.py`
+
+**Step 1: `bt_codec_observability_probe.sh`** — takes args `--duration N --phones <addr1,addr2,addr3>`. Sequentially connects each phone, waits 60 s for codec emission, records:
+- Log lines matching `BluetoothCodec: ` (the new log message from Task 4)
+- Metric values via `sqlite3 metrics.db "SELECT * FROM gauges WHERE metric LIKE 'bluetooth.a2dp.%'"`
+- `bluetoothctl info <MAC>` cross-reference
+
+Output: `events_emitted=<N>, codec_log_lines=<L>, ui_codec_displayed=<bool>, per_phone_codec=<phone1=sbc,phone2=aac,...>`.
+
+**Step 2: `bt_codec_observability_compare.py`** — reads two artifacts; compares `events_emitted` + per-phone codec table. PASS if post-change reports ≥3 codec emissions matching `bluetoothctl info` output for ≥2 of 3 phones.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/research/bt_codec_observability_*
+git commit -m "scripts(research): add codec observability probe + compare scripts"
+```
+
+---
+
+## Task 1: Add `A2dpCodecInfo` record + interface method
+
+**Files:**
+- Create: `src/Radio.Core/Interfaces/Audio/A2dpCodecInfo.cs`
+- Modify: `src/Radio.Core/Interfaces/Audio/IBluetoothService.cs`
+
+**Step 1: Create the record**
+
+```csharp
+namespace Radio.Core.Interfaces.Audio;
+
+/// <summary>
+/// Snapshot of the currently-negotiated A2DP codec for a Bluetooth device.
+/// Returned by IBluetoothService.GetA2dpCodecInfoAsync.
+/// </summary>
+public sealed record A2dpCodecInfo
+{
+  /// <summary>BlueZ codec ID (0x00 = SBC, 0x02 = AAC, 0xFF = vendor-specific).</summary>
+  public required byte CodecId { get; init; }
+
+  /// <summary>Human-readable codec name (e.g. "SBC", "AAC", "aptX", "aptX-HD", "LDAC").</summary>
+  public required string CodecName { get; init; }
+
+  /// <summary>Negotiated sample rate (e.g. 48000); 0 if unknown.</summary>
+  public required int SampleRateHz { get; init; }
+
+  /// <summary>SBC bitpool value (2–53 typical). Null for non-SBC codecs.</summary>
+  public int? BitpoolOrNull { get; init; }
+
+  /// <summary>Raw Configuration bytes (codec-specific layout). For diagnostics.</summary>
+  public required byte[] RawConfiguration { get; init; }
+}
+```
+
+**Step 2: Add interface method + event**
+
+```csharp
+/// <summary>
+/// Gets the currently-negotiated A2DP codec info for the device. Returns null
+/// if no transport is active or the codec is not yet known.
+/// </summary>
+Task<A2dpCodecInfo?> GetA2dpCodecInfoAsync(string deviceAddress, CancellationToken ct = default);
+
+/// <summary>
+/// Raised when the negotiated A2DP codec changes (on connect, or if BlueZ re-negotiates
+/// mid-session). Subscribers should refresh any cached codec state.
+/// </summary>
+event EventHandler<A2dpCodecChangedEventArgs>? A2dpCodecChanged;
+```
+
+Plus event-args:
+
+```csharp
+public class A2dpCodecChangedEventArgs : EventArgs
+{
+  public required string DeviceAddress { get; init; }
+  public required A2dpCodecInfo CodecInfo { get; init; }
+}
+```
+
+**Step 3: Stubs in Windows + Mock implementations**
+
+```csharp
+public Task<A2dpCodecInfo?> GetA2dpCodecInfoAsync(string deviceAddress, CancellationToken ct = default)
+  => Task.FromResult<A2dpCodecInfo?>(null);
+public event EventHandler<A2dpCodecChangedEventArgs>? A2dpCodecChanged;
+```
+
+**Step 4: Build + commit**
+
+```bash
+git add src/Radio.Core/Interfaces/Audio/A2dpCodecInfo.cs \
+        src/Radio.Core/Interfaces/Audio/IBluetoothService.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
+git commit -m "feat(bt): add A2dpCodecInfo record + IBluetoothService codec API"
+```
+
+---
+
+## Task 2: Codec parser (pure logic, testable)
+
+**Files:**
+- Create: `src/Radio.Infrastructure/Platform/Bluetooth/Linux/A2dpCodecConfigParser.cs`
+
+**Step 1: Implement the parser**
+
+```csharp
+using Radio.Core.Interfaces.Audio;
+
+namespace Radio.Infrastructure.Platform.Bluetooth.Linux;
+
+/// <summary>
+/// Pure parser for BlueZ MediaTransport1.Codec + Configuration properties.
+/// No I/O — fully testable.
+///
+/// BlueZ codec IDs (from net/bluetooth/a2dp-codecs.h):
+///   0x00 = SBC, 0x02 = MPEG-2/4 AAC, 0xFF = vendor-specific (aptX, LDAC, etc.)
+///
+/// SBC Configuration layout (4 bytes):
+///   byte 0: sampling-freq (bit 4..7) | channel-mode (bit 0..3)
+///   byte 1: block-length (bit 4..7) | subbands (bit 2..3) | allocation (bit 0..1)
+///   byte 2: min-bitpool
+///   byte 3: max-bitpool
+///
+/// AAC Configuration is 6 bytes; vendor-specific is variable.
+/// </summary>
+internal static class A2dpCodecConfigParser
+{
+  public static A2dpCodecInfo Parse(byte codecId, byte[] configuration)
+  {
+    var name = CodecName(codecId, configuration);
+    var sampleRate = SampleRate(codecId, configuration);
+    var bitpool = (codecId == 0x00 && configuration.Length >= 4)
+      ? configuration[3]  // max-bitpool
+      : (int?)null;
+
+    return new A2dpCodecInfo
+    {
+      CodecId = codecId,
+      CodecName = name,
+      SampleRateHz = sampleRate,
+      BitpoolOrNull = bitpool,
+      RawConfiguration = configuration
+    };
+  }
+
+  internal static string CodecName(byte codecId, byte[] configuration) => codecId switch
+  {
+    0x00 => "SBC",
+    0x02 => "AAC",
+    0xFF when configuration.Length >= 6 => ParseVendorCodec(configuration),
+    _ => $"Unknown-0x{codecId:X2}"
+  };
+
+  /// <summary>
+  /// For vendor-specific (0xFF) codec, the first 6 bytes of Configuration are:
+  ///   bytes 0..3: vendor ID (little-endian)
+  ///   bytes 4..5: codec ID (little-endian)
+  /// </summary>
+  internal static string ParseVendorCodec(byte[] configuration)
+  {
+    var vendorId = (uint)(configuration[0] | (configuration[1] << 8) | (configuration[2] << 16) | (configuration[3] << 24));
+    var codecId = (ushort)(configuration[4] | (configuration[5] << 8));
+    // Vendor IDs from Bluetooth SIG company ID assignments
+    return (vendorId, codecId) switch
+    {
+      (0x004F, 0x0001) => "aptX",
+      (0x000A, 0x0001) => "aptX",         // Qualcomm/CSR
+      (0x00D7, 0x0024) => "aptX-HD",      // Qualcomm extension
+      (0x012D, 0x00AA) => "LDAC",         // Sony
+      (0x053A, 0x4C32) => "LHDC",         // Savitech
+      _ => $"Vendor-0x{vendorId:X8}/0x{codecId:X4}"
+    };
+  }
+
+  internal static int SampleRate(byte codecId, byte[] configuration)
+  {
+    if (codecId == 0x00 && configuration.Length >= 1)
+    {
+      // SBC: sampling-freq in bits 4..7 of byte 0
+      var freqBits = (configuration[0] >> 4) & 0x0F;
+      return freqBits switch
+      {
+        0x08 => 16000,
+        0x04 => 32000,
+        0x02 => 44100,
+        0x01 => 48000,
+        _ => 0
+      };
+    }
+    if (codecId == 0x02 && configuration.Length >= 4)
+    {
+      // AAC: sampling-freq is a 12-bit field starting at byte 1 bit 0
+      var freqBits = ((configuration[1] & 0xFF) << 4) | ((configuration[2] >> 4) & 0x0F);
+      return freqBits switch
+      {
+        0x800 => 8000,
+        0x400 => 11025,
+        0x200 => 12000,
+        0x100 => 16000,
+        0x080 => 22050,
+        0x040 => 24000,
+        0x020 => 32000,
+        0x010 => 44100,
+        0x008 => 48000,
+        0x004 => 64000,
+        0x002 => 88200,
+        0x001 => 96000,
+        _ => 0
+      };
+    }
+    return 0;
+  }
+}
+```
+
+**Step 2: Build + commit**
+
+```bash
+git add src/Radio.Infrastructure/Platform/Bluetooth/Linux/A2dpCodecConfigParser.cs
+git commit -m "feat(bt): A2dpCodecConfigParser for BlueZ codec/config bytes"
+```
+
+---
+
+## Task 3: Tests for the codec parser
+
+**Files:**
+- Create: `tests/Radio.Infrastructure.Tests/Platform/Bluetooth/Linux/A2dpCodecConfigParserTests.cs`
+
+**Step 1: Write tests**
+
+```csharp
+using Radio.Infrastructure.Platform.Bluetooth.Linux;
+
+namespace Radio.Infrastructure.Tests.Platform.Bluetooth.Linux;
+
+public class A2dpCodecConfigParserTests
+{
+  [Theory]
+  [InlineData(0x00, "SBC")]
+  [InlineData(0x02, "AAC")]
+  [InlineData(0x05, "Unknown-0x05")]
+  public void CodecName_KnownAndUnknown(byte codecId, string expected)
+  {
+    Assert.Equal(expected, A2dpCodecConfigParser.CodecName(codecId, new byte[6]));
+  }
+
+  [Fact]
+  public void ParseSBC_48kHz_StereoJoint_Bitpool53()
+  {
+    // SBC config: byte0 = 0x21 (48kHz=0x1<<4 | joint-stereo=0x1), byte3 = 53 (max bitpool)
+    byte[] config = { 0x21, 0x35, 2, 53 };
+    var info = A2dpCodecConfigParser.Parse(0x00, config);
+    Assert.Equal("SBC", info.CodecName);
+    Assert.Equal(48000, info.SampleRateHz);
+    Assert.Equal(53, info.BitpoolOrNull);
+  }
+
+  [Fact]
+  public void ParseSBC_44kHz_Bitpool35()
+  {
+    byte[] config = { 0x21 ^ 0x10 | 0x21, 0x35, 2, 35 };  // 44.1kHz
+    var info = A2dpCodecConfigParser.Parse(0x00, new byte[] { 0x22, 0x35, 2, 35 });
+    Assert.Equal(44100, info.SampleRateHz);
+    Assert.Equal(35, info.BitpoolOrNull);
+  }
+
+  [Fact]
+  public void ParseAAC_NoBitpool()
+  {
+    byte[] config = { 0x80, 0x01, 0x8C, 0x80, 0x00, 0xFA };  // arbitrary
+    var info = A2dpCodecConfigParser.Parse(0x02, config);
+    Assert.Equal("AAC", info.CodecName);
+    Assert.Null(info.BitpoolOrNull);
+  }
+
+  [Fact]
+  public void ParseVendor_aptX()
+  {
+    // aptX vendor=0x004F, codec=0x0001
+    byte[] config = { 0x4F, 0x00, 0x00, 0x00, 0x01, 0x00, 0x20, 0x00 };
+    var info = A2dpCodecConfigParser.Parse(0xFF, config);
+    Assert.Equal("aptX", info.CodecName);
+  }
+
+  [Fact]
+  public void ParseVendor_LDAC()
+  {
+    // LDAC vendor=0x012D, codec=0x00AA
+    byte[] config = { 0x2D, 0x01, 0x00, 0x00, 0xAA, 0x00, 0x20, 0x00 };
+    var info = A2dpCodecConfigParser.Parse(0xFF, config);
+    Assert.Equal("LDAC", info.CodecName);
+  }
+
+  [Fact]
+  public void ParseVendor_Unknown_ReturnsHexId()
+  {
+    byte[] config = { 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x00 };
+    var info = A2dpCodecConfigParser.Parse(0xFF, config);
+    Assert.StartsWith("Vendor-0x", info.CodecName);
+  }
+
+  [Fact]
+  public void RawConfigurationPreserved()
+  {
+    byte[] config = { 0x21, 0x35, 2, 53 };
+    var info = A2dpCodecConfigParser.Parse(0x00, config);
+    Assert.Equal(config, info.RawConfiguration);
+  }
+}
+```
+
+**Step 2: Run tests**
+
+```bash
+dotnet test tests/Radio.Infrastructure.Tests --filter "A2dpCodecConfigParserTests" --configuration Release -v n
+```
+Expected: 8 PASS.
+
+**Step 3: Commit**
+
+```bash
+git add tests/Radio.Infrastructure.Tests/Platform/Bluetooth/Linux/A2dpCodecConfigParserTests.cs
+git commit -m "test(bt): unit tests for A2dpCodecConfigParser"
+```
+
+---
+
+## Task 4: Read codec from BlueZ D-Bus in `LinuxBluetoothService`
+
+**Files:**
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs`
+
+**Step 1: Implement `GetA2dpCodecInfoAsync`**
+
+Use the existing `_mediaTransport` reference (already attached via `AttachMediaTransportAsync` at [L2092](../../src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs)). Read `Codec` (byte) + `Configuration` (byte[]) properties via D-Bus.
+
+```csharp
+public async Task<A2dpCodecInfo?> GetA2dpCodecInfoAsync(string deviceAddress, CancellationToken ct = default)
+{
+  var transport = _mediaTransport;
+  if (transport == null) return null;
+
+  try
+  {
+    var codecId = (byte)await transport.GetAsync("Codec");
+    var config = (byte[])await transport.GetAsync("Configuration");
+    return A2dpCodecConfigParser.Parse(codecId, config);
+  }
+  catch (Exception ex)
+  {
+    _logger.LogDebug(ex, "GetA2dpCodecInfoAsync read failed for {Address}", deviceAddress);
+    return null;
+  }
+}
+```
+
+(Adjust D-Bus property-read syntax to match the project's existing Tmds.DBus usage. Look at how `AttachMediaTransportAsync` already reads transport properties for the right pattern.)
+
+**Step 2: Raise `A2dpCodecChanged` on transport-properties change**
+
+In the existing `OnTransportPropertiesChanged` handler, when `Codec` or `Configuration` changes:
+
+```csharp
+if (changed.ContainsKey("Codec") || changed.ContainsKey("Configuration"))
+{
+  var info = await GetA2dpCodecInfoAsync(ConnectedDevice?.Address ?? "", default);
+  if (info != null && ConnectedDevice != null)
+  {
+    _logger.LogInformation(
+      "BluetoothCodec: {Address} negotiated codec={Codec} sampleRate={Rate}Hz bitpool={Bitpool}",
+      ConnectedDevice.Address, info.CodecName, info.SampleRateHz, info.BitpoolOrNull?.ToString() ?? "n/a");
+
+    _metricsCollector?.Gauge("bluetooth.a2dp.codec", info.CodecId);
+    _metricsCollector?.Gauge("bluetooth.a2dp.sample_rate_hz", info.SampleRateHz);
+    _metricsCollector?.Gauge("bluetooth.a2dp.bitpool", info.BitpoolOrNull ?? -1);
+
+    A2dpCodecChanged?.Invoke(this, new A2dpCodecChangedEventArgs
+    {
+      DeviceAddress = ConnectedDevice.Address,
+      CodecInfo = info
+    });
+  }
+}
+```
+
+**Step 3: Initial emission on transport attach**
+
+In `AttachMediaTransportAsync` after the transport reference is stored, emit once so the initial codec is logged even if no later change occurs:
+
+```csharp
+_ = Task.Run(async () =>
+{
+  await Task.Delay(500);  // give BlueZ a beat to populate properties
+  var info = await GetA2dpCodecInfoAsync(ConnectedDevice?.Address ?? "", default);
+  if (info != null && ConnectedDevice != null)
+  {
+    _logger.LogInformation(
+      "BluetoothCodec: {Address} initial codec={Codec} sampleRate={Rate}Hz bitpool={Bitpool}",
+      ConnectedDevice.Address, info.CodecName, info.SampleRateHz, info.BitpoolOrNull?.ToString() ?? "n/a");
+    _metricsCollector?.Gauge("bluetooth.a2dp.codec", info.CodecId);
+    _metricsCollector?.Gauge("bluetooth.a2dp.sample_rate_hz", info.SampleRateHz);
+    _metricsCollector?.Gauge("bluetooth.a2dp.bitpool", info.BitpoolOrNull ?? -1);
+    A2dpCodecChanged?.Invoke(this, new A2dpCodecChangedEventArgs { DeviceAddress = ConnectedDevice.Address, CodecInfo = info });
+  }
+});
+```
+
+**Step 4: Build + commit**
+
+```bash
+git add src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+git commit -m "feat(bt): read + emit A2DP codec info from BlueZ MediaTransport1"
+```
+
+---
+
+## Task 5: Surface in `BluetoothStatusDto` + UI
+
+**Files:**
+- Modify: `src/Radio.API/Models/BluetoothDtos.cs`
+- Modify: `src/Radio.Web/Models/ApiModels.cs`
+- Modify: `src/Radio.API/Controllers/BluetoothController.cs`
+- Modify: `src/Radio.Web/Components/Pages/BluetoothPage.razor`
+
+**Step 1: Add fields to both DTOs** (Web has its own copy per MEMORY: "Web project has its own DTO records"):
+
+```csharp
+public string? CodecName { get; set; }
+public int? SampleRateHz { get; set; }
+public int? Bitpool { get; set; }
+```
+
+**Step 2: Populate in `BluetoothController.BuildStatus()`**
+
+```csharp
+var codec = await _bluetoothService.GetA2dpCodecInfoAsync(connectedDevice?.Address ?? "", CancellationToken.None);
+dto.CodecName = codec?.CodecName;
+dto.SampleRateHz = codec?.SampleRateHz;
+dto.Bitpool = codec?.BitpoolOrNull;
+```
+
+(`BuildStatus` may be sync today; if so, make it async or do a fire-and-forget cache pattern.)
+
+**Step 3: Render in `BluetoothPage.razor`**
+
+In the Connected Device Card, alongside name + address:
+
+```razor
+@if (!string.IsNullOrEmpty(_status.CodecName))
+{
+  <RadzenBadge Variant="Variant.Outlined" BadgeStyle="BadgeStyle.Info" Style="margin-top:4px">
+    @_status.CodecName
+    @if (_status.SampleRateHz is > 0)
+    {
+      <span>@((_status.SampleRateHz.Value / 1000.0).ToString("F1")) kHz</span>
+    }
+    @if (_status.Bitpool is > 0)
+    {
+      <span>bitpool @_status.Bitpool</span>
+    }
+  </RadzenBadge>
+}
+```
+
+**Step 4: Build + commit**
+
+```bash
+git add src/Radio.API/Models/BluetoothDtos.cs \
+        src/Radio.Web/Models/ApiModels.cs \
+        src/Radio.API/Controllers/BluetoothController.cs \
+        src/Radio.Web/Components/Pages/BluetoothPage.razor
+git commit -m "feat(bt): show negotiated codec in BluetoothPage"
+```
+
+---
+
+## Task 6: Full build + test
+
+```bash
+dotnet build --configuration Release
+dotnet test --configuration Release --verbosity normal
+```
+Expected: 0 warnings; all ~1,697+ tests pass.
+
+---
+
+## Task 7: Deploy + integration test
+
+```bash
+./deploy/Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64
+```
+
+Connect each test phone in turn; verify:
+
+```bash
+ssh mmack@radio "journalctl -u radio-api --since '1 minute ago' | grep BluetoothCodec"
+```
+Expected: one `BluetoothCodec: ... initial codec=<name>` line per phone connect.
+
+UI: visit `http://radio:5002/bluetooth` — codec badge appears next to connected device.
+
+Cross-reference with `bluetoothctl info <MAC>`:
+```bash
+ssh mmack@radio "bluetoothctl info <PHONE_MAC> | grep -iE 'codec|configuration'"
+```
+
+---
+
+## Task 8: Verify acceptance criteria
+
+Baseline + post-change via the probe script:
+
+```bash
+ssh mmack@radio "/opt/radio-console/scripts/research/bt_codec_observability_probe.sh \
+  --duration 1800 --phones 'phone-a,phone-b,phone-c'" \
+  > baseline_bt_codec.txt   # this is the BASELINE — main has no codec emission
+
+# After deploying this branch:
+ssh mmack@radio "/opt/radio-console/scripts/research/bt_codec_observability_probe.sh \
+  --duration 1800 --phones 'phone-a,phone-b,phone-c'" \
+  > after_bt_codec.txt
+```
+
+**Success criterion**:
+- `events_emitted ≥ 3` (one per phone connect) in `after_bt_codec.txt`
+- `codec_log_lines ≥ 3` with parseable codec names from the set {SBC, AAC, aptX, aptX-HD, LDAC, LHDC}
+- `ui_codec_displayed = true`
+- Cross-reference: codec name matches `bluetoothctl info <MAC>` output for `≥2` of `3` phones (third allowed to mismatch in case of non-standard vendor codec)
+
+**Debug-agent verification**:
+```bash
+python3 scripts/research/bt_codec_observability_compare.py baseline_bt_codec.txt after_bt_codec.txt
+```
+Expected: `PASS`.
+
+---
+
+## Task 9: Open PR + merge
+
+```bash
+git push -u origin feat/bt-codec-observability
+
+gh pr create --title "feat(bt): surface negotiated A2DP codec + bitpool as observable metric" --body "$(cat <<'EOF'
+## Summary
+
+Implements [Plan C from the Cast/BT research arc](../docs/plans/2026-05-22-cast-bt-phase-1-2-arc.md) — closes the FM-BT-6 visibility gap. Reads `Codec` + `Configuration` properties from BlueZ `MediaTransport1` D-Bus, parses per BlueZ's `a2dp-codecs.h` layout, emits as metrics + log + UI badge.
+
+Read-only addition — no behavior change. Establishes the diagnostic foundation needed before acting on any other FM-BT issue (e.g. "audio sounds bad" → "ah, fell to SBC bitpool 35" instead of "no data, restart").
+
+## Acceptance criteria (verified)
+
+- 3 phones with different codec capability sets → 3 distinct codec emissions
+- Cross-reference with `bluetoothctl info` matches for ≥2 of 3 phones
+- UI codec badge visible on `/bluetooth` page
+
+## Test plan
+
+- [x] 8 unit tests for codec config parser (SBC bitpool, AAC sample rate, vendor IDs)
+- [x] D-Bus property read verified on `radio` host
+- [x] Metrics emission visible in `metrics.db` gauges table
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Merge once Mark approves.
+
+---
+
+## Out of scope
+
+- **Codec pinning / negotiation forcing**: this plan ships visibility only. Pinning would be a separate, behavior-changing plan.
+- **AVRCP absolute-volume display**: separate concern; this plan is codec only.
+- **Cast-side codec observability**: HM mode's MP3 encode is a known constant (320 kbps CBR by default); DC mode ships raw PCM. Neither has the same "invisible" problem as BT.
+- **Per-codec mitigation actions** (e.g. "if SBC bitpool drops below 30, alert"): the metric is the foundation; alerts are downstream work.
+- **Windows BT path**: stub only.

--- a/docs/plans/2026-05-22-cast-bt-phase-1-2-arc.md
+++ b/docs/plans/2026-05-22-cast-bt-phase-1-2-arc.md
@@ -1,0 +1,63 @@
+# Cast/BT Research — Phase 1+2 Implementation Arc
+
+> **For Claude:** This is an arc-overview document. It does not contain executable tasks. The plans for each idea live in the per-idea files referenced below. Use `superpowers:executing-plans` against each individual plan, in the sequence specified here.
+
+**Source research**:
+- [`docs/research/2026-05-21-cast-stutter-comparison.md`](../research/2026-05-21-cast-stutter-comparison.md)
+- [`docs/research/2026-05-22-bt-audio-stabilization.md`](../research/2026-05-22-bt-audio-stabilization.md)
+
+**Selection rationale**: The 16 ideas across both research docs were prioritized using embedded-audio-engineering judgment (transcript record). Phase 1 (3 ideas) addresses known production bugs and adds the observability needed to diagnose every subsequent BT issue. Phase 2 (2 ideas) is "standard embedded-audio practice debt" — things every real-time audio system should already have. Phases 3+ are deferred until Phase 1+2 data points the finger.
+
+---
+
+## Phase 1 — Stop the bleeding (3 plans, ~280 LOC)
+
+Sequence within Phase 1 is **flexible** — the three plans touch disjoint code. They can be implemented in any order or in parallel.
+
+| Plan | Idea | Addresses | Branch | Est. LOC |
+|---|---|---|---|---|
+| [`2026-05-22-bt-capture-watchdog.md`](2026-05-22-bt-capture-watchdog.md) | #12 Watchdog on `OnProcess` interval | FM-BT-3 (known long-uptime quiescence bug) | `feat/bt-capture-watchdog` | ~80 |
+| [`2026-05-22-bt-autoswitch-gate.md`](2026-05-22-bt-autoswitch-gate.md) | #13 Gate `autoSwitchOnConnect` on PW node existence | FM-BT-1 (autoSwitch retries on missing PW node) | `feat/bt-autoswitch-gate` | ~120 |
+| [`2026-05-22-bt-codec-observability.md`](2026-05-22-bt-codec-observability.md) | #15 Surface negotiated codec + bitpool as observable metric | FM-BT-6 (codec quality degradation, currently invisible) | `feat/bt-codec-observability` | ~80 |
+
+**Phase 1 exit criteria**: all three PRs merged to `main`. Each PR's acceptance criteria (from the research's 5-block measurement scaffolding) have been verified per the plan's debug-agent verification steps.
+
+---
+
+## Phase 2 — Isolate the audio path (2 plans, ~165 LOC)
+
+Sequence within Phase 2: **#9 before #14**. CPU affinity is purely systemd-level + thin P/Invoke; doesn't depend on any other work and provides immediate measurable benefit. The PW event subscription is more involved and benefits from Phase 1 being landed (so the watchdog + gate built in Phase 1 can be optionally simplified once the event API replaces `pw-cli` scraping).
+
+| Order | Plan | Idea | Addresses | Branch | Est. LOC |
+|---|---|---|---|---|---|
+| 1 | [`2026-05-22-audio-thread-isolation.md`](2026-05-22-audio-thread-isolation.md) | #9 Pin `radio-api` to dedicated CPU cores + SCHED_FIFO | FM2 + FM8 + FM-BT-11 (host resource contention; documented "audio distortion correlates with SSH activity") | `feat/audio-thread-isolation` | ~55 |
+| 2 | [`2026-05-22-pw-event-subscription.md`](2026-05-22-pw-event-subscription.md) | #14 Replace `pw-cli` scraping with PipeWire event subscription | FM-BT-1 + FM-BT-2 (eliminates pw-cli scrape race window) | `feat/pw-event-subscription` | ~150 |
+
+**Phase 2 exit criteria**: both PRs merged. The shared `PROBE-SYS-LOAD` infrastructure (declared in both research docs' §3) is exercised by the audio-thread-isolation verification under the two-scenario protocol (light vs heavy load), confirming the load-correlation gap from MEMORY has measurably narrowed.
+
+---
+
+## Shared scaffolding — author this once before Phase 1 starts
+
+The research docs declare several probe scaffolds as part of the research deliverable. They are *not* shipped to production — they live in `scripts/research/` and are used by the debug-agent verification steps in each plan.
+
+| Script | Used by | Status |
+|---|---|---|
+| `scripts/research/sysload_capture.sh` | All Phase 1+2 plans (concurrent-load discipline) | Author before any plan begins |
+| `scripts/research/sysload_correlate.py` | All plans (post-process audio events vs load) | Author before any plan begins |
+| `scripts/research/bt_stall_detect.py` | Plan A — watchdog | Author as Task 0 of Plan A |
+| `scripts/research/bt_autoswitch_audit.py` | Plan B — autoswitch gate | Author as Task 0 of Plan B |
+| `scripts/research/bt_codec_observability_probe.sh` | Plan C — codec observability | Author as Task 0 of Plan C |
+| `scripts/research/heavy_load_harness.sh` | Plan D — CPU affinity (two-scenario protocol) | Author as Task 0 of Plan D |
+| `scripts/research/bt_pair_cycle_harness.sh` | Plan E — PW event subscription | Author as Task 0 of Plan E |
+
+Each plan begins with a **Task 0: Author the probe scripts** step so the baseline run can be performed *before* the implementation lands.
+
+---
+
+## Workflow notes
+
+- **One PR per plan**. Each plan ends with a `gh pr create` step. Plans do not merge each other.
+- **Branches off `main`**, not stacked. The 5 plans are independent enough that stacking adds coordination overhead.
+- **Measurement-driven acceptance**: every plan ends with a "Task N: Verify acceptance criteria" step that runs the baseline + post-change probes per the research's 5-block measurement structure and produces a single PASS/FAIL artifact. Do not merge a plan whose verification artifact is FAIL.
+- **Phase 3 ideas (#1, #10, #11 + remaining cast-side) remain in research** until Phase 1+2 measurement data identifies which gaps remain. Do not pre-commit them.

--- a/docs/plans/2026-05-22-pw-event-subscription.md
+++ b/docs/plans/2026-05-22-pw-event-subscription.md
@@ -1,0 +1,643 @@
+# PipeWire Event Subscription Implementation Plan (Phase 2 / Plan E)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Replace `LinuxBluetoothService`'s `pw-cli ls Node` text-scrape (currently used by `ParsePwCliOutputForBtNode` + the periodic re-scan loop from Plan B) with a real PipeWire registry-event subscription via `pw_registry_add_listener` P/Invoke. Detection of node appearance/disappearance becomes event-driven (target ≤200 ms latency) instead of polled (currently bounded by `CaptureNodeRescanIntervalMs = 1000 ms` from Plan B).
+
+**Architecture:**
+
+- New P/Invoke bindings for `pw_context_*`, `pw_core_*`, `pw_registry_*`, and the `pw_registry_events` callback struct in `PipeWireNative.cs`.
+- New `PipeWireRegistryListener` class encapsulating: context + core + registry creation, callback delegate pinning, `global_added` / `global_removed` event handling, and filter logic for `bluez_input.<MAC>.a2dp-source` node names.
+- `LinuxBluetoothService` uses `PipeWireRegistryListener` as the primary node-presence source. The existing `RescanLoopAsync` from Plan B is retained as a *fallback*: starts only if `PipeWireRegistryListener.IsHealthy == false`. The existing `ParsePwCliOutputForBtNode` static method is retained for unit-test value (PR #314's 13 tests pass against it) and as the parser used by the fallback.
+
+This plan benefits from Plan B being shipped first because:
+1. The `CaptureNodeAvailable` event contract already exists; this plan only changes what triggers it (registry callback vs scrape).
+2. The fallback path is already wired (the periodic scrape from Plan B).
+
+The two are not strictly ordered, however — if Plan B is delayed for any reason, this plan can ship first by introducing the event and listener simultaneously.
+
+**Tech Stack:** existing PipeWire native interop (PR #262), new P/Invoke for `pw_registry_*` and `pw_proxy_*`, existing `BluetoothOptions` and metrics infrastructure.
+
+**Addresses**: FM-BT-1 (eliminates the pw-cli scrape race window from Plan B's gating logic), FM-BT-2 (faster detection of mid-session node disappearance), §6 Pattern 1 from [`docs/research/2026-05-22-bt-audio-stabilization.md`](../research/2026-05-22-bt-audio-stabilization.md) (RTest's unique use of pw-cli text-scrape vs reference systems' event APIs).
+
+---
+
+## Task 0: Author probe scripts (research deliverable)
+
+**Files:**
+- Create: `scripts/research/bt_pair_cycle_harness.sh` (if not already created in Plan B — confirm)
+- Create: `scripts/research/bt_lifecycle_summarize.py`
+- Create: `scripts/research/bt_lifecycle_compare.py`
+
+**Step 1:** Confirm `bt_pair_cycle_harness.sh` exists from Plan B's Task 0. If not, create it per Plan B's spec.
+
+**Step 2: `bt_lifecycle_summarize.py`** — reads two inputs:
+- A pair-cycle log artifact (phone-side timestamps of enable/disable events)
+- A radio-side journal artifact (`PW capture node appeared` and `PW capture node disappeared` log lines from `LinuxBluetoothService`)
+
+For each cycle, computes `detection_latency_ms` (PW-node-appears timestamp − phone-enable timestamp) and `teardown_latency_ms` (PW-node-disappears timestamp − phone-disable timestamp). Outputs per-cycle CSV + summary:
+
+```
+cycles=<N>
+detection_latency_ms_p50=<X>, p95=<Y>
+teardown_latency_ms_p50=<A>, p95=<B>
+failed_detections=<F>   # cycles where the node never appeared in the radio log
+failed_teardowns=<T>
+```
+
+**Step 3: `bt_lifecycle_compare.py`** — reads two summary artifacts; PASS/FAIL against the §7 Idea #3 success criterion.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/research/bt_lifecycle_summarize.py scripts/research/bt_lifecycle_compare.py
+# bt_pair_cycle_harness.sh from Plan B if not already there
+git commit -m "scripts(research): BT lifecycle latency summarize + compare scripts"
+```
+
+---
+
+## Task 1: P/Invoke bindings for `pw_registry_*`
+
+**Files:**
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNative.cs`
+
+**Step 1: Add the bindings**
+
+PipeWire's registry API: `pw_context_connect(context, props, user_data_size) → pw_core *`; then `pw_core_get_registry(core, version, user_data_size) → pw_registry *`; then `pw_registry_add_listener(registry, &hook, &events_struct, user_data)`.
+
+The events struct shape (from `pipewire/extensions/registry.h`):
+```c
+struct pw_registry_events {
+    uint32_t version;
+    void (*global)(void *data, uint32_t id, uint32_t permissions, const char *type, uint32_t version, const struct spa_dict *props);
+    void (*global_remove)(void *data, uint32_t id);
+};
+```
+
+Add to `PipeWireNative.cs`:
+
+```csharp
+#if !WINDOWS_TARGET
+internal const uint PW_VERSION_REGISTRY_EVENTS = 0;
+internal const uint PW_VERSION_REGISTRY = 3;
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal delegate void PwRegistryGlobalDelegate(
+  IntPtr userData, uint id, uint permissions,
+  [MarshalAs(UnmanagedType.LPStr)] string type, uint version,
+  IntPtr props);  // spa_dict* — read via pw_helper if needed
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal delegate void PwRegistryGlobalRemoveDelegate(IntPtr userData, uint id);
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct PwRegistryEvents
+{
+  public uint Version;
+  public IntPtr Global;        // PwRegistryGlobalDelegate function pointer
+  public IntPtr GlobalRemove;  // PwRegistryGlobalRemoveDelegate function pointer
+}
+
+[DllImport("libpipewire-0.3.so.0", EntryPoint = "pw_context_new")]
+internal static extern IntPtr pw_context_new(IntPtr loop, IntPtr props, IntPtr userDataSize);
+
+[DllImport("libpipewire-0.3.so.0", EntryPoint = "pw_context_connect")]
+internal static extern IntPtr pw_context_connect(IntPtr context, IntPtr props, IntPtr userDataSize);
+
+[DllImport("libpipewire-0.3.so.0", EntryPoint = "pw_context_destroy")]
+internal static extern void pw_context_destroy(IntPtr context);
+
+[DllImport("libpipewire-0.3.so.0", EntryPoint = "pw_core_get_registry")]
+internal static extern IntPtr pw_core_get_registry(IntPtr core, uint version, IntPtr userDataSize);
+
+[DllImport("libpipewire-0.3.so.0", EntryPoint = "pw_core_disconnect")]
+internal static extern int pw_core_disconnect(IntPtr core);
+
+[DllImport("libpipewire-0.3.so.0", EntryPoint = "pw_proxy_add_listener")]
+internal static extern void pw_proxy_add_listener(IntPtr proxy, IntPtr hook, IntPtr events, IntPtr data);
+
+[DllImport("libpipewire-0.3.so.0", EntryPoint = "pw_proxy_destroy")]
+internal static extern void pw_proxy_destroy(IntPtr proxy);
+
+// pw_proxy_add_listener takes a hook (spa_hook) which is a small struct the caller owns.
+// Allocate as a pinned 16-byte buffer.
+internal const int SpaHookSize = 16;
+#endif
+```
+
+**Note**: `pw_helper.c` (the existing native helper compiled to `libpw_helper.so` per MEMORY) may need an additional helper to read a property out of `spa_dict` — the `props` parameter to the `global` callback is a `spa_dict*`. Add a helper `pw_helper_spa_dict_lookup(dict_ptr, key) → char*` that returns the value string or null. Match the existing helper's layout in `/tmp/pw_helper.c` on Ubuntu.
+
+**Step 2: Build (Linux-only path)**
+
+```bash
+dotnet build src/Radio.Infrastructure --configuration Release --framework net10.0
+```
+Expected: 0 warnings on the Linux TFM.
+
+**Step 3: Commit**
+
+```bash
+git add src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNative.cs
+git commit -m "feat(bt): P/Invoke bindings for pw_registry_* + spa_dict helper signature"
+```
+
+---
+
+## Task 2: `PipeWireRegistryListener` class
+
+**Files:**
+- Create: `src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireRegistryListener.cs`
+
+**Step 1: Implement**
+
+```csharp
+#if !WINDOWS_TARGET
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using static Radio.Infrastructure.Platform.Bluetooth.Native.PipeWireNative;
+
+namespace Radio.Infrastructure.Platform.Bluetooth.Native;
+
+/// <summary>
+/// Subscribes to the PipeWire registry for global add/remove events.
+/// Filters BT capture nodes (name matches "bluez_input.&lt;MAC&gt;.a2dp-source") and
+/// forwards as managed events. Replaces pw-cli text scraping.
+///
+/// Runs its own pw_thread_loop separate from the capture stream's loop —
+/// keeping subscription survival independent of stream lifecycle.
+/// </summary>
+internal sealed class PipeWireRegistryListener : IDisposable
+{
+  private readonly ILogger _logger;
+  private IntPtr _threadLoop;
+  private IntPtr _context;
+  private IntPtr _core;
+  private IntPtr _registry;
+  private IntPtr _hook;          // pinned spa_hook buffer
+  private GCHandle _eventsHandle;
+  private GCHandle _selfHandle;
+  private PwRegistryEvents _events;
+  private readonly PwRegistryGlobalDelegate _globalDelegate;
+  private readonly PwRegistryGlobalRemoveDelegate _globalRemoveDelegate;
+  private bool _disposed;
+
+  /// <summary>Indicates whether the listener initialized successfully.</summary>
+  public bool IsHealthy { get; private set; }
+
+  public event EventHandler<BtNodeRegistryEventArgs>? NodeAppeared;
+  public event EventHandler<BtNodeRegistryEventArgs>? NodeDisappeared;
+
+  // Track id → (address, type) so we can fire NodeDisappeared with the right address
+  private readonly System.Collections.Concurrent.ConcurrentDictionary<uint, string> _idToAddress = new();
+
+  public PipeWireRegistryListener(ILogger logger)
+  {
+    _logger = logger;
+    _globalDelegate = OnGlobal;
+    _globalRemoveDelegate = OnGlobalRemove;
+  }
+
+  public void Start()
+  {
+    try
+    {
+      _threadLoop = pw_thread_loop_new("radio-bt-registry", IntPtr.Zero);
+      if (_threadLoop == IntPtr.Zero)
+        throw new InvalidOperationException("pw_thread_loop_new failed");
+      var loop = pw_thread_loop_get_loop(_threadLoop);
+
+      _context = pw_context_new(loop, IntPtr.Zero, IntPtr.Zero);
+      if (_context == IntPtr.Zero)
+        throw new InvalidOperationException("pw_context_new failed");
+
+      _core = pw_context_connect(_context, IntPtr.Zero, IntPtr.Zero);
+      if (_core == IntPtr.Zero)
+        throw new InvalidOperationException("pw_context_connect failed");
+
+      _registry = pw_core_get_registry(_core, PW_VERSION_REGISTRY, IntPtr.Zero);
+      if (_registry == IntPtr.Zero)
+        throw new InvalidOperationException("pw_core_get_registry failed");
+
+      _selfHandle = GCHandle.Alloc(this);
+      _events = new PwRegistryEvents
+      {
+        Version = PW_VERSION_REGISTRY_EVENTS,
+        Global = Marshal.GetFunctionPointerForDelegate(_globalDelegate),
+        GlobalRemove = Marshal.GetFunctionPointerForDelegate(_globalRemoveDelegate)
+      };
+      _eventsHandle = GCHandle.Alloc(_events, GCHandleType.Pinned);
+      _hook = Marshal.AllocHGlobal(SpaHookSize);
+
+      pw_proxy_add_listener(_registry, _hook,
+        _eventsHandle.AddrOfPinnedObject(),
+        GCHandle.ToIntPtr(_selfHandle));
+
+      pw_thread_loop_start(_threadLoop);
+
+      IsHealthy = true;
+      _logger.LogInformation("PipeWireRegistryListener started");
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "PipeWireRegistryListener failed to start; fallback path will be used");
+      IsHealthy = false;
+      Cleanup();
+    }
+  }
+
+  private static void OnGlobal(IntPtr userData, uint id, uint permissions, string type, uint version, IntPtr props)
+  {
+    PipeWireRegistryListener? self;
+    try { self = GCHandle.FromIntPtr(userData).Target as PipeWireRegistryListener; }
+    catch { return; }
+    if (self == null) return;
+
+    // Only PipeWire:Interface:Node matters for BT capture nodes
+    if (type != "PipeWire:Interface:Node") return;
+
+    // Read node.name via spa_dict helper
+    var nameOrNull = ReadSpaDictKey(props, "node.name");
+    if (nameOrNull == null) return;
+
+    // Filter for bluez_input.<MAC>.a2dp-source
+    if (!nameOrNull.StartsWith("bluez_input.")) return;
+    if (!nameOrNull.EndsWith(".a2dp-source")) return;
+
+    // Extract MAC: bluez_input.AA_BB_CC_DD_EE_FF.a2dp-source → AA:BB:CC:DD:EE:FF
+    var dotMac = nameOrNull.Substring("bluez_input.".Length);
+    var underscoreMac = dotMac.Substring(0, dotMac.Length - ".a2dp-source".Length);
+    var address = underscoreMac.Replace('_', ':').ToUpperInvariant();
+
+    self._idToAddress[id] = address;
+    self._logger.LogInformation("PW registry: BT node appeared id={Id} address={Address}", id, address);
+    self.NodeAppeared?.Invoke(self, new BtNodeRegistryEventArgs { Id = id, DeviceAddress = address });
+  }
+
+  private static void OnGlobalRemove(IntPtr userData, uint id)
+  {
+    PipeWireRegistryListener? self;
+    try { self = GCHandle.FromIntPtr(userData).Target as PipeWireRegistryListener; }
+    catch { return; }
+    if (self == null) return;
+
+    if (self._idToAddress.TryRemove(id, out var address))
+    {
+      self._logger.LogInformation("PW registry: BT node disappeared id={Id} address={Address}", id, address);
+      self.NodeDisappeared?.Invoke(self, new BtNodeRegistryEventArgs { Id = id, DeviceAddress = address });
+    }
+  }
+
+  private static string? ReadSpaDictKey(IntPtr propsPtr, string key)
+  {
+    // Calls into libpw_helper.so's pw_helper_spa_dict_lookup; returns null if key missing.
+    var resultPtr = pw_helper_spa_dict_lookup(propsPtr, key);
+    return resultPtr == IntPtr.Zero ? null : Marshal.PtrToStringAnsi(resultPtr);
+  }
+
+  [DllImport("libpw_helper.so")]
+  private static extern IntPtr pw_helper_spa_dict_lookup(IntPtr dict, [MarshalAs(UnmanagedType.LPStr)] string key);
+
+  public void Dispose()
+  {
+    if (_disposed) return;
+    _disposed = true;
+    Cleanup();
+  }
+
+  private void Cleanup()
+  {
+    if (_threadLoop != IntPtr.Zero)
+    {
+      pw_thread_loop_lock(_threadLoop);
+      try
+      {
+        if (_registry != IntPtr.Zero) { pw_proxy_destroy(_registry); _registry = IntPtr.Zero; }
+        if (_core != IntPtr.Zero) { pw_core_disconnect(_core); _core = IntPtr.Zero; }
+        if (_context != IntPtr.Zero) { pw_context_destroy(_context); _context = IntPtr.Zero; }
+      }
+      finally { pw_thread_loop_unlock(_threadLoop); }
+
+      pw_thread_loop_stop(_threadLoop);
+      pw_thread_loop_destroy(_threadLoop);
+      _threadLoop = IntPtr.Zero;
+    }
+    if (_hook != IntPtr.Zero) { Marshal.FreeHGlobal(_hook); _hook = IntPtr.Zero; }
+    if (_eventsHandle.IsAllocated) _eventsHandle.Free();
+    if (_selfHandle.IsAllocated) _selfHandle.Free();
+    IsHealthy = false;
+  }
+}
+
+internal class BtNodeRegistryEventArgs : EventArgs
+{
+  public required uint Id { get; init; }
+  public required string DeviceAddress { get; init; }
+}
+#endif
+```
+
+**Step 2:** Update `pw_helper.c` (Ubuntu source at `/tmp/pw_helper.c`) to add `pw_helper_spa_dict_lookup`:
+
+```c
+const char *pw_helper_spa_dict_lookup(const struct spa_dict *dict, const char *key) {
+    if (!dict) return NULL;
+    return spa_dict_lookup(dict, key);
+}
+```
+
+Rebuild `libpw_helper.so` per the existing deploy procedure (per MEMORY: "libpw_helper.so compiled on Ubuntu, installed to `/usr/local/lib` via ldconfig").
+
+**Step 3: Build + commit**
+
+```bash
+git add src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireRegistryListener.cs \
+        # plus any pw_helper source update if checked in
+git commit -m "feat(bt): PipeWireRegistryListener for event-driven node lifecycle"
+```
+
+---
+
+## Task 3: Integrate into `LinuxBluetoothService` — primary path with fallback
+
+**Files:**
+- Modify: `src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs`
+
+**Step 1: Add the listener field + init in constructor or `StartAsync`**
+
+```csharp
+private PipeWireRegistryListener? _registryListener;
+
+// In StartAsync after BlueZ is initialized:
+_registryListener = new PipeWireRegistryListener(_logger);
+_registryListener.NodeAppeared += OnRegistryNodeAppeared;
+_registryListener.NodeDisappeared += OnRegistryNodeDisappeared;
+_registryListener.Start();
+
+if (!_registryListener.IsHealthy)
+{
+  _logger.LogWarning("PipeWireRegistryListener unhealthy — falling back to periodic re-scan loop");
+  // The existing RescanLoopAsync from Plan B continues to run as fallback.
+}
+else
+{
+  // Don't start the periodic re-scan loop — the listener is doing the job.
+  _logger.LogInformation("PipeWireRegistryListener active — periodic re-scan disabled");
+}
+```
+
+**Step 2: Gate the periodic re-scan loop on listener health**
+
+In `EnsureRescanLoopRunning` (from Plan B):
+
+```csharp
+private void EnsureRescanLoopRunning()
+{
+  // If the event-driven listener is healthy, skip the periodic scrape entirely.
+  if (_registryListener?.IsHealthy == true) return;
+
+  // Existing periodic scrape logic from Plan B
+  // ...
+}
+```
+
+**Step 3: Map the listener's events to `CaptureNodeAvailable`**
+
+```csharp
+private void OnRegistryNodeAppeared(object? sender, BtNodeRegistryEventArgs e)
+{
+  lock (_knownNodesLock)
+  {
+    _knownNodeAddresses.Add(e.DeviceAddress);
+  }
+  _metricsCollector?.Increment("bluetooth.capture_node_appeared_total");
+  // The PW serial is the registry id (uint) — use it directly
+  CaptureNodeAvailable?.Invoke(this, new CaptureNodeAvailableEventArgs
+  {
+    DeviceAddress = e.DeviceAddress,
+    PipeWireSerial = (int)e.Id
+  });
+}
+
+private void OnRegistryNodeDisappeared(object? sender, BtNodeRegistryEventArgs e)
+{
+  lock (_knownNodesLock)
+  {
+    _knownNodeAddresses.Remove(e.DeviceAddress);
+  }
+  _metricsCollector?.Increment("bluetooth.capture_node_disappeared_total");
+  // New event for downstream consumers — separate from existing reconnect path
+  // because BT-layer disconnect signals may not yet have fired.
+  _logger.LogInformation("BT capture node disappeared via registry event: {Address}", e.DeviceAddress);
+}
+```
+
+**Step 4: Dispose the listener**
+
+In `Dispose` / shutdown path:
+
+```csharp
+_registryListener?.Dispose();
+_registryListener = null;
+```
+
+**Step 5: Build + commit**
+
+```bash
+git add src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+git commit -m "feat(bt): use PipeWireRegistryListener as primary, scrape as fallback"
+```
+
+---
+
+## Task 4: Unit tests for the listener filter logic
+
+**Files:**
+- Create: `tests/Radio.Infrastructure.Tests/Platform/Bluetooth/Native/PipeWireRegistryFilterTests.cs`
+
+**Step 1:** The listener's interop is not directly testable in unit tests (requires real PipeWire daemon). However, the *filter logic* — recognizing `bluez_input.<MAC>.a2dp-source` names and extracting the MAC — is pure and testable.
+
+Extract the filter into a static helper:
+
+```csharp
+internal static class PipeWireRegistryFilter
+{
+  public static bool TryExtractBtCaptureAddress(string nodeName, out string address)
+  {
+    address = string.Empty;
+    if (!nodeName.StartsWith("bluez_input.")) return false;
+    if (!nodeName.EndsWith(".a2dp-source")) return false;
+    var dotMac = nodeName.Substring("bluez_input.".Length);
+    var underscoreMac = dotMac.Substring(0, dotMac.Length - ".a2dp-source".Length);
+    if (underscoreMac.Length != 17) return false; // AA_BB_CC_DD_EE_FF = 17 chars
+    address = underscoreMac.Replace('_', ':').ToUpperInvariant();
+    return true;
+  }
+}
+```
+
+Refactor the listener's `OnGlobal` to use this helper.
+
+**Step 2: Tests**
+
+```csharp
+public class PipeWireRegistryFilterTests
+{
+  [Theory]
+  [InlineData("bluez_input.78_20_51_F5_FB_A7.a2dp-source", "78:20:51:F5:FB:A7")]
+  [InlineData("bluez_input.aa_bb_cc_dd_ee_ff.a2dp-source", "AA:BB:CC:DD:EE:FF")]
+  public void TryExtract_ValidBtNode_ReturnsTrue(string nodeName, string expected)
+  {
+    var ok = PipeWireRegistryFilter.TryExtractBtCaptureAddress(nodeName, out var address);
+    Assert.True(ok);
+    Assert.Equal(expected, address);
+  }
+
+  [Theory]
+  [InlineData("alsa_input.usb-some-mic.analog-stereo")]
+  [InlineData("bluez_input.78_20_51_F5_FB_A7.hfp-ag")]          // HFP, not A2DP
+  [InlineData("bluez_input.too_short.a2dp-source")]              // malformed MAC
+  [InlineData("bluez_input.78_20_51_F5_FB_A7_EXTRA.a2dp-source")] // too long
+  [InlineData("")]
+  public void TryExtract_InvalidNode_ReturnsFalse(string nodeName)
+  {
+    var ok = PipeWireRegistryFilter.TryExtractBtCaptureAddress(nodeName, out _);
+    Assert.False(ok);
+  }
+}
+```
+
+**Step 3: Run + commit**
+
+```bash
+dotnet test tests/Radio.Infrastructure.Tests --filter "PipeWireRegistryFilterTests" --configuration Release -v n
+# Expected: 7 PASS
+
+git add tests/Radio.Infrastructure.Tests/Platform/Bluetooth/Native/PipeWireRegistryFilterTests.cs \
+        src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireRegistryListener.cs
+git commit -m "test(bt): unit tests for PipeWireRegistryFilter"
+```
+
+---
+
+## Task 5: Full build + test
+
+```bash
+dotnet build --configuration Release
+dotnet test --configuration Release --verbosity normal
+```
+Expected: 0 warnings; all tests pass. The existing 13 `ParsePwCliOutputForBtNode` tests from PR #314 continue to pass (parser retained for fallback).
+
+---
+
+## Task 6: Deploy + integration test
+
+```bash
+./deploy/Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64
+```
+
+Confirm libpw_helper.so still has the new `pw_helper_spa_dict_lookup` symbol:
+```bash
+ssh mmack@radio "nm -D /usr/local/lib/libpw_helper.so | grep pw_helper_spa_dict_lookup"
+```
+If absent, rebuild per MEMORY's `libpw_helper.so` deploy procedure:
+```bash
+ssh mmack@radio "cd /tmp && gcc -shared -fPIC -o libpw_helper.so pw_helper.c $(pkg-config --cflags --libs libpipewire-0.3) && sudo cp libpw_helper.so /usr/local/lib/ && sudo ldconfig"
+```
+
+Restart radio-api + verify the listener started:
+```bash
+ssh mmack@radio "journalctl -u radio-api --since '1 minute ago' | grep -iE 'PipeWireRegistryListener|PW registry'"
+```
+Expected: `PipeWireRegistryListener started`. If it logged `unhealthy`, the helper or P/Invoke binding is broken — fix before proceeding.
+
+---
+
+## Task 7: Verify acceptance criteria — the lifecycle-latency measurement
+
+**Baseline probe** (against `main` — has Plan B's periodic scrape only, no event listener):
+
+```bash
+ssh mmack@radio "/opt/radio-console/scripts/research/bt_pair_cycle_harness.sh \
+  --cycles 60 --period-sec 60" \
+  > baseline_bt_lifecycle.txt
+
+ssh mmack@radio "/opt/radio-console/scripts/research/sysload_capture.sh 3600" \
+  > baseline_bt_lifecycle_sysload.txt
+
+python3 scripts/research/bt_lifecycle_summarize.py \
+  baseline_bt_lifecycle.txt baseline_bt_lifecycle_sysload.txt \
+  > baseline_bt_lifecycle_classified.txt
+```
+
+**Post-change probe** (this branch deployed):
+
+Same 60-cycle harness; same parsers; save as `after_bt_lifecycle_classified.txt`.
+
+**Success criterion** (must hold):
+
+- `detection_latency_ms_p95` drops from baseline (expected `>1000 ms` due to 1 s scrape interval) to `≤200 ms`
+- `teardown_latency_ms_p95` drops to `≤500 ms` (today often "never" until reconnect)
+- `failed_detections` drops to `0`
+- `failed_teardowns` drops to `0`
+- **Negative check**: existing 13 `ParsePwCliOutputForBtNode` unit tests continue to pass (fallback retained)
+- **Negative check**: if `PipeWireRegistryListener.IsHealthy = false`, the fallback periodic-scrape path correctly takes over (verify via `journalctl` simulation: deliberately uninstall `libpw_helper.so` symbol, restart, verify warning + scrape resumes)
+
+**Debug-agent verification**:
+
+```bash
+python3 scripts/research/bt_lifecycle_compare.py baseline_bt_lifecycle_classified.txt after_bt_lifecycle_classified.txt
+```
+
+Expected: `PASS`.
+
+---
+
+## Task 8: Open PR + merge
+
+```bash
+git push -u origin feat/pw-event-subscription
+
+gh pr create --title "feat(bt): PipeWire event subscription replaces pw-cli scraping for BT node lifecycle" --body "$(cat <<'EOF'
+## Summary
+
+Implements [Plan E from the Cast/BT research arc](../docs/plans/2026-05-22-cast-bt-phase-1-2-arc.md). Replaces the `pw-cli ls Node` text scraping pattern used by `LinuxBluetoothService.GetAudioCaptureDeviceAsync` + Plan B's periodic re-scan with a real PipeWire registry-event subscription (`pw_registry_add_listener`).
+
+§6 Pattern 1 from the research doc: RTest was the only system among the four reference systems still using text-scrape; this PR aligns with the reference cluster's event-driven approach.
+
+Existing `ParsePwCliOutputForBtNode` + its 13 unit tests retained as the fallback parser. Plan B's periodic scrape is gated to run only when `PipeWireRegistryListener.IsHealthy == false`.
+
+## Acceptance criteria (verified)
+
+- `detection_latency_ms_p95` drops from >1000 ms to ≤200 ms
+- `teardown_latency_ms_p95` drops to ≤500 ms
+- `failed_detections` = 0; `failed_teardowns` = 0
+- Existing 13 parser tests still pass (fallback intact)
+- Fallback path correctly takes over when listener is unhealthy
+- See attached `bt_lifecycle_compare.py` PASS artifact
+
+## Test plan
+
+- [x] 7 unit tests for `PipeWireRegistryFilter` (extracted from listener)
+- [x] 13 existing `ParsePwCliOutputForBtNode` tests still pass
+- [x] 60-cycle pair/unpair harness on `radio`
+- [x] Healthy-listener path: detection p95 ≤ 200 ms
+- [x] Unhealthy-listener fallback: scrape path resumes
+- [x] libpw_helper.so rebuild + ldconfig verified on Ubuntu
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Merge once Mark approves.
+
+---
+
+## Out of scope
+
+- **Replacing the actual capture stream connect path** (`pw_stream_connect`): no change. This plan only changes how we *discover* the node; once discovered, capture acquisition uses the same `PipeWireNativeStream` as before.
+- **Subscribing to non-BT nodes**: the filter rejects everything except `bluez_input.<MAC>.a2dp-source`. Future plans (e.g. monitoring other PW nodes) would extend the filter.
+- **Sink-side observation** (the local speaker sink): out of scope; this plan is about BT source detection.
+- **Cast side**: Cast has no equivalent failure mode (no node discovery model — Cast uses mDNS/SSDP).
+- **Windows BT path**: stub only.


### PR DESCRIPTION
## Summary

Consumes the cast/BT research arc (PR #387) per embedded-audio-engineering prioritization. Five per-idea implementation plans + one arc-overview document.

**Plans**: each plan is self-contained (Goal, Architecture, Tasks with literal code, acceptance-criteria verification step). Format matches existing `docs/plans/2026-03-11-bt-disconnect-reason.md`. Acceptance criteria for each plan come from the research's 5-block measurement structure — a debug agent runs the \`*_compare.py\` PASS/FAIL gate before merge.

**Phase 1 — stop the bleeding** (~280 LOC, 3 plans, parallelizable):
- \`bt-capture-watchdog.md\` — FM-BT-3 (known long-uptime quiescence)
- \`bt-autoswitch-gate.md\` — FM-BT-1 (autoswitch on missing PW node)
- \`bt-codec-observability.md\` — FM-BT-6 (codec quality invisibility)

**Phase 2 — isolate the audio path** (~165 LOC, 2 plans, sequential):
- \`audio-thread-isolation.md\` — FM2 + FM8 + FM-BT-11 (load contention)
- \`pw-event-subscription.md\` — FM-BT-1 + FM-BT-2 (pw-cli scrape race)

**Arc doc**: \`2026-05-22-cast-bt-phase-1-2-arc.md\` sequences the five plans, enumerates shared probe scaffolding declared in each plan's Task 0.

## Test plan

This PR is documentation-only.

- [x] All 6 plan files render cleanly in markdown
- [x] Each plan has Goal + Architecture + numbered Tasks + acceptance-criteria Task + Out of scope
- [x] Each plan's acceptance criteria pull from the research doc's 5-block measurement structure
- [x] ROADMAP.md planning-queue section references all 5 plans
- [x] Cross-references between plans (e.g. Plan E's fallback path references Plan B) are consistent
- [x] All branch names match across docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)