### PR TITLE
fix(deploy): radio-api/radio-web run as mmack + LimitNICE order + sysload script

### DIFF
--- a/deploy/common/radio-api.service
+++ b/deploy/common/radio-api.service
@@ -5,7 +5,9 @@ Wants=avahi-daemon.service radio-pipewire-access.service radio-bt-setup.service
 
 [Service]
 Type=simple
-User=radio
+# Runs as mmack (uid 1000) — needed for PipeWire access via XDG_RUNTIME_DIR=/run/user/1000.
+# Group=audio gives access to /dev/snd/* devices.
+User=mmack
 Group=audio
 WorkingDirectory=/opt/radio-console
 

--- a/deploy/common/radio-api.service
+++ b/deploy/common/radio-api.service
@@ -13,13 +13,14 @@ WorkingDirectory=/opt/radio-console
 
 # === Audio-thread isolation (added 2026-05-22, Plan D) ===
 # Pin to cores 2,3 (leave 0,1 for OS + journald + sshd + radio-web).
-# Verify against `nproc` on each deployment target — radio (N100) has 4 cores;
-# Pi 5 has 4 cores; both layouts identical.
+# Ubuntu N100 has 4 cores; layout: [OS,web] [audio,audio].
 CPUAffinity=2 3
 
-# Boost scheduling priority. Requires LimitNICE below to be actually grant-able.
+# Boost scheduling priority. LimitNICE is soft:hard where soft=highest-allowed-nice
+# (least privilege) and hard=lowest-allowed-nice (most privilege). To allow the
+# process to lower its nice to -5 we need hard=-5, soft=0 (or any value ≥ -5).
 Nice=-5
-LimitNICE=-5:0
+LimitNICE=0:-5
 
 # IO best-effort near-realtime (class 2, priority 2). Class 1 (realtime) is
 # usually overkill for application audio; class 2 + low prio matches CCRMA/JACK

--- a/deploy/common/radio-web.service
+++ b/deploy/common/radio-web.service
@@ -5,8 +5,9 @@ Requires=radio-api.service
 
 [Service]
 Type=simple
-User=radio
-Group=radio
+# Matches radio-api's user/group for consistent file ownership in /opt/radio-console.
+User=mmack
+Group=mmack
 WorkingDirectory=/opt/radio-console
 
 # === Complement to radio-api's pin to cores 2,3 (Plan D, 2026-05-22) ===

--- a/scripts/research/sysload_capture.sh
+++ b/scripts/research/sysload_capture.sh
@@ -4,7 +4,7 @@
 # Captures one row per second of:
 #   - CPU/IO/scheduler stats from vmstat 1
 #   - Per-device IO from iostat -x 1
-#   - Per-process CPU/IO for radio-api/radio-web/journald/sqlite3/sshd via pidstat
+#   - Per-process CPU/IO for Radio.API/Radio.Web/journald/sqlite3/sshd via pidstat
 #   - Per-second journald log-line count
 #   - Per-second active sshd session count
 #
@@ -25,6 +25,16 @@ DURATION="${1:-60}"
 if ! [[ "$DURATION" =~ ^[0-9]+$ ]]; then
   echo "Usage: $0 <duration_seconds>" >&2
   exit 2
+fi
+
+# Required external tools — fail fast with an actionable message.
+if ! command -v iostat >/dev/null 2>&1; then
+  echo "ERROR: iostat not found. Install sysstat: sudo apt install -y sysstat" >&2
+  exit 3
+fi
+if ! command -v vmstat >/dev/null 2>&1; then
+  echo "ERROR: vmstat not found (should be in procps)" >&2
+  exit 3
 fi
 
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
@@ -57,17 +67,22 @@ iostat -x 1 "$DURATION" 2>/dev/null \
 IOSTAT_PID=$!
 
 # Per-process CPU sampler — resolve PIDs each second; missing process == 0.
+# pgrep -x requires the comm to match exactly. The Radio.API/Radio.Web .NET
+# single-file binaries publish to /opt/radio-console/{api,web}/Radio.API and
+# Radio.Web; the kernel comm field is the basename ("Radio.API", "Radio.Web").
+# Without -x, pgrep also matches things like "Radio.API.Tests" if any process
+# happens to be running with that name.
 ( for ((i=0; i<DURATION; i++)); do
     api_cpu=0; web_cpu=0; jrn_cpu=0; sql_cpu=0; ssh_cpu=0
-    for pid in $(pgrep -d ' ' radio-api 2>/dev/null); do
+    for pid in $(pgrep -d ' ' -x Radio.API 2>/dev/null); do
       v=$(awk -v pid="$pid" '$1==pid {print $9}' <(top -b -n 1 -p "$pid" 2>/dev/null | tail -n +8))
       api_cpu=$(awk -v a="$api_cpu" -v b="${v:-0}" 'BEGIN{print a+b}')
     done
-    for pid in $(pgrep -d ' ' radio-web 2>/dev/null); do
+    for pid in $(pgrep -d ' ' -x Radio.Web 2>/dev/null); do
       v=$(awk -v pid="$pid" '$1==pid {print $9}' <(top -b -n 1 -p "$pid" 2>/dev/null | tail -n +8))
       web_cpu=$(awk -v a="$web_cpu" -v b="${v:-0}" 'BEGIN{print a+b}')
     done
-    for pid in $(pgrep -d ' ' systemd-journald 2>/dev/null); do
+    for pid in $(pgrep -d ' ' -x systemd-journald 2>/dev/null); do
       v=$(awk -v pid="$pid" '$1==pid {print $9}' <(top -b -n 1 -p "$pid" 2>/dev/null | tail -n +8))
       jrn_cpu=$(awk -v a="$jrn_cpu" -v b="${v:-0}" 'BEGIN{print a+b}')
     done
@@ -108,5 +123,15 @@ paste "$TMPDIR/meter.tsv" "$TMPDIR/vmstat.tsv" "$TMPDIR/iostat.tsv" "$TMPDIR/pid
       api=$11; web=$12; jrn=$13; sql=$14; ssd=$15
       print mono"\t"wall"\t"us"\t"sy"\t"id"\t"wa"\t"drd"\t"dwr"\t"logs"\t"ssh"\t"api"\t"web"\t"jrn"\t"sql"\t"ssd
     }' >> "$OUTFILE"
+
+# Sanity check — warn if the merge produced only the header. Most common cause
+# is a per-producer command failing silently (e.g., iostat missing, pgrep
+# matching no PIDs because the process names are wrong).
+LINES=$(wc -l < "$OUTFILE")
+if [ "$LINES" -lt 2 ]; then
+  echo "WARNING: sysload_capture produced only header (no data rows). Check producer output:" >&2
+  ls -la "$TMPDIR/" >&2
+  wc -l "$TMPDIR"/*.tsv >&2
+fi
 
 echo "$OUTFILE"


### PR DESCRIPTION
## Summary

Three small fixes surfaced during the cast/BT Phase 2 deployment to `mmack@radio` (Ubuntu N100) on 2026-05-22:

1. `User=radio` → `User=mmack` in both `radio-api.service` and `radio-web.service`. Per MEMORY, radio-api must run as `mmack` for PipeWire access via `/run/user/1000`. The repo files were stale; deploying them caused .NET single-file bundle extraction EACCES and a crash loop (exit 160). Fixed at deploy time by hand; this PR sources the fix back to the repo.
2. `LimitNICE=-5:0` → `LimitNICE=0:-5`. systemd syntax is `soft:hard` where soft = highest-allowed-nice (least privilege); the original had it reversed and systemd logged `Soft resource limit chosen higher than hard limit, ignoring`. Plan D's `Nice=-5` was working by chance via the running process's already-elevated capabilities.
3. `sysload_capture.sh` matches `Radio.API`/`Radio.Web` (case + dot), checks for `sysstat`/`iostat` upfront, and warns if no data rows were captured. Previously the per-process CPU sampler matched zero PIDs and the tsv contained only the header.

## Pre-merge fixes

n/a — three independent surgical fixes; no code-review subagent dispatched because the diff is purely configuration + a research script.

## Test plan

- [x] `dotnet build --configuration Release` clean (0 errors, pre-existing IDE0011 warnings only)
- [x] `dotnet test --configuration Release` all-green (2,193 passed, 0 failed, 2 RTL-SDR hardware integration tests skipped)
- [x] `bash -n scripts/research/sysload_capture.sh` passes syntax check
- [ ] Mark verifies post-merge deploy to `mmack@radio`: services start clean as `mmack`, no `LimitNICE` warning in `journalctl -u radio-api`, `sysload_capture.sh 60` produces data rows (>1 line).

## Operator note

Post-merge deploy will overwrite the hand-patched unit files on `radio` with this PR's content — but the content is identical to what is already running there, so the only visible effect is the LimitNICE warning disappearing from the journal on next radio-api restart.

## Docs Impact

None. No `BUILDER_QUEUE.md` row to flip (this tranche was direct-tasked); no audience-doc changes; no roadmap status change. WORK-LOG.md update deferred — these are infra fixes folded into the broader Phase 2 deploy session already logged today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)