### PR TITLE
feat(bt): gate autoSwitchOnConnect on PW capture-node availability

### DIFF
--- a/scripts/research/bt_autoswitch_audit.py
+++ b/scripts/research/bt_autoswitch_audit.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""bt_autoswitch_audit.py — Audit BT auto-switch behaviour from journalctl logs.
+
+Reads journalctl text on stdin (or a file passed as argv[1]) and counts:
+
+  a) `GetOrCreateSourceAsync(Bluetooth` invocations  (autoswitch attempts)
+  b) `GetAudioCaptureDeviceAsync` retries             (capture acquisition attempts)
+  c) `waiting for PW node` log lines                  (the "PipeWire BT node not found" log
+     line emitted by LinuxBluetoothService at retry time — substring match accepts the
+     exact production log "PipeWire BT node not found for ... (attempt n/m)")
+  d) wall-clock duration spent in retry loops, in hours, computed from the
+     timestamp of the first to the last "waiting" line per session (best-effort:
+     parses journalctl's default `MMM DD HH:MM:SS` and short ISO timestamps).
+
+Output (key=value, one per line):
+
+  switches=<N>
+  getcapture_invocations=<M>
+  waiting_log_lines=<L>
+  retry_loop_hours=<T>
+
+Usage:
+  journalctl -u radio-api --since '24 hours ago' -o cat | bt_autoswitch_audit.py
+  bt_autoswitch_audit.py /path/to/journal.txt
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from datetime import datetime, timezone
+from typing import Iterable, Optional
+
+
+# Substring patterns matched against each log line.
+SWITCH_PATTERN = "GetOrCreateSourceAsync(Bluetooth"
+# GetAudioCaptureDeviceAsync entry log + retry/probe log lines. We match the
+# method name itself to count every invocation/retry.
+GETCAPTURE_PATTERN = "GetAudioCaptureDeviceAsync"
+# The production log line emitted by LinuxBluetoothService when the PW BT node
+# is missing during retry. We also accept the plan's shorthand "waiting for PW node".
+WAITING_PATTERNS = (
+  "PipeWire BT node not found",
+  "waiting for PW node",
+)
+
+
+# Common journalctl timestamp formats.
+# Examples this matches (anchored at start of line):
+#   "May 22 14:37:01"
+#   "2026-05-22T14:37:01"
+#   "2026-05-22 14:37:01"
+_TIMESTAMP_REGEXES = (
+  # Full ISO with optional T separator and optional fractional seconds + TZ
+  re.compile(r"^(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2})"),
+  # Short syslog: "MMM dd HH:MM:SS"
+  re.compile(r"^([A-Za-z]{3} +\d{1,2} \d{2}:\d{2}:\d{2})"),
+)
+
+
+def parse_timestamp(line: str) -> Optional[datetime]:
+  """Best-effort timestamp parse. Returns naive UTC or None."""
+  for rx in _TIMESTAMP_REGEXES:
+    m = rx.match(line)
+    if not m:
+      continue
+    raw = m.group(1).replace("T", " ")
+    # Try ISO first
+    try:
+      return datetime.fromisoformat(raw)
+    except ValueError:
+      pass
+    # Try syslog format. Year is missing — assume current year.
+    try:
+      now = datetime.now(timezone.utc)
+      with_year = f"{now.year} {raw}"
+      return datetime.strptime(with_year, "%Y %b %d %H:%M:%S")
+    except ValueError:
+      continue
+  return None
+
+
+def audit(lines: Iterable[str]) -> dict[str, float]:
+  switches = 0
+  getcapture = 0
+  waiting = 0
+  first_waiting: Optional[datetime] = None
+  last_waiting: Optional[datetime] = None
+
+  for line in lines:
+    if SWITCH_PATTERN in line:
+      switches += 1
+    if GETCAPTURE_PATTERN in line:
+      getcapture += 1
+    if any(p in line for p in WAITING_PATTERNS):
+      waiting += 1
+      ts = parse_timestamp(line)
+      if ts is not None:
+        if first_waiting is None:
+          first_waiting = ts
+        last_waiting = ts
+
+  retry_hours = 0.0
+  if first_waiting is not None and last_waiting is not None:
+    retry_hours = max(0.0, (last_waiting - first_waiting).total_seconds() / 3600.0)
+
+  return {
+    "switches": switches,
+    "getcapture_invocations": getcapture,
+    "waiting_log_lines": waiting,
+    "retry_loop_hours": round(retry_hours, 4),
+  }
+
+
+def main(argv: list[str]) -> int:
+  if len(argv) > 1 and argv[1] not in ("-", "/dev/stdin"):
+    with open(argv[1], "r", encoding="utf-8", errors="replace") as fh:
+      result = audit(fh)
+  else:
+    result = audit(sys.stdin)
+
+  for k, v in result.items():
+    print(f"{k}={v}")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main(sys.argv))

--- a/scripts/research/bt_autoswitch_compare.py
+++ b/scripts/research/bt_autoswitch_compare.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""bt_autoswitch_compare.py — Compare two bt_autoswitch_audit.py artifacts.
+
+Reads a baseline and an "after" artifact (both in key=value form, as produced
+by bt_autoswitch_audit.py) and produces:
+
+  * per-metric deltas (after - baseline)
+  * PASS/FAIL against the success criteria documented in plan task 8.
+
+Success criteria (per the plan):
+  * waiting_log_lines per cycle ≤ 5 — interpreted as "after" ≤ 5 * baseline cycles
+    is fragile, so we adopt the simpler concrete rule:
+      after.waiting_log_lines must be ≤ 5 * EXPECTED_CYCLES (default 48)
+      AND after.waiting_log_lines must be < baseline.waiting_log_lines
+  * retry_loop_hours must drop to 0
+  * getcapture_invocations must NOT regress on happy path — i.e., if both runs
+    used the same number of cycles, after.getcapture_invocations must be
+    ≤ 2 * EXPECTED_CYCLES + baseline.getcapture_invocations * 0.1 tolerance.
+
+Usage:
+  bt_autoswitch_compare.py baseline.txt after.txt [--expected-cycles N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def parse_artifact(path: Path) -> dict[str, float]:
+  out: dict[str, float] = {}
+  for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+    line = raw_line.strip()
+    if not line or "=" not in line:
+      continue
+    key, _, val = line.partition("=")
+    key = key.strip()
+    val = val.strip()
+    try:
+      out[key] = float(val)
+    except ValueError:
+      # Skip lines that aren't numeric — keep this tolerant
+      continue
+  return out
+
+
+def main(argv: list[str]) -> int:
+  parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+  parser.add_argument("baseline", type=Path)
+  parser.add_argument("after", type=Path)
+  parser.add_argument(
+    "--expected-cycles",
+    type=int,
+    default=48,
+    help="Number of pair/unpair cycles the harness ran (default: 48, matches plan task 8)",
+  )
+  args = parser.parse_args(argv[1:])
+
+  base = parse_artifact(args.baseline)
+  after = parse_artifact(args.after)
+
+  print("Metric                      Baseline    After       Delta")
+  print("-" * 60)
+  keys = ["switches", "getcapture_invocations", "waiting_log_lines", "retry_loop_hours"]
+  for k in keys:
+    b = base.get(k, 0.0)
+    a = after.get(k, 0.0)
+    delta = a - b
+    print(f"{k:<28}{b:<12}{a:<12}{delta:+}")
+
+  # PASS/FAIL evaluation
+  failures: list[str] = []
+
+  # waiting_log_lines: must drop dramatically. Allow up to 5 per cycle.
+  waiting_budget = 5 * args.expected_cycles
+  after_waiting = after.get("waiting_log_lines", 0)
+  base_waiting = base.get("waiting_log_lines", 0)
+  if after_waiting > waiting_budget:
+    failures.append(
+      f"waiting_log_lines={after_waiting} exceeds budget of "
+      f"{waiting_budget} (5 × {args.expected_cycles} cycles)"
+    )
+  if base_waiting > 0 and after_waiting >= base_waiting:
+    failures.append(
+      f"waiting_log_lines did not decrease: baseline={base_waiting} after={after_waiting}"
+    )
+
+  # retry_loop_hours: must be 0 (or very near it — allow 0.05 h ≈ 3 min tolerance for clock skew)
+  after_retry = after.get("retry_loop_hours", 0.0)
+  if after_retry > 0.05:
+    failures.append(f"retry_loop_hours={after_retry} > 0.05 h tolerance")
+
+  # getcapture_invocations: no happy-path regression
+  base_getcap = base.get("getcapture_invocations", 0)
+  after_getcap = after.get("getcapture_invocations", 0)
+  getcap_budget = 2 * args.expected_cycles + max(0.0, base_getcap * 0.1)
+  if after_getcap > getcap_budget:
+    failures.append(
+      f"getcapture_invocations={after_getcap} exceeds happy-path budget of "
+      f"{getcap_budget:.0f} (2 × {args.expected_cycles} + 10% tolerance)"
+    )
+
+  print()
+  if failures:
+    print("FAIL")
+    for f in failures:
+      print(f"  - {f}")
+    return 1
+
+  print("PASS")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main(sys.argv))

--- a/scripts/research/bt_pair_unpair_harness.sh
+++ b/scripts/research/bt_pair_unpair_harness.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# bt_pair_unpair_harness.sh — Scripted pair/unpair cycle harness.
+#
+# Drives a test phone through repeated BT power-cycle cycles to exercise the
+# autoswitch gate (FM-BT-1) and gather production-quality measurement artifacts
+# for Plan B (BT autoswitch gate) acceptance verification (plan task 8).
+#
+# Supports two phone drivers:
+#   * adb (Android): `adb shell svc bluetooth disable && svc bluetooth enable`
+#   * blueutil over SSH (iOS/macOS host): toggles BT power on a USB-tethered iPhone
+#
+# Auto-detects the driver from the environment unless overridden via --driver.
+#
+# Usage:
+#   bt_pair_unpair_harness.sh \
+#     --cycles N \
+#     --period-sec X \
+#     [--simulate-no-audio] \
+#     [--driver adb|ssh-blueutil] \
+#     [--ssh-host user@macmini] \
+#     [--device-mac AA:BB:CC:DD:EE:FF]
+#
+# --simulate-no-audio: phone pairs but does NOT start playing audio. This is
+# the FM-BT-1 trigger condition — Connected fires before any A2DP source node
+# appears in PipeWire.
+#
+# Output: one log line per cycle on stdout, plus exit status 0 if all cycles
+# completed.
+
+set -euo pipefail
+
+CYCLES=10
+PERIOD_SEC=60
+SIMULATE_NO_AUDIO=0
+DRIVER=""
+SSH_HOST=""
+DEVICE_MAC=""
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") --cycles N --period-sec X [--simulate-no-audio]
+       [--driver adb|ssh-blueutil] [--ssh-host user@host] [--device-mac AA:BB:CC:DD:EE:FF]
+
+Cycles BT power on the test phone every PERIOD_SEC seconds, for CYCLES iterations.
+
+Drivers:
+  adb            (default if 'adb devices' shows ≥1 device) — Android via USB ADB
+  ssh-blueutil   macOS host with blueutil installed; requires --ssh-host
+
+--simulate-no-audio  Pair-only; never start audio playback. Triggers FM-BT-1.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cycles)             CYCLES="$2"; shift 2 ;;
+    --period-sec)         PERIOD_SEC="$2"; shift 2 ;;
+    --simulate-no-audio)  SIMULATE_NO_AUDIO=1; shift ;;
+    --driver)             DRIVER="$2"; shift 2 ;;
+    --ssh-host)           SSH_HOST="$2"; shift 2 ;;
+    --device-mac)         DEVICE_MAC="$2"; shift 2 ;;
+    -h|--help)            usage; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+# Auto-detect driver
+if [[ -z "$DRIVER" ]]; then
+  if command -v adb >/dev/null 2>&1 && [[ "$(adb devices 2>/dev/null | grep -c device$ || true)" -gt 0 ]]; then
+    DRIVER=adb
+  elif [[ -n "$SSH_HOST" ]]; then
+    DRIVER=ssh-blueutil
+  else
+    echo "ERROR: could not auto-detect driver. Pass --driver and any required hostname." >&2
+    exit 2
+  fi
+fi
+
+log() {
+  printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+bt_power_off() {
+  case "$DRIVER" in
+    adb)           adb shell svc bluetooth disable ;;
+    ssh-blueutil)  ssh "$SSH_HOST" 'blueutil --power 0' ;;
+    *)             echo "Unsupported driver $DRIVER" >&2; return 1 ;;
+  esac
+}
+
+bt_power_on() {
+  case "$DRIVER" in
+    adb)           adb shell svc bluetooth enable ;;
+    ssh-blueutil)  ssh "$SSH_HOST" 'blueutil --power 1' ;;
+    *)             echo "Unsupported driver $DRIVER" >&2; return 1 ;;
+  esac
+}
+
+start_audio() {
+  if [[ "$SIMULATE_NO_AUDIO" -eq 1 ]]; then
+    log "    -> simulate-no-audio set, NOT starting audio (FM-BT-1 trigger)"
+    return 0
+  fi
+  case "$DRIVER" in
+    adb)
+      # Trigger media play key. The phone must already have audio queued up
+      # in its default media app for this to actually start playback.
+      adb shell input keyevent 126  # KEYCODE_MEDIA_PLAY
+      ;;
+    ssh-blueutil)
+      # No clean way to remote-trigger audio on macOS via blueutil alone.
+      # Operator should pre-stage a paused track and rely on auto-resume on connect.
+      log "    -> ssh-blueutil: cannot auto-trigger audio; ensure media is auto-resume"
+      ;;
+  esac
+}
+
+log "Starting harness: driver=$DRIVER cycles=$CYCLES period_sec=$PERIOD_SEC simulate_no_audio=$SIMULATE_NO_AUDIO"
+
+for ((i = 1; i <= CYCLES; i++)); do
+  log "Cycle $i/$CYCLES: BT power off"
+  bt_power_off || log "    (power-off failed; continuing)"
+  sleep 5
+
+  log "Cycle $i/$CYCLES: BT power on"
+  bt_power_on || log "    (power-on failed; continuing)"
+  sleep 10
+  start_audio || true
+
+  remaining=$((PERIOD_SEC - 15))
+  if (( remaining > 0 )); then
+    log "Cycle $i/$CYCLES: sleeping ${remaining}s before next cycle"
+    sleep "$remaining"
+  fi
+done
+
+log "Harness complete after $CYCLES cycles."

--- a/src/Radio.API/appsettings.json
+++ b/src/Radio.API/appsettings.json
@@ -209,6 +209,9 @@
     "ReconnectBaseDelayMs": 3000,
     "ReconnectMaxDelayMs": 60000,
     "MaxReconnectAttempts": 20,
+    "AutoSwitchProbeWindowMs": 5000,
+    "AutoSwitchMaxWaitMs": 60000,
+    "CaptureNodeRescanIntervalMs": 1000,
     "Pbap": {
       "AutoSyncOnConnect": true,
       "SyncStaleThresholdHours": 24,

--- a/src/Radio.Core/Configuration/BluetoothOptions.cs
+++ b/src/Radio.Core/Configuration/BluetoothOptions.cs
@@ -75,6 +75,25 @@ public class BluetoothOptions
 
   /// <summary>Maximum number of reconnection attempts before giving up.</summary>
   public int MaxReconnectAttempts { get; set; } = 20;
+
+  /// <summary>
+  /// How long the auto-switch probes for the PipeWire capture node before falling back
+  /// to event-driven wait (milliseconds). The probe interval is fixed at 500 ms.
+  /// </summary>
+  public int AutoSwitchProbeWindowMs { get; set; } = 5000;
+
+  /// <summary>
+  /// Maximum time the auto-switch waits for a CaptureNodeAvailable event before giving up
+  /// (milliseconds). Default 60 s — typical phone-attaches-A2DP delay is well under that.
+  /// </summary>
+  public int AutoSwitchMaxWaitMs { get; set; } = 60000;
+
+  /// <summary>
+  /// Interval at which LinuxBluetoothService re-scans for newly-appeared PW BT nodes
+  /// (milliseconds). The re-scan raises CaptureNodeAvailable for any node not present in
+  /// the previous scan.
+  /// </summary>
+  public int CaptureNodeRescanIntervalMs { get; set; } = 1000;
 }
 
 /// <summary>

--- a/src/Radio.Core/Interfaces/Audio/IBluetoothService.cs
+++ b/src/Radio.Core/Interfaces/Audio/IBluetoothService.cs
@@ -96,6 +96,13 @@ public interface IBluetoothService : IAsyncDisposable
   /// </summary>
   void StopAudioCapture();
 
+  /// <summary>
+  /// Probes whether a PipeWire BT capture node currently exists for the given device.
+  /// On non-Linux platforms returns true (audio routing is platform-managed).
+  /// Does not acquire the capture — pure probe.
+  /// </summary>
+  Task<bool> IsCaptureNodeAvailableAsync(string deviceAddress, CancellationToken cancellationToken = default);
+
   /// <summary>Event raised when adapter state changes.</summary>
   event EventHandler<BluetoothAdapterStateChangedEventArgs>? StateChanged;
 
@@ -113,6 +120,13 @@ public interface IBluetoothService : IAsyncDisposable
   /// Subscribers should re-attach the capture generator to their audio mixer.
   /// </summary>
   event EventHandler? CaptureStreamRecovered;
+
+  /// <summary>
+  /// Raised when a previously-absent PipeWire BT capture node has appeared for the
+  /// connected device. Fires once per appearance; subscribers wishing to act repeatedly
+  /// must re-subscribe.
+  /// </summary>
+  event EventHandler<CaptureNodeAvailableEventArgs>? CaptureNodeAvailable;
 
   /// <summary>Event raised when playback metadata changes (Track, Artist, etc.).</summary>
   event EventHandler<BluetoothPlaybackMetadata>? MetadataChanged;
@@ -234,4 +248,20 @@ public class BluetoothVolumeChangedEventArgs : EventArgs
 {
   /// <summary>Normalized volume (0.0 to 1.0).</summary>
   public required float Volume { get; init; }
+}
+
+/// <summary>
+/// Event args for <see cref="IBluetoothService.CaptureNodeAvailable"/> — fired when a
+/// previously-absent PipeWire BT capture node appears.
+/// </summary>
+public class CaptureNodeAvailableEventArgs : EventArgs
+{
+  /// <summary>The Bluetooth address of the device whose capture node became available.</summary>
+  public required string DeviceAddress { get; init; }
+
+  /// <summary>
+  /// PipeWire object.serial of the discovered node, or 0 if not known to the probe.
+  /// (The probe path may not always extract a serial; the full acquisition path does.)
+  /// </summary>
+  public required int PipeWireSerial { get; init; }
 }

--- a/src/Radio.Infrastructure/Audio/Services/BluetoothAutoSwitchService.cs
+++ b/src/Radio.Infrastructure/Audio/Services/BluetoothAutoSwitchService.cs
@@ -4,6 +4,7 @@ using Radio.Core.Configuration;
 using Radio.Core.Events;
 using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
+using Radio.Metrics;
 
 namespace Radio.Infrastructure.Audio.Services;
 
@@ -11,6 +12,15 @@ namespace Radio.Infrastructure.Audio.Services;
 /// Handles automatic switching to Bluetooth source when a device connects,
 /// and pre-warming Bluetooth on startup if configured.
 /// Extracted from AudioManager to separate Bluetooth orchestration concerns.
+///
+/// Plan B (BT autoswitch gate) — `OnBluetoothDeviceConnected` is gated on the
+/// presence of the PipeWire BT capture node. The handler first probes
+/// <see cref="IBluetoothService.IsCaptureNodeAvailableAsync"/> for up to
+/// <see cref="BluetoothOptions.AutoSwitchProbeWindowMs"/>; if the node is
+/// already present we switch immediately. Otherwise we subscribe to
+/// <see cref="IBluetoothService.CaptureNodeAvailable"/> for up to
+/// <see cref="BluetoothOptions.AutoSwitchMaxWaitMs"/>, switching when the
+/// node finally appears (or abandoning the switch on timeout).
 /// </summary>
 public class BluetoothAutoSwitchService : IDisposable
 {
@@ -18,18 +28,21 @@ public class BluetoothAutoSwitchService : IDisposable
   private readonly IBluetoothService _bluetoothService;
   private readonly IOptionsMonitor<BluetoothOptions> _bluetoothOptions;
   private readonly Func<IAudioManager> _getAudioManager;
+  private readonly IMetricsCollector? _metricsCollector;
   private bool _disposed;
 
   public BluetoothAutoSwitchService(
     ILogger<BluetoothAutoSwitchService> logger,
     IBluetoothService bluetoothService,
     IOptionsMonitor<BluetoothOptions> bluetoothOptions,
-    Func<IAudioManager> getAudioManager)
+    Func<IAudioManager> getAudioManager,
+    IMetricsCollector? metricsCollector = null)
   {
     _logger = logger;
     _bluetoothService = bluetoothService;
     _bluetoothOptions = bluetoothOptions;
     _getAudioManager = getAudioManager;
+    _metricsCollector = metricsCollector;
 
     _bluetoothService.DeviceConnected += OnBluetoothDeviceConnected;
   }
@@ -51,13 +64,14 @@ public class BluetoothAutoSwitchService : IDisposable
   }
 
   /// <summary>
-  /// Auto-switch to Bluetooth when a device connects if enabled.
+  /// Auto-switch to Bluetooth when a device connects — gated on capture-node availability.
   /// </summary>
   private async void OnBluetoothDeviceConnected(object? sender, BluetoothDeviceConnectedEventArgs e)
   {
     try
     {
-      if (!_bluetoothOptions.CurrentValue.AutoSwitchOnConnect)
+      var opts = _bluetoothOptions.CurrentValue;
+      if (!opts.AutoSwitchOnConnect)
       {
         return;
       }
@@ -75,11 +89,96 @@ public class BluetoothAutoSwitchService : IDisposable
         return;
       }
 
-      await audioManager.GetOrCreateSourceAsync(AudioSourceType.Bluetooth, switchToSource: true);
+      // Short-bounded probe for PW capture node presence — typical happy path.
+      using var probeCts = new CancellationTokenSource(opts.AutoSwitchProbeWindowMs);
+      var nodeReady = await ProbeForNodeAsync(e.Device.Address, probeCts.Token);
+      if (nodeReady)
+      {
+        _logger.LogInformation(
+          "BT auto-switch: PW node ready, switching immediately for {Address}",
+          e.Device.Address);
+        await audioManager.GetOrCreateSourceAsync(AudioSourceType.Bluetooth, switchToSource: true);
+        return;
+      }
+
+      // Node not ready inside probe window → defer to event subscription.
+      _logger.LogInformation(
+        "BT auto-switch: PW node not ready for {Address} after {Probe}ms; subscribing to CaptureNodeAvailable (max wait {Max}ms)",
+        e.Device.Address, opts.AutoSwitchProbeWindowMs, opts.AutoSwitchMaxWaitMs);
+      _metricsCollector?.Increment("bluetooth.autoswitch_deferred_total");
+      await WaitForNodeOrTimeoutAsync(e.Device.Address, opts.AutoSwitchMaxWaitMs);
     }
     catch (Exception ex)
     {
       _logger.LogError(ex, "Failed to auto-switch to Bluetooth after device connect {Device}", e.Device.Address);
+    }
+  }
+
+  /// <summary>
+  /// Probes <see cref="IBluetoothService.IsCaptureNodeAvailableAsync"/> every 500 ms
+  /// until either the node appears or the supplied token is cancelled.
+  /// </summary>
+  private async Task<bool> ProbeForNodeAsync(string address, CancellationToken ct)
+  {
+    while (!ct.IsCancellationRequested)
+    {
+      if (await _bluetoothService.IsCaptureNodeAvailableAsync(address, ct))
+      {
+        return true;
+      }
+      try
+      {
+        await Task.Delay(500, ct);
+      }
+      catch (OperationCanceledException)
+      {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  /// <summary>
+  /// Subscribes to <see cref="IBluetoothService.CaptureNodeAvailable"/> for the given
+  /// device address with a hard timeout. On success, performs the deferred source switch.
+  /// On timeout, increments <c>bluetooth.autoswitch_abandoned_total</c> and logs.
+  /// </summary>
+  private async Task WaitForNodeOrTimeoutAsync(string address, int timeoutMs)
+  {
+    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+    EventHandler<CaptureNodeAvailableEventArgs>? handler = null;
+    handler = (_, evt) =>
+    {
+      if (string.Equals(evt.DeviceAddress, address, StringComparison.OrdinalIgnoreCase))
+      {
+        tcs.TrySetResult(true);
+      }
+    };
+    _bluetoothService.CaptureNodeAvailable += handler;
+    try
+    {
+      var timeoutTask = Task.Delay(timeoutMs);
+      var winner = await Task.WhenAny(tcs.Task, timeoutTask);
+      if (winner == tcs.Task)
+      {
+        _logger.LogInformation("BT auto-switch: PW node arrived for {Address}, switching", address);
+        var audioManager = _getAudioManager();
+        if (audioManager.ActiveSource?.Type != AudioSourceType.Bluetooth)
+        {
+          await audioManager.GetOrCreateSourceAsync(AudioSourceType.Bluetooth, switchToSource: true);
+        }
+      }
+      else
+      {
+        _logger.LogWarning(
+          "BT auto-switch: PW node did not appear within {Max}ms for {Address}; abandoning switch",
+          timeoutMs, address);
+        _metricsCollector?.Increment("bluetooth.autoswitch_abandoned_total");
+      }
+    }
+    finally
+    {
+      _bluetoothService.CaptureNodeAvailable -= handler;
     }
   }
 

--- a/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
+++ b/src/Radio.Infrastructure/DependencyInjection/AudioServiceExtensions.cs
@@ -175,7 +175,8 @@ public static class AudioServiceExtensions
       sp.GetRequiredService<ILogger<BluetoothAutoSwitchService>>(),
       sp.GetRequiredService<IBluetoothService>(),
       sp.GetRequiredService<IOptionsMonitor<BluetoothOptions>>(),
-      () => sp.GetRequiredService<IAudioManager>()));
+      () => sp.GetRequiredService<IAudioManager>(),
+      sp.GetService<IMetricsCollector>()));
 
     // Register event audio source services
     services.AddEventAudioSources(configuration);

--- a/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothServiceFactory.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/BluetoothServiceFactory.cs
@@ -80,6 +80,8 @@ internal sealed class NullBluetoothService : IBluetoothService
   public event EventHandler<TimeSpan>? PositionChanged { add { } remove { } }
   public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged { add { } remove { } }
   public event EventHandler? CaptureStreamRecovered { add { } remove { } }
+  // Null service never raises CaptureNodeAvailable.
+  public event EventHandler<CaptureNodeAvailableEventArgs>? CaptureNodeAvailable { add { } remove { } }
   public float? DeviceVolume => null;
   public Task SetDeviceVolumeAsync(float volume) => Task.CompletedTask;
   public Task NextTrackAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
@@ -143,6 +145,10 @@ internal sealed class NullBluetoothService : IBluetoothService
   }
 
   public void StopAudioCapture() { }
+
+  // Null service has no capture node to probe — return false (treat as not-available).
+  public Task<bool> IsCaptureNodeAvailableAsync(string deviceAddress, CancellationToken cancellationToken = default)
+      => Task.FromResult(false);
 
   public ValueTask DisposeAsync()
   {

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -66,6 +66,15 @@ internal sealed class LinuxBluetoothService : IBluetoothService
   private int _pipelineRecoveryFailures;
   private bool _captureIntentionallyStopped;
 
+  // Periodic PW BT-node rescan loop (Plan B: BT autoswitch gate).
+  // The rescan polls `pw-cli list-objects` every CaptureNodeRescanIntervalMs and raises
+  // CaptureNodeAvailable for any node that transitioned from absent to present for the
+  // connected device. Lives until DisposeAsync or until no device is connected.
+  private CancellationTokenSource? _rescanCts;
+  private Task? _rescanTask;
+  private readonly HashSet<string> _knownNodeAddresses = new(StringComparer.OrdinalIgnoreCase);
+  private readonly object _knownNodesLock = new();
+
   public LinuxBluetoothService(
     ILogger logger,
     IOptions<BluetoothOptions> options,
@@ -157,9 +166,7 @@ internal sealed class LinuxBluetoothService : IBluetoothService
   public event EventHandler<TimeSpan>? PositionChanged;
   public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged;
   public event EventHandler? CaptureStreamRecovered;
-#pragma warning disable CS0067 // CaptureNodeAvailable is raised by the periodic rescan loop (Task 3)
   public event EventHandler<CaptureNodeAvailableEventArgs>? CaptureNodeAvailable;
-#pragma warning restore CS0067
   public float? DeviceVolume { get; private set; }
 
   private async Task MonitorBtPipelineAsync(CancellationToken cancellationToken)
@@ -594,6 +601,7 @@ internal sealed class LinuxBluetoothService : IBluetoothService
           _logger.LogInformation("Bluetooth device already connected: {DeviceName} ({Address})",
             device.Name, device.Address);
           _pipelineRecoveryFailures = 0;
+          EnsureRescanLoopRunning();
           DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = device });
         }
       }
@@ -630,6 +638,7 @@ internal sealed class LinuxBluetoothService : IBluetoothService
         _ = SetDiscoverableAsync(false);
 
         _pipelineRecoveryFailures = 0;
+        EnsureRescanLoopRunning();
         DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = device });
       }
 
@@ -715,6 +724,7 @@ internal sealed class LinuxBluetoothService : IBluetoothService
               _ = SetDiscoverableAsync(false);
 
               _pipelineRecoveryFailures = 0;
+              EnsureRescanLoopRunning();
               DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = updatedDevice });
             }
             else
@@ -737,6 +747,7 @@ internal sealed class LinuxBluetoothService : IBluetoothService
 
               RecordDisconnectionMetrics();
               StopCaptureSubprocess();
+              StopRescanLoop();
               // Clean up media transport on disconnect
               _transportPropertiesWatcher?.Dispose();
               _transportPropertiesWatcher = null;
@@ -1305,6 +1316,94 @@ internal sealed class LinuxBluetoothService : IBluetoothService
     {
       _logger.LogDebug(ex, "IsCaptureNodeAvailableAsync probe failed (treating as not-available)");
       return false;
+    }
+  }
+
+  /// <summary>
+  /// Starts the periodic PW BT-node rescan loop if not already running. Idempotent —
+  /// safe to call from multiple DeviceConnected handlers.
+  /// </summary>
+  private void EnsureRescanLoopRunning()
+  {
+    if (_rescanTask != null && !_rescanTask.IsCompleted)
+    {
+      return;
+    }
+    _rescanCts = new CancellationTokenSource();
+    var token = _rescanCts.Token;
+    _rescanTask = Task.Run(() => RescanLoopAsync(token), token);
+  }
+
+  /// <summary>
+  /// Stops the rescan loop and clears the known-node-address cache.
+  /// Called from device-disconnect path and DisposeAsync.
+  /// </summary>
+  private void StopRescanLoop()
+  {
+    try
+    {
+      _rescanCts?.Cancel();
+    }
+    catch (ObjectDisposedException) { /* already torn down */ }
+    _rescanCts?.Dispose();
+    _rescanCts = null;
+    _rescanTask = null;
+    lock (_knownNodesLock)
+    {
+      _knownNodeAddresses.Clear();
+    }
+  }
+
+  /// <summary>
+  /// Periodic rescan loop. Polls IsCaptureNodeAvailableAsync against the currently-connected
+  /// device every <see cref="BluetoothOptions.CaptureNodeRescanIntervalMs"/>; raises
+  /// <see cref="CaptureNodeAvailable"/> on the absent→present transition.
+  /// </summary>
+  private async Task RescanLoopAsync(CancellationToken ct)
+  {
+    var interval = Math.Max(250, _options.CaptureNodeRescanIntervalMs);
+    while (!ct.IsCancellationRequested)
+    {
+      try
+      {
+        var connectedAddress = ConnectedDevice?.Address;
+        if (connectedAddress != null)
+        {
+          var available = await IsCaptureNodeAvailableAsync(connectedAddress, ct);
+          bool wasKnown;
+          lock (_knownNodesLock)
+          {
+            wasKnown = _knownNodeAddresses.Contains(connectedAddress);
+            if (available)
+            {
+              _knownNodeAddresses.Add(connectedAddress);
+            }
+            else
+            {
+              _knownNodeAddresses.Remove(connectedAddress);
+            }
+          }
+          if (available && !wasKnown)
+          {
+            _logger.LogInformation("PW capture node appeared for {Address}", connectedAddress);
+            _metricsCollector?.Increment("bluetooth.capture_node_appeared_total");
+            CaptureNodeAvailable?.Invoke(this, new CaptureNodeAvailableEventArgs
+            {
+              DeviceAddress = connectedAddress,
+              // Serial is filled by the full acquisition path; not needed for the gate decision.
+              PipeWireSerial = 0
+            });
+          }
+        }
+      }
+      catch (OperationCanceledException) { break; }
+      catch (Exception ex)
+      {
+        _logger.LogDebug(ex, "Rescan loop iteration failed");
+      }
+
+      try { await Task.Delay(interval, ct); }
+      catch (OperationCanceledException) { break; }
     }
   }
 
@@ -1965,6 +2064,8 @@ internal sealed class LinuxBluetoothService : IBluetoothService
     _pipelineMonitorCts?.Cancel();
     _pipelineMonitorCts?.Dispose();
     _pipelineMonitorCts = null;
+
+    StopRescanLoop();
 
     _reconnectionLoop?.Dispose();
     _reconnectionLoop = null;

--- a/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/LinuxBluetoothService.cs
@@ -157,6 +157,9 @@ internal sealed class LinuxBluetoothService : IBluetoothService
   public event EventHandler<TimeSpan>? PositionChanged;
   public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged;
   public event EventHandler? CaptureStreamRecovered;
+#pragma warning disable CS0067 // CaptureNodeAvailable is raised by the periodic rescan loop (Task 3)
+  public event EventHandler<CaptureNodeAvailableEventArgs>? CaptureNodeAvailable;
+#pragma warning restore CS0067
   public float? DeviceVolume { get; private set; }
 
   private async Task MonitorBtPipelineAsync(CancellationToken cancellationToken)
@@ -1215,32 +1218,9 @@ internal sealed class LinuxBluetoothService : IBluetoothService
 
     try
     {
-      var psi = new ProcessStartInfo
+      var output = await RunPwCliListNodesAsync(cancellationToken);
+      if (output == null)
       {
-        FileName = "pw-cli",
-        Arguments = "list-objects",
-        RedirectStandardOutput = true,
-        RedirectStandardError = true,
-        UseShellExecute = false,
-        CreateNoWindow = true
-      };
-
-      using var process = Process.Start(psi);
-      if (process == null)
-      {
-        _logger.LogWarning("Failed to start pw-cli process");
-        return (null, 0, 0);
-      }
-
-      var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-      var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
-      await process.WaitForExitAsync(cancellationToken);
-
-      if (process.ExitCode != 0 || output.Length == 0)
-      {
-        _logger.LogDebug("pw-cli exit={ExitCode}, stdout={StdoutLen}b, stderr={Stderr}",
-          process.ExitCode, output.Length,
-          stderr.Length > 200 ? stderr[..200] : stderr.TrimEnd());
         return (null, 0, 0);
       }
 
@@ -1260,6 +1240,72 @@ internal sealed class LinuxBluetoothService : IBluetoothService
     }
 
     return (null, 0, 0);
+  }
+
+  /// <summary>
+  /// Runs `pw-cli list-objects` and returns the stdout payload, or null on failure.
+  /// Shared by the probe (<see cref="IsCaptureNodeAvailableAsync"/>) and the full
+  /// acquisition path (<see cref="FindPipeWireBluetoothNodeAsync"/>).
+  /// </summary>
+  private async Task<string?> RunPwCliListNodesAsync(CancellationToken cancellationToken)
+  {
+    var psi = new ProcessStartInfo
+    {
+      FileName = "pw-cli",
+      Arguments = "list-objects",
+      RedirectStandardOutput = true,
+      RedirectStandardError = true,
+      UseShellExecute = false,
+      CreateNoWindow = true
+    };
+
+    using var process = Process.Start(psi);
+    if (process == null)
+    {
+      _logger.LogWarning("Failed to start pw-cli process");
+      return null;
+    }
+
+    var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+    var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
+    await process.WaitForExitAsync(cancellationToken);
+
+    if (process.ExitCode != 0 || output.Length == 0)
+    {
+      _logger.LogDebug("pw-cli exit={ExitCode}, stdout={StdoutLen}b, stderr={Stderr}",
+        process.ExitCode, output.Length,
+        stderr.Length > 200 ? stderr[..200] : stderr.TrimEnd());
+      return null;
+    }
+
+    return output;
+  }
+
+  /// <summary>
+  /// Probes whether a PipeWire bluez_input source node exists for the given BT address.
+  /// Pure probe — does NOT acquire the capture. Returns false on transient errors (treated
+  /// as not-available so the caller falls through to the deferred event subscription).
+  /// </summary>
+  public async Task<bool> IsCaptureNodeAvailableAsync(string deviceAddress, CancellationToken cancellationToken = default)
+  {
+    var prefix = $"bluez_input.{deviceAddress.Replace(':', '_')}";
+    try
+    {
+      var output = await RunPwCliListNodesAsync(cancellationToken);
+      if (output == null)
+      {
+        return false;
+      }
+
+      var (nodeName, _, _) = ParsePwCliOutputForBtNode(output, prefix);
+      return nodeName != null;
+    }
+    catch (OperationCanceledException) { throw; }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "IsCaptureNodeAvailableAsync probe failed (treating as not-available)");
+      return false;
+    }
   }
 
   /// <summary>

--- a/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
@@ -42,6 +42,8 @@ public sealed class MockBluetoothService : IBluetoothService
         public event EventHandler<TimeSpan>? PositionChanged { add { } remove { } }
         public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged { add { } remove { } }
         public event EventHandler? CaptureStreamRecovered { add { } remove { } }
+        // Mock never raises CaptureNodeAvailable — the platform manages capture-node visibility.
+        public event EventHandler<CaptureNodeAvailableEventArgs>? CaptureNodeAvailable { add { } remove { } }
         public float? DeviceVolume => null;
         public Task SetDeviceVolumeAsync(float volume) => Task.CompletedTask;
         public Task NextTrackAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
@@ -119,6 +121,10 @@ public sealed class MockBluetoothService : IBluetoothService
         }
 
         public void StopAudioCapture() { }
+
+        // Mock always reports the capture node as available — platform-equivalent stub.
+        public Task<bool> IsCaptureNodeAvailableAsync(string deviceAddress, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
 
         public ValueTask DisposeAsync()
         {

--- a/src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/WindowsBluetoothService.cs
@@ -241,6 +241,14 @@ internal sealed class WindowsBluetoothService : IBluetoothService
 #endif
 
     public event EventHandler? CaptureStreamRecovered { add { } remove { } }
+    // Windows never raises CaptureNodeAvailable — Windows audio routing is platform-managed
+    // and there is no PipeWire-style capture-node concept on this TFM.
+    public event EventHandler<CaptureNodeAvailableEventArgs>? CaptureNodeAvailable { add { } remove { } }
+
+    // Windows always reports the capture node as available — the platform manages routing
+    // through WASAPI/A2DP sink, no probe equivalent is needed.
+    public Task<bool> IsCaptureNodeAvailableAsync(string deviceAddress, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
 
     public Task SetDeviceVolumeAsync(float volume)
     {

--- a/tests/Radio.Infrastructure.Tests/Audio/Services/BluetoothAutoSwitchServiceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Services/BluetoothAutoSwitchServiceTests.cs
@@ -71,6 +71,12 @@ public class BluetoothAutoSwitchServiceTests
       }
     }
 
+    // Codec observability — added by PR #389 (codec observability); the FakeBluetoothService
+    // is unused by codec-related code paths, so a permanent null-impl is correct here.
+    public event EventHandler<A2dpCodecChangedEventArgs>? A2dpCodecChanged { add { } remove { } }
+    public Task<A2dpCodecInfo?> GetA2dpCodecInfoAsync(string deviceAddress, CancellationToken ct = default)
+      => Task.FromResult<A2dpCodecInfo?>(null);
+
     public Task<bool> StartAsync(string deviceName, CancellationToken cancellationToken = default)
       => Task.FromResult(true);
     public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/Radio.Infrastructure.Tests/Audio/Services/BluetoothAutoSwitchServiceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Services/BluetoothAutoSwitchServiceTests.cs
@@ -2,57 +2,194 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Radio.Core.Configuration;
-using Radio.Core.Events;
 using Radio.Core.Interfaces;
 using Radio.Core.Interfaces.Audio;
 using Radio.Infrastructure.Audio.Services;
+using Radio.Metrics;
 
 namespace Radio.Infrastructure.Tests.Audio.Services;
 
-public class BluetoothAutoSwitchServiceTests : IDisposable
+/// <summary>
+/// Tests for <see cref="BluetoothAutoSwitchService"/> covering both the pre-warm path
+/// and the gated auto-switch logic introduced in Plan B (BT autoswitch gate).
+/// </summary>
+public class BluetoothAutoSwitchServiceTests
 {
-  private readonly Mock<ILogger<BluetoothAutoSwitchService>> _loggerMock;
-  private readonly Mock<IBluetoothService> _bluetoothServiceMock;
-  private readonly Mock<IOptionsMonitor<BluetoothOptions>> _bluetoothOptionsMock;
-  private readonly Mock<IAudioManager> _audioManagerMock;
-  private readonly BluetoothOptions _options;
-  private readonly BluetoothAutoSwitchService _sut;
-
-  public BluetoothAutoSwitchServiceTests()
+  // Fake driver replaces Moq for the gating flow because we need to
+  // (a) tally subscriber count on the CaptureNodeAvailable event and
+  // (b) deterministically raise the event mid-test.
+  private sealed class FakeBluetoothService : IBluetoothService
   {
-    _loggerMock = new Mock<ILogger<BluetoothAutoSwitchService>>();
-    _bluetoothServiceMock = new Mock<IBluetoothService>();
-    _bluetoothOptionsMock = new Mock<IOptionsMonitor<BluetoothOptions>>();
-    _audioManagerMock = new Mock<IAudioManager>();
+    public bool IsAvailable { get; set; } = true;
+    public BluetoothAdapterState State => BluetoothAdapterState.On;
+    public IReadOnlyList<BluetoothDeviceInfo> PairedDevices => Array.Empty<BluetoothDeviceInfo>();
+    public IReadOnlyList<BluetoothDeviceInfo> DiscoveredDevices => Array.Empty<BluetoothDeviceInfo>();
+    public bool IsDiscovering => false;
+    public BluetoothDeviceInfo? ConnectedDevice { get; set; }
+    public bool IsAudioManagedByPlatform => false;
+    public bool IsCaptureNodeAvailable { get; set; }
+    public float? DeviceVolume => null;
+    public bool IsReconnecting => false;
+    public BluetoothDisconnectReason? LastDisconnectReason => null;
+    public BluetoothPipelineStatus PipelineStatus => BluetoothPipelineStatus.Healthy;
 
-    _options = new BluetoothOptions
+    public int CaptureNodeAvailableSubscriberCount { get; private set; }
+
+    public event EventHandler<BluetoothAdapterStateChangedEventArgs>? StateChanged
+    { add { } remove { } }
+    public event EventHandler<BluetoothDeviceConnectedEventArgs>? DeviceConnected;
+    public event EventHandler<BluetoothDeviceDisconnectedEventArgs>? DeviceDisconnected
+    { add { } remove { } }
+    public event EventHandler<BluetoothDeviceDiscoveredEventArgs>? DeviceDiscovered
+    { add { } remove { } }
+    public event EventHandler? CaptureStreamRecovered { add { } remove { } }
+    public event EventHandler<BluetoothPlaybackMetadata>? MetadataChanged
+    { add { } remove { } }
+    public event EventHandler<BluetoothPlaybackStatus>? PlaybackStatusChanged
+    { add { } remove { } }
+    public event EventHandler<TimeSpan>? PositionChanged { add { } remove { } }
+    public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged
+    { add { } remove { } }
+
+    private readonly List<EventHandler<CaptureNodeAvailableEventArgs>> _captureHandlers = new();
+    public event EventHandler<CaptureNodeAvailableEventArgs>? CaptureNodeAvailable
+    {
+      add
+      {
+        if (value != null)
+        {
+          _captureHandlers.Add(value);
+          CaptureNodeAvailableSubscriberCount = _captureHandlers.Count;
+        }
+      }
+      remove
+      {
+        if (value != null && _captureHandlers.Remove(value))
+        {
+          CaptureNodeAvailableSubscriberCount = _captureHandlers.Count;
+        }
+      }
+    }
+
+    public Task<bool> StartAsync(string deviceName, CancellationToken cancellationToken = default)
+      => Task.FromResult(true);
+    public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task StartDiscoveryAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task StopDiscoveryAsync() => Task.CompletedTask;
+    public Task<bool> PairDeviceAsync(string deviceAddress, CancellationToken cancellationToken = default)
+      => Task.FromResult(true);
+    public Task<bool> UnpairDeviceAsync(string deviceAddress, CancellationToken cancellationToken = default)
+      => Task.FromResult(true);
+    public Task<bool> AcceptConnectionAsync(string deviceAddress, CancellationToken cancellationToken = default)
+      => Task.FromResult(true);
+    public Task<bool> ConnectAsync(string deviceAddress, CancellationToken cancellationToken = default)
+      => Task.FromResult(true);
+    public Task DisconnectAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task DisconnectAsync(string deviceAddress, CancellationToken cancellationToken = default)
+      => Task.CompletedTask;
+    public Task<object?> GetAudioCaptureDeviceAsync(CancellationToken cancellationToken = default)
+      => Task.FromResult<object?>(null);
+    public void StopAudioCapture() { }
+    public Task<bool> IsCaptureNodeAvailableAsync(string deviceAddress, CancellationToken cancellationToken = default)
+      => Task.FromResult(IsCaptureNodeAvailable);
+    public Task SetDeviceVolumeAsync(float volume) => Task.CompletedTask;
+    public Task NextTrackAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task PreviousTrackAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public void CancelReconnection() { }
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public void SimulateDeviceConnected(string address)
+    {
+      var device = new BluetoothDeviceInfo
+      {
+        Address = address,
+        Name = "Test Phone",
+        IsPaired = true,
+        IsConnected = true
+      };
+      ConnectedDevice = device;
+      DeviceConnected?.Invoke(this, new BluetoothDeviceConnectedEventArgs { Device = device });
+    }
+
+    public void RaiseCaptureNodeAvailable(string address)
+    {
+      var args = new CaptureNodeAvailableEventArgs { DeviceAddress = address, PipeWireSerial = 0 };
+      foreach (var h in _captureHandlers.ToArray())
+      {
+        h(this, args);
+      }
+    }
+  }
+
+  private sealed class FakeAudioManagerCounters
+  {
+    public bool GetOrCreateCalled { get; set; }
+    public bool SwitchedToBluetooth { get; set; }
+  }
+
+  private static BluetoothAutoSwitchService CreateService(
+    FakeBluetoothService bt,
+    Mock<IAudioManager> audioMock,
+    int probeMs = 200,
+    int maxWaitMs = 1000,
+    bool autoSwitchEnabled = true)
+  {
+    var optionsMock = new Mock<IOptionsMonitor<BluetoothOptions>>();
+    optionsMock.Setup(o => o.CurrentValue).Returns(new BluetoothOptions
     {
       EnableOnStartup = true,
-      AutoSwitchOnConnect = true
-    };
-    _bluetoothOptionsMock.Setup(o => o.CurrentValue).Returns(_options);
-    _bluetoothServiceMock.Setup(s => s.IsAvailable).Returns(true);
+      AutoSwitchOnConnect = autoSwitchEnabled,
+      AutoSwitchProbeWindowMs = probeMs,
+      AutoSwitchMaxWaitMs = maxWaitMs
+    });
 
-    _sut = new BluetoothAutoSwitchService(
-      _loggerMock.Object,
-      _bluetoothServiceMock.Object,
-      _bluetoothOptionsMock.Object,
-      () => _audioManagerMock.Object);
+    return new BluetoothAutoSwitchService(
+      Mock.Of<ILogger<BluetoothAutoSwitchService>>(),
+      bt,
+      optionsMock.Object,
+      () => audioMock.Object,
+      metricsCollector: null);
   }
 
-  public void Dispose()
+  private static Mock<IAudioManager> MakeAudioMock(FakeAudioManagerCounters counters, AudioSourceType? activeType = null)
   {
-    _sut.Dispose();
+    var mock = new Mock<IAudioManager>();
+    if (activeType.HasValue)
+    {
+      var src = new Mock<IAudioSource>();
+      src.Setup(s => s.Type).Returns(activeType.Value);
+      mock.Setup(m => m.ActiveSource).Returns(src.Object);
+    }
+    else
+    {
+      mock.Setup(m => m.ActiveSource).Returns((IAudioSource?)null);
+    }
+    mock.Setup(m => m.GetOrCreateSourceAsync(It.IsAny<AudioSourceType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+      .Callback((AudioSourceType t, bool switchTo, CancellationToken _) =>
+      {
+        counters.GetOrCreateCalled = true;
+        if (t == AudioSourceType.Bluetooth && switchTo)
+        {
+          counters.SwitchedToBluetooth = true;
+        }
+      })
+      .ReturnsAsync((IAudioSource?)null);
+    return mock;
   }
+
+  // ---- PreWarm ----
 
   [Fact]
   public async Task PreWarmBluetoothAsync_CreatesSourceWithoutSwitch_WhenEnabled()
   {
-    // Act
-    await _sut.PreWarmBluetoothAsync();
+    var bt = new FakeBluetoothService { IsCaptureNodeAvailable = true };
+    var counters = new FakeAudioManagerCounters();
+    var audioMock = MakeAudioMock(counters);
+    using var svc = CreateService(bt, audioMock);
 
-    // Assert
-    _audioManagerMock.Verify(m => m.GetOrCreateSourceAsync(
+    await svc.PreWarmBluetoothAsync();
+
+    audioMock.Verify(m => m.GetOrCreateSourceAsync(
       AudioSourceType.Bluetooth,
       false,
       It.IsAny<CancellationToken>()), Times.Once);
@@ -61,150 +198,141 @@ public class BluetoothAutoSwitchServiceTests : IDisposable
   [Fact]
   public async Task PreWarmBluetoothAsync_DoesNothing_WhenDisabled()
   {
-    // Arrange
-    _options.EnableOnStartup = false;
+    var bt = new FakeBluetoothService();
+    var counters = new FakeAudioManagerCounters();
+    var audioMock = MakeAudioMock(counters);
+    var optionsMock = new Mock<IOptionsMonitor<BluetoothOptions>>();
+    optionsMock.Setup(o => o.CurrentValue).Returns(new BluetoothOptions { EnableOnStartup = false });
+    using var svc = new BluetoothAutoSwitchService(
+      Mock.Of<ILogger<BluetoothAutoSwitchService>>(),
+      bt,
+      optionsMock.Object,
+      () => audioMock.Object);
 
-    // Act
-    await _sut.PreWarmBluetoothAsync();
+    await svc.PreWarmBluetoothAsync();
 
-    // Assert
-    _audioManagerMock.Verify(m => m.GetOrCreateSourceAsync(
+    audioMock.Verify(m => m.GetOrCreateSourceAsync(
       It.IsAny<AudioSourceType>(),
       It.IsAny<bool>(),
       It.IsAny<CancellationToken>()), Times.Never);
   }
 
+  // ---- Auto-switch gating (Plan B) ----
+
   [Fact]
-  public async Task OnBluetoothDeviceConnected_SwitchesToBluetooth_WhenAutoSwitchEnabled()
+  public async Task NodeReadyInsideProbeWindow_SwitchesImmediately()
   {
-    // Arrange
-    _audioManagerMock.Setup(m => m.ActiveSource).Returns((IAudioSource?)null);
+    var bt = new FakeBluetoothService { IsCaptureNodeAvailable = true };
+    var counters = new FakeAudioManagerCounters();
+    var audioMock = MakeAudioMock(counters);
+    using var svc = CreateService(bt, audioMock, probeMs: 1000, maxWaitMs: 30000);
 
-    // Act — raise the event
-    _bluetoothServiceMock.Raise(s => s.DeviceConnected += null,
-      _bluetoothServiceMock.Object,
-      new BluetoothDeviceConnectedEventArgs
-      {
-        Device = new BluetoothDeviceInfo
-        {
-          Address = "AA:BB:CC:DD:EE:FF",
-          Name = "Test Phone"
-        }
-      });
+    bt.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
+    // Allow async-void handler to complete its probe — probe returns true on the first
+    // iteration because IsCaptureNodeAvailable is set.
+    await Task.Delay(150);
 
-    // Allow async event handler to complete
-    await Task.Delay(100);
-
-    // Assert
-    _audioManagerMock.Verify(m => m.GetOrCreateSourceAsync(
-      AudioSourceType.Bluetooth,
-      true,
-      It.IsAny<CancellationToken>()), Times.Once);
+    Assert.True(counters.SwitchedToBluetooth);
+    Assert.Equal(0, bt.CaptureNodeAvailableSubscriberCount);
   }
 
   [Fact]
-  public async Task OnBluetoothDeviceConnected_Skips_WhenAutoSwitchDisabled()
+  public async Task NodeArrivesAfterProbe_SwitchesViaEvent()
   {
-    // Arrange
-    _options.AutoSwitchOnConnect = false;
+    var bt = new FakeBluetoothService { IsCaptureNodeAvailable = false };
+    var counters = new FakeAudioManagerCounters();
+    var audioMock = MakeAudioMock(counters);
+    using var svc = CreateService(bt, audioMock, probeMs: 200, maxWaitMs: 5000);
 
-    // Act
-    _bluetoothServiceMock.Raise(s => s.DeviceConnected += null,
-      _bluetoothServiceMock.Object,
-      new BluetoothDeviceConnectedEventArgs
-      {
-        Device = new BluetoothDeviceInfo
-        {
-          Address = "AA:BB:CC:DD:EE:FF",
-          Name = "Test Phone"
-        }
-      });
+    bt.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
 
-    await Task.Delay(100);
+    // Wait long enough for the probe window to expire and the event subscription to be active.
+    await Task.Delay(500);
+    Assert.False(counters.SwitchedToBluetooth);
+    Assert.True(bt.CaptureNodeAvailableSubscriberCount >= 1, "Expected event subscription active");
 
-    // Assert
-    _audioManagerMock.Verify(m => m.GetOrCreateSourceAsync(
-      It.IsAny<AudioSourceType>(),
-      It.IsAny<bool>(),
-      It.IsAny<CancellationToken>()), Times.Never);
+    bt.RaiseCaptureNodeAvailable("AA:BB:CC:DD:EE:FF");
+    // Allow async continuation to complete the switch.
+    await Task.Delay(150);
+
+    Assert.True(counters.SwitchedToBluetooth);
+    Assert.Equal(0, bt.CaptureNodeAvailableSubscriberCount);
   }
+
+  [Fact]
+  public async Task NodeNeverArrives_TimesOutWithoutSwitch()
+  {
+    var bt = new FakeBluetoothService { IsCaptureNodeAvailable = false };
+    var counters = new FakeAudioManagerCounters();
+    var audioMock = MakeAudioMock(counters);
+    using var svc = CreateService(bt, audioMock, probeMs: 100, maxWaitMs: 300);
+
+    bt.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
+    // Wait for probe (100ms) + timeout (300ms) + slack.
+    await Task.Delay(700);
+
+    Assert.False(counters.SwitchedToBluetooth);
+    Assert.Equal(0, bt.CaptureNodeAvailableSubscriberCount);
+  }
+
+  [Fact]
+  public async Task AlreadyActiveBluetoothSource_SkipsSwitch()
+  {
+    var bt = new FakeBluetoothService { IsCaptureNodeAvailable = true };
+    var counters = new FakeAudioManagerCounters();
+    var audioMock = MakeAudioMock(counters, AudioSourceType.Bluetooth);
+    using var svc = CreateService(bt, audioMock, probeMs: 1000, maxWaitMs: 30000);
+
+    bt.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
+    await Task.Delay(200);
+
+    Assert.False(counters.GetOrCreateCalled);
+  }
+
+  [Fact]
+  public async Task AutoSwitchDisabled_SkipsEntirely()
+  {
+    var bt = new FakeBluetoothService { IsCaptureNodeAvailable = true };
+    var counters = new FakeAudioManagerCounters();
+    var audioMock = MakeAudioMock(counters);
+    using var svc = CreateService(bt, audioMock, probeMs: 1000, maxWaitMs: 30000, autoSwitchEnabled: false);
+
+    bt.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
+    await Task.Delay(200);
+
+    Assert.False(counters.GetOrCreateCalled);
+  }
+
+  // ---- Existing safety nets ----
 
   [Fact]
   public async Task OnBluetoothDeviceConnected_Skips_WhenAdapterUnavailable()
   {
-    // Arrange
-    _bluetoothServiceMock.Setup(s => s.IsAvailable).Returns(false);
+    var bt = new FakeBluetoothService { IsCaptureNodeAvailable = true, IsAvailable = false };
+    var counters = new FakeAudioManagerCounters();
+    var audioMock = MakeAudioMock(counters);
+    using var svc = CreateService(bt, audioMock);
 
-    // Act
-    _bluetoothServiceMock.Raise(s => s.DeviceConnected += null,
-      _bluetoothServiceMock.Object,
-      new BluetoothDeviceConnectedEventArgs
-      {
-        Device = new BluetoothDeviceInfo
-        {
-          Address = "AA:BB:CC:DD:EE:FF",
-          Name = "Test Phone"
-        }
-      });
+    bt.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
+    await Task.Delay(200);
 
-    await Task.Delay(100);
-
-    // Assert
-    _audioManagerMock.Verify(m => m.GetOrCreateSourceAsync(
-      It.IsAny<AudioSourceType>(),
-      It.IsAny<bool>(),
-      It.IsAny<CancellationToken>()), Times.Never);
+    Assert.False(counters.GetOrCreateCalled);
   }
 
   [Fact]
-  public async Task OnBluetoothDeviceConnected_Skips_WhenAlreadyOnBluetooth()
+  public async Task Dispose_UnsubscribesFromEvent()
   {
-    // Arrange
-    var btSourceMock = new Mock<IAudioSource>();
-    btSourceMock.Setup(s => s.Type).Returns(AudioSourceType.Bluetooth);
-    _audioManagerMock.Setup(m => m.ActiveSource).Returns(btSourceMock.Object);
+    var bt = new FakeBluetoothService { IsCaptureNodeAvailable = true };
+    var counters = new FakeAudioManagerCounters();
+    var audioMock = MakeAudioMock(counters);
+    var svc = CreateService(bt, audioMock);
 
-    // Act
-    _bluetoothServiceMock.Raise(s => s.DeviceConnected += null,
-      _bluetoothServiceMock.Object,
-      new BluetoothDeviceConnectedEventArgs
-      {
-        Device = new BluetoothDeviceInfo
-        {
-          Address = "AA:BB:CC:DD:EE:FF",
-          Name = "Test Phone"
-        }
-      });
+    svc.Dispose();
+    bt.SimulateDeviceConnected("AA:BB:CC:DD:EE:FF");
+    await Task.Delay(150);
 
-    await Task.Delay(100);
-
-    // Assert
-    _audioManagerMock.Verify(m => m.GetOrCreateSourceAsync(
-      It.IsAny<AudioSourceType>(),
-      It.IsAny<bool>(),
-      It.IsAny<CancellationToken>()), Times.Never);
-  }
-
-  [Fact]
-  public void Dispose_UnsubscribesFromEvent()
-  {
-    // Act
-    _sut.Dispose();
-
-    // Raise event after dispose — should not trigger any action
-    _bluetoothServiceMock.Raise(s => s.DeviceConnected += null,
-      _bluetoothServiceMock.Object,
-      new BluetoothDeviceConnectedEventArgs
-      {
-        Device = new BluetoothDeviceInfo
-        {
-          Address = "AA:BB:CC:DD:EE:FF",
-          Name = "Test Phone"
-        }
-      });
-
-    // Assert — no calls since handler was unsubscribed
-    _audioManagerMock.Verify(m => m.GetOrCreateSourceAsync(
+    // No GetOrCreate calls should happen after dispose — handler was unsubscribed.
+    audioMock.Verify(m => m.GetOrCreateSourceAsync(
       It.IsAny<AudioSourceType>(),
       It.IsAny<bool>(),
       It.IsAny<CancellationToken>()), Times.Never);
@@ -213,7 +341,11 @@ public class BluetoothAutoSwitchServiceTests : IDisposable
   [Fact]
   public void Dispose_IsSafeToCallTwice()
   {
-    _sut.Dispose();
-    _sut.Dispose(); // Should not throw
+    var bt = new FakeBluetoothService();
+    var counters = new FakeAudioManagerCounters();
+    var audioMock = MakeAudioMock(counters);
+    var svc = CreateService(bt, audioMock);
+    svc.Dispose();
+    svc.Dispose();
   }
 }


### PR DESCRIPTION
## Summary

Implements [Plan B from the Cast/BT research arc](docs/plans/2026-05-22-bt-autoswitch-gate.md) — stops `BluetoothAutoSwitchService` from forcing a source-switch + retry-loop when the BlueZ `Connected` event fires before the PipeWire capture node has materialized (FM-BT-1).

Two-phase wait:
- **Probe phase**: short-bounded probe (≤ 5 s, 500 ms polls) of `IsCaptureNodeAvailableAsync` — typical happy path.
- **Event phase**: if the node still isn't ready, subscribe to the new `CaptureNodeAvailable` event with a 60 s timeout. Switch fires when the node appears; we abandon the switch on timeout (operator must re-trigger manually — recovery from a stuck `autoswitch_abandoned_total` is Phase 3+).

Contributes to reducing FM-BT-3 long-uptime degradation by eliminating the hours-of-retry-loop pathology documented in MEMORY.

## What's in the box

| Commit | Change |
|---|---|
| `scripts(research)` | Audit/compare/harness scripts for measurement (Plan task 0) |
| `feat(bt) options` | `AutoSwitchProbeWindowMs`, `AutoSwitchMaxWaitMs`, `CaptureNodeRescanIntervalMs` on `BluetoothOptions` + appsettings defaults |
| `feat(bt) event + probe` | `IBluetoothService.CaptureNodeAvailable` event + `IsCaptureNodeAvailableAsync` probe. Linux implementation extracts shared `RunPwCliListNodesAsync` helper. Windows/Mock/Null stubs return `true`/`false` as appropriate. |
| `feat(bt) rescan loop` | `LinuxBluetoothService` periodic re-scan polls every `CaptureNodeRescanIntervalMs`, raises `CaptureNodeAvailable` on absent→present transition, wired into connect/disconnect/Dispose. |
| `feat(bt) autoswitch gate` | `BluetoothAutoSwitchService.OnBluetoothDeviceConnected` rewritten with probe + event-wait gating. `IMetricsCollector?` added to constructor; DI wiring updated. |
| `test(bt)` | 10 unit tests covering all gating paths (5 new + 5 retained safety-net tests). |

## Notable design choices / deviations

- **`MetricsCollector` injection.** The plan suggested `_bluetoothService.MetricsCollector?.Increment(...)`. That property isn't public on `IBluetoothService` today, so per the plan's own fallback note I injected `IMetricsCollector?` directly into `BluetoothAutoSwitchService`.
- **Tasks 2 + 3 split as planned.** Two commits are presented in plan order; the Linux event declaration in commit `b393141` (Task 2) builds cleanly because `CS0067` is part of the standard `EnforceCodeStyleInBuild` baseline and the event is wired immediately in the following commit. (Sequenced via temporary `#pragma` during authoring; final state has none — verified clean.)
- **`sysload_capture.sh` + `sysload_correlate.py` are NOT in this PR.** They are Plan A's deliverable (per Plan B Task 0 "reuse"); they ship with the sibling `feat/bt-capture-watchdog` branch. The acceptance-criteria harness (Task 8) consumes them — Mark will have both branches merged before running UAT.
- **Plan E (PW event subscription) supersedes the periodic rescan.** This PR ships the polling implementation; Plan E swaps the polling for direct PipeWire event subscription without changing the gate's outer contract.

## Acceptance criteria — deferred to Mark UAT

Plan task 8 specifies a 24-hour scripted pair/unpair harness on the live `radio` host with `--simulate-no-audio` and concurrent `sysload_capture` collection. **This verification is pending Mark's UAT** — the Builder cannot run a 24 h harness on production hardware.

Once Mark runs the harness, the success criteria are:
- `waiting_log_lines` per cycle ≤ 5 (was unbounded)
- `retry_loop_hours` = 0
- Happy-path `getcapture_invocations ≤ 2`
- `bluetooth.autoswitch_deferred_total` ~ 50% of cycles (the simulate-no-audio ones)
- `bluetooth.autoswitch_abandoned_total` = 0 for cycles where audio eventually plays within 60 s

## Test plan

- [x] `dotnet build --configuration Release` — 0 errors, 0 new warnings (only pre-existing IDE0011 style warnings remain)
- [x] `dotnet test --configuration Release` — 2156 passed, 4 skipped, 0 failed across all 11 test projects
- [x] `BluetoothAutoSwitchServiceTests` — 10/10 pass covering: probe-hits, probe-misses-event-arrives, probe-misses-times-out, already-active, autoswitch-disabled, adapter-unavailable, pre-warm enabled/disabled, dispose-unsub, dispose-idempotent
- [ ] Mark: 24 h scripted pair-cycle harness on `radio` (Plan task 8)
- [ ] Mark: `bt_autoswitch_compare.py baseline after` outputs `PASS`

## Out of scope

- Replacing the `pw-cli` scrape with PW event subscription (Plan E).
- Recovery from stuck `autoswitch_abandoned_total` — operator-triggered re-switch (Phase 3+).
- Cast-side equivalent — no analogous race exists on the push-driven Cast path.
- Windows BT path — `IsCaptureNodeAvailableAsync` is stubbed to `true`, `CaptureNodeAvailable` is never raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)