### PR TITLE
feat(audio): observability for BufferedSoundGenerator underrun + drift compensation

### DIFF
--- a/scripts/research/bt_drift_analyze.py
+++ b/scripts/research/bt_drift_analyze.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""bt_drift_analyze.py — quantify BufferedSoundGenerator underrun + clock-drift compensation.
+
+Reads journald text from stdin (or --input <file>) and emits a single summary
+block with underrun + drift-compensation event rates plus an estimated clock-skew
+in parts-per-million.
+
+Matches two journal line shapes produced by
+src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs:
+
+  ⚠️ Buffer underrun (<Type>): <N> underruns, <M> zero samples in last <T>s
+    (buffer: <buffered>/<capacity>, total underruns: <total>)
+
+  🔄 Clock drift compensation (<Type>): <N> events, <M> duplicated samples in
+    last <T>s (buffer: <level>→<new>/<capacity>, total compensated: <total>)
+
+Both throttle to once per ~5 s in production, so the per-burst <N>/<M>/<T> values
+are summed across the input window. The "total" field is sanity-checked against
+the running sum.
+
+PPM math (see notes in `--help`): with stereo audio, the effective sample-rate
+is `sample_rate_hz * channels`. The net buffer deficit rate is
+`(net_deficit_samples / window_seconds)`, and the ppm estimate is
+`deficit_per_sec / effective_sample_rate * 1e6`.
+
+Usage:
+  journalctl -u radio-api --since "1 hour ago" | python3 bt_drift_analyze.py
+  python3 bt_drift_analyze.py --input radio_journal.log --sample-rate 48000 --channels 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime
+
+# journalctl --output=short-iso prefix: "2026-05-22T12:34:56+0000"
+ISO_TS_RE = re.compile(
+    r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[+-]\d{2}:?\d{2}|Z)?)"
+)
+
+# "Buffer underrun (Single): 5 underruns, 2048 zero samples in last 4.8s ... total underruns: 82)"
+UNDERRUN_RE = re.compile(
+    r"Buffer underrun \([^)]+\):\s+(\d+)\s+underruns,\s+(\d+)\s+zero samples in last\s+([\d.]+)s.*?"
+    r"total underruns:\s+(\d+)",
+    re.IGNORECASE,
+)
+
+# Two compensation shapes we accept:
+#  (new, throttled)  "Clock drift compensation (Single): 3 events, 480 duplicated samples in last 5.1s ... total compensated: 12480"
+#  (old, single-line) "Clock drift compensation: duplicated 160 samples (buffer: ... total compensated: 1280)"
+COMP_BURST_RE = re.compile(
+    r"Clock drift compensation \([^)]+\):\s+(\d+)\s+events,\s+(\d+)\s+duplicated samples in last\s+([\d.]+)s.*?"
+    r"total compensated:\s+(\d+)",
+    re.IGNORECASE,
+)
+COMP_SINGLE_RE = re.compile(
+    r"Clock drift compensation:\s+duplicated\s+(\d+)\s+samples.*?total compensated:\s+(\d+)",
+    re.IGNORECASE,
+)
+
+
+def parse_ts(line: str):
+  m = ISO_TS_RE.search(line)
+  if not m:
+    return None
+  raw = m.group(1).replace("Z", "+00:00")
+  try:
+    return datetime.fromisoformat(raw)
+  except ValueError:
+    return None
+
+
+def main() -> int:
+  ap = argparse.ArgumentParser(
+      description="Summarize underrun + drift-compensation events from radio-api journal text",
+  )
+  ap.add_argument("--input", type=str, default=None,
+                  help="Path to journal text file (default: stdin)")
+  ap.add_argument("--sample-rate", type=int, default=48000,
+                  help="Audio sample rate in Hz (default: 48000)")
+  ap.add_argument("--channels", type=int, default=2,
+                  help="Channel count for effective sample-rate math (default: 2)")
+  args = ap.parse_args()
+
+  src = open(args.input, "r", encoding="utf-8", errors="replace") if args.input else sys.stdin
+
+  underrun_events = 0
+  underrun_samples = 0
+  underrun_total_seen = 0
+  comp_events = 0
+  comp_samples = 0
+  comp_total_seen = 0
+  first_ts = None
+  last_ts = None
+
+  for line in src:
+    ts = parse_ts(line)
+    if ts is not None:
+      if first_ts is None:
+        first_ts = ts
+      last_ts = ts
+
+    m = UNDERRUN_RE.search(line)
+    if m:
+      underrun_events += int(m.group(1))
+      underrun_samples += int(m.group(2))
+      underrun_total_seen = max(underrun_total_seen, int(m.group(4)))
+      continue
+
+    m = COMP_BURST_RE.search(line)
+    if m:
+      comp_events += int(m.group(1))
+      comp_samples += int(m.group(2))
+      comp_total_seen = max(comp_total_seen, int(m.group(4)))
+      continue
+
+    m = COMP_SINGLE_RE.search(line)
+    if m:
+      # Pre-throttle / legacy compensation log: one event per line.
+      comp_events += 1
+      comp_samples += int(m.group(1))
+      comp_total_seen = max(comp_total_seen, int(m.group(2)))
+
+  if args.input:
+    src.close()
+
+  if first_ts is None or last_ts is None or first_ts == last_ts:
+    print("ERROR: no parseable timestamps in input (use journalctl --output=short-iso)",
+          file=sys.stderr)
+    return 1
+
+  window_secs = (last_ts - first_ts).total_seconds()
+  window_hours = window_secs / 3600.0
+
+  underrun_rate_hr = underrun_events / window_hours if window_hours > 0 else 0
+  underrun_samples_rate_hr = underrun_samples / window_hours if window_hours > 0 else 0
+  comp_rate_hr = comp_events / window_hours if window_hours > 0 else 0
+  comp_samples_rate_hr = comp_samples / window_hours if window_hours > 0 else 0
+
+  # Net buffer-deficit rate: compensation samples are duplicated to PREVENT
+  # underrun, so on a perfectly tracked clock the system would have run dry by
+  # exactly `comp_samples - underrun_samples` (compensated samples patched the
+  # gap; underrun samples are zero-fill where compensation couldn't keep up).
+  # We treat compensation_samples + underrun_samples as the total samples
+  # the consumer would otherwise have starved for.
+  total_deficit_samples = comp_samples + underrun_samples
+  deficit_per_sec = total_deficit_samples / window_secs if window_secs > 0 else 0
+  effective_rate = args.sample_rate * args.channels
+  ppm = (deficit_per_sec / effective_rate) * 1e6 if effective_rate > 0 else 0
+
+  # Format duration as "<H>h <M>m"
+  dur_h = int(window_secs // 3600)
+  dur_m = int((window_secs % 3600) // 60)
+
+  print(f"Window: {first_ts.isoformat()} -> {last_ts.isoformat()}  "
+        f"(duration: {dur_h}h {dur_m}m, {window_secs:.0f}s)")
+  print(f"Underrun events:           {underrun_events:<6d}  "
+        f"(rate: {underrun_rate_hr:.1f}/hour, {underrun_samples_rate_hr:.0f} samples/hour)")
+  print(f"  cumulative-total seen:   {underrun_total_seen}")
+  print(f"Compensation events:       {comp_events:<6d}  "
+        f"(rate: {comp_rate_hr:.1f}/hour, {comp_samples_rate_hr:.0f} samples/hour)")
+  print(f"  cumulative-total seen:   {comp_total_seen}")
+  print(f"Net buffer deficit:        {total_deficit_samples} samples "
+        f"({deficit_per_sec:.2f} samples/sec)")
+  print(f"Estimated clock skew:      {ppm:.1f} ppm "
+        f"(assuming effective_rate = {effective_rate} Hz "
+        f"= {args.sample_rate} Hz × {args.channels} ch)")
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
@@ -61,6 +61,9 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
     private DateTime _lastUnderrunLogTime;
     private long _underrunSamplesSinceLastLog;
     private int _underrunCountSinceLastLog;
+    private DateTime _lastCompensationLogTime;
+    private long _compensationSamplesSinceLastLog;
+    private int _compensationCountSinceLastLog;
 
     // Buffer level tracking between log intervals
     private int _minBufferSinceLastLog = int.MaxValue;
@@ -433,6 +436,13 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
                 _underrunSamplesSinceLastLog += deficit;
                 _underrunCountSinceLastLog++;
 
+                // Counters bump on EVERY underrun (independent of log throttle)
+                if (_metricsCollector != null && _metricsTags != null)
+                {
+                    _metricsCollector.Increment("audio.buffer.underrun_total", 1, _metricsTags);
+                    _metricsCollector.Increment("audio.buffer.underrun_samples_total", deficit, _metricsTags);
+                }
+
                 // Log underrun bursts: throttled to once per second to avoid log spam
                 // while still revealing the pattern of when underruns occur.
                 var now = DateTime.UtcNow;
@@ -524,6 +534,7 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
 
             if (deficit > 0)
             {
+                bool applied = false;
                 lock (_bufferLock)
                 {
                     if (_count + deficit <= _maxBufferSamples)
@@ -531,12 +542,42 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
                         _readPos = (_readPos - deficit + _maxBufferSamples) % _maxBufferSamples;
                         _count += deficit;
                         _totalSamplesCompensated += deficit;
+                        applied = true;
                     }
                 }
 
-                _logger.LogDebug(
-                    "🔄 Clock drift compensation: duplicated {Samples} samples (buffer: {Level}→{NewLevel}/{Capacity}, total compensated: {Total})",
-                    deficit, currentLevel, currentLevel + deficit, _maxBufferSamples, _totalSamplesCompensated);
+                if (applied)
+                {
+                    // Counters bump on EVERY successful compensation (independent of log throttle)
+                    if (_metricsCollector != null && _metricsTags != null)
+                    {
+                        _metricsCollector.Increment("audio.buffer.drift_compensation_total", 1, _metricsTags);
+                        _metricsCollector.Increment("audio.buffer.drift_compensation_samples_total", deficit, _metricsTags);
+                    }
+
+                    _compensationCountSinceLastLog++;
+                    _compensationSamplesSinceLastLog += deficit;
+
+                    // Log compensation bursts at Info: throttled to once per 5 seconds.
+                    // Compensation runs at most once per ~2s (per the drift check interval),
+                    // so 5s gives 2-3 events per log line and still reveals the cadence
+                    // of the audible "underwater" artifact (10ms of duplicated audio per event).
+                    var compNow = DateTime.UtcNow;
+                    var compSinceLastLog = _lastCompensationLogTime == default
+                        ? 0.0 : (compNow - _lastCompensationLogTime).TotalSeconds;
+                    if (compSinceLastLog >= 5.0 || _lastCompensationLogTime == default)
+                    {
+                        _logger.LogInformation(
+                            "🔄 Clock drift compensation ({Type}): {Count} events, {Samples} duplicated samples in last {Interval:F1}s " +
+                            "(buffer: {Level}→{NewLevel}/{Capacity}, total compensated: {Total})",
+                            typeof(T).Name, _compensationCountSinceLastLog, _compensationSamplesSinceLastLog,
+                            compSinceLastLog,
+                            currentLevel, currentLevel + deficit, _maxBufferSamples, _totalSamplesCompensated);
+                        _compensationSamplesSinceLastLog = 0;
+                        _compensationCountSinceLastLog = 0;
+                        _lastCompensationLogTime = compNow;
+                    }
+                }
             }
         }
 

--- a/tests/Radio.Infrastructure.Tests/Audio/SoundFlow/BufferedSoundGeneratorTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/SoundFlow/BufferedSoundGeneratorTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Moq;
 using Radio.Infrastructure.Audio.SoundFlow;
+using Radio.Metrics;
 using SoundFlow.Abstracts;
 using SoundFlow.Enums;
 using SoundFlow.Structs;
@@ -22,8 +23,9 @@ namespace Radio.Infrastructure.Tests.Audio.SoundFlow;
       // Subclass to expose protected method
       private class TestBufferedGenerator<T> : BufferedSoundGenerator<T> where T : struct
       {
-          public TestBufferedGenerator(AudioEngine engine, AudioFormat format, ILogger logger)
-              : base(engine, format, logger) { }
+          public TestBufferedGenerator(AudioEngine engine, AudioFormat format, ILogger logger,
+              IMetricsCollector? metricsCollector = null)
+              : base(engine, format, logger, metricsCollector: metricsCollector) { }
 
           public int Read(Span<float> buffer)
           {
@@ -34,7 +36,7 @@ namespace Radio.Infrastructure.Tests.Audio.SoundFlow;
               // BufferedSoundGenerator implementation of GenerateAudio fills the buffer.
               // It doesn't return count.
               // So we assume it fills as much as possible up to buffer.Length.
-              
+
               GenerateAudio(buffer, Format.Channels);
               return buffer.Length; // Approximation
           }
@@ -96,12 +98,170 @@ namespace Radio.Infrastructure.Tests.Audio.SoundFlow;
           var generator = new TestBufferedGenerator<float>(_engineMock.Object, format, _loggerMock.Object);
 
           float[] output = new float[4];
-          
+
           // Act
           int read = generator.Read(output);
 
           // Assert
           Assert.Equal(4, read);
           Assert.All(output, x => Assert.Equal(0f, x));
+      }
+
+      [Fact]
+      public void Underrun_IncrementsCounter_OnEachEvent()
+      {
+          // Arrange
+          var format = new AudioFormat { SampleRate = 48000, Channels = 2, Format = SampleFormat.F32 };
+          var metrics = new Mock<IMetricsCollector>();
+          var generator = new TestBufferedGenerator<float>(
+              _engineMock.Object, format, _loggerMock.Object, metrics.Object);
+
+          // Seed _totalSamplesReceived > 0 so underruns are counted (not idle).
+          generator.AddSamples(new float[] { 0.1f, 0.2f });
+
+          // Drain whatever is in the buffer
+          var drain = new float[2];
+          generator.Read(drain);
+
+          // Act: 3 reads that all underrun (empty buffer, demanding 8 samples)
+          var output = new float[8];
+          for (int i = 0; i < 3; i++)
+          {
+              generator.Read(output);
+          }
+
+          // Assert: counter incremented per underrun event (3 events).
+          metrics.Verify(
+              m => m.Increment("audio.buffer.underrun_total", 1, It.IsAny<IDictionary<string, string>>()),
+              Times.Exactly(3));
+          // Samples counter incremented with the per-event deficit (8 samples each)
+          metrics.Verify(
+              m => m.Increment("audio.buffer.underrun_samples_total", 8, It.IsAny<IDictionary<string, string>>()),
+              Times.Exactly(3));
+      }
+
+      [Fact]
+      public void Underrun_LogsAtWarning_WithThrottle()
+      {
+          // Arrange
+          var format = new AudioFormat { SampleRate = 48000, Channels = 2, Format = SampleFormat.F32 };
+          var generator = new TestBufferedGenerator<float>(
+              _engineMock.Object, format, _loggerMock.Object);
+
+          // Seed _totalSamplesReceived > 0
+          generator.AddSamples(new float[] { 0.1f, 0.2f });
+          var drain = new float[2];
+          generator.Read(drain);
+
+          // Act: trigger an underrun
+          var output = new float[8];
+          generator.Read(output);
+
+          // Assert: the underrun log is at Warning level (existing behavior).
+          _loggerMock.Verify(
+              l => l.Log(
+                  LogLevel.Warning,
+                  It.IsAny<EventId>(),
+                  It.Is<It.IsAnyType>((v, _) => v!.ToString()!.Contains("Buffer underrun")),
+                  null,
+                  It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+              Times.AtLeastOnce);
+      }
+
+      [Fact]
+      public void DriftCompensation_IncrementsCounter_OnEachEvent()
+      {
+          // Arrange — small buffer so compensation threshold is reachable in test time
+          var format = new AudioFormat { SampleRate = 48000, Channels = 2, Format = SampleFormat.F32 };
+          var metrics = new Mock<IMetricsCollector>();
+          var generator = new TestBufferedGenerator<float>(
+              _engineMock.Object, format, _loggerMock.Object, metrics.Object);
+
+          // To trigger CompensateClockDrift we need:
+          //  - samplesWritten == buffer.Length (full read) on each call
+          //  - DropOldest strategy (default)
+          //  - >= 2 seconds elapsed between drift checks
+          //  - > 3 drift checks before first compensation
+          //  - buffer below 15 % threshold + draining
+          //
+          // Approach: feed a small amount of audio, read it fully (full reads), wait
+          // 2.1 s between checks. Total ≈ 8.5 s for 4 successful drift checks.
+          // With default 4s maxBuffer at 48 kHz stereo = 384 000 samples,
+          // threshold = 57 600 samples. We feed ~10 000 samples → well under threshold.
+          var prefill = new float[10_000];
+          for (int i = 0; i < prefill.Length; i++)
+          {
+              prefill[i] = 0.1f;
+          }
+
+          var output = new float[512]; // smaller than prefill so full reads succeed
+          int readCount = 0;
+
+          // First drift check: anchor timestamp (no compensation).
+          generator.AddSamples(prefill);
+          generator.Read(output); readCount++;
+
+          // Wait > 2 s between each subsequent read so the drift-check timer fires.
+          for (int check = 0; check < 4; check++)
+          {
+              Thread.Sleep(2100);
+              // Top up just enough to keep level draining but under threshold.
+              generator.AddSamples(new float[256]);
+              generator.Read(output); readCount++;
+          }
+
+          // Assert: compensation counter was incremented at least once.
+          // (Exact count varies with timing; >= 1 is the contract we care about.)
+          metrics.Verify(
+              m => m.Increment(
+                  "audio.buffer.drift_compensation_total",
+                  1,
+                  It.IsAny<IDictionary<string, string>>()),
+              Times.AtLeastOnce);
+
+          metrics.Verify(
+              m => m.Increment(
+                  "audio.buffer.drift_compensation_samples_total",
+                  It.Is<double>(v => v > 0),
+                  It.IsAny<IDictionary<string, string>>()),
+              Times.AtLeastOnce);
+      }
+
+      [Fact]
+      public void DriftCompensation_LogsAtInformation_WhenTriggered()
+      {
+          // Arrange
+          var format = new AudioFormat { SampleRate = 48000, Channels = 2, Format = SampleFormat.F32 };
+          var generator = new TestBufferedGenerator<float>(
+              _engineMock.Object, format, _loggerMock.Object);
+
+          // Same setup as compensation counter test
+          var prefill = new float[10_000];
+          for (int i = 0; i < prefill.Length; i++)
+          {
+              prefill[i] = 0.1f;
+          }
+          var output = new float[512];
+
+          generator.AddSamples(prefill);
+          generator.Read(output);
+
+          for (int check = 0; check < 4; check++)
+          {
+              Thread.Sleep(2100);
+              generator.AddSamples(new float[256]);
+              generator.Read(output);
+          }
+
+          // Assert: the compensation log is now at Information level (the change being tested).
+          _loggerMock.Verify(
+              l => l.Log(
+                  LogLevel.Information,
+                  It.IsAny<EventId>(),
+                  It.Is<It.IsAnyType>((v, _) =>
+                      v!.ToString()!.Contains("Clock drift compensation")),
+                  null,
+                  It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+              Times.AtLeastOnce);
       }
   }


### PR DESCRIPTION
## Summary

Adds observability for the `BufferedSoundGenerator<T>` underrun + clock-drift compensation paths so the audible "underwater" / "slow" artifact (which is `CompensateClockDrift` duplicating 10ms of audio when the buffer drains below 15 %) can be quantified rather than guessed at.

### Diagnostic finding that motivates this

While streaming BT -> Cast on `radio`, Mark reported "underwater" audio. SSH diagnostic showed underrun events at a steady rate (~5 per 3-5 minutes) but `CompensateClockDrift` events (the actual cause of the audible artifact) were invisible — logged at `LogDebug` which the production Serilog config filters out (only Warning+ is captured per `appsettings.json`). This PR makes them visible.

## Three additions

1. **Compensation log promoted to throttled Info** — same once-per-5-seconds throttle pattern as the existing underrun log. New fields `_lastCompensationLogTime` / `_compensationCountSinceLastLog` / `_compensationSamplesSinceLastLog` mirror the underrun triple.
2. **Four new counters** registered via the existing `IMetricsCollector` pattern (PR #390 / #391):
   - `audio.buffer.underrun_total`
   - `audio.buffer.underrun_samples_total`
   - `audio.buffer.drift_compensation_total`
   - `audio.buffer.drift_compensation_samples_total`

   Critical: counter increments fire on **every** event site, independent of the log throttle, so rates are accurate even when individual events are throttled out of the log.
3. **`scripts/research/bt_drift_analyze.py`** — single-pass journal parser that emits net buffer-deficit rate + estimated clock skew in ppm.

## DI plumbing

`BufferedSoundGenerator<T>` already takes `IMetricsCollector?` (nullable). All four production call sites already pass `MetricsCollector` — no DI wiring changes required:
- `LinuxBluetoothService.cs:1193`
- `BluetoothAudioSource.cs:499`
- `SDRRadioAudioSource.cs:928`
- `USBAudioSourceBase.cs:316`
- `WasapiLoopbackCaptureSource.cs:44`

## Sample probe output

Against a synthetic 90-min BT-Cast session:

```
Window: 2026-05-22T09:00:00+00:00 -> 2026-05-22T10:34:16+00:00  (duration: 1h 34m, 5656s)
Underrun events:           120     (rate: 76.4/hour, 44577 samples/hour)
  cumulative-total seen:   120
Compensation events:       0       (rate: 0.0/hour, 0 samples/hour)
  cumulative-total seen:   0
Net buffer deficit:        70036 samples (12.38 samples/sec)
Estimated clock skew:      129.0 ppm (assuming effective_rate = 96000 Hz = 48000 Hz x 2 ch)
```

The synthetic input had no compensation events (matching today's reality — they're Debug-filtered). Once this PR is deployed, the probe will produce a coherent ppm estimate from real data.

## Acceptance

After deploy to `mmack@radio`:
- `journalctl -u radio-api | grep '🔄 Clock drift compensation'` shows compensation events (currently empty because LogDebug-filtered)
- `sqlite3 metrics.db "SELECT * FROM MetricDefinitions WHERE Key LIKE 'audio.buffer.%'"` shows the four new counters
- `python3 scripts/research/bt_drift_analyze.py < radio_journal.log` emits a coherent ppm estimate against a 1-hour BT-Cast playback session

## Test plan

- [x] Unit test: underrun counter increments on each event (3 per test, both counters)
- [x] Unit test: underrun logs at Warning level
- [x] Unit test: drift compensation counter increments on each event (uses `Thread.Sleep(2100)` between checks since `CompensateClockDrift` is wall-clock-gated)
- [x] Unit test: drift compensation log promoted to Information
- [x] `dotnet build --configuration Release` clean (0 errors, only pre-existing IDE0011 warnings)
- [x] `dotnet test --configuration Release` — all 2,136 non-flake tests pass; the one failing test (`CoverArtPipelineIntegrationTests.CoverArtArchive_ReturnsValidUrl_ForKnownRecording`) is an external HTTP 500 from Cover Art Archive, unrelated
- [x] Probe script syntax check + synthetic-input smoke test
- [ ] Mark: deploy + verify compensation events become visible + run `bt_drift_analyze.py` against a session

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>