### PR TITLE
feat(web): output picker popover (replaces /devices nav stub)

### DIFF
--- a/src/Radio.Web/Components/Layout/MainLayout.razor
+++ b/src/Radio.Web/Components/Layout/MainLayout.razor
@@ -85,13 +85,22 @@
         </div>
       }
 
-      <!-- Output picker entry (for non-Cast switches) -->
-      <button type="button" class="nav-pill" @onclick="ToggleOutputPicker"
-              aria-label="Output device picker"
-              title="Select audio output">
-        <RadzenIcon Icon="speaker" />
-        <span class="nav-pill-label">Out</span>
-      </button>
+      <!-- Output picker entry (for non-Cast switches).
+           Wrapper provides the absolute-positioning anchor for the popover. -->
+      <div style="position: relative;">
+        <button type="button" class="nav-pill" @onclick="ToggleOutputPicker"
+                aria-label="Output device picker"
+                title="Select audio output">
+          <RadzenIcon Icon="speaker" />
+          <span class="nav-pill-label">Out</span>
+        </button>
+        <OutputPickerDropdown IsOpen="_showOutputDropdown"
+                              IsOpenChanged="@((bool v) => { _showOutputDropdown = v; StateHasChanged(); })"
+                              OnOutputSelected="OnLocalOutputSelectedAsync"
+                              CurrentOutputId="@_selectedOutputId"
+                              AvailableOutputs="_availableOutputs"
+                              DeviceAliases="DeviceAliases" />
+      </div>
 
       <!-- Nav pills (right-aligned) -->
       <div class="topbar-nav">
@@ -223,6 +232,7 @@
   private CastDeviceDto? _defaultCastDevice;
   private bool _isCastConnecting;
   private bool _showCastDropdown;
+  private bool _showOutputDropdown;
 
   private int _queueCount = 0;
   private DotNetObjectReference<MainLayout>? _selfReference;
@@ -592,6 +602,13 @@
 
     if (newOutputId == "google-cast")
     {
+      // Cast pill closes the sibling Output picker so the two popovers never
+      // overlap (the two are mutually exclusive — see ToggleOutputPicker).
+      if (_showOutputDropdown)
+      {
+        _showOutputDropdown = false;
+      }
+
       // Cast already active → toggle dropdown for device switching
       if (newOutputId == _selectedOutputId)
       {
@@ -633,11 +650,57 @@
     }
   }
 
+  /// <summary>
+  /// Toggles the output-picker popover. The two topbar popovers (Cast and Output)
+  /// are mutually exclusive — opening Output closes Cast and vice versa — so the
+  /// user can't end up with overlapping menus.
+  /// </summary>
   private void ToggleOutputPicker()
   {
-    // Output device picker is a deferred concern (PR 3 owns DeviceManagementPage).
-    // For PR 2 the pill simply navigates to the Devices page so the user can pick.
-    NavigationManager.NavigateTo("/devices");
+    _showOutputDropdown = !_showOutputDropdown;
+    if (_showOutputDropdown && _showCastDropdown)
+    {
+      _showCastDropdown = false;
+    }
+    StateHasChanged();
+  }
+
+  /// <summary>
+  /// Output-picker selection handler. Calls the same API endpoint that the
+  /// legacy <c>/devices</c> page already uses; the server side
+  /// (<c>DevicesController.SetOutputDevice</c>) handles the mutual-exclusivity
+  /// invariant — tearing down the Cast + HTTP outputs and un-muting local
+  /// speakers when a local device is selected — so no extra Cast disconnect
+  /// dispatch is needed here.
+  /// </summary>
+  private async Task OnLocalOutputSelectedAsync(AudioDeviceDto device)
+  {
+    if (device is null || string.IsNullOrEmpty(device.Id))
+    {
+      return;
+    }
+    if (device.Id == _selectedOutputId)
+    {
+      return;
+    }
+
+    try
+    {
+      var success = await DevicesApi.SetOutputDeviceAsync(device.Id);
+      if (success)
+      {
+        _selectedOutputId = device.Id;
+        Logger.LogInformation("Switched audio output via picker to: {Name} ({Id})", device.Name, device.Id);
+      }
+      else
+      {
+        Logger.LogWarning("DevicesApi.SetOutputDeviceAsync returned false for {Id}", device.Id);
+      }
+    }
+    catch (Exception ex)
+    {
+      Logger.LogError(ex, "Failed to switch audio output via picker to {Id}", device.Id);
+    }
   }
 
   private async Task AutoConnectCastDeviceAsync(string outputId)

--- a/src/Radio.Web/Components/Shared/OutputPickerDropdown.razor
+++ b/src/Radio.Web/Components/Shared/OutputPickerDropdown.razor
@@ -1,0 +1,177 @@
+@using Radio.Web.Formatting
+@using Radio.Web.Models
+
+@*
+  OutputPickerDropdown — popover-style picker for the topbar "Out" pill.
+  Mirrors CastDeviceDropdown's visual + interaction pattern (lightweight popover,
+  click-away overlay with stopPropagation per MEMORY note) so the two popovers
+  feel like siblings.
+
+  Lists *local* outputs only — the Cast entry is filtered out so it stays
+  owned by CastDeviceDropdown (separate scan/connect lifecycle). Selecting a
+  local output here calls the parent's OnOutputSelected callback, which is
+  expected to route through DevicesApiService.SetOutputDeviceAsync; the API
+  side (DevicesController.SetOutputDevice) already enforces mutual-exclusivity
+  by tearing down Cast/HTTP outputs and un-muting local speakers when a local
+  device is selected — so this component does not need to dispatch a separate
+  Cast-disconnect call.
+
+  The parent owns _availableOutputs loading; this component is presentational.
+*@
+
+<!-- Click-away overlay (onclick + ontouchend for reliable touch dismissal) -->
+@if (IsOpen)
+{
+  <div @onclick="HandleClickAwayAsync" @onclick:stopPropagation="true"
+       @ontouchend="HandleClickAwayAsync" @ontouchend:stopPropagation="true"
+       style="position: fixed; inset: 0; z-index: 99; -webkit-tap-highlight-color: transparent;"></div>
+  <div @onclick:stopPropagation="true" @ontouchend:stopPropagation="true"
+       class="output-picker-popover"
+       style="position: absolute; top: 100%; right: 0; z-index: 100; min-width: 260px; max-width: 340px;
+              background: rgba(30,30,30,0.95); backdrop-filter: blur(12px);
+              border: 1px solid rgba(255,255,255,0.15); border-radius: 8px;
+              box-shadow: 0 8px 24px rgba(0,0,0,0.5); overflow: hidden;">
+
+    <!-- Header -->
+    <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px;
+                border-bottom: 1px solid rgba(255,255,255,0.1); background: rgba(0,0,0,0.3);">
+      <RadzenIcon Icon="speaker" Style="font-size: 16px; color: var(--text-medium);" />
+      <span style="font-size: 12px; font-weight: 500; color: var(--text-medium);">Select Output</span>
+    </div>
+
+    <!-- Device list -->
+    <div style="max-height: 240px; overflow-y: auto;">
+      @{
+        // Filter out the Cast virtual output — CastDeviceDropdown owns that selection.
+        var localOutputs = AvailableOutputs.Where(d => !IsCastOutput(d)).ToList();
+      }
+      @if (localOutputs.Count > 0)
+      {
+        @foreach (var device in localOutputs)
+        {
+          var isActive = device.Id == CurrentOutputId;
+          <div @onclick="@(() => HandleSelectAsync(device))"
+               class="output-picker-row @(isActive ? "is-active" : "")"
+               style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; cursor: pointer;
+                      @(isActive ? "background: rgba(76,175,80,0.12);" : "")
+                      transition: background 0.15s;">
+            <RadzenIcon Icon="@GetIconForDevice(device)"
+                        Style="@($"font-size: 18px; color: {(isActive ? "var(--rz-success)" : "var(--text-medium)")};")" />
+            <div style="flex: 1; min-width: 0;">
+              <div class="output-picker-name"
+                   style="font-size: 12px; color: var(--text-high); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                @DisplayNames.Device(device, DeviceAliases)
+              </div>
+              @if (device.IsUSBDevice && !string.IsNullOrEmpty(device.USBPort))
+              {
+                <div style="font-size: 10px; color: var(--text-low);">USB · @device.USBPort</div>
+              }
+            </div>
+            @if (isActive)
+            {
+              <RadzenIcon Icon="check" Class="output-picker-checkmark"
+                          Style="font-size: 18px; color: var(--rz-success);" />
+            }
+          </div>
+        }
+      }
+      else
+      {
+        <div class="output-picker-empty"
+             style="padding: 16px; text-align: center; font-size: 12px; color: var(--text-low);">
+          No local outputs detected.
+        </div>
+      }
+    </div>
+  </div>
+}
+
+<style>
+  .output-picker-row:not(.is-active):hover {
+    background: rgba(255,255,255,0.06);
+  }
+</style>
+
+@code {
+  /// <summary>
+  /// Controls popover visibility. Bind via <c>IsOpenChanged</c> so parent can
+  /// flip the flag from click-away handlers without round-tripping state.
+  /// </summary>
+  [Parameter] public bool IsOpen { get; set; }
+
+  /// <summary>
+  /// Fires whenever the popover wants to close itself (click-away, post-select).
+  /// Parent should mirror the new value into its own state field.
+  /// </summary>
+  [Parameter] public EventCallback<bool> IsOpenChanged { get; set; }
+
+  /// <summary>
+  /// Fires when the user picks a device. Parent is expected to call
+  /// <c>DevicesApiService.SetOutputDeviceAsync</c>. The popover closes itself
+  /// before invoking this callback so the visual feedback feels instant.
+  /// </summary>
+  [Parameter] public EventCallback<AudioDeviceDto> OnOutputSelected { get; set; }
+
+  /// <summary>
+  /// Currently-selected output's id — used to render the active row's check.
+  /// </summary>
+  [Parameter] public string? CurrentOutputId { get; set; }
+
+  /// <summary>
+  /// All available output devices (already filtered for hidden devices upstream
+  /// in MainLayout.LoadOutputDevicesAsync). The picker filters out Cast itself
+  /// before rendering.
+  /// </summary>
+  [Parameter] public List<AudioDeviceDto> AvailableOutputs { get; set; } = new();
+
+  /// <summary>
+  /// Optional alias map (raw-name → friendly-name) passed through to
+  /// <see cref="DisplayNames.Device"/>. MainLayout reads this from
+  /// <c>IOptionsMonitor&lt;DevicesOptions&gt;</c> so config edits hot-reload.
+  /// </summary>
+  [Parameter] public IDictionary<string, string>? DeviceAliases { get; set; }
+
+  private async Task HandleSelectAsync(AudioDeviceDto device)
+  {
+    // Close first so the popover feels responsive even if SetOutputDeviceAsync
+    // takes a moment server-side.
+    await IsOpenChanged.InvokeAsync(false);
+    await OnOutputSelected.InvokeAsync(device);
+  }
+
+  private Task HandleClickAwayAsync() => IsOpenChanged.InvokeAsync(false);
+
+  /// <summary>
+  /// Sentinel id used by DevicesController to identify the virtual Cast
+  /// output (see <c>DevicesController.SetOutputDevice</c>). Hard-coded here
+  /// to mirror the sentinel used at <c>MainLayout.razor:55,71,555</c>.
+  /// </summary>
+  private static bool IsCastOutput(AudioDeviceDto d) =>
+    d.Id.Equals("google-cast", StringComparison.OrdinalIgnoreCase);
+
+  /// <summary>
+  /// Best-effort icon mapping based on a few common device-name heuristics.
+  /// Falls back to a generic speaker glyph so every row stays visually consistent.
+  /// </summary>
+  private static string GetIconForDevice(AudioDeviceDto d)
+  {
+    if (d.IsUSBDevice)
+    {
+      return "usb";
+    }
+    var name = (d.Name ?? "").ToLowerInvariant();
+    if (name.Contains("hdmi") || name.Contains("display"))
+    {
+      return "tv";
+    }
+    if (name.Contains("headphone") || name.Contains("headset"))
+    {
+      return "headphones";
+    }
+    if (name.Contains("bluetooth") || name.Contains("a2dp"))
+    {
+      return "bluetooth";
+    }
+    return "speaker";
+  }
+}

--- a/tests/Radio.Web.Tests/Components/Shared/OutputPickerDropdownTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/OutputPickerDropdownTests.cs
@@ -1,0 +1,166 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Radzen;
+using Radio.Web.Components.Shared;
+using Radio.Web.Models;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for <see cref="OutputPickerDropdown"/> — the topbar "Out" pill's
+/// popover-style picker introduced to replace the legacy /devices-page nav stub.
+///
+/// The component is intentionally presentational: the parent
+/// (<c>MainLayout</c>) owns the API call and the "available outputs" list.
+/// These tests verify the contracts the parent relies on:
+///
+/// <list type="bullet">
+///   <item>Closed renders nothing — no row markup leaks into the DOM.</item>
+///   <item>Open lists every non-Cast output (Cast is filtered: it has its own
+///         popover).</item>
+///   <item>Current selection gets the <c>is-active</c> class and a checkmark.</item>
+///   <item>Clicking a row invokes <c>OnOutputSelected</c> with the chosen DTO
+///         and closes the popover via <c>IsOpenChanged(false)</c>.</item>
+///   <item>Clicking the click-away overlay closes the popover.</item>
+/// </list>
+///
+/// Radzen components use JS interop for some icon/sizing behaviour, so
+/// <see cref="JSRuntimeMode.Loose"/> is required — same pattern MEMORY documents
+/// for MudBlazor tests.
+/// </summary>
+public class OutputPickerDropdownTests : TestContext
+{
+  public OutputPickerDropdownTests()
+  {
+    Services.AddRadzenComponents();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+  }
+
+  /// <summary>
+  /// When <c>IsOpen</c> is false, the popover root and click-away overlay must
+  /// not render — otherwise stray overlays would block taps elsewhere on the
+  /// topbar.
+  /// </summary>
+  [Fact]
+  public void Closed_RendersNothing()
+  {
+    var cut = RenderComponent<OutputPickerDropdown>(p => p
+      .Add(c => c.IsOpen, false)
+      .Add(c => c.AvailableOutputs, BuildSampleOutputs()));
+
+    Assert.Empty(cut.FindAll(".output-picker-popover"));
+    Assert.Empty(cut.FindAll(".output-picker-row"));
+  }
+
+  /// <summary>
+  /// Opening the picker must list every available output except the virtual
+  /// <c>google-cast</c> sentinel (Cast lives in CastDeviceDropdown, not here).
+  /// </summary>
+  [Fact]
+  public void Open_ListsNonCastOutputsOnly()
+  {
+    var outputs = BuildSampleOutputs();
+    var cut = RenderComponent<OutputPickerDropdown>(p => p
+      .Add(c => c.IsOpen, true)
+      .Add(c => c.AvailableOutputs, outputs));
+
+    var rows = cut.FindAll(".output-picker-row");
+    // outputs contains 3 entries: local-1, usb-1, google-cast — Cast filtered out.
+    Assert.Equal(2, rows.Count);
+
+    var text = string.Join(" ", rows.Select(r => r.TextContent));
+    Assert.Contains("Built-in Audio", text);
+    Assert.Contains("USB Audio Device", text);
+    Assert.DoesNotContain("Google Cast", text);
+  }
+
+  /// <summary>
+  /// The row whose id matches <c>CurrentOutputId</c> should pick up the
+  /// <c>is-active</c> class and render a check glyph so users see which
+  /// output is live.
+  /// </summary>
+  [Fact]
+  public void CurrentSelection_GetsActiveClassAndCheckmark()
+  {
+    var outputs = BuildSampleOutputs();
+    var cut = RenderComponent<OutputPickerDropdown>(p => p
+      .Add(c => c.IsOpen, true)
+      .Add(c => c.AvailableOutputs, outputs)
+      .Add(c => c.CurrentOutputId, "usb-1"));
+
+    var active = cut.FindAll(".output-picker-row.is-active");
+    Assert.Single(active);
+    Assert.Contains("USB Audio Device", active[0].TextContent);
+
+    var checks = cut.FindAll(".output-picker-checkmark");
+    Assert.Single(checks);
+  }
+
+  /// <summary>
+  /// Clicking a row must invoke <c>OnOutputSelected</c> with the chosen DTO
+  /// and ask the parent to close the popover via <c>IsOpenChanged(false)</c>.
+  /// </summary>
+  [Fact]
+  public void OutputSelected_InvokesCallbackAndCloses()
+  {
+    var outputs = BuildSampleOutputs();
+    AudioDeviceDto? selected = null;
+    var openStates = new List<bool>();
+
+    var cut = RenderComponent<OutputPickerDropdown>(p => p
+      .Add(c => c.IsOpen, true)
+      .Add(c => c.AvailableOutputs, outputs)
+      .Add(c => c.OnOutputSelected, EventCallback.Factory.Create<AudioDeviceDto>(
+        this, d => selected = d))
+      .Add(c => c.IsOpenChanged, EventCallback.Factory.Create<bool>(
+        this, v => openStates.Add(v))));
+
+    var rows = cut.FindAll(".output-picker-row");
+    // Click the first non-Cast row (Built-in Audio).
+    rows[0].Click();
+
+    Assert.NotNull(selected);
+    Assert.Equal("local-1", selected!.Id);
+    // The popover must request close (false) at least once.
+    Assert.Contains(false, openStates);
+  }
+
+  /// <summary>
+  /// Clicking the click-away overlay must request the popover to close
+  /// without firing <c>OnOutputSelected</c> — the user changed their mind.
+  /// </summary>
+  [Fact]
+  public void ClickAway_ClosesPopover()
+  {
+    var outputs = BuildSampleOutputs();
+    var selectedCount = 0;
+    var openStates = new List<bool>();
+
+    var cut = RenderComponent<OutputPickerDropdown>(p => p
+      .Add(c => c.IsOpen, true)
+      .Add(c => c.AvailableOutputs, outputs)
+      .Add(c => c.OnOutputSelected, EventCallback.Factory.Create<AudioDeviceDto>(
+        this, _ => selectedCount++))
+      .Add(c => c.IsOpenChanged, EventCallback.Factory.Create<bool>(
+        this, v => openStates.Add(v))));
+
+    // The overlay is the first absolute-positioned div in the rendered output.
+    // Per the component template, IsOpen=true emits the overlay before the
+    // popover root. Find it via the fixed-inset style.
+    var overlay = cut.FindAll("div").First(d =>
+      d.GetAttribute("style")?.Contains("position: fixed") == true &&
+      d.GetAttribute("style")?.Contains("inset: 0") == true);
+    overlay.Click();
+
+    Assert.Equal(0, selectedCount);
+    Assert.Contains(false, openStates);
+  }
+
+  private static List<AudioDeviceDto> BuildSampleOutputs() => new()
+  {
+    new AudioDeviceDto { Id = "local-1", Name = "Built-in Audio", Type = "Playback" },
+    new AudioDeviceDto { Id = "usb-1", Name = "USB Audio Device", Type = "Playback", IsUSBDevice = true, USBPort = "usb-0:1" },
+    new AudioDeviceDto { Id = "google-cast", Name = "Google Cast", Type = "Cast" },
+  };
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder "Out" topbar pill (which previously navigated to `/devices`) with a proper popover-style output picker. Mirrors the existing `CastDeviceDropdown` visual + interaction pattern (lightweight popover, click-away overlay with `@onclick:stopPropagation`).

Resolves Mark's UX complaint from 2026-05-22: *"from the UI there's no obvious/simple way to choose the single audio output like there used to be. This needs a cleaner UI."*

Plan: [`docs/plans/2026-05-22-output-picker-ui.md`](docs/plans/2026-05-22-output-picker-ui.md). Part 2 of the BT dual-routing fix arc — Part 1 (`wp-bt-route-exclusivity`) is in flight in parallel and touches disjoint files (WP config + deploy script vs Web UI + DevicesController).

## Behavior

- Click "Out" in topbar → popover toggles open, listing all non-Cast local outputs (built-in, USB audio devices, etc.)
- Select an output → `DevicesApi.SetOutputDeviceAsync(deviceId)` → server-side `DevicesController.SetOutputDevice` tears down `_castOutput` / `_httpOutput` and un-mutes local speakers (mutual-exclusivity invariant)
- Click outside the popover → closes via the click-away overlay
- Opening Cast popover closes Output, and vice versa — the two are mutually exclusive

## Task 3 (controller mutual-exclusivity)

Audit verified `DevicesController.SetOutputDevice` already enforces the invariant for local device selection (lines 222-226):

```csharp
await DeactivateOutputAsync(_castOutput, "Google Cast");
await DeactivateOutputAsync(_httpOutput, "HTTP Stream");
_audioEngine?.SetLocalOutputMuted(false);
```

No controller changes needed.

## Test plan

- [x] 5 bUnit tests (`OutputPickerDropdownTests`) all pass locally
- [x] Full `dotnet build --configuration Release` clean (0 errors)
- [x] Full `dotnet test --configuration Release` — all suites pass except 4 `SrcVariableResamplerTests.*` failing on Windows due to missing `libsamplerate.so.0` (Linux-only native dep, pre-existing from #404, will pass on Linux CI)
- [ ] Mark UAT (post-merge, per plan Task 6): deploy + verify the popover appears, lists local outputs, switching disconnects Cast when active

## Out of scope (per plan)

- Combining Cast + local in a single picker — they stay separate
- Reworking the `/devices` page — still the full management surface
- USB hotplug live-refresh — the picker renders whatever `_availableOutputs` holds at render time (the existing SignalR audio-state events already drive that list)
- Path B (PipeWire dual-routing) — handled in sister PR for `wp-bt-route-exclusivity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)