### PR TITLE
docs: BT dual-routing investigation + WP-rule + output-picker plans

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -68,7 +68,19 @@ PR #400's observability surfaced 217–391 ppm clock skew between the BT phone c
 
 - **Research**: [`docs/research/2026-05-22-bt-clock-skew-measurement.md`](research/2026-05-22-bt-clock-skew-measurement.md) — measurement methodology, architectural analysis, mitigation menu
 - **Plan in flight**: [`docs/plans/2026-05-22-bt-drift-compensation-refinement.md`](plans/2026-05-22-bt-drift-compensation-refinement.md) — Path C: smaller, more-frequent compensation events with cosine-ramp crossfade smoothing. Branch `feat/bt-drift-compensation-refinement`.
-- **Path D (variable-rate resampler) deferred** pending Path C subjective UAT result.
+- **Path D shipped** (PR #404 / commit `781a455`). UAT showed objective metrics REGRESSED across all 3 criteria — but diagnosis revealed this was a measurement artifact from a previously-undiagnosed dual-audio-path issue, not a Path D failure.
+
+### Active follow-up arc — BT dual-routing fix + output picker UI (selected 2026-05-22)
+
+`pactl list sink-inputs` on radio revealed **two independent audio paths** feeding the local soundbar simultaneously:
+1. **Path A (designed)**: BT → Radio.API → audio engine → outputs
+2. **Path B (rogue)**: BT → PipeWire stream-restore → default sink directly (bypassing Radio.API entirely)
+
+The dual-path explains both Mark's "audio from both soundbar AND Cast" complaint AND the Path D regression (the resampler added latency to Path A while Path B remained delay-free, creating comb-filter "underwater" artifacts).
+
+- **Research**: [`docs/research/2026-05-22-bt-dual-routing-investigation.md`](research/2026-05-22-bt-dual-routing-investigation.md)
+- **Plan: WP rule (Part 1, critical-path)**: [`docs/plans/2026-05-22-wp-bt-route-exclusivity.md`](plans/2026-05-22-wp-bt-route-exclusivity.md) — WirePlumber config that prevents BT A2DP from auto-routing to default sink. Without this, Path D can't be measured cleanly. ~30 LOC infra config.
+- **Plan: Output picker UI (Part 2, UX)**: [`docs/plans/2026-05-22-output-picker-ui.md`](plans/2026-05-22-output-picker-ui.md) — replaces the `MainLayout.razor:636-641` stub (currently `NavigationManager.NavigateTo("/devices")`) with a real popover. ~150-200 LOC mirroring `CastDeviceDropdown.razor`.
 
 ### CI infrastructure — RTest appserver runner migration
 

--- a/docs/plans/2026-05-22-output-picker-ui.md
+++ b/docs/plans/2026-05-22-output-picker-ui.md
@@ -1,0 +1,356 @@
+# Output picker UI — replace the `/devices`-navigation stub
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Replace the placeholder "Out" topbar pill (which currently just navigates to the `/devices` page) with a proper popover-style output picker that lets the user pick between local audio outputs (soundbar, USB audio device, etc.) without leaving the current page. Mirrors the existing `CastDeviceDropdown.razor` pattern for visual consistency. Resolves Mark's UX complaint: "there's no obvious/simple way to choose the single audio output like there used to be."
+
+**Source research**: [`docs/research/2026-05-22-bt-dual-routing-investigation.md`](../research/2026-05-22-bt-dual-routing-investigation.md) §"For the UI complaint" — the "Out" pill at `src/Radio.Web/Components/Layout/MainLayout.razor:636-641` was explicitly stubbed by an earlier "PR 3 will own this" comment that never materialized.
+
+**Architecture**:
+
+Today's state at `MainLayout.razor:88-94`:
+```razor
+<button type="button" class="nav-pill" @onclick="ToggleOutputPicker" ...>
+  <RadzenIcon Icon="speaker" />
+  <span class="nav-pill-label">Out</span>
+</button>
+
+private void ToggleOutputPicker() => NavigationManager.NavigateTo("/devices");
+```
+
+Target state:
+```razor
+<button type="button" class="nav-pill" @onclick="ToggleOutputPicker" ...>
+  <RadzenIcon Icon="speaker" />
+  <span class="nav-pill-label">Out</span>
+</button>
+<OutputPickerDropdown IsOpen="_showOutputDropdown"
+                     IsOpenChanged="@((bool v) => { _showOutputDropdown = v; StateHasChanged(); })"
+                     OnOutputSelected="OnLocalOutputSelectedAsync"
+                     CurrentOutputId="@_selectedOutputId"
+                     AvailableOutputs="_availableOutputs" />
+```
+
+The dropdown lists all non-Cast outputs (built-in audio, USB audio devices, headphones). Selecting one calls the existing `DevicesController.SetOutputDeviceAsync` endpoint, which mutes Cast paths if a Cast is connected (`SetLocalOutputMuted(false)`-style logic already in `DevicesController.cs`).
+
+**Tech Stack**: Blazor Server, Radzen components for consistency with `CastDeviceDropdown.razor`. No new dependencies.
+
+**Addresses**: UI gap explicitly called out by Mark on 2026-05-22 — "from the UI there's no obvious/simple way to choose the single audio output like there used to be. This needs a cleaner UI."
+
+---
+
+## Task 1: Author `OutputPickerDropdown.razor`
+
+**Files:**
+- Create: `src/Radio.Web/Components/Shared/OutputPickerDropdown.razor`
+
+**Step 1:** Mirror the structure of `src/Radio.Web/Components/Shared/CastDeviceDropdown.razor`. Read that file first to understand:
+- The popover-vs-MudDialog choice (the lightweight popover per MEMORY)
+- The click-away handling (`@onclick:stopPropagation="true"` per MEMORY note)
+- The event-callback signatures
+- The visual styling (Radzen + project's design-system.css tokens)
+
+**Step 2:** Outline the new component:
+
+```razor
+@inject Radio.Web.Services.ApiClients.DevicesApiService DevicesApi
+@inject Microsoft.Extensions.Logging.ILogger<OutputPickerDropdown> Logger
+
+@if (IsOpen)
+{
+  <div class="output-picker-overlay" @onclick="HandleClickAway"></div>
+  <div class="output-picker-popover" @onclick:stopPropagation="true">
+    <div class="output-picker-header">
+      <RadzenIcon Icon="speaker" />
+      <span>Select Output</span>
+    </div>
+
+    @foreach (var device in AvailableOutputs.Where(d => !IsCastOutput(d)))
+    {
+      <button type="button"
+              class="output-picker-row @(device.Id == CurrentOutputId ? "is-active" : "")"
+              @onclick="@(() => HandleSelectAsync(device))">
+        <RadzenIcon Icon="@GetIconForDevice(device)" />
+        <span class="output-picker-name">@DisplayNames.Device(device)</span>
+        @if (device.Id == CurrentOutputId)
+        {
+          <RadzenIcon Icon="check" Class="output-picker-checkmark" />
+        }
+      </button>
+    }
+
+    @if (!AvailableOutputs.Any(d => !IsCastOutput(d)))
+    {
+      <div class="output-picker-empty">No local outputs detected.</div>
+    }
+  </div>
+}
+
+@code {
+  [Parameter] public bool IsOpen { get; set; }
+  [Parameter] public EventCallback<bool> IsOpenChanged { get; set; }
+  [Parameter] public EventCallback<AudioDeviceDto> OnOutputSelected { get; set; }
+  [Parameter] public string? CurrentOutputId { get; set; }
+  [Parameter] public List<AudioDeviceDto> AvailableOutputs { get; set; } = new();
+
+  private async Task HandleSelectAsync(AudioDeviceDto device)
+  {
+    await OnOutputSelected.InvokeAsync(device);
+    await IsOpenChanged.InvokeAsync(false);
+  }
+
+  private async Task HandleClickAway()
+  {
+    await IsOpenChanged.InvokeAsync(false);
+  }
+
+  private static bool IsCastOutput(AudioDeviceDto d) =>
+    d.Id.Equals("google-cast", StringComparison.OrdinalIgnoreCase);
+
+  private static string GetIconForDevice(AudioDeviceDto d)
+  {
+    // Best-effort icon mapping based on device name heuristics
+    var name = (d.Name ?? "").ToLowerInvariant();
+    if (name.Contains("usb")) return "usb";
+    if (name.Contains("hdmi")) return "tv";
+    if (name.Contains("headphone") || name.Contains("phone")) return "headphones";
+    return "speaker";
+  }
+}
+```
+
+**Step 3:** CSS — add styles to `src/Radio.Web/wwwroot/css/components/output-picker.css` (or extend `cast-dropdown.css` and rename to a shared file). The visual should be near-identical to `CastDeviceDropdown` for consistency.
+
+**Step 4:** Build verification:
+
+```bash
+dotnet build src/Radio.Web/Radio.Web.csproj --configuration Release
+```
+Expected: 0 errors, only pre-existing IDE0011 warnings.
+
+**Step 5:** Commit:
+
+```bash
+git add src/Radio.Web/Components/Shared/OutputPickerDropdown.razor src/Radio.Web/wwwroot/css/components/output-picker.css
+git commit -m "feat(web): OutputPickerDropdown popover (mirrors CastDeviceDropdown shape)"
+```
+
+---
+
+## Task 2: Wire into MainLayout
+
+**Files:**
+- Modify: `src/Radio.Web/Components/Layout/MainLayout.razor`
+
+**Step 1:** Replace the stub `ToggleOutputPicker` body. Current:
+
+```csharp
+private void ToggleOutputPicker()
+{
+  NavigationManager.NavigateTo("/devices");
+}
+```
+
+New:
+
+```csharp
+private bool _showOutputDropdown;
+
+private void ToggleOutputPicker()
+{
+  _showOutputDropdown = !_showOutputDropdown;
+  // Close Cast dropdown if it was open — they're mutually exclusive popovers
+  if (_showOutputDropdown && _showCastDropdown)
+  {
+    _showCastDropdown = false;
+  }
+  StateHasChanged();
+}
+
+private async Task OnLocalOutputSelectedAsync(AudioDeviceDto device)
+{
+  if (string.IsNullOrEmpty(device?.Id) || device.Id == _selectedOutputId) return;
+
+  // If Cast is currently selected: disconnect (un-mute will fire via DevicesController on output switch)
+  if (_selectedOutputId == "google-cast")
+  {
+    // The output switch below will handle Cast teardown via DevicesController
+  }
+
+  try
+  {
+    var success = await DevicesApi.SetOutputDeviceAsync(device.Id);
+    if (success)
+    {
+      _selectedOutputId = device.Id;
+      Logger.LogInformation("Switched to local output: {Name} ({Id})", device.Name, device.Id);
+    }
+  }
+  catch (Exception ex)
+  {
+    Logger.LogError(ex, "Failed to switch output");
+  }
+}
+```
+
+**Step 2:** Add the dropdown component immediately after the "Out" pill in the markup:
+
+```razor
+<!-- Output picker entry -->
+<button type="button" class="nav-pill" @onclick="ToggleOutputPicker"
+        aria-label="Output device picker"
+        title="Select audio output">
+  <RadzenIcon Icon="speaker" />
+  <span class="nav-pill-label">Out</span>
+</button>
+
+<OutputPickerDropdown IsOpen="_showOutputDropdown"
+                     IsOpenChanged="@((bool v) => { _showOutputDropdown = v; StateHasChanged(); })"
+                     OnOutputSelected="OnLocalOutputSelectedAsync"
+                     CurrentOutputId="@_selectedOutputId"
+                     AvailableOutputs="_availableOutputs" />
+```
+
+**Step 3:** Build + commit:
+
+```bash
+dotnet build src/Radio.Web/Radio.Web.csproj --configuration Release
+git add src/Radio.Web/Components/Layout/MainLayout.razor
+git commit -m "feat(web): wire OutputPickerDropdown into MainLayout (replaces /devices nav stub)"
+```
+
+---
+
+## Task 3: Mutual-exclusivity behavior on output switch
+
+**Files:**
+- Modify: `src/Radio.API/Controllers/DevicesController.cs` (verify, may already do this)
+- Maybe modify: `src/Radio.Infrastructure/Audio/Engine/...` for any source-of-truth on "single active output"
+
+**Step 1:** Audit current behavior. In `DevicesController.cs`, find `SetOutputDeviceAsync` (the endpoint that the UI calls). Read it to understand the existing logic around:
+- When local output is selected: does it auto-disconnect Cast?
+- When Cast is selected: does it auto-mute local? (yes — verified earlier at lines 205, 214, 1341)
+- Is there a "single active output" invariant?
+
+**Step 2:** If selecting a local output doesn't auto-disconnect Cast: add a call to `_castOutput.DisconnectAsync()` or equivalent at the start of the local-output-switch branch. Document the invariant: at any time, exactly one of {local output, cast output} is active.
+
+**Step 3:** Verify by integration test (or note for Mark UAT): selecting a local output via the new picker should silence Cast within 1-2 seconds.
+
+**Step 4:** Build + commit if changes needed:
+
+```bash
+git add src/Radio.API/Controllers/DevicesController.cs
+git commit -m "feat(api): enforce mutual exclusivity between local + Cast output paths"
+```
+
+---
+
+## Task 4: Tests
+
+**Files:**
+- Create: `tests/Radio.Web.Tests/Components/Shared/OutputPickerDropdownTests.cs`
+
+**Step 1:** Add bUnit tests mirroring `CastDeviceDropdownTests.cs` if it exists, or write fresh:
+
+```csharp
+public class OutputPickerDropdownTests : TestContext
+{
+  [Fact]
+  public void Closed_RendersNothing()
+  {
+    var cut = RenderComponent<OutputPickerDropdown>(p => p.Add(c => c.IsOpen, false));
+    Assert.Empty(cut.FindAll(".output-picker-popover"));
+  }
+
+  [Fact]
+  public void Open_ListsNonCastOutputsOnly()
+  {
+    var outputs = new List<AudioDeviceDto> {
+      new() { Id = "local-1", Name = "Built-in Audio" },
+      new() { Id = "usb-1", Name = "USB Audio Device" },
+      new() { Id = "google-cast", Name = "Google Cast" },  // should NOT appear
+    };
+    var cut = RenderComponent<OutputPickerDropdown>(p => p
+      .Add(c => c.IsOpen, true)
+      .Add(c => c.AvailableOutputs, outputs));
+    var rows = cut.FindAll(".output-picker-row");
+    Assert.Equal(2, rows.Count);  // local + usb, not cast
+  }
+
+  [Fact]
+  public void CurrentSelection_GetsActiveClassAndCheckmark()
+  { /* ... */ }
+
+  [Fact]
+  public void OutputSelected_InvokesCallback()
+  { /* ... */ }
+
+  [Fact]
+  public void ClickAway_ClosesPopover()
+  { /* ... */ }
+}
+```
+
+**Step 2:** Run + commit:
+
+```bash
+dotnet test tests/Radio.Web.Tests/Radio.Web.Tests.csproj --configuration Release --filter "OutputPickerDropdownTests"
+git add tests/Radio.Web.Tests/Components/Shared/OutputPickerDropdownTests.cs
+git commit -m "test(web): OutputPickerDropdown component tests"
+```
+
+---
+
+## Task 5: Build + open PR + auto-merge
+
+```bash
+dotnet build --configuration Release
+dotnet test --configuration Release --verbosity normal
+git push -u origin feat/output-picker-ui
+gh pr create --title "feat(web): output picker popover (replaces /devices nav stub)" --body "<see PR template below>"
+```
+
+PR template:
+
+```markdown
+## Summary
+
+Replaces the placeholder "Out" topbar pill (which previously navigated to /devices) with a proper popover-style output picker. Mirrors the existing CastDeviceDropdown visual + interaction pattern.
+
+Resolves Mark's UX complaint from 2026-05-22: "from the UI there's no obvious/simple way to choose the single audio output like there used to be. This needs a cleaner UI."
+
+## Behavior
+
+- Click "Out" in topbar → popover opens listing all non-Cast local outputs (soundbar, USB, etc.)
+- Select an output → DevicesApi.SetOutputDeviceAsync fires → exclusive selection (auto-disconnects Cast if it was active)
+- Click outside the popover → closes
+- Active output gets is-active class + checkmark
+
+## Test plan
+
+- [x] OutputPickerDropdown bUnit tests (5 cases)
+- [x] Build clean
+- [ ] Mark UAT: open the dropdown, switch between local outputs, confirm Cast disconnects when switching to local
+```
+
+Auto-merge after CI green per the current tranche's authorization.
+
+---
+
+## Task 6: Deploy + UAT (operator action — Mark, post-merge)
+
+```bash
+pwsh.exe -NoProfile -Command "& './deploy/Deploy-ToLinux.ps1' -TargetHost radio -Runtime linux-x64"
+```
+
+Then open `http://radio:5002`, click "Out" in topbar, verify the popover appears + lists local outputs. Select one. Confirm Cast disconnects if it was active.
+
+---
+
+## Out of scope
+
+- **Combining Cast + local in a single picker.** Cast picker stays separate (it has its own scan/connect lifecycle and a different visual treatment). Two pills, two popovers — by design.
+- **Output picker on `/devices` page** (the explicit-management page). That page stays as the full management surface; this plan only adds the quick-switch popover in the topbar.
+- **Headphone/USB hotplug.** The popover renders whatever `_availableOutputs` contains at render time. If a USB device is plugged in mid-session, the list refreshes via the same mechanism the page already uses (SignalR audio-state events).
+- **Visual design refinement.** First-pass visual matches CastDeviceDropdown for consistency. Mark may want polish later.
+- **Path B (PipeWire dual-routing).** Separate plan at `docs/plans/2026-05-22-wp-bt-route-exclusivity.md`.

--- a/docs/plans/2026-05-22-wp-bt-route-exclusivity.md
+++ b/docs/plans/2026-05-22-wp-bt-route-exclusivity.md
@@ -1,0 +1,160 @@
+# WirePlumber rule: BT A2DP source exclusivity (no auto-route to default sink)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Stop PipeWire's `module-stream-restore` from auto-routing the BT phone's A2DP source stream directly to the default sink (the local soundbar). When Radio.API is the only consumer of BT audio, there should be exactly ONE path: `phone → bluez_input → Radio.API → output(s)`. The rogue parallel path `phone → default sink` is what's causing the dual-audio Mark hears AND the comb-filter "underwater" artifact that masked Path D's true effectiveness.
+
+**Source research**: [`docs/research/2026-05-22-bt-dual-routing-investigation.md`](../research/2026-05-22-bt-dual-routing-investigation.md) — confirms the dual-path via `pactl list sink-inputs` showing both `application.name="Radio.API"` (the designed path) AND `media.name="Pixel 10 Pro XL"` (the rogue path) feeding the same sink.
+
+**Architecture**: WirePlumber rule that intercepts BT-A2DP-source-derived streams at routing time. The rule sets `node.passive=true` (or similar) on streams whose `node.target` would otherwise resolve to the system's default sink, preventing auto-routing. Radio.API's capture node is a SEPARATE graph endpoint (bluez_input → application stream) and is not affected by this rule.
+
+**Tech Stack**: WirePlumber Lua config (the canonical mechanism per existing project pattern at `/etc/wireplumber/bluetooth.lua.d/`). Linux-only operator change; no .NET code touched.
+
+**Addresses**:
+- "Audio coming from both the soundbar AND Cast device on startup" (Mark's report, 2026-05-22)
+- Path D measurement noise — once the rogue path is silenced, Path D's true effectiveness becomes measurable
+
+---
+
+## Task 0: Confirm the dual-path is still active (operator action — Mark, not Builder)
+
+Before any change, capture the current sink-input list to confirm the dual-routing is reproducible:
+
+```bash
+ssh mmack@radio "pactl list sink-inputs | grep -E 'Sink Input #|application.name|media.name|client'"
+```
+
+Expected: at least two sink-inputs feeding the same sink — one for `application.name="Radio.API"` and one for `media.name` matching a paired BT device.
+
+If the second one is absent: PipeWire's stream-restore hasn't saved a route for the current BT device yet (e.g., factory-fresh PipeWire state). The fix is still valid as a preventive measure but the symptom won't reproduce locally until the device gets paired AND the user once-routes to the sink manually.
+
+---
+
+## Task 1: WirePlumber rule — refuse auto-route for BT A2DP source streams
+
+**Files:**
+- Create: `deploy/common/wireplumber/51-bt-a2dp-no-default-route.lua` (or similar — match existing project convention)
+- Modify: `deploy/Deploy-ToLinux.ps1` (or the wireplumber install path within it) to scp the rule into `/etc/wireplumber/wireplumber.conf.d/` on radio
+
+**Step 1:** Audit current WP config layout on radio:
+
+```bash
+ssh mmack@radio "ls -la /etc/wireplumber/ /etc/wireplumber/main.lua.d/ /etc/wireplumber/wireplumber.conf.d/ 2>&1 | head -30"
+```
+
+The rule's destination depends on whether radio runs WirePlumber's old (0.4.x — Lua) or new (0.5.x — script) config model. Older Ubuntu N100 likely 0.4.x → `/etc/wireplumber/main.lua.d/`. Verify with `wireplumber --version` on the box.
+
+**Step 2:** Author the rule. For WP 0.4.x (Lua):
+
+```lua
+-- /etc/wireplumber/main.lua.d/51-bt-a2dp-no-default-route.lua
+--
+-- Prevent PipeWire's stream-restore module from auto-routing BT A2DP source
+-- streams to the system's default sink. Radio Console is the intended consumer
+-- of BT audio (via its capture node graph endpoint, which is unaffected by
+-- this rule). Without this, PipeWire creates a parallel direct-playback path
+-- from BT → default sink that causes dual-audio + comb-filter artifacts.
+--
+-- See docs/research/2026-05-22-bt-dual-routing-investigation.md for the
+-- diagnostic that motivated this rule.
+
+table.insert(default_policy.policy.roles, {
+  ["match"] = {
+    {
+      ["node.name"] = "matches", "bluez_input.*",      -- any BT-source node
+      ["media.class"] = "Audio/Source",                 -- A2DP source class
+    },
+  },
+  ["actions"] = {
+    ["update-props"] = {
+      ["node.target"] = "null",                         -- refuse target sink
+      ["node.dont-reconnect"] = true,                   -- don't auto-link to default sink
+      ["session.suspend-timeout-seconds"] = 0,
+    },
+  },
+})
+```
+
+Alternative for WP 0.5.x (TOML/JSON-conf): same intent, different syntax. The plan-execution Builder will adapt to the runtime version found in Step 1.
+
+**Step 3:** Adapt the deploy script to push the rule on every deploy. In `deploy/Deploy-ToLinux.ps1`, add a step (around where the existing systemd unit files are scp'd):
+
+```powershell
+# Push WirePlumber rules
+Write-Host "  Syncing WirePlumber rules..."
+scp deploy/common/wireplumber/*.lua "${SshTarget}:/tmp/" 2>&1
+ssh $SshTarget "sudo mv /tmp/51-bt-a2dp-no-default-route.lua /etc/wireplumber/main.lua.d/ && sudo systemctl restart --user wireplumber || true"
+```
+
+Note: `systemctl --user restart wireplumber` may need to run as the actual `mmack` user; if `sudo` over SSH doesn't have access to the user-mode systemd, fall back to `pkill -HUP wireplumber` (signals the daemon to reload).
+
+**Step 4:** Build verification — N/A (config-only change).
+
+**Step 5:** Commit:
+
+```bash
+git add deploy/common/wireplumber/51-bt-a2dp-no-default-route.lua deploy/Deploy-ToLinux.ps1
+git commit -m "fix(audio): WP rule preventing BT A2DP source from auto-routing to default sink"
+```
+
+---
+
+## Task 2: Clear pre-existing stream-restore decisions for known BT devices (one-time)
+
+The WP rule prevents NEW auto-routing decisions. Already-saved stream-restore entries from prior sessions still exist in `~/.local/state/pipewire/stream-restore` or similar. Clear them so the rule takes effect for existing BT devices.
+
+**Step 1:** Operator action on radio (Mark, after deploy):
+
+```bash
+ssh mmack@radio "rm -f ~/.local/state/pipewire/stream-restore && pkill -HUP wireplumber"
+```
+
+(Builder documents this; doesn't execute.)
+
+---
+
+## Task 3: Deploy + verify acceptance criteria (operator action — Mark, post-merge)
+
+**Step 1:** Deploy:
+
+```bash
+pwsh.exe -NoProfile -Command "& './deploy/Deploy-ToLinux.ps1' -TargetHost radio -Runtime linux-x64"
+```
+
+**Step 2:** Verify the WP rule is active. Reconnect the BT phone, then:
+
+```bash
+ssh mmack@radio "pactl list sink-inputs"
+```
+
+**Success criterion** (primary):
+- ONLY `application.name="Radio.API"` sink-input should be present
+- NO `media.name="Pixel ..."` or other BT-device sink-input on the soundbar's sink
+
+**Step 3:** Subjective verification:
+- Disconnect Cast. Confirm soundbar is silent (Radio.API muted local because Cast was previously selected; this state should persist).
+- Or: ensure no Cast is selected. Audio should flow normally through Radio.API → soundbar (Path A only).
+
+**Step 4:** Re-run Path D UAT under the now-single-path condition:
+
+```bash
+ssh mmack@radio bash /tmp/path_d_uat.sh
+```
+
+Expected after Part 1 lands AND Path D is given a fair test:
+- `D1 comp reduction ratio` should drop to ≤0.1 (the resampler can finally do its job without competing against direct-routing)
+- `D2 underrun events/hour` should be 0
+- `D3 residual |ppm|` should drop near 0
+- Subjective: "underwater" gone
+
+If Path D's metrics still don't pass: that's a real Path D problem worth deeper investigation (SincMedium quality, closed-loop ratio control). But likely the metrics now reflect actual Radio.API behavior.
+
+---
+
+## Out of scope
+
+- **Universal stream-restore disabling.** This plan only narrows the rule to BT A2DP source streams. Other audio (file player, system sounds) keeps stream-restore functionality.
+- **A second BT device.** If Mark pairs a different phone, the rule applies to it too (matches any `bluez_input.*`). No per-device customization needed.
+- **The "Out" pill stub** — separate plan at `docs/plans/2026-05-22-output-picker-ui.md`.
+- **WirePlumber 0.5.x TOML config migration.** If radio is on 0.4.x today and upgrades to 0.5.x in a future Ubuntu release, this rule will need re-authoring in the new format. Note in the file's docstring so a future maintainer sees the version dependency.
+- **Path D quality-mode tuning.** Pending Part 1's measurement-cleanup before any quality-mode escalation is justified.

--- a/docs/research/2026-05-22-bt-dual-routing-investigation.md
+++ b/docs/research/2026-05-22-bt-dual-routing-investigation.md
@@ -1,0 +1,103 @@
+# BT dual-routing investigation — the actual cause of "underwater" audio
+
+**Status**: complete (root cause confirmed).
+**Author**: Mark + Claude, 2026-05-22.
+**Motivation**: After deploying Path D (variable-rate SRC) and running 15-minute UAT, the objective metrics REGRESSED (comp events +20%, underruns +200%, ppm +27%) instead of improving. Subjective "underwater" persisted. Mark also reported: audio is coming from BOTH the local soundbar AND the Google Cast device simultaneously on startup. This document captures the root-cause investigation.
+
+## Path D UAT result (the regression that triggered this dig)
+
+```
+                    Path D UAT — 2026-05-22T17:29
+==================================================================
+Resampler init log: ✓ "SrcVariableResampler initialized: quality=SincFastest,
+                    channels=2, initial ratio=1.000250"
+
+Recent compensation events (target ~0): 10  in 15 min
+Recent underrun events (target 0):       2  in 15 min
+
+                    Objective comparison vs Path C baseline
+==================================================================
+                       baseline (Path C)    after (Path D)
+comp events/hour          1880.4               2262.6     (+20% — FAIL)
+underrun events/hour        12.1                 36.4     (+200% — FAIL)
+clock skew (ppm)          1071                  1356      (+27% — FAIL)
+
+OVERALL: FAIL on all three criteria
+```
+
+On its face: Path D made things worse. But that contradicts the architecture — a real variable-rate SRC should *eliminate* rate-mismatch artifacts, not amplify them.
+
+## Root cause — dual audio paths via PipeWire
+
+Live diagnostic on `mmack@radio` revealed **two independent audio paths feeding the local soundbar simultaneously**:
+
+```bash
+$ pactl list sink-inputs
+Sink Input #14615
+    application.name = "Radio.API"
+    media.name = "miniaudio:0"
+    module-stream-restore.id = "sink-input-by-application-name:Radio.API"
+
+Sink Input #14689
+    media.name = "Pixel 10 Pro XL (codec aptX HD)"
+    module-stream-restore.id = "sink-input-by-media-name:Pixel 10 Pro XL (codec aptX HD)"
+```
+
+### Path A (the designed path)
+```
+BT phone (aptX HD)
+  → PipeWire BT capture node (bluez_input.B0_D5_FB_D2_0D_68.a2dp-source)
+  → PipeWireNativeStream.OnProcess
+  → SrcVariableResampler  ← Path D
+  → BufferedSoundGenerator
+  → MasterMixer
+  → PlaybackDevice (with _localOutputMuted=true → volume=0)  ← muted, correctly
+  → also tapped: TappedOutputStream → HttpStreamOutput → Google Cast
+```
+
+### Path B (the rogue path — discovered today)
+```
+BT phone (aptX HD)
+  → PipeWire stream-restore module: "I've seen this device before, route to default sink"
+  → directly to alsa_output.pci-0000_00_1f.3.analog-stereo (soundbar)
+```
+
+**PipeWire's `module-stream-restore` is a PulseAudio-compatibility module that remembers per-stream routing decisions.** The first time the Pixel 10 connected as an A2DP source after fresh `radio-api` install, it apparently auto-routed to the default sink (the soundbar). PipeWire saved that routing decision keyed by `media-name`. Every subsequent connection: PipeWire restores the saved routing, sending the BT audio directly to the soundbar **without any Radio.API involvement**.
+
+Radio.API's `SetLocalOutputMuted(true)` correctly silences sink-input #14615 (the Radio.API stream) by setting its PlaybackDevice MasterMixer.Volume to 0. But it has no knowledge or control over sink-input #14689 (the rogue BT-direct stream).
+
+## Implications
+
+### For Path D
+The Path D regression is a **measurement artifact**, not a Path D failure. With two paths feeding the soundbar at different latencies (Path A picked up ~1-3 ms when the resampler landed), the listener hears a comb filter / phase artifact between the two paths. That comb-filter sound is exactly "underwater" / "slow." Radio.API's BufferedSoundGenerator sees increased rate disagreement (because the consumer side now has additional drift caused by the resampler), drives compensation harder.
+
+**Path D may be working as designed but cannot be measured in isolation until Path B is silenced.** Re-evaluate Path D's effectiveness AFTER Part 1 of this investigation lands.
+
+### For the "two audio outputs" complaint
+Same root cause. Mark's "audio comes from both the soundbar AND the Cast device on startup" is the dual-routing in action:
+- Cast → Office speaker (the legitimate selection)
+- Soundbar → because of PipeWire's stream-restore auto-routing
+
+`SetLocalOutputMuted(true)` from Radio.API's perspective is correctly being called and IS muting the Radio.API sink-input, but the rogue BT-direct sink-input is unaffected.
+
+### For the UI complaint
+Separate concern. The "Out" pill at `src/Radio.Web/Components/Layout/MainLayout.razor:636-641` literally just navigates to `/devices` — explicitly stubbed by an earlier "PR 3 will own this" comment. There's no popover-based output picker. Even if Part 1 silences the rogue path, the UX gap remains: the user has no quick way to pick speakers vs Cast from the topbar.
+
+## Mitigation options for Path B
+
+1. **Stream-restore exclusion via WirePlumber rule** — tell WP to NEVER auto-route BT-A2DP sources to a real sink. Routes them to a null sink (or no sink at all) by default. Radio.API's capture node is unaffected (it's a different graph endpoint). This is the cleanest fix — addresses the root cause without disabling stream-restore globally.
+2. **Clear the saved stream-restore decision** for the specific BT MAC — fix is temporary (re-saved on next "user routes BT to sink" decision). Surface-level patch.
+3. **Disable `module-stream-restore` entirely** — affects all audio devices, not just BT. Heavy hammer, has UX side effects (volume / device choice resets every session for everything).
+
+**Option 1 is the right move.** Lives in `/etc/wireplumber/` per the existing project pattern (MEMORY: "Radio Console manages all `/etc/wireplumber/bluetooth.lua.d/` configs"). Documented as Plan in `docs/plans/2026-05-22-wp-bt-route-exclusivity.md` (companion document).
+
+## Decision
+
+Two plans queued, both surfaced for review before implementation:
+
+1. **`docs/plans/2026-05-22-wp-bt-route-exclusivity.md`** — Part 1: WirePlumber config to silence Path B. ~30 LOC infra config. **Critical-path** because without it, Path D and any future audio-routing work cannot be measured.
+2. **`docs/plans/2026-05-22-output-picker-ui.md`** — Part 2: real output-picker popover replacing the `/devices`-navigation stub. ~150-200 LOC UI work, modeled on `CastDeviceDropdown.razor`.
+
+After Part 1 lands and is verified: re-run Path D UAT. Expectation: comp events drop dramatically (resampler can finally work without competing against direct-routing); subjective "underwater" gone or substantially reduced; ppm settles near 0 (resampler's actual purpose, now measurable).
+
+If Path D's re-measurement still shows symptoms after Part 1: that's the moment to consider quality-mode tuning (SincFastest → SincMedium) or Phase 2 closed-loop ratio control.


### PR DESCRIPTION
Captures the Path D UAT regression diagnosis — root cause is a previously-undiagnosed dual PipeWire path (BT → default sink directly, parallel with BT → Radio.API). Two follow-up plans ship: (1) WirePlumber rule preventing the rogue route (critical-path; Path D can't be evaluated cleanly until this lands); (2) real output-picker UI replacing the /devices-navigation stub.

See `docs/research/2026-05-22-bt-dual-routing-investigation.md` for the diagnostic + architecture analysis.