### PR TITLE
fix(web): normalize Windows path separators in DisplayNames (unblocks main CI)

### DIFF
--- a/src/Radio.Web/Formatting/DisplayNames.cs
+++ b/src/Radio.Web/Formatting/DisplayNames.cs
@@ -255,10 +255,19 @@ public static partial class DisplayNames
       return string.Empty;
     }
 
+    // File paths in NowPlayingDto.FilePath or ExtendedMetadata["FilePath"] arrive from
+    // multiple sources (file-browser scans, fingerprinting metadata, AVRCP Position
+    // metadata, restored play-history rows) — any of which may carry Windows-style
+    // separators even though radio-api runs on Linux. Path.GetFileNameWithoutExtension
+    // honors the *runtime* platform's separator only, so on Linux it would keep
+    // `C:\music\...\file.mp3` as a single filename. Normalize both separators to `/`
+    // so the cross-platform extraction is deterministic.
+    var normalized = path.Replace('\\', '/');
+
     string fileName;
     try
     {
-      fileName = Path.GetFileNameWithoutExtension(path) ?? string.Empty;
+      fileName = Path.GetFileNameWithoutExtension(normalized) ?? string.Empty;
     }
     catch (ArgumentException)
     {


### PR DESCRIPTION
## Summary

Fixes 3 \`Radio.Web.Tests\` failures that have been red on every \`main\` CI build since 2026-05-18 — confirmed via \`gh run list --branch main --workflow build.yml\`:

- \`Track_GenericTitle_ParsesFromFilePath\`
- \`Track_GenericTitle_ReadsTypedFilePathProperty_Preferred\`
- \`NowPlayingPanel_DisplayNamesTrackProjection_AppliedFromHubPush\`

**Root cause:** \`Path.GetFileNameWithoutExtension\` only recognizes the runtime platform's directory separator. The failing tests use Windows-style paths (\`C:\music\…\08 opening night.mp3\`), and on Linux CI the function leaves the whole path intact — so the title-case + track-number-strip ran on the wrong input.

These paths legitimately arrive in \`NowPlayingDto\` from file-browser scans, fingerprinting metadata, restored play-history rows, etc., regardless of which OS \`radio-api\` itself runs on. The implementation needs to handle both separator styles.

**Fix:** one-line normalization (\`path.Replace('\\', '/')\`) before calling \`GetFileNameWithoutExtension\`. Deterministic; no behavior change on Windows; the existing \`Track_FilePathWithMixedCase_PreservesOriginalCasing\` test (forward-slash path) already passed cross-platform and continues to.

## Why this is being shipped now

PRs #389 / #390 / #391 (Phase 1 of the cast/BT research arc) are all blocked from auto-merge because their CI shows the \`build\` job failing — but with the same 3 pre-existing failures that have been red on \`main\` for 5+ days. All three Builders independently identified the failures as unrelated to BT work and refused to merge per their "no merge on CI fail" rule. This PR clears the way.

## Test plan

- [x] Local \`Radio.Web.Tests\`: 528/528 pass (no Windows regression)
- [x] Filtered run of the 3 named tests + \`Track_FilePathWithMixedCase\`: 4/4 pass
- [x] \`dotnet build src/Radio.Web --configuration Release\`: 0 errors, only pre-existing IDE0011 style warnings
- [ ] CI on this branch: should be the first all-green \`build\` since 2026-05-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)