### PR TITLE
fix(bt): route pw_core_get_registry through libpw_helper wrapper

### DIFF
--- a/src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNative.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireNative.cs
@@ -86,6 +86,15 @@ internal static class PipeWireNative
   // `pw_core_get_registry(core, version, sz) → pw_registry *`;
   // `pw_proxy_add_listener(registry, &hook, &events_struct, user_data)`.
   // Each pw_thread_loop owns its own context/core/registry chain.
+  //
+  // CAUTION: `pw_core_get_registry` is declared `static inline` in
+  // <pipewire/core.h> (it expands the `spa_interface_call_res` vtable-dispatch
+  // macro), so no real symbol of that name exists in libpipewire-0.3.so. .NET
+  // P/Invoke against `pipewire-0.3` would throw EntryPointNotFoundException at
+  // first call. We instead bind to a thin wrapper exported from libpw_helper
+  // (see pw_helper.c::pw_helper_core_get_registry). Do not "fix" this binding
+  // back to PipeWireLib — it will break PipeWireRegistryListener.Start() and
+  // force the consumer back onto the periodic pw-cli scrape fallback.
 
   [DllImport(PipeWireLib, CallingConvention = CallingConvention.Cdecl)]
   public static extern IntPtr pw_context_new(IntPtr loop, IntPtr props, UIntPtr userDataSize);
@@ -96,7 +105,10 @@ internal static class PipeWireNative
   [DllImport(PipeWireLib, CallingConvention = CallingConvention.Cdecl)]
   public static extern void pw_context_destroy(IntPtr context);
 
-  [DllImport(PipeWireLib, CallingConvention = CallingConvention.Cdecl)]
+  // Bound to libpw_helper because pw_core_get_registry is static inline in
+  // PipeWire's public headers — see header comment block above.
+  [DllImport(HelperLib, EntryPoint = "pw_helper_core_get_registry",
+    CallingConvention = CallingConvention.Cdecl)]
   public static extern IntPtr pw_core_get_registry(IntPtr core, uint version, UIntPtr userDataSize);
 
   [DllImport(PipeWireLib, CallingConvention = CallingConvention.Cdecl)]

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireRegistryListener.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Native/PipeWireRegistryListener.cs
@@ -194,17 +194,25 @@ internal sealed class PipeWireRegistryListener : IDisposable
     {
       _logger.LogWarning(
         ex,
-        "PipeWireRegistryListener: native library missing (libpipewire-0.3 or libpw_helper); "
-        + "falling back to periodic pw-cli scrape");
+        "PipeWireRegistryListener: native library {Library} not found "
+        + "(check ldconfig cache for libpipewire-0.3 and libpw_helper); "
+        + "falling back to periodic pw-cli scrape",
+        ex.Message);
       IsHealthy = false;
       Cleanup();
     }
     catch (EntryPointNotFoundException ex)
     {
+      // Log the actual missing symbol + library — the previous message blamed
+      // libpw_helper.so for every entry-point miss, which masked the real cause
+      // (pw_core_get_registry is static inline in libpipewire-0.3 headers, so
+      // it has no real symbol; we bind it through libpw_helper now — see
+      // PipeWireNative.pw_core_get_registry).
       _logger.LogWarning(
         ex,
-        "PipeWireRegistryListener: required native symbol missing "
-        + "(rebuild libpw_helper.so?); falling back to periodic pw-cli scrape");
+        "PipeWireRegistryListener: required native entry point missing: {Detail}; "
+        + "falling back to periodic pw-cli scrape",
+        ex.Message);
       IsHealthy = false;
       Cleanup();
     }
@@ -212,7 +220,9 @@ internal sealed class PipeWireRegistryListener : IDisposable
     {
       _logger.LogWarning(
         ex,
-        "PipeWireRegistryListener failed to start; falling back to periodic pw-cli scrape");
+        "PipeWireRegistryListener failed to start ({ExceptionType}: {Message}); "
+        + "falling back to periodic pw-cli scrape",
+        ex.GetType().Name, ex.Message);
       IsHealthy = false;
       Cleanup();
     }

--- a/src/Radio.Infrastructure/Platform/Bluetooth/Native/pw_helper.c
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/Native/pw_helper.c
@@ -1,19 +1,34 @@
 /*
- * pw_helper.c — Minimal helper for building SPA format pods from C#.
+ * pw_helper.c — Thin C wrappers exposing PipeWire helpers that .NET cannot
+ * P/Invoke directly. PipeWire 0.3 ships a number of useful APIs as either
+ *   1. preprocessor macros (e.g., SPA pod builders), or
+ *   2. `static inline` functions that expand the `spa_interface_call_res`
+ *      vtable-dispatch macro (e.g., `pw_core_get_registry`,
+ *      `pw_registry_add_listener`, `spa_dict_lookup`).
  *
- * PipeWire's SPA pod builder macros are C-preprocessor-only and cannot
- * be called via P/Invoke. This tiny shared library exposes a single
- * function that builds an SPA_FORMAT_AUDIO_RAW pod (S16_LE, given rate
- * and channels) into a caller-supplied buffer.
+ * Neither is reachable via DllImport because no real symbol is exported from
+ * libpipewire-0.3.so. We materialise each one as an exported helper here.
+ *
+ * Currently exposed:
+ *   - pw_helper_build_s16le_format_pod  (SPA pod builder, macro-only in headers)
+ *   - pw_helper_spa_dict_lookup         (spa_dict_lookup, static-inline)
+ *   - pw_helper_core_get_registry       (pw_core_get_registry, static-inline)
  *
  * Build:
- *   gcc -shared -fPIC -o libpw_helper.so pw_helper.c \
+ *   gcc -shared -fPIC -O2 -o libpw_helper.so pw_helper.c \
  *       $(pkg-config --cflags --libs libpipewire-0.3)
+ *   sudo cp libpw_helper.so /usr/local/lib/
+ *   sudo ldconfig
+ *
+ * The ldconfig step matters: the .NET runtime resolves `libpw_helper` via
+ * the dynamic linker, which only sees the file once it's been picked up by
+ * ldconfig (or `LD_LIBRARY_PATH`).
  */
 
 #include <spa/param/audio/format-utils.h>
 #include <spa/pod/builder.h>
 #include <spa/utils/dict.h>
+#include <pipewire/pipewire.h>
 
 /**
  * Builds an SPA_FORMAT_AUDIO_RAW pod for S16_LE capture.
@@ -64,4 +79,30 @@ const char *pw_helper_spa_dict_lookup(const struct spa_dict *dict, const char *k
     if (!dict || !key)
         return NULL;
     return spa_dict_lookup(dict, key);
+}
+
+/**
+ * Wraps the static-inline `pw_core_get_registry` from <pipewire/core.h>.
+ *
+ * The PipeWire 0.3 ABI exposes `pw_core_get_registry` ONLY as a `static inline`
+ * helper that expands the `spa_interface_call_res` vtable-dispatch macro. There
+ * is no exported symbol named `pw_core_get_registry` in libpipewire-0.3.so, so
+ * .NET P/Invoke cannot bind to it directly (it throws EntryPointNotFoundException).
+ *
+ * This thin wrapper compiles the inline helper into a real, exported symbol
+ * (`pw_helper_core_get_registry`) that managed callers can DllImport via
+ * `libpw_helper`. The semantics are identical: returns a `pw_registry*` or NULL.
+ *
+ * @param core            pw_core* returned by pw_context_connect. Safe to pass NULL.
+ * @param version         Registry interface version (PW_VERSION_REGISTRY = 3).
+ * @param user_data_size  Bytes of caller user-data to attach to the proxy
+ *                        (0 for the common case).
+ * @return                pw_registry* on success, NULL if `core` is NULL or
+ *                        the vtable call failed.
+ */
+void *pw_helper_core_get_registry(void *core, uint32_t version, size_t user_data_size)
+{
+    if (!core)
+        return NULL;
+    return pw_core_get_registry((struct pw_core *)core, version, user_data_size);
 }

--- a/tests/Radio.Infrastructure.Tests/Platform/Bluetooth/Native/PipeWireRegistryListenerTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Platform/Bluetooth/Native/PipeWireRegistryListenerTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging.Abstractions;
 using Radio.Infrastructure.Platform.Bluetooth.Native;
 
@@ -59,5 +61,33 @@ public class PipeWireRegistryListenerTests
     listener.Dispose();
 
     Assert.Throws<ObjectDisposedException>(() => listener.Start());
+  }
+
+  /// <summary>
+  /// Regression guard: <c>pw_core_get_registry</c> is declared <c>static inline</c>
+  /// in <c>pipewire/core.h</c> (it expands the <c>spa_interface_call_res</c>
+  /// vtable-dispatch macro), so no real symbol of that name exists in
+  /// <c>libpipewire-0.3.so</c>. Binding the DllImport against <c>pipewire-0.3</c>
+  /// throws <see cref="EntryPointNotFoundException"/> at first call and forces
+  /// the registry listener back onto the periodic <c>pw-cli</c> scrape fallback.
+  /// The fix routes the call through <c>libpw_helper</c>'s
+  /// <c>pw_helper_core_get_registry</c> wrapper. This test locks that wiring in
+  /// so an unwitting "cleanup" doesn't move the binding back to PipeWireLib.
+  /// </summary>
+  [Fact]
+  public void PwCoreGetRegistry_IsBoundToHelperLibrary_NotPipeWireLib()
+  {
+    var method = typeof(PipeWireNative).GetMethod(
+      "pw_core_get_registry",
+      BindingFlags.Public | BindingFlags.Static)!;
+    Assert.NotNull(method);
+
+    var dllImport = method.GetCustomAttribute<DllImportAttribute>()!;
+    Assert.NotNull(dllImport);
+
+    // Must be bound through the helper shared library (which exports a real
+    // pw_helper_core_get_registry symbol that wraps the static-inline call).
+    Assert.Equal("pw_helper", dllImport.Value);
+    Assert.Equal("pw_helper_core_get_registry", dllImport.EntryPoint);
   }
 }


### PR DESCRIPTION
## Summary

Diagnoses + fixes the `PipeWireRegistryListener.Start()` symbol-resolution failure on `mmack@radio`. Background:

- `libpw_helper.so` HAS the required symbol (verified by `nm`)
- `ldconfig` cache lists the .so at `/usr/local/lib`
- But the .NET catch fired "symbol missing" and the listener fell back to Plan B's periodic scrape (designed graceful degradation, but suboptimal)

**Root cause**: `pw_core_get_registry` is declared `static inline` in `<pipewire/core.h>` — it expands the `spa_interface_call_res` vtable-dispatch macro at compile time, so no exported symbol of that name exists in `libpipewire-0.3.so.0`. The previous `[DllImport("pipewire-0.3")] static extern IntPtr pw_core_get_registry(...)` therefore threw `EntryPointNotFoundException` on first call.

Verified on radio:

```bash
$ nm -D /usr/lib/x86_64-linux-gnu/libpipewire-0.3.so.0 | grep -E ' T pw_core'
... pw_core_disconnect, pw_core_export, pw_core_find_proxy, ...
# Note: pw_core_get_registry is NOT in the list

$ grep -n 'pw_core_get_registry' /usr/include/pipewire-0.3/pipewire/core.h
358:pw_core_get_registry(struct pw_core *core, uint32_t version, size_t user_data_size)
# (preceded by `static inline`)
```

The warning's hint to "rebuild libpw_helper.so" was a red herring — the helper library was always fine.

**Fix**:
1. Add `pw_helper_core_get_registry()` wrapper in `pw_helper.c` that compiles the static inline into a real exported symbol.
2. Re-point the .NET `DllImport` binding for `pw_core_get_registry` at `libpw_helper` with `EntryPoint = "pw_helper_core_get_registry"`.
3. Improve the catch-block diagnostics in `PipeWireRegistryListener.Start()` so future symbol failures log the actual missing entry point + exception type instead of always blaming `libpw_helper.so`.
4. Add a regression test (`PwCoreGetRegistry_IsBoundToHelperLibrary_NotPipeWireLib`) that asserts the DllImport stays wired to the helper library — so a well-meaning cleanup doesn't quietly re-introduce the bug.

The Plan B periodic-scrape fallback is unchanged; it remains the safety net for any other failure mode.

## Pre-merge fixes
- None — single diagnostic-then-fix commit. Code review pass on the listener still applied.

## Acceptance
- [x] Deploy to radio + restart → `PipeWireRegistryListener started` log line replaces the "unhealthy" warning (verified at 14:09:47 EDT)
- [x] No `EntryPointNotFoundException` / no `falling back to periodic pw-cli scrape` in journal after deploy
- [x] `nm -D /usr/local/lib/libpw_helper.so | grep pw_helper_core_get_registry` shows the new symbol
- [x] 4 existing `PipeWireRegistryListenerTests` + 1 new regression test still pass
- [x] Full solution test run green (1,837+ tests, 4 skipped for hardware reasons)

## Operator note

Existing radio boxes already have the new `libpw_helper.so` symbol if Mark's running this PR's deploy script. For a fresh radio host (or a new box), rebuild `libpw_helper.so` via:

```bash
cd /tmp
gcc -shared -fPIC -O2 -o libpw_helper.so pw_helper.c $(pkg-config --cflags --libs libpipewire-0.3)
sudo cp libpw_helper.so /usr/local/lib/
sudo ldconfig
```

(Source at `src/Radio.Infrastructure/Platform/Bluetooth/Native/pw_helper.c`; helper script at `build-pw-helper.sh` in the same dir.)

## Test plan

- [x] `dotnet build --configuration Release` clean (0 errors, pre-existing IDE0011 warnings only)
- [x] `dotnet test --configuration Release` all pass (1,837+ tests)
- [x] Live verification on radio: `journalctl -u radio-api` shows `PipeWireRegistryListener started` + `PW registry listener active — Plan B periodic re-scan disabled`
- [ ] (UAT) BT pair → confirm node-appearance latency drops from ~1s (scrape interval) to <200ms (event-driven). Live PW registry events are now firing; the latency drop is the natural consequence and is most easily observed by Mark on the next BT pair.

## Docs Impact

- None. `pw_helper.c`'s header comment block was expanded to describe why each wrapper exists (preprocessor macros vs. static-inline vtable dispatch) so future readers don't repeat this diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)