### PR TITLE
feat(bt): capture watchdog for FM-BT-3 long-uptime quiescence

### DIFF
--- a/scripts/research/bt_stall_compare.py
+++ b/scripts/research/bt_stall_compare.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""bt_stall_compare.py — compare baseline vs post-change classified BT stalls.
+
+Inputs:
+  argv[1]  baseline classified-event artifact (output of sysload_correlate.py)
+  argv[2]  after classified-event artifact (same format)
+
+Computes per-class counts and PASS/FAIL against the success criterion from
+docs/plans/2026-05-22-bt-capture-watchdog.md Task 9:
+
+  - quiet_host events drop to <= 1 over the soak window
+  - load_correlated events do not regress (delta <= 0 OR within tolerance)
+
+Outputs a brief report to stdout with per-class deltas and a final PASS/FAIL.
+"""
+
+from __future__ import annotations
+
+import csv
+import sys
+
+
+def load(path: str):
+  rows = []
+  with open(path, newline="", encoding="utf-8") as f:
+    reader = csv.reader(f, delimiter="\t")
+    header = next(reader, None)
+    if header is None:
+      return rows
+    for parts in reader:
+      if len(parts) < 7:
+        continue
+      rows.append({
+        "event_ts": parts[0],
+        "metric_value": parts[1],
+        "cpu_5s_median": float(parts[2] or 0),
+        "io_5s_total_mb": float(parts[3] or 0),
+        "log_rate_5s_median": float(parts[4] or 0),
+        "ssh_5s_max": int(parts[5] or 0),
+        "classification": parts[6],
+      })
+  return rows
+
+
+def summarize(rows):
+  quiet = sum(1 for r in rows if r["classification"] == "quiet_host")
+  load = sum(1 for r in rows if r["classification"] == "load_correlated")
+  return quiet, load
+
+
+def main() -> int:
+  if len(sys.argv) < 3:
+    print(f"Usage: {sys.argv[0]} <baseline.tsv> <after.tsv>", file=sys.stderr)
+    return 2
+
+  baseline = load(sys.argv[1])
+  after = load(sys.argv[2])
+
+  b_quiet, b_load = summarize(baseline)
+  a_quiet, a_load = summarize(after)
+
+  d_quiet = a_quiet - b_quiet
+  d_load = a_load - b_load
+
+  print(f"baseline: quiet_host={b_quiet}, load_correlated={b_load}, total={b_quiet+b_load}")
+  print(f"after:    quiet_host={a_quiet}, load_correlated={a_load}, total={a_quiet+a_load}")
+  print(f"delta:    quiet_host={d_quiet:+d}, load_correlated={d_load:+d}")
+
+  # Success criterion: quiet_host <= 1 after AND load_correlated did not regress.
+  pass_quiet = a_quiet <= 1
+  pass_load = d_load <= 0
+  result = "PASS" if (pass_quiet and pass_load) else "FAIL"
+  print(f"quiet_host_after_<=1: {pass_quiet}")
+  print(f"load_correlated_not_regressed: {pass_load}")
+  print(result)
+  return 0 if result == "PASS" else 1
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/scripts/research/bt_stall_detect.py
+++ b/scripts/research/bt_stall_detect.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""bt_stall_detect.py — detect BT capture OnProcess stalls in journald output.
+
+Reads journalctl text on stdin. Identifies gaps where the
+"PipeWire OnProcess: ..." log line has been silent for >= --window seconds
+despite the most recent "BluetoothAudioSource" state-line indicating an active
+BT capture (Playing, Ready, or capture-active variants).
+
+Output (stdout, one event per line, tab-separated):
+  start_ts<TAB>end_ts<TAB>gap_seconds
+
+Notes:
+  - The OnProcess log line is emitted every ~10s when capture is healthy (see
+    PipeWireNativeStream.cs OnProcess stat logging window).
+  - Default --window is 60s, which catches single-emission misses while
+    tolerating brief transient gaps; tune to the source data.
+  - Timestamps are taken from the journalctl line prefix; use
+    `--output=short-iso` or `--output=short-iso-precise` for ISO timestamps.
+
+Used by the BT capture watchdog (Plan A) acceptance criteria and by the
+Phase 1 baseline-vs-after comparison (bt_stall_compare.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime, timezone
+
+# journalctl --output=short-iso prefix: "2026-05-22T12:34:56+0000"
+ISO_TS_RE = re.compile(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[+-]\d{2}:?\d{2}|Z)?)")
+ON_PROCESS_RE = re.compile(r"PipeWire OnProcess", re.IGNORECASE)
+BT_PLAYING_RE = re.compile(r"BluetoothAudioSource.*(state\s*==\s*Playing|state\s*=\s*Playing|"
+                           r"capture (bridge|generator|stream).*(active|acquired|added))",
+                           re.IGNORECASE)
+
+
+def parse_ts(line: str):
+  m = ISO_TS_RE.search(line)
+  if not m:
+    return None
+  s = m.group(1)
+  if s.endswith("Z"):
+    s = s[:-1] + "+00:00"
+  # Normalize "+0000" → "+00:00" for fromisoformat
+  if re.search(r"[+-]\d{4}$", s):
+    s = s[:-2] + ":" + s[-2:]
+  try:
+    dt = datetime.fromisoformat(s)
+  except ValueError:
+    return None
+  if dt.tzinfo is None:
+    dt = dt.replace(tzinfo=timezone.utc)
+  return dt.astimezone(timezone.utc)
+
+
+def main() -> int:
+  ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+  ap.add_argument("--window", type=float, default=60.0,
+                  help="minimum gap between OnProcess emissions to flag (s)")
+  args = ap.parse_args()
+
+  last_on_process: datetime | None = None
+  bt_active: bool = False
+  events = []
+
+  for line in sys.stdin:
+    ts = parse_ts(line)
+    if ts is None:
+      continue
+    if BT_PLAYING_RE.search(line):
+      bt_active = True
+    if "BluetoothAudioSource" in line and "Stopped" in line:
+      bt_active = False
+      last_on_process = None
+      continue
+    if ON_PROCESS_RE.search(line):
+      if last_on_process is not None and bt_active:
+        gap = (ts - last_on_process).total_seconds()
+        if gap >= args.window:
+          events.append((last_on_process, ts, gap))
+      last_on_process = ts
+
+  for start, end, gap in events:
+    sys.stdout.write(
+      f"{start.isoformat().replace('+00:00','Z')}\t"
+      f"{end.isoformat().replace('+00:00','Z')}\t{gap:.2f}\n"
+    )
+
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/scripts/research/sysload_capture.sh
+++ b/scripts/research/sysload_capture.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# sysload_capture.sh — concurrent system-load capture for Cast/BT audio research.
+#
+# Captures one row per second of:
+#   - CPU/IO/scheduler stats from vmstat 1
+#   - Per-device IO from iostat -x 1
+#   - Per-process CPU/IO for radio-api/radio-web/journald/sqlite3/sshd via pidstat
+#   - Per-second journald log-line count
+#   - Per-second active sshd session count
+#
+# All rows are timestamped with the monotonic clock (CLOCK_MONOTONIC nanoseconds)
+# and the wall-clock UTC second. Output is a single tab-separated
+# `sysload_<ts>.tsv` artifact merged from the four concurrent streams.
+#
+# Usage:
+#   bash scripts/research/sysload_capture.sh <duration_seconds>
+#
+# Used by Phase 1+2 plans (BT capture watchdog, BT codec observability, Cast HM
+# DC parity, CPU affinity for FM-BT-11/FM-CAST-7). See
+# docs/research/2026-05-22-bt-audio-stabilization.md §7 Idea #1 (PROBE-SYS-LOAD).
+
+set -eu
+
+DURATION="${1:-60}"
+if ! [[ "$DURATION" =~ ^[0-9]+$ ]]; then
+  echo "Usage: $0 <duration_seconds>" >&2
+  exit 2
+fi
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUTFILE="sysload_${TS}.tsv"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Header
+printf 'monotonic_ns\twall_utc\tcpu_user\tcpu_sys\tcpu_idle\tcpu_iowait\tdisk_read_kbps\tdisk_write_kbps\tlog_lines_1s\tssh_sessions\tradio_api_cpu\tradio_web_cpu\tjournald_cpu\tsqlite_cpu\tsshd_cpu\n' \
+  > "$OUTFILE"
+
+# vmstat 1 producer — outputs lines like: r b swpd free ... us sy id wa st
+# We extract us, sy, id, wa columns (positions 13-16).
+vmstat 1 "$DURATION" 2>/dev/null \
+  | awk 'NR>2 {print $13"\t"$14"\t"$15"\t"$16}' \
+  > "$TMPDIR/vmstat.tsv" &
+VMSTAT_PID=$!
+
+# iostat 1 producer — summary line per interval (Device row totals)
+iostat -x 1 "$DURATION" 2>/dev/null \
+  | awk '
+    /^avg-cpu/ { skip=1; next }
+    /^Device/  { in_devices=1; read_sum=0; write_sum=0; next }
+    in_devices && NF>=6 { read_sum += $3; write_sum += $9 }
+    /^$/ && in_devices {
+      print read_sum"\t"write_sum
+      in_devices=0
+    }
+  ' > "$TMPDIR/iostat.tsv" &
+IOSTAT_PID=$!
+
+# Per-process CPU sampler — resolve PIDs each second; missing process == 0.
+( for ((i=0; i<DURATION; i++)); do
+    api_cpu=0; web_cpu=0; jrn_cpu=0; sql_cpu=0; ssh_cpu=0
+    for pid in $(pgrep -d ' ' radio-api 2>/dev/null); do
+      v=$(awk -v pid="$pid" '$1==pid {print $9}' <(top -b -n 1 -p "$pid" 2>/dev/null | tail -n +8))
+      api_cpu=$(awk -v a="$api_cpu" -v b="${v:-0}" 'BEGIN{print a+b}')
+    done
+    for pid in $(pgrep -d ' ' radio-web 2>/dev/null); do
+      v=$(awk -v pid="$pid" '$1==pid {print $9}' <(top -b -n 1 -p "$pid" 2>/dev/null | tail -n +8))
+      web_cpu=$(awk -v a="$web_cpu" -v b="${v:-0}" 'BEGIN{print a+b}')
+    done
+    for pid in $(pgrep -d ' ' systemd-journald 2>/dev/null); do
+      v=$(awk -v pid="$pid" '$1==pid {print $9}' <(top -b -n 1 -p "$pid" 2>/dev/null | tail -n +8))
+      jrn_cpu=$(awk -v a="$jrn_cpu" -v b="${v:-0}" 'BEGIN{print a+b}')
+    done
+    for pid in $(pgrep -d ' ' sqlite3 2>/dev/null); do
+      v=$(awk -v pid="$pid" '$1==pid {print $9}' <(top -b -n 1 -p "$pid" 2>/dev/null | tail -n +8))
+      sql_cpu=$(awk -v a="$sql_cpu" -v b="${v:-0}" 'BEGIN{print a+b}')
+    done
+    for pid in $(pgrep -d ' ' sshd 2>/dev/null); do
+      v=$(awk -v pid="$pid" '$1==pid {print $9}' <(top -b -n 1 -p "$pid" 2>/dev/null | tail -n +8))
+      ssh_cpu=$(awk -v a="$ssh_cpu" -v b="${v:-0}" 'BEGIN{print a+b}')
+    done
+    printf '%s\t%s\t%s\t%s\t%s\n' "$api_cpu" "$web_cpu" "$jrn_cpu" "$sql_cpu" "$ssh_cpu"
+    sleep 1
+  done ) > "$TMPDIR/pidstat.tsv" &
+PIDSTAT_PID=$!
+
+# log/ssh meter producer — one line per second with timestamps
+( for ((i=0; i<DURATION; i++)); do
+    mono_ns=$(awk 'BEGIN{srand(); printf "%.0f", systime()*1e9}')
+    wall_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    log_lines=$(journalctl --since '1 second ago' -o cat 2>/dev/null | wc -l)
+    ssh_count=$(pgrep -c '^sshd:' 2>/dev/null || echo 0)
+    printf '%s\t%s\t%s\t%s\n' "$mono_ns" "$wall_utc" "$log_lines" "$ssh_count"
+    sleep 1
+  done ) > "$TMPDIR/meter.tsv" &
+METER_PID=$!
+
+# Wait for all producers
+wait "$VMSTAT_PID" "$IOSTAT_PID" "$PIDSTAT_PID" "$METER_PID" 2>/dev/null || true
+
+# Merge row by row. Each file should have approximately DURATION rows; align
+# by line number. Use paste so missing rows become empty fields (still readable).
+paste "$TMPDIR/meter.tsv" "$TMPDIR/vmstat.tsv" "$TMPDIR/iostat.tsv" "$TMPDIR/pidstat.tsv" \
+  | awk -F'\t' '{
+      mono=$1; wall=$2; logs=$3; ssh=$4
+      us=$5; sy=$6; id=$7; wa=$8
+      drd=$9; dwr=$10
+      api=$11; web=$12; jrn=$13; sql=$14; ssd=$15
+      print mono"\t"wall"\t"us"\t"sy"\t"id"\t"wa"\t"drd"\t"dwr"\t"logs"\t"ssh"\t"api"\t"web"\t"jrn"\t"sql"\t"ssd
+    }' >> "$OUTFILE"
+
+echo "$OUTFILE"

--- a/scripts/research/sysload_correlate.py
+++ b/scripts/research/sysload_correlate.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""sysload_correlate.py — correlate audio events with host-load TSV.
+
+Inputs:
+  argv[1]  audio-event-list artifact (one event per line:
+             event_ts<TAB>metric_value
+           where event_ts is an ISO-8601 UTC timestamp parseable by
+           datetime.fromisoformat (Z suffix tolerated).)
+  argv[2]  sysload TSV produced by sysload_capture.sh
+
+For each event, computes a 5-second pre-event window:
+  - cpu_5s_median  = median of (cpu_user + cpu_sys) over the 5s window
+  - io_5s_total    = sum of (disk_read_kbps + disk_write_kbps) / 1024 (MB)
+  - log_rate_5s    = median log_lines_1s
+  - ssh_5s_max     = max ssh_sessions
+
+Classifies each event:
+  quiet_host        cpu_5s_median <  70 AND log_rate_5s < 100 AND ssh_5s_max == 0
+  load_correlated   otherwise
+
+Outputs to stdout, tab-separated:
+  event_ts<TAB>metric_value<TAB>cpu_5s_median<TAB>io_5s_total_mb<TAB>
+    log_rate_5s_median<TAB>ssh_5s_max<TAB>classification
+
+See docs/research/2026-05-22-bt-audio-stabilization.md §7 Idea #1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import statistics
+import sys
+from datetime import datetime, timedelta, timezone
+
+
+def _parse_iso(ts: str) -> datetime:
+  """Parse ISO-8601 timestamps with a tolerant Z suffix."""
+  s = ts.strip()
+  if s.endswith("Z"):
+    s = s[:-1] + "+00:00"
+  dt = datetime.fromisoformat(s)
+  if dt.tzinfo is None:
+    dt = dt.replace(tzinfo=timezone.utc)
+  return dt.astimezone(timezone.utc)
+
+
+def load_sysload(path: str):
+  rows = []
+  with open(path, newline="", encoding="utf-8") as f:
+    reader = csv.reader(f, delimiter="\t")
+    header = next(reader, None)
+    if header is None:
+      return rows
+    for parts in reader:
+      if len(parts) < 15:
+        continue
+      try:
+        wall = _parse_iso(parts[1])
+      except Exception:
+        continue
+      try:
+        cpu_user = float(parts[2] or 0)
+        cpu_sys = float(parts[3] or 0)
+        disk_read = float(parts[6] or 0)
+        disk_write = float(parts[7] or 0)
+        log_lines = int(parts[8] or 0)
+        ssh_sessions = int(parts[9] or 0)
+      except ValueError:
+        continue
+      rows.append({
+        "wall": wall,
+        "cpu_total": cpu_user + cpu_sys,
+        "disk_kbps": disk_read + disk_write,
+        "log_lines": log_lines,
+        "ssh_sessions": ssh_sessions,
+      })
+  return rows
+
+
+def load_events(path: str):
+  events = []
+  with open(path, newline="", encoding="utf-8") as f:
+    for raw in f:
+      line = raw.strip()
+      if not line or line.startswith("#"):
+        continue
+      parts = line.split("\t")
+      ts_str = parts[0]
+      metric = parts[1] if len(parts) > 1 else ""
+      try:
+        ts = _parse_iso(ts_str)
+      except Exception:
+        continue
+      events.append((ts, metric))
+  return events
+
+
+def window_around(rows, end_ts: datetime, window_seconds: int = 5):
+  start_ts = end_ts - timedelta(seconds=window_seconds)
+  return [r for r in rows if start_ts <= r["wall"] <= end_ts]
+
+
+def classify(cpu_med: float, log_med: float, ssh_max: int) -> str:
+  if cpu_med < 70 and log_med < 100 and ssh_max == 0:
+    return "quiet_host"
+  return "load_correlated"
+
+
+def main() -> int:
+  ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+  ap.add_argument("events", help="audio-event-list artifact")
+  ap.add_argument("sysload", help="sysload TSV from sysload_capture.sh")
+  ap.add_argument("--window", type=int, default=5, help="pre-event window (s)")
+  args = ap.parse_args()
+
+  sysload = load_sysload(args.sysload)
+  events = load_events(args.events)
+
+  writer = csv.writer(sys.stdout, delimiter="\t", lineterminator="\n")
+  writer.writerow([
+    "event_ts", "metric_value", "cpu_5s_median", "io_5s_total_mb",
+    "log_rate_5s_median", "ssh_5s_max", "classification",
+  ])
+
+  for ts, metric in events:
+    window = window_around(sysload, ts, args.window)
+    if not window:
+      cpu_med = 0.0
+      io_total_mb = 0.0
+      log_med = 0.0
+      ssh_max = 0
+    else:
+      cpu_med = statistics.median(r["cpu_total"] for r in window)
+      io_total_mb = sum(r["disk_kbps"] for r in window) / 1024.0
+      log_med = statistics.median(r["log_lines"] for r in window)
+      ssh_max = max(r["ssh_sessions"] for r in window)
+    cls = classify(cpu_med, log_med, ssh_max)
+    writer.writerow([
+      ts.isoformat().replace("+00:00", "Z"),
+      metric,
+      f"{cpu_med:.2f}",
+      f"{io_total_mb:.3f}",
+      f"{log_med:.2f}",
+      str(ssh_max),
+      cls,
+    ])
+
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/src/Radio.API/appsettings.json
+++ b/src/Radio.API/appsettings.json
@@ -209,6 +209,9 @@
     "ReconnectBaseDelayMs": 3000,
     "ReconnectMaxDelayMs": 60000,
     "MaxReconnectAttempts": 20,
+    "OnProcessStallThresholdMs": 5000,
+    "WatchdogTickIntervalMs": 2000,
+    "ConsecutiveStalledChecks": 3,
     "Pbap": {
       "AutoSyncOnConnect": true,
       "SyncStaleThresholdHours": 24,

--- a/src/Radio.Core/Configuration/BluetoothOptions.cs
+++ b/src/Radio.Core/Configuration/BluetoothOptions.cs
@@ -75,6 +75,26 @@ public class BluetoothOptions
 
   /// <summary>Maximum number of reconnection attempts before giving up.</summary>
   public int MaxReconnectAttempts { get; set; } = 20;
+
+  /// <summary>
+  /// Threshold in milliseconds for the OnProcess-interval watchdog (FM-BT-3 detection).
+  /// When wall-clock now minus the last OnProcess timestamp exceeds this for
+  /// <see cref="ConsecutiveStalledChecks"/> consecutive watchdog ticks, the watchdog
+  /// raises CaptureStreamStalled. Set to 0 to disable the watchdog entirely.
+  /// </summary>
+  public int OnProcessStallThresholdMs { get; set; } = 5000;
+
+  /// <summary>
+  /// How often the watchdog checks the OnProcess timestamp (milliseconds).
+  /// </summary>
+  public int WatchdogTickIntervalMs { get; set; } = 2000;
+
+  /// <summary>
+  /// Number of consecutive watchdog ticks past <see cref="OnProcessStallThresholdMs"/>
+  /// required before the watchdog raises the stall event. Default 3 (~6 s @ 2 s tick)
+  /// to suppress single transient hiccups.
+  /// </summary>
+  public int ConsecutiveStalledChecks { get; set; } = 3;
 }
 
 /// <summary>

--- a/src/Radio.Core/Interfaces/Audio/IBluetoothService.cs
+++ b/src/Radio.Core/Interfaces/Audio/IBluetoothService.cs
@@ -114,6 +114,13 @@ public interface IBluetoothService : IAsyncDisposable
   /// </summary>
   event EventHandler? CaptureStreamRecovered;
 
+  /// <summary>
+  /// Raised when the watchdog detects that the BT capture stream's OnProcess callback
+  /// has been silent past the configured threshold (FM-BT-3 detection).
+  /// Subscribers should attempt recovery via the same path used for OnGeneratorStalled.
+  /// </summary>
+  event EventHandler<CaptureStreamStalledEventArgs>? CaptureStreamStalled;
+
   /// <summary>Event raised when playback metadata changes (Track, Artist, etc.).</summary>
   event EventHandler<BluetoothPlaybackMetadata>? MetadataChanged;
 
@@ -234,4 +241,21 @@ public class BluetoothVolumeChangedEventArgs : EventArgs
 {
   /// <summary>Normalized volume (0.0 to 1.0).</summary>
   public required float Volume { get; init; }
+}
+
+/// <summary>
+/// Raised by the BluetoothCaptureWatchdog when the OnProcess callback on the
+/// active PipeWire capture stream has been silent past the configured threshold
+/// for the configured number of consecutive watchdog ticks (FM-BT-3 detection).
+/// </summary>
+public class CaptureStreamStalledEventArgs : EventArgs
+{
+  /// <summary>BlueZ device address of the currently connected device (e.g., "AA:BB:CC:DD:EE:FF").</summary>
+  public required string DeviceAddress { get; init; }
+
+  /// <summary>Elapsed milliseconds since the most recent OnProcess callback fired.</summary>
+  public required long ElapsedMsSinceLastCallback { get; init; }
+
+  /// <summary>Number of consecutive watchdog ticks above threshold when the stall was raised.</summary>
+  public required int ConsecutiveStalledChecks { get; init; }
 }

--- a/src/Radio.Infrastructure/Audio/Services/BluetoothCaptureWatchdog.cs
+++ b/src/Radio.Infrastructure/Audio/Services/BluetoothCaptureWatchdog.cs
@@ -5,9 +5,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
-#if !WINDOWS_TARGET
-using Radio.Infrastructure.Platform.Bluetooth;
-#endif
 
 namespace Radio.Infrastructure.Audio.Services;
 
@@ -22,38 +19,40 @@ namespace Radio.Infrastructure.Audio.Services;
 /// generator-stall recovery.
 /// </summary>
 /// <remarks>
-/// Linux-only. On Windows the watchdog compiles as a no-op (no Linux service to
-/// observe).
+/// Depends on <see cref="ICaptureStreamSnapshotSource"/>, which on Linux is
+/// implemented by <c>LinuxBluetoothService</c>. On Windows / Mock /
+/// BT-disabled, the registered implementation is
+/// <see cref="NullCaptureStreamSnapshotSource"/>, which always returns
+/// <c>null</c>; the watchdog then idles without ever firing.
 /// </remarks>
 internal sealed class BluetoothCaptureWatchdog : BackgroundService
 {
   private readonly ILogger<BluetoothCaptureWatchdog> _logger;
-#if !WINDOWS_TARGET
   private readonly IOptionsMonitor<BluetoothOptions> _options;
-  private readonly LinuxBluetoothService? _linuxService;
+  private readonly ICaptureStreamSnapshotSource _snapshotSource;
   private int _consecutiveStalledChecks;
 
   public BluetoothCaptureWatchdog(
     ILogger<BluetoothCaptureWatchdog> logger,
     IOptionsMonitor<BluetoothOptions> options,
-    LinuxBluetoothService? linuxService = null)
+    ICaptureStreamSnapshotSource snapshotSource)
   {
     _logger = logger;
     _options = options;
-    _linuxService = linuxService;
+    _snapshotSource = snapshotSource;
   }
 
   /// <summary>
   /// Exposed for unit tests via <c>InternalsVisibleTo</c> for
-  /// <c>Radio.Infrastructure.Tests</c>. Production code observes the watchdog's
-  /// effect via the <see cref="LinuxBluetoothService.CaptureStreamStalled"/>
-  /// event, not this counter.
+  /// <c>Radio.Infrastructure.Tests</c>. Production code observes the
+  /// watchdog's effect via the BT service's <c>CaptureStreamStalled</c> event,
+  /// not this counter.
   /// </summary>
   internal int ConsecutiveStalledChecksForTest => _consecutiveStalledChecks;
 
   protected override async Task ExecuteAsync(CancellationToken stoppingToken)
   {
-    if (_linuxService == null)
+    if (_snapshotSource is NullCaptureStreamSnapshotSource)
     {
       _logger.LogInformation(
         "BluetoothCaptureWatchdog: no Linux BT service available, watchdog disabled");
@@ -69,7 +68,7 @@ internal sealed class BluetoothCaptureWatchdog : BackgroundService
     while (!stoppingToken.IsCancellationRequested)
     {
       var opts = _options.CurrentValue;
-      var tickMs = Math.Max(100, opts.WatchdogTickIntervalMs);
+      var tickMs = Math.Max(10, opts.WatchdogTickIntervalMs);
 
       try
       {
@@ -80,7 +79,7 @@ internal sealed class BluetoothCaptureWatchdog : BackgroundService
           continue;
         }
 
-        var snapshot = _linuxService.GetCaptureStreamSnapshot();
+        var snapshot = _snapshotSource.GetCaptureStreamSnapshot();
         if (snapshot == null)
         {
           // No active native capture stream — reset the consecutive counter.
@@ -91,7 +90,7 @@ internal sealed class BluetoothCaptureWatchdog : BackgroundService
           _consecutiveStalledChecks++;
           if (_consecutiveStalledChecks >= opts.ConsecutiveStalledChecks)
           {
-            _linuxService.RaiseCaptureStreamStalled(
+            _snapshotSource.RaiseCaptureStreamStalled(
               snapshot.Value.Address,
               snapshot.Value.ElapsedMs,
               _consecutiveStalledChecks);
@@ -128,21 +127,4 @@ internal sealed class BluetoothCaptureWatchdog : BackgroundService
 
     _logger.LogInformation("BluetoothCaptureWatchdog: stopped");
   }
-#else
-  // Windows: no Linux BT service exists, watchdog is a no-op for API symmetry.
-  public BluetoothCaptureWatchdog(
-    ILogger<BluetoothCaptureWatchdog> logger,
-    IOptionsMonitor<BluetoothOptions> options)
-  {
-    _logger = logger;
-    _ = options;
-  }
-
-  protected override Task ExecuteAsync(CancellationToken stoppingToken)
-  {
-    _logger.LogInformation(
-      "BluetoothCaptureWatchdog: Windows build, watchdog disabled (Linux-only feature)");
-    return Task.CompletedTask;
-  }
-#endif
 }

--- a/src/Radio.Infrastructure/Audio/Services/BluetoothCaptureWatchdog.cs
+++ b/src/Radio.Infrastructure/Audio/Services/BluetoothCaptureWatchdog.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Radio.Core.Configuration;
+#if !WINDOWS_TARGET
+using Radio.Infrastructure.Platform.Bluetooth;
+#endif
+
+namespace Radio.Infrastructure.Audio.Services;
+
+/// <summary>
+/// Periodic watchdog that detects FM-BT-3 — silent OnProcess quiescence on a
+/// long-running PipeWire BT capture stream. When the active stream's
+/// <c>MillisecondsSinceLastOnProcess</c> exceeds
+/// <see cref="BluetoothOptions.OnProcessStallThresholdMs"/> for
+/// <see cref="BluetoothOptions.ConsecutiveStalledChecks"/> consecutive ticks,
+/// raises <c>CaptureStreamStalled</c> on the Bluetooth service so the existing
+/// recovery interlock in <c>BluetoothAudioSource</c> can dedup with downstream
+/// generator-stall recovery.
+/// </summary>
+/// <remarks>
+/// Linux-only. On Windows the watchdog compiles as a no-op (no Linux service to
+/// observe).
+/// </remarks>
+internal sealed class BluetoothCaptureWatchdog : BackgroundService
+{
+  private readonly ILogger<BluetoothCaptureWatchdog> _logger;
+#if !WINDOWS_TARGET
+  private readonly IOptionsMonitor<BluetoothOptions> _options;
+  private readonly LinuxBluetoothService? _linuxService;
+  private int _consecutiveStalledChecks;
+
+  public BluetoothCaptureWatchdog(
+    ILogger<BluetoothCaptureWatchdog> logger,
+    IOptionsMonitor<BluetoothOptions> options,
+    LinuxBluetoothService? linuxService = null)
+  {
+    _logger = logger;
+    _options = options;
+    _linuxService = linuxService;
+  }
+
+  /// <summary>
+  /// Exposed for unit tests via <c>InternalsVisibleTo</c> for
+  /// <c>Radio.Infrastructure.Tests</c>. Production code observes the watchdog's
+  /// effect via the <see cref="LinuxBluetoothService.CaptureStreamStalled"/>
+  /// event, not this counter.
+  /// </summary>
+  internal int ConsecutiveStalledChecksForTest => _consecutiveStalledChecks;
+
+  protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    if (_linuxService == null)
+    {
+      _logger.LogInformation(
+        "BluetoothCaptureWatchdog: no Linux BT service available, watchdog disabled");
+      return;
+    }
+
+    _logger.LogInformation(
+      "BluetoothCaptureWatchdog: starting (threshold={Threshold}ms, tick={Tick}ms, consecutive={N})",
+      _options.CurrentValue.OnProcessStallThresholdMs,
+      _options.CurrentValue.WatchdogTickIntervalMs,
+      _options.CurrentValue.ConsecutiveStalledChecks);
+
+    while (!stoppingToken.IsCancellationRequested)
+    {
+      var opts = _options.CurrentValue;
+      var tickMs = Math.Max(100, opts.WatchdogTickIntervalMs);
+
+      try
+      {
+        if (opts.OnProcessStallThresholdMs <= 0)
+        {
+          // Watchdog disabled by config — sleep and re-check
+          await Task.Delay(tickMs, stoppingToken).ConfigureAwait(false);
+          continue;
+        }
+
+        var snapshot = _linuxService.GetCaptureStreamSnapshot();
+        if (snapshot == null)
+        {
+          // No active native capture stream — reset the consecutive counter.
+          _consecutiveStalledChecks = 0;
+        }
+        else if (snapshot.Value.ElapsedMs >= opts.OnProcessStallThresholdMs)
+        {
+          _consecutiveStalledChecks++;
+          if (_consecutiveStalledChecks >= opts.ConsecutiveStalledChecks)
+          {
+            _linuxService.RaiseCaptureStreamStalled(
+              snapshot.Value.Address,
+              snapshot.Value.ElapsedMs,
+              _consecutiveStalledChecks);
+            // Reset so we don't re-fire every tick after the first detection;
+            // BluetoothAudioSource will run a full StopCore/PlayCore which
+            // rebuilds the native stream and restarts the OnProcess clock.
+            _consecutiveStalledChecks = 0;
+          }
+        }
+        else
+        {
+          _consecutiveStalledChecks = 0;
+        }
+
+        await Task.Delay(tickMs, stoppingToken).ConfigureAwait(false);
+      }
+      catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+      {
+        break;
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "BluetoothCaptureWatchdog: unhandled tick exception");
+        try
+        {
+          await Task.Delay(tickMs, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+          break;
+        }
+      }
+    }
+
+    _logger.LogInformation("BluetoothCaptureWatchdog: stopped");
+  }
+#else
+  // Windows: no Linux BT service exists, watchdog is a no-op for API symmetry.
+  public BluetoothCaptureWatchdog(
+    ILogger<BluetoothCaptureWatchdog> logger,
+    IOptionsMonitor<BluetoothOptions> options)
+  {
+    _logger = logger;
+    _ = options;
+  }
+
+  protected override Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    _logger.LogInformation(
+      "BluetoothCaptureWatchdog: Windows build, watchdog disabled (Linux-only feature)");
+    return Task.CompletedTask;
+  }
+#endif
+}

--- a/src/Radio.Infrastructure/Audio/Services/ICaptureStreamSnapshotSource.cs
+++ b/src/Radio.Infrastructure/Audio/Services/ICaptureStreamSnapshotSource.cs
@@ -1,0 +1,47 @@
+namespace Radio.Infrastructure.Audio.Services;
+
+/// <summary>
+/// Snapshot accessor consumed by <see cref="BluetoothCaptureWatchdog"/>. Returns
+/// the currently active BT capture stream's last-OnProcess gap, or <c>null</c>
+/// when no native stream is running. Extracted as an interface so the watchdog
+/// can be unit-tested without instantiating <c>LinuxBluetoothService</c>'s
+/// D-Bus dependencies.
+/// </summary>
+/// <remarks>
+/// Implemented in production by <c>LinuxBluetoothService</c>; tests provide a
+/// fake. Cross-TFM (compiles on Windows too — see <see cref="NullCaptureStreamSnapshotSource"/>).
+/// </remarks>
+internal interface ICaptureStreamSnapshotSource
+{
+  /// <summary>
+  /// Returns the connected device's address and elapsed ms since the last
+  /// OnProcess callback fired, or <c>null</c> when no native capture stream is
+  /// active.
+  /// </summary>
+  (string Address, long ElapsedMs)? GetCaptureStreamSnapshot();
+
+  /// <summary>
+  /// Invoked when the watchdog has confirmed a stall (threshold + consecutive
+  /// checks). Raises the BT service's <c>CaptureStreamStalled</c> event.
+  /// </summary>
+  void RaiseCaptureStreamStalled(string address, long elapsedMs, int consecutiveChecks);
+}
+
+/// <summary>
+/// No-op fallback used when no Linux BT service is available (Windows, Mock,
+/// or BT disabled). The watchdog's null check still drives a "watchdog disabled"
+/// log path; this fallback is registered to ensure constructor injection works.
+/// </summary>
+internal sealed class NullCaptureStreamSnapshotSource : ICaptureStreamSnapshotSource
+{
+  public static readonly NullCaptureStreamSnapshotSource Instance = new();
+
+  private NullCaptureStreamSnapshotSource() { }
+
+  public (string Address, long ElapsedMs)? GetCaptureStreamSnapshot() => null;
+
+  public void RaiseCaptureStreamStalled(string address, long elapsedMs, int consecutiveChecks)
+  {
+    // No-op: there is no underlying BT service to raise on this platform.
+  }
+}

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -82,6 +82,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
     _bluetoothService.DeviceConnected += OnDeviceConnected;
     _bluetoothService.DeviceDisconnected += OnDeviceDisconnected;
     _bluetoothService.CaptureStreamRecovered += OnCaptureStreamRecovered;
+    _bluetoothService.CaptureStreamStalled += OnCaptureStreamStalled;
 
     if (_playbackService != null)
     {
@@ -295,6 +296,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
     _bluetoothService.DeviceConnected -= OnDeviceConnected;
     _bluetoothService.DeviceDisconnected -= OnDeviceDisconnected;
     _bluetoothService.CaptureStreamRecovered -= OnCaptureStreamRecovered;
+    _bluetoothService.CaptureStreamStalled -= OnCaptureStreamStalled;
 
     if (_playbackService != null)
     {
@@ -355,6 +357,22 @@ public class BluetoothAudioSource : USBAudioSourceBase
   {
     Logger.LogInformation("BluetoothAudioSource: capture stream recovered by pipeline monitor");
     _ = TryAcquireAudioCaptureAsync();
+  }
+
+  /// <summary>
+  /// Handler for FM-BT-3 watchdog detection. Funnels into the same recovery
+  /// path used for SoundFlow downstream generator stalls so the existing
+  /// <c>_recoveryInProgress</c> interlock dedups both stall sources.
+  /// </summary>
+  private void OnCaptureStreamStalled(object? sender, CaptureStreamStalledEventArgs e)
+  {
+    Logger.LogWarning(
+      "BluetoothAudioSource: capture stream stall detected via watchdog ({Address}, elapsed={Elapsed}ms, consecutive={N}); triggering recovery",
+      e.DeviceAddress, e.ElapsedMsSinceLastCallback, e.ConsecutiveStalledChecks);
+    // OnGeneratorStalled accepts either _playbackId or Id — use Id so recovery
+    // fires even if _playbackId hasn't been set yet (capture acquired but not
+    // yet routed through the mixer).
+    OnGeneratorStalled(Id);
   }
 
   private void OnGeneratorStalled(string sourceId)

--- a/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
+++ b/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
@@ -121,15 +121,54 @@ public static class AudioServiceExtensions
     services.AddSingleton<Platform.Bluetooth.BluetoothMgmtMonitor>();
     services.AddHostedService(sp => sp.GetRequiredService<Platform.Bluetooth.BluetoothMgmtMonitor>());
 
-    // Register Bluetooth service factory + service
+#if !WINDOWS_TARGET
+    // On Linux, register LinuxBluetoothService as the concrete type so the
+    // BluetoothCaptureWatchdog (FM-BT-3) can resolve it to read the native
+    // PipeWire OnProcess timestamp. The IBluetoothService below resolves the
+    // same instance via GetService<LinuxBluetoothService>() to avoid creating
+    // two competing instances of the BT service.
+    if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+          System.Runtime.InteropServices.OSPlatform.Linux))
+    {
+      services.AddSingleton<Platform.Bluetooth.LinuxBluetoothService>(sp =>
+      {
+        var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+        var options = sp.GetRequiredService<IOptions<BluetoothOptions>>();
+        var deviceManager = sp.GetRequiredService<IAudioDeviceManager>() as SoundFlowDeviceManager;
+        var metricsCollector = sp.GetService<IMetricsCollector>();
+        var playbackService = sp.GetService<Audio.SoundFlow.SoundFlowPlaybackService>();
+        var mgmtMonitor = sp.GetService<Platform.Bluetooth.BluetoothMgmtMonitor>();
+        return new Platform.Bluetooth.LinuxBluetoothService(
+          loggerFactory.CreateLogger<Platform.Bluetooth.LinuxBluetoothService>(),
+          options, deviceManager, metricsCollector, playbackService, mgmtMonitor);
+      });
+    }
+#endif
+
+    // Register Bluetooth service. On Linux + enabled, reuse the LinuxBluetoothService
+    // concrete singleton registered above; otherwise fall back to the factory.
     services.AddSingleton<IBluetoothService>(sp =>
     {
+#if !WINDOWS_TARGET
+      var linuxService = sp.GetService<Platform.Bluetooth.LinuxBluetoothService>();
+      if (linuxService != null)
+      {
+        return linuxService;
+      }
+#endif
       var logger = sp.GetRequiredService<ILoggerFactory>();
       var options = sp.GetRequiredService<IOptions<BluetoothOptions>>();
       var deviceManager = sp.GetRequiredService<IAudioDeviceManager>() as SoundFlowDeviceManager;
       var metricsCollector = sp.GetService<IMetricsCollector>();
       return Platform.Bluetooth.BluetoothServiceFactory.Create(sp, options, logger, deviceManager, metricsCollector);
     });
+
+    // FM-BT-3 watchdog (Linux-only; constructor receives null on Windows/Mock
+    // and logs once before exiting). Uses the AddSingleton + AddHostedService
+    // factory pattern so the concrete type is resolvable from DI (per MEMORY
+    // "DI / Hosted Service Gotchas").
+    services.AddSingleton<BluetoothCaptureWatchdog>();
+    services.AddHostedService(sp => sp.GetRequiredService<BluetoothCaptureWatchdog>());
 
     // Register album art cache service (singleton for disk-backed image cache)
     services.AddSingleton<AlbumArtCacheService>();

--- a/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
+++ b/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
@@ -163,10 +163,24 @@ public static class AudioServiceExtensions
       return Platform.Bluetooth.BluetoothServiceFactory.Create(sp, options, logger, deviceManager, metricsCollector);
     });
 
-    // FM-BT-3 watchdog (Linux-only; constructor receives null on Windows/Mock
-    // and logs once before exiting). Uses the AddSingleton + AddHostedService
-    // factory pattern so the concrete type is resolvable from DI (per MEMORY
-    // "DI / Hosted Service Gotchas").
+    // FM-BT-3 watchdog snapshot source. On Linux this resolves to the
+    // LinuxBluetoothService singleton; on Windows / Mock / BT-disabled, the
+    // null fallback keeps the watchdog idle.
+    services.AddSingleton<ICaptureStreamSnapshotSource>(sp =>
+    {
+#if !WINDOWS_TARGET
+      var linuxService = sp.GetService<Platform.Bluetooth.LinuxBluetoothService>();
+      if (linuxService != null)
+      {
+        return linuxService;
+      }
+#endif
+      return NullCaptureStreamSnapshotSource.Instance;
+    });
+
+    // FM-BT-3 watchdog. AddSingleton + AddHostedService(factory) so the
+    // concrete type is resolvable from DI (per MEMORY "DI / Hosted Service
+    // Gotchas").
     services.AddSingleton<BluetoothCaptureWatchdog>();
     services.AddHostedService(sp => sp.GetRequiredService<BluetoothCaptureWatchdog>());
 

--- a/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothServiceFactory.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothServiceFactory.cs
@@ -80,6 +80,7 @@ internal sealed class NullBluetoothService : IBluetoothService
   public event EventHandler<TimeSpan>? PositionChanged { add { } remove { } }
   public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged { add { } remove { } }
   public event EventHandler? CaptureStreamRecovered { add { } remove { } }
+  public event EventHandler<CaptureStreamStalledEventArgs>? CaptureStreamStalled { add { } remove { } }
   public float? DeviceVolume => null;
   public Task SetDeviceVolumeAsync(float volume) => Task.CompletedTask;
   public Task NextTrackAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Options;
 using Radio.Core.Configuration;
 using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
+using Radio.Infrastructure.Audio.Services;
 using Radio.Infrastructure.Audio.SoundFlow;
 using Radio.Infrastructure.Platform.Bluetooth.Native;
 using Radio.Metrics;
@@ -21,7 +22,7 @@ using Tmds.DBus;
 
 namespace Radio.Infrastructure.Platform.Bluetooth;
 
-internal sealed class LinuxBluetoothService : IBluetoothService
+internal sealed class LinuxBluetoothService : IBluetoothService, ICaptureStreamSnapshotSource
 {
   private readonly ILogger _logger;
   private readonly BluetoothOptions _options;
@@ -161,12 +162,13 @@ internal sealed class LinuxBluetoothService : IBluetoothService
   public float? DeviceVolume { get; private set; }
 
   /// <summary>
-  /// Snapshot for BluetoothCaptureWatchdog: connected device address + elapsed
-  /// milliseconds since the native capture stream's last OnProcess callback.
-  /// Returns null when no native capture stream is active (no connected device,
-  /// or capture intentionally stopped, or running pw-record fallback).
+  /// Snapshot for <see cref="BluetoothCaptureWatchdog"/>: connected device
+  /// address + elapsed milliseconds since the native capture stream's last
+  /// OnProcess callback. Returns null when no native capture stream is active
+  /// (no connected device, capture intentionally stopped, or running pw-record
+  /// fallback). Implements <see cref="ICaptureStreamSnapshotSource"/>.
   /// </summary>
-  internal (string Address, long ElapsedMs)? GetCaptureStreamSnapshot()
+  public (string Address, long ElapsedMs)? GetCaptureStreamSnapshot()
   {
     var stream = _nativeStream;
     var device = ConnectedDevice;
@@ -178,10 +180,11 @@ internal sealed class LinuxBluetoothService : IBluetoothService
   }
 
   /// <summary>
-  /// Invoked by BluetoothCaptureWatchdog when a stall is confirmed. Raises
-  /// <see cref="CaptureStreamStalled"/> and increments the detection metric.
+  /// Invoked by <see cref="BluetoothCaptureWatchdog"/> when a stall is
+  /// confirmed. Raises <see cref="CaptureStreamStalled"/> and increments the
+  /// detection metric. Implements <see cref="ICaptureStreamSnapshotSource"/>.
   /// </summary>
-  internal void RaiseCaptureStreamStalled(string address, long elapsedMs, int consecutiveChecks)
+  public void RaiseCaptureStreamStalled(string address, long elapsedMs, int consecutiveChecks)
   {
     _metricsCollector?.Increment("bluetooth.capture_stall_detected_total");
     _logger.LogWarning(

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -157,6 +157,10 @@ internal sealed class LinuxBluetoothService : IBluetoothService
   public event EventHandler<TimeSpan>? PositionChanged;
   public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged;
   public event EventHandler? CaptureStreamRecovered;
+  // Raised via RaiseCaptureStreamStalled() invoked by BluetoothCaptureWatchdog (Task 4).
+#pragma warning disable CS0067
+  public event EventHandler<CaptureStreamStalledEventArgs>? CaptureStreamStalled;
+#pragma warning restore CS0067
   public float? DeviceVolume { get; private set; }
 
   private async Task MonitorBtPipelineAsync(CancellationToken cancellationToken)

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -157,11 +157,43 @@ internal sealed class LinuxBluetoothService : IBluetoothService
   public event EventHandler<TimeSpan>? PositionChanged;
   public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged;
   public event EventHandler? CaptureStreamRecovered;
-  // Raised via RaiseCaptureStreamStalled() invoked by BluetoothCaptureWatchdog (Task 4).
-#pragma warning disable CS0067
   public event EventHandler<CaptureStreamStalledEventArgs>? CaptureStreamStalled;
-#pragma warning restore CS0067
   public float? DeviceVolume { get; private set; }
+
+  /// <summary>
+  /// Snapshot for BluetoothCaptureWatchdog: connected device address + elapsed
+  /// milliseconds since the native capture stream's last OnProcess callback.
+  /// Returns null when no native capture stream is active (no connected device,
+  /// or capture intentionally stopped, or running pw-record fallback).
+  /// </summary>
+  internal (string Address, long ElapsedMs)? GetCaptureStreamSnapshot()
+  {
+    var stream = _nativeStream;
+    var device = ConnectedDevice;
+    if (stream == null || device == null)
+    {
+      return null;
+    }
+    return (device.Address, stream.MillisecondsSinceLastOnProcess());
+  }
+
+  /// <summary>
+  /// Invoked by BluetoothCaptureWatchdog when a stall is confirmed. Raises
+  /// <see cref="CaptureStreamStalled"/> and increments the detection metric.
+  /// </summary>
+  internal void RaiseCaptureStreamStalled(string address, long elapsedMs, int consecutiveChecks)
+  {
+    _metricsCollector?.Increment("bluetooth.capture_stall_detected_total");
+    _logger.LogWarning(
+      "BluetoothCaptureWatchdog: stall detected for {Address}, elapsed {Elapsed}ms after {N} consecutive checks",
+      address, elapsedMs, consecutiveChecks);
+    CaptureStreamStalled?.Invoke(this, new CaptureStreamStalledEventArgs
+    {
+      DeviceAddress = address,
+      ElapsedMsSinceLastCallback = elapsedMs,
+      ConsecutiveStalledChecks = consecutiveChecks,
+    });
+  }
 
   private async Task MonitorBtPipelineAsync(CancellationToken cancellationToken)
   {

--- a/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
@@ -42,6 +42,7 @@ public sealed class MockBluetoothService : IBluetoothService
         public event EventHandler<TimeSpan>? PositionChanged { add { } remove { } }
         public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged { add { } remove { } }
         public event EventHandler? CaptureStreamRecovered { add { } remove { } }
+        public event EventHandler<CaptureStreamStalledEventArgs>? CaptureStreamStalled { add { } remove { } }
         public float? DeviceVolume => null;
         public Task SetDeviceVolumeAsync(float volume) => Task.CompletedTask;
         public Task NextTrackAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNativeStream.cs
@@ -3,6 +3,7 @@ using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 using static Radio.Infrastructure.Platform.Bluetooth.Native.PipeWireNative;
 
@@ -48,6 +49,27 @@ internal sealed class PipeWireNativeStream : IDisposable
   private long _onProcessBurstCount; // intervals < 1ms (burst delivery)
   private double _maxOnProcessExecutionMs;
   private DateTime _lastOnProcessLogTime;
+
+  /// <summary>
+  /// Wall-clock-equivalent stopwatch timestamp of the most recent OnProcess callback.
+  /// Zero if OnProcess has not fired yet. Used by BluetoothCaptureWatchdog to detect
+  /// FM-BT-3 silent quiescence. Safe to read from any thread.
+  /// </summary>
+  public long LastOnProcessTimestamp => Volatile.Read(ref _lastOnProcessTimestamp);
+
+  /// <summary>
+  /// Returns the elapsed milliseconds since the last OnProcess callback, or
+  /// <see cref="long.MaxValue"/> if no callback has fired yet.
+  /// </summary>
+  public long MillisecondsSinceLastOnProcess()
+  {
+    var last = LastOnProcessTimestamp;
+    if (last == 0)
+    {
+      return long.MaxValue;
+    }
+    return (long)((Stopwatch.GetTimestamp() - last) / (double)Stopwatch.Frequency * 1000.0);
+  }
 
   // Pinned delegate references to prevent GC collection during native callbacks
   private readonly ProcessDelegate _processDelegate;

--- a/src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs
@@ -241,6 +241,7 @@ internal sealed class WindowsBluetoothService : IBluetoothService
 #endif
 
     public event EventHandler? CaptureStreamRecovered { add { } remove { } }
+    public event EventHandler<CaptureStreamStalledEventArgs>? CaptureStreamStalled { add { } remove { } }
 
     public Task SetDeviceVolumeAsync(float volume)
     {

--- a/tests/Radio.Infrastructure.Tests/Audio/Services/BluetoothCaptureWatchdogTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Services/BluetoothCaptureWatchdogTests.cs
@@ -1,0 +1,179 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Radio.Core.Configuration;
+using Radio.Infrastructure.Audio.Services;
+using Xunit;
+
+namespace Radio.Infrastructure.Tests.Audio.Services;
+
+/// <summary>
+/// Unit tests for <see cref="BluetoothCaptureWatchdog"/>. Uses a fake
+/// <see cref="ICaptureStreamSnapshotSource"/> so the watchdog's threshold +
+/// consecutive-check logic can be exercised without instantiating
+/// <c>LinuxBluetoothService</c> or its D-Bus dependencies.
+/// </summary>
+public class BluetoothCaptureWatchdogTests
+{
+  private static BluetoothCaptureWatchdog CreateWatchdog(
+    ICaptureStreamSnapshotSource source,
+    int thresholdMs,
+    int tickMs,
+    int consecutive)
+  {
+    var opts = new BluetoothOptions
+    {
+      OnProcessStallThresholdMs = thresholdMs,
+      WatchdogTickIntervalMs = tickMs,
+      ConsecutiveStalledChecks = consecutive,
+    };
+    var monitor = new StaticOptionsMonitor<BluetoothOptions>(opts);
+    return new BluetoothCaptureWatchdog(
+      NullLogger<BluetoothCaptureWatchdog>.Instance, monitor, source);
+  }
+
+  private static async Task RunForMsAsync(BluetoothCaptureWatchdog watchdog, int durationMs)
+  {
+    using var cts = new CancellationTokenSource();
+    await watchdog.StartAsync(cts.Token);
+    await Task.Delay(durationMs);
+    cts.Cancel();
+    await watchdog.StopAsync(CancellationToken.None);
+  }
+
+  [Fact]
+  public async Task NoActiveStream_DoesNotRaise()
+  {
+    var source = new FakeSnapshotSource(snapshot: null);
+    var watchdog = CreateWatchdog(source, thresholdMs: 1000, tickMs: 20, consecutive: 2);
+    await RunForMsAsync(watchdog, 250);
+    Assert.Equal(0, source.RaiseCount);
+  }
+
+  [Fact]
+  public async Task BelowThreshold_DoesNotRaise()
+  {
+    var source = new FakeSnapshotSource(("AA:BB:CC:DD:EE:FF", 500L));
+    var watchdog = CreateWatchdog(source, thresholdMs: 1000, tickMs: 20, consecutive: 2);
+    await RunForMsAsync(watchdog, 250);
+    Assert.Equal(0, source.RaiseCount);
+  }
+
+  [Fact]
+  public async Task AboveThreshold_RaisesAfterConsecutiveChecks()
+  {
+    var source = new FakeSnapshotSource(("AA:BB:CC:DD:EE:FF", 6000L));
+    var watchdog = CreateWatchdog(source, thresholdMs: 5000, tickMs: 20, consecutive: 3);
+    await RunForMsAsync(watchdog, 300); // plenty of ticks for 3 consecutive
+    Assert.True(source.RaiseCount >= 1,
+      $"Expected RaiseCount >= 1, got {source.RaiseCount}");
+    Assert.Equal("AA:BB:CC:DD:EE:FF", source.LastRaiseAddress);
+    Assert.Equal(6000L, source.LastRaiseElapsedMs);
+    Assert.True(source.LastRaiseConsecutive >= 3);
+  }
+
+  [Fact]
+  public async Task DisabledByZeroThreshold_DoesNotRaise()
+  {
+    var source = new FakeSnapshotSource(("AA:BB:CC:DD:EE:FF", 99999L));
+    var watchdog = CreateWatchdog(source, thresholdMs: 0, tickMs: 20, consecutive: 1);
+    await RunForMsAsync(watchdog, 200);
+    Assert.Equal(0, source.RaiseCount);
+  }
+
+  [Fact]
+  public async Task IntermittentStall_ResetsCounter()
+  {
+    var source = new FakeSnapshotSource(snapshot: null);
+    var watchdog = CreateWatchdog(source, thresholdMs: 5000, tickMs: 20, consecutive: 5);
+
+    using var cts = new CancellationTokenSource();
+    await watchdog.StartAsync(cts.Token);
+
+    // Phase 1: above threshold for ~2 ticks
+    source.Set(("AA:BB:CC:DD:EE:FF", 6000L));
+    await Task.Delay(60);
+    // Phase 2: recover for ~2 ticks (resets counter)
+    source.Set(("AA:BB:CC:DD:EE:FF", 100L));
+    await Task.Delay(60);
+    // Phase 3: above threshold for ~2 ticks (never reaches 5 consecutive)
+    source.Set(("AA:BB:CC:DD:EE:FF", 6000L));
+    await Task.Delay(60);
+
+    cts.Cancel();
+    await watchdog.StopAsync(CancellationToken.None);
+
+    Assert.Equal(0, source.RaiseCount);
+  }
+
+  /// <summary>
+  /// Verifies that the watchdog idles (never enters its main loop) when a
+  /// <see cref="NullCaptureStreamSnapshotSource"/> is registered. This is the
+  /// Windows / Mock / BT-disabled production path.
+  /// </summary>
+  [Fact]
+  public async Task NullSnapshotSource_ExitsImmediatelyWithoutRaising()
+  {
+    var watchdog = CreateWatchdog(
+      NullCaptureStreamSnapshotSource.Instance,
+      thresholdMs: 1000,
+      tickMs: 20,
+      consecutive: 2);
+    using var cts = new CancellationTokenSource();
+    await watchdog.StartAsync(cts.Token);
+    await Task.Delay(100);
+    Assert.Equal(0, watchdog.ConsecutiveStalledChecksForTest);
+    cts.Cancel();
+    await watchdog.StopAsync(CancellationToken.None);
+  }
+
+  // ---- Test helpers --------------------------------------------------------
+
+  private sealed class FakeSnapshotSource : ICaptureStreamSnapshotSource
+  {
+    private (string Address, long ElapsedMs)? _snapshot;
+    private readonly object _lock = new();
+    public int RaiseCount { get; private set; }
+    public string? LastRaiseAddress { get; private set; }
+    public long LastRaiseElapsedMs { get; private set; }
+    public int LastRaiseConsecutive { get; private set; }
+
+    public FakeSnapshotSource(
+      (string Address, long ElapsedMs)? snapshot = null)
+    {
+      _snapshot = snapshot;
+    }
+
+    public void Set((string Address, long ElapsedMs)? snapshot)
+    {
+      lock (_lock) { _snapshot = snapshot; }
+    }
+
+    public (string Address, long ElapsedMs)? GetCaptureStreamSnapshot()
+    {
+      lock (_lock) { return _snapshot; }
+    }
+
+    public void RaiseCaptureStreamStalled(string address, long elapsedMs, int consecutiveChecks)
+    {
+      lock (_lock)
+      {
+        RaiseCount++;
+        LastRaiseAddress = address;
+        LastRaiseElapsedMs = elapsedMs;
+        LastRaiseConsecutive = consecutiveChecks;
+      }
+    }
+  }
+
+  private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+  {
+    private readonly T _value;
+    public StaticOptionsMonitor(T value) { _value = value; }
+    public T CurrentValue => _value;
+    public T Get(string? name) => _value;
+    public IDisposable OnChange(Action<T, string?> listener) => new NullDisposable();
+
+    private sealed class NullDisposable : IDisposable { public void Dispose() { } }
+  }
+}


### PR DESCRIPTION
## Summary

Implements Plan A from the Cast/BT research arc — a periodic watchdog that detects FM-BT-3 (silent PipeWire OnProcess callback cessation on a long-running BT capture stream), addressing the production bug documented in MEMORY ("Long-running capture device lifecycle bug").

- `PipeWireNativeStream` now exposes `LastOnProcessTimestamp` + `MillisecondsSinceLastOnProcess()` (volatile read, thread-safe).
- New `BluetoothCaptureWatchdog` (`BackgroundService`) polls a thin `ICaptureStreamSnapshotSource` every `BluetoothOptions.WatchdogTickIntervalMs` (default 2 s). If the elapsed time exceeds `OnProcessStallThresholdMs` (default 5 s) for `ConsecutiveStalledChecks` (default 3) consecutive ticks, raises `CaptureStreamStalled` on `IBluetoothService` and increments `bluetooth.capture_stall_detected_total`.
- `BluetoothAudioSource.OnCaptureStreamStalled` funnels into the existing `OnGeneratorStalled(Id)` recovery path, so the `_recoveryInProgress` interlock dedups watchdog-driven recovery with downstream generator-stall recovery.
- Linux-only: on Windows / Mock / BT-disabled the registered `ICaptureStreamSnapshotSource` is `NullCaptureStreamSnapshotSource`, and the watchdog logs once and exits.
- Cross-TFM clean: 0 errors on both `net10.0` and `net10.0-windows10.0.19041.0`.

## Build & test gates

- `dotnet build --configuration Release` → 0 errors, 42 pre-existing IDE0011 analyzer warnings (no new warnings).
- Full test suite (~2,160 tests across 11 test projects) → 0 failed, 4 skipped (pre-existing).
- 6 new unit tests in `tests/Radio.Infrastructure.Tests/Audio/Services/BluetoothCaptureWatchdogTests.cs` covering: no active stream, below threshold, above threshold + consecutive checks, disabled by zero threshold, intermittent stall (counter reset), and Null snapshot source (Windows / Mock path).

## Acceptance criteria (pending Mark UAT)

The plan's Task 9 acceptance criteria — 72 h soak baseline vs. post-change on the live `radio` Ubuntu host, classified by `quiet_host` vs `load_correlated` via `scripts/research/sysload_capture.sh` + `sysload_correlate.py` + `bt_stall_detect.py` + `bt_stall_compare.py` — requires the running production host. **Acceptance-criteria verification pending Mark UAT** (72 h soak + sysload classification per plan Task 9). Success criterion: `events_quiet_host` drops to ≤ 1 over a 72 h soak, with `events_load_correlated` not regressed.

## Operator note (deploy)

Plan Task 8 (Deploy to Ubuntu via `./deploy/Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64`) is deferred to Mark's host. After deploy, verify the watchdog started with:

```bash
ssh mmack@radio "journalctl -u radio-api -p info --since '1 minute ago' | grep -i 'BluetoothCaptureWatchdog'"
```

Expected first log line: `BluetoothCaptureWatchdog: starting (threshold=5000ms, tick=2000ms, consecutive=3)`.

To disable the watchdog without redeploying, set `Bluetooth.OnProcessStallThresholdMs` to `0` in the SQLite config bridge — the IOptionsMonitor change-token will pick it up on the next tick.

## Test plan

- [x] Unit tests for watchdog logic (6 cases incl. threshold, consecutive, disabled, intermittent, null source)
- [x] Build clean across Linux + Windows TFMs (0 errors, no new warnings)
- [x] Full solution test suite passes (~2,160 tests, 0 failed)
- [ ] Deploy to `radio` (Ubuntu N100) — **Mark performs**
- [ ] 72 h soak, verify `events_quiet_host ≤ 1` — **Mark verifies via Task 9 scripts**
- [ ] Verify `events_load_correlated` not regressed — **Mark verifies**
- [ ] Verify no false positives in 1 h paused-phone soak — **Mark verifies**

## Docs Impact

- This PR is implementation-only; the plan/research docs already merged in #387 + #388 describe the design.
- No user/operator/architecture doc updates needed (operator behavior surface is the journald log line + the optional kill-switch via config).

## Out of scope

- Load-correlated stalls (FM-BT-11) — Plan D (CPU affinity), not this PR.
- Recovery quality — this PR triggers existing recovery; whether recovery itself works as well as it could is a separate question.
- Cast-side watchdogs — Cast HM has `LoadMediaWithRecoveryAsync`; DC mode would need its own watchdog (Cast research §7 Idea #8, deferred to Phase 3+).

Branch: \`feat/bt-capture-watchdog\` from \`main\` (PR #388 base).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>