### PR TITLE
fix(audio): WP rule preventing BT A2DP source from dual-routing to default sink

### DIFF
--- a/deploy/Deploy-ToLinux.ps1
+++ b/deploy/Deploy-ToLinux.ps1
@@ -217,6 +217,80 @@ if ($LASTEXITCODE -ne 0) {
   exit 1
 }
 
+# Sync WirePlumber Lua rules.
+#
+# Two destinations, distinguished by source-filename prefix (we keep them
+# flat in deploy/common/ so they live next to the existing config artifacts):
+#   * 4x-*.lua            -> /etc/wireplumber/main.lua.d/
+#                            (currently: stream-restore behaviour overrides)
+#   * 8x-*.lua / 9x-*.lua -> /etc/wireplumber/bluetooth.lua.d/
+#                            (bluez_monitor properties + bluez per-node rules)
+#
+# WirePlumber needs a SIGHUP-equivalent restart to reload Lua scripts. The
+# user-mode unit is owned by the desktop user (mmack); we restart it as that
+# user via XDG_RUNTIME_DIR. We do not run with `sudo --user mmack` because the
+# script may already be running as mmack over SSH.
+#
+# Explicit file names (no `cp deploy/common/*.lua`) so dropping unrelated
+# .lua artifacts into deploy/common/ never accidentally lands them in
+# /etc/wireplumber. Mirror this list in deploy/debian-x64/setup.sh and
+# deploy/common/radio-bt-setup.sh (verify_wp_configs).
+$wpMainRules = @(
+  "41-disable-bt-input-restore-target.lua"
+)
+$wpBluetoothRules = @(
+  "90-disable-bt-input-autolink.lua"
+)
+
+$wpRulesChanged = $false
+function Sync-WpRule($name, $remoteDir) {
+  $localPath = Join-Path $RepoRoot "deploy\common\$name"
+  if (-not (Test-Path $localPath)) {
+    Write-Host "  WARNING: missing $localPath (skipped)" -ForegroundColor Yellow
+    return $false
+  }
+  $remoteTmp = "/tmp/wp-rule-$name"
+  scp -q $localPath "${SshTarget}:${remoteTmp}" 2>&1 | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    Write-Host "  WARNING: scp $name failed" -ForegroundColor Yellow
+    return $false
+  }
+  # Compare-and-install only when content changes, so we know whether to
+  # restart wireplumber. cmp returns 0 = equal, 1 = different, 2 = missing.
+  $cmpScript = "sudo mkdir -p $remoteDir && if cmp -s $remoteTmp $remoteDir/$name 2>/dev/null; then echo 'unchanged'; rm -f $remoteTmp; else sudo install -m 0644 -o root -g root $remoteTmp $remoteDir/$name && rm -f $remoteTmp && echo 'changed'; fi"
+  $result = ssh $SshTarget $cmpScript
+  if ($LASTEXITCODE -ne 0) {
+    Write-Host "  WARNING: install $name failed" -ForegroundColor Yellow
+    return $false
+  }
+  if ($result -match 'changed') {
+    Write-Host "    + $remoteDir/$name" -ForegroundColor DarkGray
+    return $true
+  }
+  return $false
+}
+
+Write-Host "  Syncing WirePlumber rules..." -ForegroundColor DarkGray
+foreach ($r in $wpMainRules) {
+  if (Sync-WpRule -name $r -remoteDir "/etc/wireplumber/main.lua.d") { $wpRulesChanged = $true }
+}
+foreach ($r in $wpBluetoothRules) {
+  if (Sync-WpRule -name $r -remoteDir "/etc/wireplumber/bluetooth.lua.d") { $wpRulesChanged = $true }
+}
+
+if ($wpRulesChanged) {
+  Write-Host "  WirePlumber rules changed — restarting wireplumber..." -ForegroundColor DarkGray
+  # User-mode systemd: must run as the desktop user, with XDG_RUNTIME_DIR so
+  # systemctl --user can reach the right session bus.
+  ssh $SshTarget "XDG_RUNTIME_DIR=/run/user/1000 systemctl --user restart wireplumber 2>&1 || true"
+  # restart-stream module re-reads its state on next stream connect, no extra
+  # action needed. Existing saved targets only re-apply on stream re-creation
+  # (i.e. next BT reconnect) — the operator clears `~/.local/state/wireplumber/restore-stream`
+  # to take effect for already-saved BT routings (see plan Task 2).
+} else {
+  Write-Host "    WirePlumber rules up to date" -ForegroundColor DarkGray
+}
+
 Write-Host "  Files synced" -ForegroundColor Green
 
 # --- Step 4: Restart ---

--- a/deploy/common/41-disable-bt-input-restore-target.lua
+++ b/deploy/common/41-disable-bt-input-restore-target.lua
@@ -1,0 +1,58 @@
+-- /etc/wireplumber/main.lua.d/41-disable-bt-input-restore-target.lua
+--
+-- Prevent WirePlumber's restore-stream script from restoring a saved routing
+-- target (and saved volume) for BT A2DP source nodes. Radio Console is the
+-- intended consumer of BT audio: it captures the bluez_input node directly via
+-- a PipeWire native stream (`radio-bt-stream`) and routes through its own
+-- mixer / outputs.
+--
+-- Without this rule, restore-stream remembers a per-stream target (keyed by
+-- media.name e.g. "Pixel 10 Pro XL (codec aptX HD)") and on every subsequent
+-- BT connect writes a `target.node` metadata entry that policy-node.lua then
+-- uses to auto-link the BT source straight to the default sink (local
+-- soundbar). The result is a parallel audio path that runs alongside the
+-- designed `phone -> bluez_input -> Radio.API -> output(s)` flow, producing
+-- dual playback + a comb-filter "underwater" artifact (the two paths have
+-- different latencies). See
+-- docs/research/2026-05-22-bt-dual-routing-investigation.md for the
+-- diagnostic that motivated this rule.
+--
+-- The companion rule at bluetooth.lua.d/90-disable-bt-input-autolink.lua sets
+-- `node.autoconnect = false` on the same nodes, which stops the policy
+-- module's *default* auto-link behaviour but does not stop restore-stream
+-- from writing `target.node` metadata. Both rules are needed.
+--
+-- Radio.API's capture is unaffected: it is a separate `pw_stream`
+-- (`radio-bt-stream`) that links its own input ports to the bluez_input
+-- output ports independently of restore-stream.
+--
+-- Scope: matches only `bluez_input.*` nodes. File-player, system sounds,
+-- Chromium, etc. keep restore-stream functionality. HFP/voice profiles on
+-- hci1 (RotaryPhone's adapter) are unaffected: they expose nodes named
+-- `bluez_output.*` or HSP/HFP variants, not `bluez_input.*`.
+--
+-- WirePlumber version note: written for WP 0.4.x (Lua-based config). If the
+-- runtime moves to WP 0.5.x (JSON/TOML config), this rule needs to be
+-- re-authored with the equivalent `wireplumber.settings` shape under
+-- `node.restore-target` / `node.restore-props`.
+
+stream_defaults.rules = stream_defaults.rules or {}
+table.insert(stream_defaults.rules, {
+  matches = {
+    {
+      { "node.name", "matches", "bluez_input.*" },
+    },
+  },
+  apply_properties = {
+    -- Stop restore-stream from writing target.node metadata for this node
+    -- on connect. Without target.node, policy-node.lua leaves the node
+    -- unlinked (consistent with node.autoconnect = false).
+    ["state.restore-target"] = false,
+    -- Also stop restoring the saved channel volume. The saved value for
+    -- this BT device may be a leftover from a manual once-routing decision
+    -- (e.g. user once dragged the stream onto the soundbar with volume at
+    -- 30%). If the rule above is ever bypassed, we do not want a stale
+    -- volume to bleed into the real sink.
+    ["state.restore-props"] = false,
+  },
+})

--- a/deploy/common/radio-bt-setup.sh
+++ b/deploy/common/radio-bt-setup.sh
@@ -67,6 +67,23 @@ verify_wp_configs() {
   else
     log "WARNING: $missing WP bluetooth config(s) missing — BT audio may not work correctly"
   fi
+
+  # main.lua.d rules — restore-stream exclusion for BT (Path B prevention).
+  # If this rule is missing, restore-stream may auto-route BT to default sink
+  # on reconnect, producing dual audio paths.
+  local main_dir="/etc/wireplumber/main.lua.d"
+  local main_missing=0
+  for f in 41-disable-bt-input-restore-target.lua; do
+    if [[ ! -f "$main_dir/$f" ]]; then
+      log "WARNING: Missing WP main config: $main_dir/$f"
+      main_missing=$((main_missing + 1))
+    fi
+  done
+  if [[ $main_missing -eq 0 ]]; then
+    log "WP main configs: OK (1/1 present)"
+  else
+    log "WARNING: $main_missing WP main config(s) missing — BT may dual-route via restore-stream"
+  fi
 }
 
 # If --patch-only, just verify patches and exit

--- a/deploy/debian-x64/setup.sh
+++ b/deploy/debian-x64/setup.sh
@@ -293,15 +293,31 @@ else
   echo "  No USB BT adapter detected — skipping Intel BT disable"
 fi
 
-# WirePlumber: prevent auto-linking BT input to speakers
-# Radio Console captures BT audio via PipeWire native stream and routes through
-# its own mixer. Without this, WirePlumber auto-links bluez_input → default sink,
-# causing duplicate audio that bypasses volume/mute controls.
+# WirePlumber: prevent auto-linking BT input to speakers (two complementary rules).
+#
+# bluetooth.lua.d/90-disable-bt-input-autolink.lua sets `node.autoconnect = false`
+# on bluez_input nodes, which stops policy-node.lua from picking a default target
+# and auto-linking.
+#
+# main.lua.d/41-disable-bt-input-restore-target.lua additionally tells
+# restore-stream.lua to NOT save/restore the per-stream `target.node` for these
+# nodes. Without this second rule, restore-stream remembers a once-routed target
+# (e.g. the soundbar sink) keyed by media.name and re-writes target.node metadata
+# on every BT reconnect — which policy-node.lua then honours, producing a rogue
+# parallel audio path that bypasses Radio.API entirely. See
+# docs/research/2026-05-22-bt-dual-routing-investigation.md.
 WP_BT_RULE="$SCRIPT_DIR_COMMON/90-disable-bt-input-autolink.lua"
 if [ -f "$WP_BT_RULE" ]; then
   mkdir -p /etc/wireplumber/bluetooth.lua.d
   cp "$WP_BT_RULE" /etc/wireplumber/bluetooth.lua.d/
   echo "  WirePlumber BT auto-link prevention rule installed"
+fi
+
+WP_MAIN_RULE="$SCRIPT_DIR_COMMON/41-disable-bt-input-restore-target.lua"
+if [ -f "$WP_MAIN_RULE" ]; then
+  mkdir -p /etc/wireplumber/main.lua.d
+  cp "$WP_MAIN_RULE" /etc/wireplumber/main.lua.d/
+  echo "  WirePlumber BT stream-restore exclusion rule installed"
 fi
 
 # ---- 8. Configure Audio & Bluetooth ----


### PR DESCRIPTION
## Summary

Part 1 of the BT dual-routing fix arc (companion plan
`docs/plans/2026-05-22-wp-bt-route-exclusivity.md`). Silences the rogue
parallel audio path that PR #404's UAT exposed — BT phone audio reaching
the local soundbar directly via PipeWire's stream-restore, bypassing
Radio.API entirely. That dual-path is what caused Mark's "audio from both
soundbar AND Cast" symptom and the comb-filter "underwater" artifact
that made Path D's metrics regress.

- **New rule** `deploy/common/41-disable-bt-input-restore-target.lua` (installs
  to `/etc/wireplumber/main.lua.d/`): sets `state.restore-target = false`
  and `state.restore-props = false` on every `bluez_input.*` node, so
  WirePlumber's `restore-stream` script stops saving/restoring per-stream
  target metadata for BT sources. Complements the existing
  `bluetooth.lua.d/90-disable-bt-input-autolink.lua` rule
  (`node.autoconnect = false`) — both are needed.
- **Deploy script** (`deploy/Deploy-ToLinux.ps1`) gains a WP-rule sync
  step that scp's, cmp-and-installs, and conditionally restarts
  wireplumber. Same pattern extended to the existing bluetooth.lua.d
  rule so iterative edits propagate too.
- **First-time setup** (`deploy/debian-x64/setup.sh`) also installs the
  new rule.
- **Boot hook** (`deploy/common/radio-bt-setup.sh::verify_wp_configs`)
  now warns if the main.lua.d rule is missing (e.g. after a WirePlumber
  package upgrade wipes `/etc/wireplumber`).

Radio.API's own capture is unaffected — its `pw_stream`
(`radio-bt-stream`) is a separate graph endpoint from the bluez_input
node's policy-managed routing.

## Diagnostic context

Live `pactl list sink-inputs` on `radio` showed two sink-inputs feeding
the same sink:

- `application.name="Radio.API"` (the designed path: `phone -> bluez_input -> Radio.API -> output`)
- `media.name="Pixel 10 Pro XL (codec aptX HD)"` (the rogue path:
  `phone -> bluez_input -> default sink` via restore-stream-resurrected
  `target.node` metadata)

The rogue stream's saved volume in
`~/.local/state/wireplumber/restore-stream` confirms restore-stream
was the resurrecting actor. The current `90-disable-bt-input-autolink.lua`
rule stops policy-node's *default* auto-link but does not stop
restore-stream from writing `target.node` metadata that policy-node then
honours.

Full investigation:
`docs/research/2026-05-22-bt-dual-routing-investigation.md`.

## Test plan

Local + sanity:
- [x] `dotnet build --configuration Release` clean (no .NET changes; 0 errors, pre-existing IDE warnings only)
- [x] `dotnet test --configuration Release` runs — 4 failures in `SrcVariableResamplerTests` are pre-existing libsamplerate native interop issues on Windows from PR #404, unrelated to this PR
- [x] PowerShell parse-check on `Deploy-ToLinux.ps1` — OK
- [x] `bash -n` on `radio-bt-setup.sh` and `setup.sh` — OK
- [x] Rule deploy-tested on radio (WP 0.4.17): installed via scp+install,
      wireplumber restarted cleanly, journal shows zero Lua errors,
      `systemctl --user is-active wireplumber` -> `active`. Test install
      removed; clean state restored.

Awaiting operator (Mark) post-merge:
- [ ] Run `./deploy/Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64` — confirm "Syncing WirePlumber rules..." step lands both files and restarts wireplumber on first deploy
- [ ] One-time: `rm -f ~/.local/state/wireplumber/restore-stream` (clears already-saved BT routings — required for the rule to take effect for previously-paired devices; plan Task 2)
- [ ] Reconnect Pixel 10 → run `pactl list sink-inputs` → expect ONLY `application.name="Radio.API"` sink-input present on the default sink (no `media.name="Pixel ..."` entry)
- [ ] Subjective: confirm audio is single-pathed (no "underwater" / no dual playback)
- [ ] Re-run Path D UAT — expect `comp events/hour` to drop substantially, `underrun events/hour` -> 0, `|ppm|` -> near 0

## Operator note (deploy-relevant)

After deploy, run `rm -f ~/.local/state/wireplumber/restore-stream` on
radio. The rule prevents NEW save/restore decisions but cannot
retroactively clear entries already saved from prior sessions (e.g. the
existing "Pixel 10 Pro XL (codec aptX HD)" entry with volume 0.31).
The deploy script does not do this automatically because the file is in
the user's home — see plan Task 2 for context.

## Docs Impact

- `docs/plans/2026-05-22-wp-bt-route-exclusivity.md` — Task 1, 3, 4
  (Builder side: rule + deploy script + verify hook). Task 0, 2 remain
  operator actions documented in this PR's Test plan.
- `docs/research/2026-05-22-bt-dual-routing-investigation.md` — referenced
  from the rule's docstring.

## Out of scope

- WP 0.5.x TOML rewrite (deferred until Ubuntu upgrades WirePlumber package).
- Raspberry Pi target (uses WP 0.5.x JSON config — different rule shape).
- Output picker UI (`docs/plans/2026-05-22-output-picker-ui.md` — Part 2,
  separate sister PR).
- Path D quality-mode tuning (pending Part 1 verification before any
  quality-mode escalation is justified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)