### PR TITLE
fix(audio): refine BT drift compensation — smaller corrections + crossfade

### DIFF
--- a/scripts/research/bt_drift_compare.py
+++ b/scripts/research/bt_drift_compare.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""bt_drift_compare.py — PASS/FAIL gate for Path C drift-compensation refinement.
+
+Inputs (positional):
+  1. baseline_drift   — output of bt_drift_analyze.py BEFORE the refinement
+  2. after_drift      — output of bt_drift_analyze.py AFTER the refinement
+  3. baseline_metrics — sqlite3 pipe-delimited "key|sum" rows BEFORE
+  4. after_metrics    — same, AFTER
+
+The metric snapshots come from:
+
+  ssh mmack@radio "sqlite3 /opt/radio-console/data/metrics.db \\
+    \"SELECT md.Key, SUM(mm.ValueSum) FROM MetricData_Minute mm \\
+     JOIN MetricDefinitions md ON mm.MetricId=md.Id \\
+     WHERE md.Key LIKE 'audio.buffer.%' \\
+       AND mm.Timestamp > strftime('%s','now','-15 minutes')*1000 \\
+     GROUP BY md.Key;\""
+
+Success criteria (objective only — subjective UAT is operator-run):
+  - C2.events:   after.comp_events_per_hour / baseline.comp_events_per_hour >= 3.0
+                 (smaller-more-frequent: many more events at ~1/5th the size)
+  - C2.samples:  after.comp_samples_total / baseline.comp_samples_total in [0.8, 1.2]
+                 (same total compensation, redistributed across more events)
+  - C3.underrun: after.underrun_events_per_hour / baseline.underrun_events_per_hour <= 0.5
+                 (smaller-more-frequent compensation should hold the buffer further
+                 from zero on average)
+
+Exit 0 on PASS, 1 on FAIL. The subjective "underwater" UAT is reported as
+informational only — the operator is the authority on that criterion.
+
+Plan reference: docs/plans/2026-05-22-bt-drift-compensation-refinement.md §5.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+# Lines we parse out of bt_drift_analyze.py:
+#   Underrun events:           13     (rate: 52.6/hour, 36000 samples/hour)
+#   Compensation events:       10     (rate: 40.4/hour, 39000 samples/hour)
+UNDERRUN_LINE_RE = re.compile(
+    r"Underrun events:\s+(\d+)\s+\(rate:\s+([\d.]+)/hour,\s+([\d.]+)\s+samples/hour\)"
+)
+COMP_LINE_RE = re.compile(
+    r"Compensation events:\s+(\d+)\s+\(rate:\s+([\d.]+)/hour,\s+([\d.]+)\s+samples/hour\)"
+)
+
+
+def parse_drift_artifact(path: str) -> dict[str, float]:
+    """Return a dict with keys:
+      underrun_events, underrun_events_per_hour, underrun_samples_per_hour,
+      comp_events, comp_events_per_hour, comp_samples_per_hour
+    """
+    out = {
+        "underrun_events": 0.0,
+        "underrun_events_per_hour": 0.0,
+        "underrun_samples_per_hour": 0.0,
+        "comp_events": 0.0,
+        "comp_events_per_hour": 0.0,
+        "comp_samples_per_hour": 0.0,
+    }
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            m = UNDERRUN_LINE_RE.search(line)
+            if m:
+                out["underrun_events"] = float(m.group(1))
+                out["underrun_events_per_hour"] = float(m.group(2))
+                out["underrun_samples_per_hour"] = float(m.group(3))
+                continue
+            m = COMP_LINE_RE.search(line)
+            if m:
+                out["comp_events"] = float(m.group(1))
+                out["comp_events_per_hour"] = float(m.group(2))
+                out["comp_samples_per_hour"] = float(m.group(3))
+    return out
+
+
+def parse_metrics_artifact(path: str) -> dict[str, float]:
+    """Parse pipe-delimited 'key|sum' rows from sqlite output."""
+    out: dict[str, float] = {}
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or "|" not in line:
+                continue
+            key, _, value = line.partition("|")
+            key = key.strip()
+            value = value.strip()
+            if not key:
+                continue
+            try:
+                out[key] = float(value)
+            except ValueError:
+                continue
+    return out
+
+
+def ratio(after: float, before: float, floor: float = 0.1) -> float:
+    """Return `after / max(before, floor)` — `floor` guards divide-by-near-zero."""
+    return after / max(before, floor)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare baseline vs post-change drift metrics for Path C acceptance."
+    )
+    parser.add_argument("baseline_drift", help="bt_drift_analyze.py output, baseline")
+    parser.add_argument("after_drift", help="bt_drift_analyze.py output, after refinement")
+    parser.add_argument("baseline_metrics", help="sqlite key|sum dump, baseline")
+    parser.add_argument("after_metrics", help="sqlite key|sum dump, after refinement")
+    args = parser.parse_args()
+
+    base_d = parse_drift_artifact(args.baseline_drift)
+    after_d = parse_drift_artifact(args.after_drift)
+    base_m = parse_metrics_artifact(args.baseline_metrics)
+    after_m = parse_metrics_artifact(args.after_metrics)
+
+    # --- Criterion C2.events: comp events/hour >= 3x baseline ---
+    comp_ratio = ratio(
+        after_d["comp_events_per_hour"], base_d["comp_events_per_hour"], floor=0.1
+    )
+    c2_events_pass = comp_ratio >= 3.0
+
+    # --- Criterion C2.samples: comp samples/hour stays within +/-20% ---
+    # Prefer the metric-derived value (cumulative counter) over the log-derived
+    # value because the counter is exact and the log-derived value can be off
+    # if the log throttle drops events.
+    base_samples = base_m.get(
+        "audio.buffer.drift_compensation_samples_total",
+        base_d["comp_samples_per_hour"],
+    )
+    after_samples = after_m.get(
+        "audio.buffer.drift_compensation_samples_total",
+        after_d["comp_samples_per_hour"],
+    )
+    sample_ratio = ratio(after_samples, base_samples, floor=1.0)
+    c2_samples_pass = 0.8 <= sample_ratio <= 1.2
+
+    # --- Criterion C3: underrun events/hour drops by >=50% (ratio <= 0.5) ---
+    underrun_ratio = ratio(
+        after_d["underrun_events_per_hour"],
+        base_d["underrun_events_per_hour"],
+        floor=0.1,
+    )
+    c3_pass = underrun_ratio <= 0.5
+
+    overall_pass = c2_events_pass and c2_samples_pass and c3_pass
+
+    print("=== Path C objective acceptance ===")
+    print(f"baseline window comp events/hour:     {base_d['comp_events_per_hour']:.1f}")
+    print(f"after window comp events/hour:        {after_d['comp_events_per_hour']:.1f}")
+    print(f"baseline window underrun events/hour: {base_d['underrun_events_per_hour']:.1f}")
+    print(f"after window underrun events/hour:    {after_d['underrun_events_per_hour']:.1f}")
+    print(f"baseline comp samples (metric/log):   {base_samples:.0f}")
+    print(f"after comp samples (metric/log):      {after_samples:.0f}")
+    print()
+    print(
+        f"C2.events  comp ratio:    {comp_ratio:6.2f}x  "
+        f"(target >= 3.0): {'PASS' if c2_events_pass else 'FAIL'}"
+    )
+    print(
+        f"C2.samples sample ratio:  {sample_ratio:6.2f}x  "
+        f"(target 0.80-1.20): {'PASS' if c2_samples_pass else 'FAIL'}"
+    )
+    print(
+        f"C3         underrun ratio:{underrun_ratio:6.2f}x  "
+        f"(target <= 0.50): {'PASS' if c3_pass else 'FAIL'}"
+    )
+    print()
+    print(f"OVERALL (objective):     {'PASS' if overall_pass else 'FAIL'}")
+    print()
+    print("Subjective (audible 'underwater' artifact gone): Mark UAT")
+    print(
+        "  If objective PASS but subjective FAIL: Path D (real variable-rate "
+        "resampler) is the next plan."
+    )
+    return 0 if overall_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
@@ -479,6 +479,12 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
     }
 
     /// <summary>
+    /// Cosine-ramp crossfade length (samples) applied at the rewind boundary to
+    /// blend the duplicated chunk smoothly. ~0.67 ms at 48 kHz stereo (16 frames).
+    /// </summary>
+    private const int CrossfadeSamples = 32;
+
+    /// <summary>
     /// Detects clock drift between producer and consumer by monitoring buffer level
     /// trends. When the buffer is consistently draining (producer slower than consumer),
     /// rewinds the read pointer to duplicate recent audio and prevent underrun.
@@ -486,7 +492,9 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
     ///
     /// Path C refinement (2026-05-22): per-call cap dropped from 10 ms to 2 ms and the
     /// 2-second cooldown was removed so the same total compensation is redistributed
-    /// across ~5× more events that are each individually sub-perceptual. See
+    /// across ~5× more events that are each individually sub-perceptual. A cosine-ramp
+    /// crossfade is applied across the rewind boundary on the float ring buffer to
+    /// eliminate the boundary discontinuity click. See
     /// docs/plans/2026-05-22-bt-drift-compensation-refinement.md.
     /// </summary>
     private void CompensateClockDrift(int channels)
@@ -538,11 +546,13 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
             if (deficit > 0)
             {
                 bool applied = false;
+                int rewindStartPos = 0;
                 lock (_bufferLock)
                 {
                     if (_count + deficit <= _maxBufferSamples)
                     {
                         _readPos = (_readPos - deficit + _maxBufferSamples) % _maxBufferSamples;
+                        rewindStartPos = _readPos;
                         _count += deficit;
                         _totalSamplesCompensated += deficit;
                         applied = true;
@@ -551,6 +561,20 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
 
                 if (applied)
                 {
+                    // Apply cosine-ramp crossfade across the rewind boundary for the
+                    // float ring buffer (BT/A2DP path). Short path is non-musical
+                    // (radio TTS / synth events) and left untouched.
+                    if (typeof(T) == typeof(float))
+                    {
+                        var rampLen = Math.Min(CrossfadeSamples, deficit);
+                        // Frame-align ramp length so we never split a multi-channel frame.
+                        rampLen = (rampLen / frameSamples) * frameSamples;
+                        if (rampLen > 0)
+                        {
+                            ApplyCrossfadeFloat(rewindStartPos, rampLen);
+                        }
+                    }
+
                     // Counters bump on EVERY successful compensation (independent of log throttle)
                     if (_metricsCollector != null && _metricsTags != null)
                     {
@@ -586,6 +610,42 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
 
         _lastDriftCheckLevel = currentLevel;
         _lastDriftCheckTime = now;
+    }
+
+    /// <summary>
+    /// Applies a cosine-ramp gain (0 → 1) across <paramref name="rampLength"/> samples
+    /// starting at <paramref name="startPos"/> in the float ring buffer. Used to blend
+    /// the boundary between the original signal and the duplicated chunk produced by
+    /// <see cref="CompensateClockDrift"/>, eliminating the discontinuity click that
+    /// otherwise contributes to the perceived "underwater" artifact.
+    ///
+    /// Safe to mutate the buffer in place: <see cref="BufferedSoundGenerator{T}"/> is
+    /// single-consumer (the master mixer reads via <see cref="GenerateAudio"/>); the
+    /// crossfade is applied immediately after the rewind under the buffer lock so no
+    /// reader has yet observed the duplicated samples.
+    /// </summary>
+    private void ApplyCrossfadeFloat(int startPos, int rampLength)
+    {
+        if (rampLength <= 0)
+        {
+            return;
+        }
+
+        // _ringBuffer is typed T[]; at this branch T == float so the cast is safe.
+        // MemoryMarshal.Cast reinterprets the existing array; no allocation.
+        var floatRing = MemoryMarshal.Cast<T, float>(_ringBuffer.AsSpan());
+
+        lock (_bufferLock)
+        {
+            for (int i = 0; i < rampLength; i++)
+            {
+                // Cosine ramp: 0 → 1 over rampLength samples (raised-cosine half-window).
+                var phase = (i / (double)rampLength) * Math.PI;
+                var gain = (float)((1.0 - Math.Cos(phase)) * 0.5);
+                var idx = (startPos + i) % _maxBufferSamples;
+                floatRing[idx] = floatRing[idx] * gain;
+            }
+        }
     }
 
     private void LogStats()

--- a/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/BufferedSoundGenerator.cs
@@ -483,6 +483,11 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
     /// trends. When the buffer is consistently draining (producer slower than consumer),
     /// rewinds the read pointer to duplicate recent audio and prevent underrun.
     /// This compensates for BT/PipeWire running on a different clock than ALSA playback.
+    ///
+    /// Path C refinement (2026-05-22): per-call cap dropped from 10 ms to 2 ms and the
+    /// 2-second cooldown was removed so the same total compensation is redistributed
+    /// across ~5× more events that are each individually sub-perceptual. See
+    /// docs/plans/2026-05-22-bt-drift-compensation-refinement.md.
     /// </summary>
     private void CompensateClockDrift(int channels)
     {
@@ -497,11 +502,10 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
             return;
         }
 
-        // Check every ~2 seconds to smooth out transient jitter
-        if ((now - _lastDriftCheckTime).TotalSeconds < 2.0)
-        {
-            return;
-        }
+        // No cooldown — the per-call cap below keeps each correction small (≤2 ms),
+        // so running on every Process call redistributes the necessary compensation
+        // across many short events rather than concentrating it into audible 10 ms
+        // duplications every ~2 seconds.
 
         int currentLevel;
         lock (_bufferLock)
@@ -523,13 +527,12 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
 
         if (isDraining)
         {
-            // Rewind read pointer to duplicate recent audio back up to target level.
-            // Frame-align the compensation amount to avoid splitting stereo pairs.
-            var deficit = _driftCompensationTarget - currentLevel;
+            // Per-call cap: 2 ms of audio (96 samples at 48 kHz stereo). Smaller events
+            // are less audible per occurrence; total samples compensated per second stays
+            // roughly the same because it is driven by the underlying rate mismatch.
             var frameSamples = Math.Max(channels, 2);
-            // Align to frame boundary and cap at 10ms of audio to keep it inaudible
-            var maxCompensation = (int)(Format.SampleRate * Format.Channels * 0.01); // 10ms
-            deficit = Math.Min(deficit, maxCompensation);
+            var maxCompensationPerCall = (int)(Format.SampleRate * Format.Channels * 0.002);
+            var deficit = Math.Min(_driftCompensationTarget - currentLevel, maxCompensationPerCall);
             deficit = (deficit / frameSamples) * frameSamples; // frame-align
 
             if (deficit > 0)
@@ -559,9 +562,9 @@ public class BufferedSoundGenerator<T> : SoundComponent where T : struct
                     _compensationSamplesSinceLastLog += deficit;
 
                     // Log compensation bursts at Info: throttled to once per 5 seconds.
-                    // Compensation runs at most once per ~2s (per the drift check interval),
-                    // so 5s gives 2-3 events per log line and still reveals the cadence
-                    // of the audible "underwater" artifact (10ms of duplicated audio per event).
+                    // With no cooldown, compensation can now fire on every Process call
+                    // while draining; the 5 s throttle aggregates the burst into a single
+                    // line revealing event-count + total-duplicated-samples cadence.
                     var compNow = DateTime.UtcNow;
                     var compSinceLastLog = _lastCompensationLogTime == default
                         ? 0.0 : (compNow - _lastCompensationLogTime).TotalSeconds;

--- a/tests/Radio.Infrastructure.Tests/Audio/Diagnostics/PipelineDistortionTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/Diagnostics/PipelineDistortionTests.cs
@@ -127,36 +127,73 @@ public class PipelineDistortionTests
     var reference = WavFileHelper.GenerateStereoSineWave(
       leftHz: 200, rightHz: 300, durationSamples: durationSamples, amplitude: 0.8f);
 
+    // Pre-fill the buffer above the drift-compensation threshold so the
+    // interleaved push/pull below stays in the "healthy" buffer-fill region
+    // and the clock-drift compensation path stays dormant. The test's purpose
+    // is signal-integrity through the basic ring-buffer transport, not
+    // compensation behaviour; compensation has its own dedicated tests in
+    // BufferedSoundGeneratorTests.cs.
+    //
+    // Path C (docs/plans/2026-05-22-bt-drift-compensation-refinement.md)
+    // removed the 2-second cooldown that previously kept compensation
+    // dormant during this tight push/pull simulation; without the prefill,
+    // the buffer drains to a level below the 15 % threshold on every cycle
+    // and triggers continuous compensation events that legitimately distort
+    // the test signal (rewind + crossfade by design).
+    //
+    // Threshold = 15 % of 4-second buffer = ~600 ms = ~57 600 samples; we
+    // prefill 1.5 s = 144 000 samples to ride comfortably above it. The
+    // prefilled silence comes out of the generator first; we capture and
+    // discard those leading samples before comparing the reference against
+    // the trailing samples that contain the actual signal.
+    generator.PreFillSilence(1.5f);
+    var prefillSamples = (int)(SampleRate * Channels * 1.5);
+
     // Interleave push/pull (simulating real producer/consumer behavior)
     // Push a chunk, then pull the same amount — prevents buffer overflow.
+    // Pull `prefillSamples + reference.Length` total: the leading prefill
+    // samples are silence (discarded), the trailing samples are the signal.
     var pushChunkSize = 6554; // ~2 RTL-SDR callbacks worth of stereo
     var pullChunkSize = 512;  // Mixer quantum
-    var output = new float[reference.Length];
+    var totalPullSamples = prefillSamples + reference.Length;
+    var fullOutput = new float[totalPullSamples];
     var pushOffset = 0;
     var pullOffset = 0;
 
-    while (pushOffset < reference.Length || pullOffset < output.Length)
+    while (pushOffset < reference.Length || pullOffset < fullOutput.Length)
     {
-      // Push one chunk
+      // Push one chunk. Once reference is exhausted, push silence so the
+      // buffer headroom stays above the drift-compensation threshold for
+      // the pull-only tail of the loop. The trailing silence appears past
+      // the trim window and does not affect the comparison output.
       if (pushOffset < reference.Length)
       {
         var len = Math.Min(pushChunkSize, reference.Length - pushOffset);
         generator.AddSamples(reference.AsSpan(pushOffset, len));
         pushOffset += len;
       }
+      else if (pullOffset < fullOutput.Length)
+      {
+        generator.AddSamples(new float[pushChunkSize]);
+      }
 
       // Pull equivalent amount in mixer-sized chunks
-      var toPull = Math.Min(pushChunkSize, output.Length - pullOffset);
-      while (toPull > 0 && pullOffset < output.Length)
+      var toPull = Math.Min(pushChunkSize, fullOutput.Length - pullOffset);
+      while (toPull > 0 && pullOffset < fullOutput.Length)
       {
         var pullSize = Math.Min(pullChunkSize, toPull);
-        pullSize = Math.Min(pullSize, output.Length - pullOffset);
+        pullSize = Math.Min(pullSize, fullOutput.Length - pullOffset);
         var chunk = generator.PullAudio(pullSize);
-        Array.Copy(chunk, 0, output, pullOffset, pullSize);
+        Array.Copy(chunk, 0, fullOutput, pullOffset, pullSize);
         pullOffset += pullSize;
         toPull -= pullSize;
       }
     }
+
+    // Trim the leading prefill silence; the signal lives in the trailing
+    // `reference.Length` samples.
+    var output = new float[reference.Length];
+    Array.Copy(fullOutput, prefillSamples, output, 0, reference.Length);
 
     var report = WaveformComparison.Compare(reference, output);
 

--- a/tests/Radio.Infrastructure.Tests/Audio/SoundFlow/BufferedSoundGeneratorTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/SoundFlow/BufferedSoundGeneratorTests.cs
@@ -264,4 +264,203 @@ namespace Radio.Infrastructure.Tests.Audio.SoundFlow;
                   It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
               Times.AtLeastOnce);
       }
+
+      // ---------------------------------------------------------------------
+      // Path C refinement coverage
+      // (docs/plans/2026-05-22-bt-drift-compensation-refinement.md)
+      // ---------------------------------------------------------------------
+
+      [Fact]
+      public void CompensateClockDrift_PerCallCap_LimitsToTwoMillisecondsOfSamples()
+      {
+          // Arrange: a sustained drain scenario where the buffer stays well below the
+          // drift threshold for many successive Read calls. We expect each compensation
+          // event to be capped at 2 ms (= sample_rate * channels * 0.002 = 192 samples
+          // for 48 kHz stereo), frame-aligned. Pre-refinement the cap was 10 ms.
+          var format = new AudioFormat { SampleRate = 48000, Channels = 2, Format = SampleFormat.F32 };
+          var metrics = new Mock<IMetricsCollector>();
+          var generator = new TestBufferedGenerator<float>(
+              _engineMock.Object, format, _loggerMock.Object, metrics.Object);
+
+          // 2 ms cap at 48 kHz stereo = 192 samples per event.
+          const int expectedCapSamples = 48_000 * 2 * 2 / 1000;
+          Assert.Equal(192, expectedCapSamples);
+
+          // Capture every drift-compensation samples increment so we can inspect the
+          // per-event sizes. Counter is the second argument (a double) of Increment.
+          var perEventSamples = new List<double>();
+          metrics
+              .Setup(m => m.Increment(
+                  "audio.buffer.drift_compensation_samples_total",
+                  It.IsAny<double>(),
+                  It.IsAny<IDictionary<string, string>>()))
+              .Callback<string, double, IDictionary<string, string>?>((_, v, _) => perEventSamples.Add(v));
+
+          var prefill = new float[10_000];
+          for (int i = 0; i < prefill.Length; i++)
+          {
+              prefill[i] = 0.1f;
+          }
+          var output = new float[512];
+
+          generator.AddSamples(prefill);
+          generator.Read(output); // anchor _lastDriftCheckTime
+
+          // Tight loop — no Thread.Sleep, because Path C removed the 2-second cooldown.
+          // Refill just enough each iteration to keep the drain going under the threshold.
+          for (int i = 0; i < 20; i++)
+          {
+              generator.AddSamples(new float[256]);
+              generator.Read(output);
+          }
+
+          // At least one compensation event must have fired (>3 drift-checks + draining).
+          Assert.NotEmpty(perEventSamples);
+
+          // Critical assertion: every single per-event sample count must be <= cap.
+          // No event may exceed the 2 ms cap.
+          foreach (var samples in perEventSamples)
+          {
+              Assert.True(samples <= expectedCapSamples,
+                  $"Compensation event of {samples} samples exceeded the 2 ms cap of {expectedCapSamples} samples");
+              Assert.True(samples > 0, "Compensation event recorded 0 samples (should not happen)");
+          }
+      }
+
+      [Fact]
+      public void CompensateClockDrift_AppliesCrossfade_OnFloatRingBuffer()
+      {
+          // Arrange: drive the generator into a compensation event, then inspect the
+          // ring buffer through the next Read to confirm the first 32 samples of the
+          // duplicated chunk follow a cosine ramp (start near 0, midpoint near 0.5,
+          // end approaching original amplitude).
+          var format = new AudioFormat { SampleRate = 48000, Channels = 2, Format = SampleFormat.F32 };
+          var metrics = new Mock<IMetricsCollector>();
+
+          // Track each compensation event so the test can drain just past the first one.
+          int compEventCount = 0;
+          metrics
+              .Setup(m => m.Increment(
+                  "audio.buffer.drift_compensation_total",
+                  It.IsAny<double>(),
+                  It.IsAny<IDictionary<string, string>>()))
+              .Callback<string, double, IDictionary<string, string>?>((_, _, _) => compEventCount++);
+
+          var generator = new TestBufferedGenerator<float>(
+              _engineMock.Object, format, _loggerMock.Object, metrics.Object);
+
+          // Fill with a uniform 1.0 signal so the ramp is easy to detect:
+          // post-crossfade values should equal `1.0 * cosine_gain(i, 32)`.
+          var prefill = new float[10_000];
+          for (int i = 0; i < prefill.Length; i++)
+          {
+              prefill[i] = 1.0f;
+          }
+
+          generator.AddSamples(prefill);
+
+          // Anchor + warm up _driftCheckCount > 3 + trigger the first compensation.
+          // Capture the first read AFTER the compensation event so we observe the
+          // crossfaded duplicated chunk at the start of the buffer.
+          var output = new float[512];
+          generator.Read(output); // anchor
+
+          // Helper: 1.0f top-up keeps the buffer-content uniform so we can verify
+          // the post-crossfade ramp against a known constant signal.
+          static float[] OnesBlock(int n)
+          {
+              var b = new float[n];
+              Array.Fill(b, 1.0f);
+              return b;
+          }
+
+          // Loop until a compensation event fires; then do ONE MORE Read so we
+          // observe the crossfaded region (which lives at the rewound _readPos —
+          // i.e. the first samples the next GenerateAudio call will read).
+          bool capturedAfterComp = false;
+          float[]? observedAfterCompensation = null;
+          for (int i = 0; i < 30 && !capturedAfterComp; i++)
+          {
+              int beforeComp = compEventCount;
+              generator.AddSamples(OnesBlock(256)); // tiny top-up keeps draining
+              generator.Read(output);
+              if (compEventCount > beforeComp)
+              {
+                  // Next Read consumes the rewound (and now crossfaded) region first.
+                  // Keep adding tiny samples so the buffer has data to read.
+                  generator.AddSamples(OnesBlock(512));
+                  generator.Read(output);
+                  observedAfterCompensation = output.ToArray();
+                  capturedAfterComp = true;
+              }
+          }
+
+          Assert.True(compEventCount >= 1, "Expected at least one compensation event");
+          Assert.NotNull(observedAfterCompensation);
+
+          // The crossfaded region is the FIRST 32 samples of the read AFTER the
+          // compensation event — these are the samples at the rewound _readPos.
+          // Validate the cosine ramp shape on a uniform 1.0 input:
+          //   gain(i) = (1 - cos(i/32 * π)) / 2
+          //   gain(0)  = 0
+          //   gain(16) = (1 - cos(π/2)) / 2 = 0.5
+          //   gain(31) = (1 - cos(31π/32)) / 2 ≈ 0.9976
+          //   gain(32+) past ramp → 1.0 (untouched original signal)
+          //
+          // We allow generous slack because the underlying signal is 1.0f, but the
+          // ring-buffer ordering between consecutive 256-sample top-ups can fill
+          // the seam with one zero frame; the dominant value past the ramp is 1.0.
+          Assert.True(observedAfterCompensation[0] < 0.05f,
+              $"Crossfade sample[0] expected ~0.0, got {observedAfterCompensation[0]}");
+          Assert.InRange(observedAfterCompensation[16], 0.4f, 0.6f);
+          Assert.True(observedAfterCompensation[31] > 0.9f,
+              $"Crossfade sample[31] expected ~1.0, got {observedAfterCompensation[31]}");
+      }
+
+      [Fact]
+      public void CompensateClockDrift_NoLongerRunsLessOftenThan2Seconds()
+      {
+          // The pre-refinement code returned early if (now - _lastDriftCheckTime).TotalSeconds < 2.0.
+          // Path C removed that cooldown: compensation must now run on every Process call
+          // while the buffer is draining. Verify by calling Process repeatedly within a
+          // small wall-clock window and confirming compensation fires multiple times.
+          var format = new AudioFormat { SampleRate = 48000, Channels = 2, Format = SampleFormat.F32 };
+          var metrics = new Mock<IMetricsCollector>();
+          var generator = new TestBufferedGenerator<float>(
+              _engineMock.Object, format, _loggerMock.Object, metrics.Object);
+
+          var prefill = new float[10_000];
+          for (int i = 0; i < prefill.Length; i++)
+          {
+              prefill[i] = 0.1f;
+          }
+          var output = new float[512];
+
+          generator.AddSamples(prefill);
+
+          var startTicks = System.Diagnostics.Stopwatch.GetTimestamp();
+          // Burn the _driftCheckCount > 3 warm-up reads + several more reads. The total
+          // wall time for ~30 Read calls is well under 2 s on any normal machine.
+          for (int i = 0; i < 30; i++)
+          {
+              generator.AddSamples(new float[256]);
+              generator.Read(output);
+          }
+          var elapsedSec = (System.Diagnostics.Stopwatch.GetTimestamp() - startTicks)
+              / (double)System.Diagnostics.Stopwatch.Frequency;
+
+          // Sanity-guard: if the machine ran so slowly that >= 2 s elapsed, the test
+          // doesn't actually verify the no-cooldown property. Fail loud rather than
+          // produce a false PASS.
+          Assert.True(elapsedSec < 2.0,
+              $"Test loop took {elapsedSec:F2}s — too slow to verify no-cooldown property. "
+              + "Run on a less-loaded machine.");
+
+          metrics.Verify(
+              m => m.Increment(
+                  "audio.buffer.drift_compensation_total",
+                  It.IsAny<double>(),
+                  It.IsAny<IDictionary<string, string>>()),
+              Times.AtLeast(2));
+      }
   }

--- a/tests/Radio.Infrastructure.Tests/Audio/SoundFlow/FmAudioDropoutDiagnosticTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/SoundFlow/FmAudioDropoutDiagnosticTests.cs
@@ -277,10 +277,24 @@ public class FmAudioDropoutDiagnosticTests
     var zeroRuns = FindZeroRuns(output, minRunLength: 8);
     LogMetrics("Single squelch gap", metrics, zeroRuns, output);
 
-    // Assert: Should show exactly 1 missed callback and at least one zero run
+    // Assert: The missed callback was observed by the pipeline (metric).
+    //
+    // Pre-Path-C (docs/plans/2026-05-22-bt-drift-compensation-refinement.md)
+    // the dropout symptom was directly visible as a zero-run in the output,
+    // because the cooldown-gated compensation could only fill a small slice
+    // of the 68 ms gap.
+    //
+    // Post-Path-C the per-call cap is small (2 ms) but runs on every Process
+    // callback while the buffer is draining, so the cumulative compensation
+    // across the 68 ms gap will MASK most or all of the zero-run from the
+    // output sample stream. The miss is still observable via the metric
+    // (`CallbacksMissed == 1`) and via the underrun counters emitted from
+    // BufferedSoundGenerator, but the symptom in the output waveform is
+    // intentionally suppressed. We therefore assert only on the metric,
+    // and tolerate any zero-run count >= 0.
     Assert.Equal(1, metrics.CallbacksMissed);
-    Assert.NotEmpty(zeroRuns);
-    _output.WriteLine($"DETECTED: Single missed callback creates {zeroRuns.Count} zero run(s)");
+    _output.WriteLine($"OBSERVED: Single missed callback produced {zeroRuns.Count} zero run(s) "
+      + "after Path C compensation (pre-Path-C this was always >= 1).");
     foreach (var run in zeroRuns)
     {
       var durationMs = (double)run.Length / SamplesPerSecondStereo * 1000;


### PR DESCRIPTION
## Summary

Refines `BufferedSoundGenerator<T>.CompensateClockDrift` to produce sub-perceptual corrections instead of the current 10 ms duplications that listeners hear as 'underwater' / 'slow' audio during BT → Cast playback.

This is **Path C** from the BT clock-skew research doc (`docs/research/2026-05-22-bt-clock-skew-measurement.md`), which measured 217–391 ppm skew between the BT phone clock and the local speaker clock — about 10–20× over the BT A2DP spec. The skew is unfixable in software (two crystals can't be sync'd), so the right move is to make the compensation that masks it less audible.

## Two changes

1. **Per-call compensation cap** drops from 10 ms (480 samples at 48 kHz) to 2 ms (96 samples). Total compensation per minute stays the same (driven by the underlying rate mismatch), but it's redistributed across ~5× more events that are each much shorter.

2. **Cosine-ramp crossfade** (~32 samples / ~0.67 ms) blended across the rewind boundary in the ring buffer. Eliminates the discontinuity click at the boundary that contributes to the perceived 'underwater' sound.

3. **Removed 2 s cooldown** between drift-checks so the smaller corrections can run as often as needed.

## Per-task commits

- `579233a` Task 1 — smaller-more-frequent (2 ms cap, no cooldown)
- `1bb81fe` Task 2 — cosine-ramp crossfade across rewind boundary
- `9011c1c` Task 3 — 3 new unit tests (cap, crossfade math, no-cooldown)
- `ff25242` Test fixups — two pre-existing audio diagnostic tests were implicitly relying on the removed cooldown to suppress compensation during short tight-loop scenarios. Updated to either (a) prefill the buffer above threshold so the test's signal-integrity intent is preserved (`PipelineDistortionTests.SineTone_ExtendedDuration_NoDistortion`), or (b) assert on the metric the test was supposed to be probing instead of the symptom that compensation now masks by design (`FmAudioDropoutDiagnosticTests.SquelchGap_SingleMissedCallback_ShowsDropout`).
- `b1f132e` Task 6 — `scripts/research/bt_drift_compare.py` PASS/FAIL gate for the post-merge acceptance run.

## Pre-merge fixes

Pre-existing audio diagnostic tests (`PipelineDistortionTests.SineTone_ExtendedDuration_NoDistortion` × 2, `FmAudioDropoutDiagnosticTests.SquelchGap_SingleMissedCallback_ShowsDropout`) failed under the new compensation behaviour because they were implicitly relying on the 2-second cooldown to suppress compensation. Fixed without touching the production semantics — see commit `ff25242` for the rationale.

## Acceptance (per plan Task 5)

- [ ] Mark UAT subjective: 'underwater' feel reduced or gone
- [ ] `drift_compensation_total` events/hour increases ≥3× (more events, each smaller)
- [ ] `drift_compensation_samples_total` samples/hour stays within ±20 % of baseline
- [ ] `underrun_total` events/hour drops ≥50 %
- [ ] `fill_percent` mean within ±10 of baseline

Comparator script for the gate: `scripts/research/bt_drift_compare.py baseline_drift_15min.txt after_drift_15min.txt baseline_metrics_15min.txt after_metrics_15min.txt`.

If subjective UAT fails despite objective metrics passing: escalate to **Path D** (real variable-rate resampler).

## Test plan

- [x] 3 new unit tests for the new behaviours (per-call cap, crossfade math, no-cooldown) — all pass
- [x] `dotnet build --configuration Release` clean (0 errors, 42 pre-existing IDE0011 warnings)
- [x] Full `dotnet test --configuration Release` — 2,205 passed / 4 skipped / 0 failed across all 10 test projects
- [ ] **Mark UAT (operator-run, post-merge)**: deploy + 15 min soak + `bt_drift_compare.py` PASS/FAIL + subjective listening test

## Operator note (post-merge)

After merge, run:
```bash
pwsh.exe -NoProfile -Command "& './deploy/Deploy-ToLinux.ps1' -TargetHost radio -Runtime linux-x64"
```
Then verify the new log shape (`🔄 Clock drift compensation (Single): N events, M duplicated samples …` with M ≈ N × 192 instead of N × 480) and run the 15-minute soak. Comparator script Task 6 gates the objective acceptance. Subjective listening test gates the final go/no-go for Path C; if it fails, Path D is the next plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)