### PR TITLE
ci: migrate RTest Linux workflows to self-hosted appserver runner

### DIFF
--- a/.github/workflows/audit-configuration.yml
+++ b/.github/workflows/audit-configuration.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, appserver]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/audit-configuration.yml
+++ b/.github/workflows/audit-configuration.yml
@@ -1,5 +1,23 @@
 name: Audit System Configuration
 
+# Runner placement (since 2026-05-22, RTest CI appserver migration):
+#   - Jobs run on the self-hosted appserver runner (labels:
+#     [self-hosted, linux, x64, appserver]) — eliminates the GH Actions
+#     monthly-quota dependency that surfaced during the cast/BT research
+#     arc Phase 1 rollout.
+#   - This workflow is cron-driven (Mondays 09:00 UTC) + workflow_dispatch
+#     — it does NOT trigger on PRs, so the first appserver-runner exercise
+#     of this file happens on the next Monday cron or manual dispatch.
+#     Lightweight: Python 3.x via actions/setup-python@v4 + one audit
+#     script run.
+#   - CI is ADVISORY: main branch protection is off; the Builder's local
+#     gates are the merge-blocking truth. CI here is a second-opinion
+#     signal.
+#   - Rollback: revert this PR — runs-on flips back to ubuntu-latest.
+#
+# audio-uat.yml stays on windows-latest (intentional — Windows-only
+# feature surface; appserver runner is Linux).
+
 on:
   schedule:
     - cron: '0 9 * * 1' # Mondays at 9am UTC

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, appserver]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,23 @@
 name: Build and Test
 
+# Runner placement (since 2026-05-22, RTest CI appserver migration):
+#   - Jobs run on the self-hosted appserver runner (labels:
+#     [self-hosted, linux, x64, appserver]) — eliminates the GH Actions
+#     monthly-quota dependency that surfaced during the cast/BT research
+#     arc Phase 1 rollout.
+#   - This is the heaviest of the four migrated workflows: dotnet build +
+#     dotnet test across 11 test projects + Playwright browser install
+#     (--with-deps, needs apt) + NuGet pack of 5 packages. .NET 10 SDK is
+#     installed per-job via actions/setup-dotnet@v4; pwsh and Playwright
+#     system deps resolve via apt inside the ephemeral runner container.
+#   - CI is ADVISORY: main branch protection is off; the Builder's local
+#     gates (dotnet build / dotnet test) are the merge-blocking truth.
+#     CI here is a second-opinion signal.
+#   - Rollback: revert this PR — runs-on flips back to ubuntu-latest.
+#
+# audio-uat.yml stays on windows-latest (intentional — Windows-only
+# feature surface; appserver runner is Linux).
+
 on:
   push:
     branches: [main, develop]

--- a/.github/workflows/pages-docs.yml
+++ b/.github/workflows/pages-docs.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, appserver]
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages-docs.yml
+++ b/.github/workflows/pages-docs.yml
@@ -1,5 +1,21 @@
 name: Deploy GitHub Pages (docs)
 
+# Runner placement (since 2026-05-22, RTest CI appserver migration):
+#   - Jobs run on the self-hosted appserver runner (labels:
+#     [self-hosted, linux, x64, appserver]) — eliminates the GH Actions
+#     monthly-quota dependency that surfaced during the cast/BT research
+#     arc Phase 1 rollout.
+#   - Builds the static docs site from docs/** and deploys to GitHub
+#     Pages via actions/deploy-pages@v4. Lightweight: no SDK or system
+#     deps needed beyond checkout + artifact upload + deploy-pages.
+#   - CI is ADVISORY: main branch protection is off; the Builder's local
+#     gates are the merge-blocking truth. CI here is a second-opinion
+#     signal.
+#   - Rollback: revert this PR — runs-on flips back to ubuntu-latest.
+#
+# audio-uat.yml stays on windows-latest (intentional — Windows-only
+# feature surface; appserver runner is Linux).
+
 on:
   push:
     branches:

--- a/.github/workflows/todo-to-issues.yml
+++ b/.github/workflows/todo-to-issues.yml
@@ -1,5 +1,22 @@
 name: TODO to Issues
 
+# Runner placement (since 2026-05-22, RTest CI appserver migration):
+#   - Jobs run on the self-hosted appserver runner (labels:
+#     [self-hosted, linux, x64, appserver]) — eliminates the GH Actions
+#     monthly-quota dependency that surfaced during the cast/BT research
+#     arc Phase 1 rollout.
+#   - This workflow is cron-driven (Mondays 09:00 UTC) + workflow_dispatch
+#     — it does NOT trigger on PRs, so the first appserver-runner exercise
+#     of this file happens on the next Monday cron or manual dispatch.
+#     Lightweight: a single third-party action (alstr/todo-to-issue-action).
+#   - CI is ADVISORY: main branch protection is off; the Builder's local
+#     gates are the merge-blocking truth. CI here is a second-opinion
+#     signal.
+#   - Rollback: revert this PR — runs-on flips back to ubuntu-latest.
+#
+# audio-uat.yml stays on windows-latest (intentional — Windows-only
+# feature surface; appserver runner is Linux).
+
 on:
   schedule:
     # Runs every Monday at 9am UTC

--- a/.github/workflows/todo-to-issues.yml
+++ b/.github/workflows/todo-to-issues.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   todo-issues:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, appserver]
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
## Summary

Flips 4 of RTest's 5 GitHub Actions workflows from `runs-on: ubuntu-latest` (GH-hosted) to `runs-on: [self-hosted, linux, x64, appserver]` — the same runner FamilyWorkspace migrated to in PR #618 / `chore/appserver-setup` (2026-05-17).

`audio-uat.yml` stays on `windows-latest` (intentional — Windows-only feature surface).

## Why

The cast/BT research arc's Phase 1 rollout (PRs #389/#390/#391) ran into the monthly GH Actions minutes ceiling. Self-hosted runner sidesteps the quota constraint while preserving the second-opinion CI signal.

## What's NOT in this PR

- No runner provisioning (already done by FW PR #618).
- No image bake (per-job `apt-install` of pwsh + Playwright deps is acceptable short-term overhead).
- No branch-protection change (CI is advisory; Builder local gates remain merge-blocking truth).
- No Windows-runner change.

## Test plan

- [x] Per-workflow header comments added explaining the placement + rollback path
- [ ] First CI run on this PR completes (green or red) on the appserver runner — visible via `gh run view` showing the `[self-hosted, linux, x64, appserver]` label set
- [ ] If green: merge and watch the next several PRs to confirm reliability
- [ ] If red with a runner-specific failure (network, disk, container state): revert this PR per the rollback path documented in the workflow headers

## Rollback

`git revert <merge-commit>` — both `runs-on` lines flip back to `ubuntu-latest`. The runner stays online (it's shared with FW); no infrastructure changes.

Plan: `docs/plans/2026-05-22-rtest-ci-appserver-migration.md` (merged in #395).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>