### PR TITLE
docs(research+plans): BT clock-skew measurement + Path C plan

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,6 +62,14 @@ Consumed from the cast/BT research arc per embedded-audio-engineering prioritiza
 
 **Phase 3+ ideas remain in research** until Phase 1+2 measurement points the finger.
 
+### Active follow-up arc — BT clock-skew "underwater" audio (selected 2026-05-22)
+
+PR #400's observability surfaced 217–391 ppm clock skew between the BT phone clock and the local speaker clock during BT → Cast playback — ~10–20× over BT A2DP spec. The skew is unfixable in software (two crystals cannot be sync'd); the goal is to make the compensation that masks it less audible.
+
+- **Research**: [`docs/research/2026-05-22-bt-clock-skew-measurement.md`](research/2026-05-22-bt-clock-skew-measurement.md) — measurement methodology, architectural analysis, mitigation menu
+- **Plan in flight**: [`docs/plans/2026-05-22-bt-drift-compensation-refinement.md`](plans/2026-05-22-bt-drift-compensation-refinement.md) — Path C: smaller, more-frequent compensation events with cosine-ramp crossfade smoothing. Branch `feat/bt-drift-compensation-refinement`.
+- **Path D (variable-rate resampler) deferred** pending Path C subjective UAT result.
+
 ### CI infrastructure — RTest appserver runner migration
 
 Selected as a follow-up after the cast/BT Phase 1+2 tranche revealed that the project's monthly GH Actions minutes pool can be a real blocker. Plan modeled on FamilyWorkspace's 2026-05-17 migration which already provisioned the runner.

--- a/docs/plans/2026-05-22-bt-drift-compensation-refinement.md
+++ b/docs/plans/2026-05-22-bt-drift-compensation-refinement.md
@@ -1,0 +1,439 @@
+# BT drift-compensation refinement (Path C)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Make `BufferedSoundGenerator<T>.CompensateClockDrift` produce sub-perceptual corrections instead of the current 10 ms duplications that listeners hear as "underwater" / "slow" audio during BT → Cast playback. Validated against the metrics PR #400 introduced.
+
+**Source research**: [`docs/research/2026-05-22-bt-clock-skew-measurement.md`](../research/2026-05-22-bt-clock-skew-measurement.md) — measured 217–391 ppm BT-vs-speaker clock skew driving 120 compensation events / hour, ~10 ms of repeated audio per event.
+
+**Architecture**: refinement to `src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs:477-545`. Two independent changes:
+
+1. **Smaller, more-frequent corrections.** Replace the "wait until buffer hits 15 %, then duplicate 10 ms" model with "every Process call where drain is detected, duplicate 1-2 ms with crossfade smoothing". The total compensated samples per minute stays the same (it has to, the underlying rate skew is unchanged); the per-event audible artifact drops below the perceptual threshold.
+
+2. **Linear crossfade across the rewind boundary.** Currently, when `_readPos` is rewound by `deficit` samples, the next read starts at the rewind point with a hard cut. A simple cosine-ramp crossfade across ~32 samples (~0.7 ms at 48 kHz) blends the boundary, eliminating the discontinuity click that contributes to the "underwater" perception.
+
+**Tech Stack**: `BufferedSoundGenerator<T>` (existing). No new dependencies. No DSP library required for either change — both are simple ring-buffer pointer arithmetic + a small per-sample multiply for the crossfade.
+
+**Addresses**: BT clock-skew artifacts ("underwater" audio) documented in the research doc + measured via PR #400 metrics.
+
+---
+
+## Task 0: Confirm baseline metrics before any change
+
+Before editing code, capture a 15-minute baseline against the *current* implementation deployed on `radio`. We need this artifact as the comparison reference.
+
+**Step 1:** SSH to `mmack@radio`. Confirm radio-api is currently streaming BT → Cast (look at `journalctl -u radio-api -o cat | tail -20` and verify recent `BluetoothCodec` / `Clock drift compensation` log lines).
+
+**Step 2:** Run the probe:
+
+```bash
+ssh mmack@radio "journalctl -u radio-api --since '15 minutes ago' -o short-iso" \
+  | python3 scripts/research/bt_drift_analyze.py > baseline_drift_15min.txt
+```
+
+**Step 3:** Capture the metric counters too:
+
+```bash
+ssh mmack@radio "sqlite3 /opt/radio-console/data/metrics.db \
+  \"SELECT md.Key, SUM(mm.ValueSum) FROM MetricData_Minute mm JOIN MetricDefinitions md ON mm.MetricId=md.Id WHERE md.Key LIKE 'audio.buffer.%' AND mm.Timestamp > strftime('%s','now','-15 minutes')*1000 GROUP BY md.Key;\"" \
+  > baseline_metrics_15min.txt
+```
+
+**Step 4:** Commit both artifacts:
+
+```bash
+git add baseline_drift_15min.txt baseline_metrics_15min.txt
+git commit -m "test: baseline drift-compensation metrics (pre-refinement, PR #400-instrumented)"
+```
+
+(Actually no — these artifacts shouldn't go in the repo. Keep them locally in `/tmp/` for now and reference them in the PR description.)
+
+**Exit condition**: baseline artifacts saved locally. The PR description references the baseline numbers.
+
+---
+
+## Task 1: Smaller, more-frequent corrections
+
+**Files:**
+- Modify: `src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs:477-545`
+
+**Step 1:** Replace the existing `CompensateClockDrift` body. Two changes:
+
+a) **Always run on every Process call** (remove the `(now - _lastDriftCheckTime).TotalSeconds < 2.0` early-return at lines 491-494). The 2-second cooldown was there to avoid reacting to transient jitter; with smaller per-event corrections the cooldown is unnecessary.
+
+b) **Cap each correction at `MaxCompensationPerCallSamples = (int)(Format.SampleRate * Format.Channels * 0.002)`** — 2 ms instead of 10 ms. This is the key change. The total compensated samples per minute stays roughly the same (because it MUST — the underlying rate mismatch is unchanged), but each event is much shorter and harder to perceive.
+
+The new method body (sketch — adapt to existing field naming):
+
+```csharp
+private void CompensateClockDrift(int channels)
+{
+  var now = DateTime.UtcNow;
+  if (_lastDriftCheckTime == default)
+  {
+    _lastDriftCheckTime = now;
+    lock (_bufferLock)
+    {
+      _lastDriftCheckLevel = _count;
+    }
+    return;
+  }
+
+  int currentLevel;
+  lock (_bufferLock)
+  {
+    currentLevel = _count;
+  }
+
+  _driftCheckCount++;
+
+  // Compensate when buffer is below threshold AND draining
+  var isDraining = currentLevel < _driftCompensationThreshold
+                   && currentLevel < _lastDriftCheckLevel
+                   && _driftCheckCount > 3
+                   && _totalSamplesReceived > 0;
+
+  if (isDraining)
+  {
+    // Per-call cap: 2 ms of audio. Smaller = less audible per event,
+    // even though the total samples compensated per second stays roughly
+    // the same (driven by the underlying rate mismatch).
+    var maxCompensationPerCall = (int)(Format.SampleRate * Format.Channels * 0.002);
+    var deficit = Math.Min(_driftCompensationTarget - currentLevel, maxCompensationPerCall);
+    var frameSamples = Math.Max(channels, 2);
+    deficit = (deficit / frameSamples) * frameSamples;
+
+    if (deficit > 0)
+    {
+      // Task 2 will add crossfade here. For now: existing rewind logic
+      // operating on the smaller `deficit`.
+      lock (_bufferLock)
+      {
+        if (_count + deficit <= _maxBufferSamples)
+        {
+          _readPos = (_readPos - deficit + _maxBufferSamples) % _maxBufferSamples;
+          _count += deficit;
+          _totalSamplesCompensated += deficit;
+        }
+      }
+
+      // Counter + throttled log (existing pattern; preserved from PR #400)
+      if (_metricsCollector != null && _metricsTags != null)
+      {
+        _metricsCollector.Increment("audio.buffer.drift_compensation_total", 1, _metricsTags);
+        _metricsCollector.Increment("audio.buffer.drift_compensation_samples_total", deficit, _metricsTags);
+      }
+      _compensationCountSinceLastLog++;
+      _compensationSamplesSinceLastLog += deficit;
+      // ...rest of throttled log block unchanged...
+    }
+  }
+
+  _lastDriftCheckLevel = currentLevel;
+  _lastDriftCheckTime = now;
+}
+```
+
+**Step 2:** Build clean.
+
+```bash
+dotnet build src/Radio.Infrastructure/Radio.Infrastructure.csproj --configuration Release
+```
+
+Expected: 0 errors. Pre-existing IDE0011 warnings only.
+
+**Step 3:** Commit:
+
+```bash
+git add src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
+git commit -m "fix(audio): smaller-more-frequent drift corrections (2ms vs 10ms per event)"
+```
+
+---
+
+## Task 2: Linear crossfade across the rewind boundary
+
+**Files:**
+- Modify: `src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs` (the new `CompensateClockDrift` body from Task 1)
+
+**Step 1:** When rewinding `_readPos`, the samples immediately AFTER the rewind point will be replayed. The discontinuity is between the LAST sample read before rewind, and the FIRST sample read after rewind (which is the duplicated content). This boundary is the click/pop.
+
+Approach: **apply a cosine-ramp crossfade across `CrossfadeSamples = 32` samples** (~0.67 ms at 48 kHz). On the duplicated chunk, the first 32 samples ramp up from 0 to 1 multiplied with the original signal. This makes the boundary blend smoothly. Cost: 32 multiplies per compensation event = negligible.
+
+The crossfade must operate on the buffer DATA, not the read position. So after rewinding `_readPos`, the next 32 samples that get READ from the buffer need to be attenuated. Two implementation strategies:
+
+**(a) Buffer-write approach**: write the attenuated values directly back into the ring buffer at the rewound position. Simple but mutates the buffer (problematic if there are other readers).
+
+**(b) Read-time approach**: track that we just did a rewind, and apply the ramp during the next 32 samples of `Process(buffer)`. More complex but doesn't mutate the buffer.
+
+Choose **(a)** — `BufferedSoundGenerator<T>` is single-consumer (the master mixer), so buffer mutation is safe. The implementation:
+
+```csharp
+private const int CrossfadeSamples = 32;  // ~0.67ms at 48kHz
+
+// Inside the `if (deficit > 0)` block, after the lock that rewinds _readPos:
+if (typeof(T) == typeof(float))
+{
+  ApplyCrossfadeFloat(_readPos, Math.Min(CrossfadeSamples, deficit));
+}
+// else: short path — phase 2 deferral, log-only for non-float types
+
+// New method:
+private void ApplyCrossfadeFloat(int startPos, int rampLength)
+{
+  if (rampLength <= 0) return;
+  var floatBuffer = _ringBuffer as float[];
+  if (floatBuffer == null) return;
+
+  lock (_bufferLock)
+  {
+    for (int i = 0; i < rampLength; i++)
+    {
+      // Cosine ramp: 0 → 1 over rampLength samples
+      var phase = (i / (double)rampLength) * Math.PI;
+      var gain = (float)((1.0 - Math.Cos(phase)) * 0.5);
+      var idx = (startPos + i) % _maxBufferSamples;
+      floatBuffer[idx] = floatBuffer[idx] * gain;
+    }
+  }
+}
+```
+
+**Caveat — channel-pair alignment**: the crossfade should ideally be applied per-channel-pair (don't split a stereo frame). For stereo at 48 kHz, 32 samples = 16 stereo frames — already frame-aligned. For mono, 32 samples = 32 frames. Both are fine. If channel count is > 2, ensure `rampLength` is frame-aligned: `rampLength = (rampLength / channels) * channels;`.
+
+**Step 2:** Build + commit:
+
+```bash
+dotnet build src/Radio.Infrastructure/Radio.Infrastructure.csproj --configuration Release
+git add src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
+git commit -m "fix(audio): cosine-ramp crossfade across drift-compensation rewind boundary"
+```
+
+---
+
+## Task 3: Unit tests
+
+**Files:**
+- Modify: `tests/Radio.Infrastructure.Tests/Audio/SoundFlow/BufferedSoundGeneratorTests.cs` (or wherever PR #400's tests live)
+
+**Step 1:** Add three tests:
+
+a) **`CompensateClockDrift_PerCallCap_LimitsToTwoMillisecondsOfSamples`** — populate a generator with float data, drain the buffer below threshold, call `Process` repeatedly, assert that `_totalSamplesCompensated` increases in increments ≤ `(int)(Format.SampleRate * Format.Channels * 0.002)`.
+
+b) **`CompensateClockDrift_AppliesCrossfade_OnFloatRingBuffer`** — set up a buffer with a known signal (all 1.0f), drain to threshold, trigger compensation, assert that the first 32 samples after the rewind point have been attenuated by the cosine ramp (sample 0 ≈ 0.0, sample 16 ≈ 0.5, sample 31 ≈ 0.99).
+
+c) **`CompensateClockDrift_NoLongerRunsLessOftenThan2Seconds`** — populate a draining buffer, call `Process` 10× in rapid succession (no `Task.Delay` between), assert that `_totalSamplesCompensated > 0` even though < 2 s elapsed (the new code path runs on every call when draining).
+
+**Step 2:** Run tests:
+
+```bash
+dotnet test tests/Radio.Infrastructure.Tests/Radio.Infrastructure.Tests.csproj --configuration Release --filter "BufferedSoundGeneratorTests"
+```
+
+Expected: all pre-existing + 3 new tests PASS.
+
+**Step 3:** Commit:
+
+```bash
+git add tests/Radio.Infrastructure.Tests/Audio/SoundFlow/BufferedSoundGeneratorTests.cs
+git commit -m "test(audio): drift-compensation refinement coverage (per-call cap + crossfade)"
+```
+
+---
+
+## Task 4: Full build + test verification
+
+```bash
+dotnet build --configuration Release
+dotnet test --configuration Release --verbosity normal
+```
+
+Expected: 0 errors, ~0 new warnings, ~2,200+ tests pass.
+
+If `ModePicker_ClickingFall/Phase/Ring`, `AutoPill_Click_*`, or `Reset_Click_*` fails — that's the documented bUnit click-test flake family. Re-run failed jobs via `gh run rerun <run_id> --failed` after CI; only escalate after 3 consecutive same-test failures.
+
+---
+
+## Task 5: Deploy + verify acceptance criteria
+
+**This task is operator-run by Mark** (Builder reports completion at end of Task 4 + opens the PR; Mark runs Task 5).
+
+**Step 1:** After PR merge, deploy:
+
+```bash
+pwsh.exe -NoProfile -Command "& './deploy/Deploy-ToLinux.ps1' -TargetHost radio -Runtime linux-x64"
+```
+
+**Step 2:** Verify service restarted with new behavior:
+
+```bash
+ssh mmack@radio "journalctl -u radio-api --since '2 minutes ago' -o cat | grep -E '🔄 Clock drift compensation'" | head -5
+```
+
+Expected: log lines show smaller `duplicated` sample counts per event (target: ~96 samples = 2 ms at 48 kHz stereo) and higher event rate.
+
+**Step 3:** Capture post-change metrics over a fresh 15-minute window of BT → Cast playback:
+
+```bash
+sleep 900   # 15 minutes
+ssh mmack@radio "journalctl -u radio-api --since '15 minutes ago' -o short-iso" \
+  | python3 scripts/research/bt_drift_analyze.py > after_drift_15min.txt
+ssh mmack@radio "sqlite3 /opt/radio-console/data/metrics.db \
+  \"SELECT md.Key, SUM(mm.ValueSum) FROM MetricData_Minute mm JOIN MetricDefinitions md ON mm.MetricId=md.Id WHERE md.Key LIKE 'audio.buffer.%' AND mm.Timestamp > strftime('%s','now','-15 minutes')*1000 GROUP BY md.Key;\"" \
+  > after_metrics_15min.txt
+```
+
+**Step 4:** Compare against the Task 0 baseline.
+
+**Success criteria** (in priority order):
+
+1. **PRIMARY (subjective)**: Mark reports the "underwater" / "slow" feel during BT → Cast playback is gone or substantially reduced. *This is the ultimate criterion — if subjective improvement is not achieved, escalate to Path D regardless of the objective numbers.*
+
+2. **OBJECTIVE — compensation event distribution shifts to smaller events**:
+   - `audio.buffer.drift_compensation_total` events/hour **increases by ≥3×** (target: ≥360/hour vs baseline ~120/hour) — this is GOOD, smaller more-frequent corrections are the goal
+   - `audio.buffer.drift_compensation_samples_total` samples/hour stays **within ±20 %** of baseline (target: 30–48 KB samples/hour vs baseline ~39 KB samples/hour) — confirms the same total compensation is being done, just redistributed
+   - Per-event sample count (computed: `drift_compensation_samples_total / drift_compensation_total`) drops from ~96 samples (10 ms / 2) to ~96 samples (2 ms / 2) — wait, that's the same number. Computed: ratio drops from ~325 samples/event (current 10 ms cap with 4-channel-wide path) to ~65 samples/event (2 ms cap) — a ~5× reduction in per-event size
+
+3. **OBJECTIVE — underrun rate drops**:
+   - `audio.buffer.underrun_total` events/hour drops by **≥50 %** (target: ≤25/hour vs baseline 50/hour) — smaller more-frequent corrections should keep the buffer further from zero on average
+
+4. **NEGATIVE CHECK — no new failure mode**:
+   - `audio.buffer.fill_percent` mean stays roughly the same (within ±10 percentage points of baseline)
+   - No new ERR/WRN log lines in the audio path beyond the existing ones
+
+**Debug-agent verification**:
+
+```bash
+python3 scripts/research/bt_drift_compare.py baseline_drift_15min.txt after_drift_15min.txt baseline_metrics_15min.txt after_metrics_15min.txt
+```
+
+(`bt_drift_compare.py` is a new script — see Task 6.)
+
+---
+
+## Task 6: Comparator script for Task 5
+
+**Files:**
+- Create: `scripts/research/bt_drift_compare.py`
+
+**Step 1:** Mirror the pattern of the existing `bt_stall_compare.py` from PR #390. Read two `bt_drift_analyze.py` artifacts + two metric-snapshot artifacts; output a PASS/FAIL summary against the criteria from Task 5.
+
+Structure:
+
+```python
+#!/usr/bin/env python3
+"""Compare baseline vs post-change drift metrics for Path C acceptance."""
+import sys, re, argparse
+
+def parse_drift_artifact(path):
+    """Returns dict: {underrun_events_per_hour, comp_events_per_hour, ppm}."""
+    # parse the bt_drift_analyze.py output format
+    ...
+
+def parse_metrics_artifact(path):
+    """Returns dict: {key -> sum_value}."""
+    # parse the sqlite output lines: "key|value"
+    ...
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('baseline_drift')
+    parser.add_argument('after_drift')
+    parser.add_argument('baseline_metrics')
+    parser.add_argument('after_metrics')
+    args = parser.parse_args()
+
+    base_drift = parse_drift_artifact(args.baseline_drift)
+    after_drift = parse_drift_artifact(args.after_drift)
+    base_m = parse_metrics_artifact(args.baseline_metrics)
+    after_m = parse_metrics_artifact(args.after_metrics)
+
+    # Criterion 2: comp events × at least 3
+    comp_ratio = after_drift['comp_events_per_hour'] / max(base_drift['comp_events_per_hour'], 0.1)
+    c2_events = comp_ratio >= 3.0
+    # Criterion 2: comp samples within ±20%
+    sample_ratio = after_m['audio.buffer.drift_compensation_samples_total'] / max(base_m['audio.buffer.drift_compensation_samples_total'], 1)
+    c2_samples = 0.8 <= sample_ratio <= 1.2
+    # Criterion 3: underrun events drop ≥50%
+    underrun_ratio = after_drift['underrun_events_per_hour'] / max(base_drift['underrun_events_per_hour'], 0.1)
+    c3 = underrun_ratio <= 0.5
+    # Criterion 4: fill_percent mean within ±10
+    # (computed from metrics)
+    ...
+
+    overall_pass = c2_events and c2_samples and c3 and c4
+    print(f"Comp events ratio:    {comp_ratio:.2f}× (target ≥3.0): {'PASS' if c2_events else 'FAIL'}")
+    print(f"Comp samples ratio:   {sample_ratio:.2f}× (target 0.8-1.2): {'PASS' if c2_samples else 'FAIL'}")
+    print(f"Underrun ratio:       {underrun_ratio:.2f}× (target ≤0.5): {'PASS' if c3 else 'FAIL'}")
+    # ...
+    print(f"\nOVERALL (objective): {'PASS' if overall_pass else 'FAIL'}")
+    print("Subjective (audible 'underwater' improvement): Mark UAT")
+    sys.exit(0 if overall_pass else 1)
+
+if __name__ == '__main__':
+    main()
+```
+
+**Step 2:** Syntax-check + commit:
+
+```bash
+python3 -c "import ast; ast.parse(open('scripts/research/bt_drift_compare.py').read())"
+git add scripts/research/bt_drift_compare.py
+git commit -m "scripts(research): bt_drift_compare.py — Path C acceptance PASS/FAIL gate"
+```
+
+---
+
+## Task 7: Open the PR
+
+```bash
+git push -u origin feat/bt-drift-compensation-refinement
+
+gh pr create --title "fix(audio): refine BT drift compensation — smaller corrections + crossfade" --body "$(cat <<'EOF'
+## Summary
+
+Refines `BufferedSoundGenerator<T>.CompensateClockDrift` to produce sub-perceptual corrections instead of the current 10 ms duplications that listeners hear as 'underwater' / 'slow' audio.
+
+This is **Path C** from the BT clock-skew research doc (`docs/research/2026-05-22-bt-clock-skew-measurement.md`), which measured 217–391 ppm skew between the BT phone clock and the local speaker clock — about 10–20× over the BT A2DP spec. The skew is unfixable in software (two crystals can't be sync'd), so the right move is to make the compensation that masks it less audible.
+
+## Two changes
+
+1. **Per-call compensation cap** drops from 10 ms (480 samples at 48 kHz) to 2 ms (96 samples). Total compensation per minute stays the same (driven by the underlying rate mismatch), but it's redistributed across ~5× more events that are each much shorter.
+
+2. **Cosine-ramp crossfade** (~32 samples / ~0.67 ms) blended across the rewind boundary in the ring buffer. Eliminates the discontinuity click at the boundary that contributes to the perceived 'underwater' sound.
+
+3. **Removed 2 s cooldown** between drift-checks so the smaller corrections can run as often as needed.
+
+## Acceptance (per plan Task 5)
+
+- [ ] Mark UAT subjective: 'underwater' feel reduced or gone
+- [ ] `drift_compensation_total` events/hour increases ≥3× (more events, each smaller)
+- [ ] `drift_compensation_samples_total` samples/hour stays within ±20 % of baseline
+- [ ] `underrun_total` events/hour drops ≥50 %
+- [ ] `fill_percent` mean within ±10 of baseline
+
+If subjective UAT fails despite objective metrics passing: escalate to **Path D** (real variable-rate resampler).
+
+## Test plan
+
+- [x] Unit tests for the three new behaviors (per-call cap, crossfade math, no-cooldown)
+- [x] `dotnet build --configuration Release` clean
+- [x] `dotnet test --configuration Release` all pass
+- [ ] Mark: deploy + 15-minute soak + bt_drift_compare.py PASS/FAIL
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Auto-merge after CI passes per the current tranche's authorization. Mark runs Task 5 post-merge.
+
+---
+
+## Out of scope
+
+- **Real variable-rate resampling (Path D).** That's the definitive fix and the explicit fallback if this plan's subjective acceptance fails. A separate plan document captures Path D.
+- **Phone clock identification.** Knowing WHICH phone has the 217 ppm skew would help (different phone might have less). Not actionable for the radio itself though.
+- **Local speaker clock characterization.** Same reason; the speaker is a fixed crystal.
+- **Cast HM HTTP pacing changes.** Architecturally unable to affect BT-input underrun — see research doc rejected-options section.
+- **Different default-output routing** (e.g., bypass mixer when streaming BT → Cast). Major architectural change; out of scope.

--- a/docs/research/2026-05-22-bt-clock-skew-measurement.md
+++ b/docs/research/2026-05-22-bt-clock-skew-measurement.md
@@ -1,0 +1,94 @@
+# BT-to-Cast clock-skew measurement & architectural analysis
+
+**Status**: complete (measurement + architectural analysis).
+**Author**: Mark + Claude, 2026-05-22.
+**Motivation**: While streaming BT → Cast on `mmack@radio`, Mark reported "underwater" / "slow" audio at irregular but recurring intervals. The cast/BT research arc's Phase 1+2 instrumentation didn't catch this — it was built for FM-BT-3 (silent capture quiescence), not for clock-rate mismatch artifacts. This doc captures what we measured, the architecture analysis that explains it, and the implications for fix selection.
+
+## Source data
+
+Live measurements taken after PR #400 (BufferedSoundGenerator observability) deployed to `radio`. Probe: `scripts/research/bt_drift_analyze.py` ingesting `journalctl -u radio-api -o short-iso`. Two consecutive windows:
+
+```
+15-minute window (post-deploy):
+  Underrun events:      13       (52.6/hour, 36 KB samples/hour)
+  Compensation events:  10       (40.4/hour, 39 KB samples/hour)
+  Net buffer deficit:   20.8 samples/sec
+  Estimated clock skew: ~217 ppm
+
+5-minute window (most recent):
+  Underrun events:      3        (37.2/hour)
+  Compensation events:  10       (124.1/hour)
+  Net buffer deficit:   37.5 samples/sec
+  Estimated clock skew: ~391 ppm
+```
+
+The 5-minute window has higher per-hour rates because the 15-minute window includes early post-deploy time before all metrics fully started flowing. The ~217 ppm vs ~391 ppm range is the same phenomenon viewed across two window scales; steady-state is closer to ~250–400 ppm.
+
+## Reference frames
+
+- **BT A2DP spec tolerance**: ±20 ppm crystal accuracy for the encoder's clock
+- **Measured skew on this session**: 217–391 ppm — **10–20× over spec**
+- **Implication**: this is not raw phone-clock drift alone; another contributor is in play
+
+## Audible mechanism
+
+`BufferedSoundGenerator<float>.CompensateClockDrift` (`src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs:477-545`) triggers when the buffer drains below 15 % of capacity. It "rewinds" `_readPos` by `deficit` samples (capped at 10 ms / 480 samples), causing the most-recent 10 ms of audio to be replayed.
+
+To the listener, replaying 10 ms of audio sounds like a brief pitch slide / time-stretch / **"underwater"**. At ~120 compensation events / hour observed, that's roughly **one ~10 ms stretch every 30 seconds** — exactly Mark's reported cadence.
+
+When even the 10 ms-per-2 s compensation can't keep up, the buffer hits zero and `Buffer underrun (Single)` warns — zero-fill silence is inserted. That's the "second tier" symptom — brief silence punctuating the stretches.
+
+## Architecture — the consumer is the master mixer, not Cast
+
+A correction to the original Phase 2 plan framing: when I drafted four mitigation options ("Path A/B/C/D"), Path C was named "Cast consumer paces to producer rate" — assuming the Cast HM HTTP stream is the consumer of BT samples. Re-reading the audio graph:
+
+```
+BT phone (clock A)
+  ↓ pw_stream → OnProcess delivers samples
+BufferedSoundGenerator<float> (ring buffer)
+  ↓ Process(buffer) — pulled at PlaybackDevice clock rate
+MasterMixer.Process — modifiers chain
+  ↓ TappedOutputStream.WriteToOutputTap (a Modifier)
+  ↓ also → PlaybackDevice → local speaker (clock B, but volume=0 if Cast selected)
+TappedOutputStream ring buffer
+  ↓ HttpStreamOutput.HandleClientAsync — read at wall-clock pace
+LAME MP3 encode
+  ↓ HTTP/1.1 chunked
+Chromecast (clock C, decodes + plays via its own clock)
+```
+
+The **consumer of BT samples is the MasterMixer**, driven by **PlaybackDevice's clock** (a fixed crystal-locked local-speaker clock; we cannot change its rate). The Cast HTTP stream sits **downstream of the master mixer** as a tap — it cannot affect how fast the mixer pulls from BT.
+
+So **Path C as originally framed** ("Cast consumer paces to producer rate") **cannot affect the BT-input underrun rate**. Whatever pacing changes we make at the Cast HTTP layer would only change the TappedOutputStream consumption pattern, not the BT BufferedSoundGenerator's drain rate.
+
+The skew is **between clock A (phone) and clock B (local speaker)** — two independent crystals that are off by 217–391 ppm. There is no software fix at the "Cast pacing" layer for that.
+
+## What CAN actually mitigate the BT-input underrun
+
+Three real options, ordered roughly by effort:
+
+1. **Refine the existing `CompensateClockDrift` algorithm** — smaller per-event corrections more frequently, with crossfade smoothing. The 10 ms duplication is hard to mask because the discontinuity at the rewind point is abrupt. A 1-2 ms duplication done 5× more often, with a linear crossfade across a few samples, can drop the per-event artifact below the perceptual threshold. This is a **reinterpretation of "Path C"** — an algorithmic improvement, not a routing change.
+
+2. **Real variable-rate resampling** ("Path D") — apply a proper sample-rate converter on the BT input that runs at `phone_rate / speaker_rate` ratio (~0.99975 in this case). Eliminates audible stretches entirely. Needs a real SRC library (libsamplerate, libsoxr, or `Mathnet.Numerics`-based implementation). Higher CPU cost (~5-10 % on a slow core for stereo 48 kHz audio) and ~1-3 ms added latency. Best long-term fix.
+
+3. **Skip compensation entirely; accept underruns as occasional silence** ("Path B" from the original menu) — turn off `CompensateClockDrift`. Listener hears occasional brief silence instead of stretched audio. Probably worse-sounding than even the current state.
+
+## What we should NOT do (rejected)
+
+- **"Cast HM HTTP reader paces to TappedOutputStream fill level"** — could be done, but addresses the wrong layer. Would change Cast-side dynamics without touching BT-input underrun. Marked here so a future researcher doesn't propose this thinking it'll help.
+- **"Sync the local speaker clock to BT"** — physical clock is crystal-locked at the hardware level; no software path to retune it.
+- **"Run the master mixer at the BT effective rate"** — mixer rate is dictated by PlaybackDevice clock; cannot decouple within SoundFlow's model.
+
+## Decision
+
+Mark requested in-conversation: ship Path C first (refined algorithm), evaluate impact on the metrics + listener subjective experience, then decide on Path D if needed.
+
+**Path C plan**: `docs/plans/2026-05-22-bt-drift-compensation-refinement.md` (companion document).
+
+**Acceptance criteria (from research data)**: per the measurement-discipline pattern established in the cast/BT research arc, success is defined as:
+- **Primary subjective**: Mark reports the "underwater" feel is no longer perceptible during BT → Cast playback
+- **Primary objective**: `audio.buffer.drift_compensation_total` events/hour can increase (smaller events = more events is fine), but `audio.buffer.drift_compensation_samples_total` should stay roughly flat (same total samples redistributed across more events)
+- **Secondary**: `audio.buffer.underrun_total` events/hour drops by ≥50 % (smoother compensation should let the buffer recover before hitting zero more often)
+- **Probe**: re-run `bt_drift_analyze.py` against a fresh 15-minute window pre vs post change
+
+If Path C does not achieve subjective improvement: Path D (real resampler) becomes the next plan.


### PR DESCRIPTION
## Summary

PR #400's observability surfaced **217–391 ppm clock skew** between the BT phone clock and the local speaker clock during BT → Cast playback — ~10–20× over BT A2DP spec. The clock skew itself is unfixable in software (two crystals can't be sync'd); the goal is to make the compensation that masks it less audible.

This PR ships two docs:

1. **Research note** \`docs/research/2026-05-22-bt-clock-skew-measurement.md\` — measurement methodology, the ppm numbers, and an architectural analysis that corrects an inaccuracy in the original mitigation menu I drafted (I'd framed \"Path C\" as Cast HM HTTP pacing changes; the audio graph makes that ineffective because Cast HM is downstream of the master mixer which is the actual consumer of BT samples).

2. **Refined Path C plan** \`docs/plans/2026-05-22-bt-drift-compensation-refinement.md\` — improve the \`BufferedSoundGenerator<T>.CompensateClockDrift\` *algorithm* so each event is sub-perceptual:
   - Smaller per-call cap (2 ms vs current 10 ms) — ~5× more events but each much shorter
   - Cosine-ramp crossfade across the rewind boundary (~32 samples / 0.67 ms) to eliminate the discontinuity click
   - Remove the 2 s drift-check cooldown so the smaller corrections can run as needed

If subjective UAT after Path C still hears 'underwater': escalate to Path D (real variable-rate resampler) — separate plan, deferred.

## Acceptance criteria for the implementation PR (Builder dispatches next)

- Mark UAT subjective: 'underwater' feel reduced or gone
- \`drift_compensation_total\` events/hour increases ≥3× (more, smaller events)
- \`drift_compensation_samples_total\` samples/hour stays within ±20 % of baseline
- \`underrun_total\` events/hour drops ≥50 %
- \`fill_percent\` mean stays within ±10 of baseline

## Test plan

This PR is documentation-only.

- [x] Research note documents the architectural analysis honestly (including the rejected Cast HM pacing option)
- [x] Plan tasks are concrete with literal code sketches + commit messages + acceptance criteria
- [x] ROADMAP.md registers the active follow-up arc

🤖 Generated with [Claude Code](https://claude.com/claude-code)