### PR TITLE
fix(audio): enforce exclusive output on startup + graceful Cast shutdown + runtime tear-down

### DIFF
--- a/src/Radio.API/Controllers/DevicesController.cs
+++ b/src/Radio.API/Controllers/DevicesController.cs
@@ -1341,10 +1341,9 @@ public class DevicesController : ControllerBase
 
         await _castOutput.StartAsync();
 
-        // Mute local speakers — audio pipeline continues for Cast streaming
-        _audioEngine?.SetLocalOutputMuted(true);
+        // (Gate already muted local in the caller; no per-call mute needed here.)
 
-        _logger.LogInformation("Auto-connected to default Cast device: {Name} (mode: {Mode}, local output muted)",
+        _logger.LogInformation("Auto-connected to default Cast device: {Name} (mode: {Mode})",
           device.FriendlyName, autoConnectOptions.StreamingMode);
       }
       catch (Exception ex)

--- a/src/Radio.API/Controllers/DevicesController.cs
+++ b/src/Radio.API/Controllers/DevicesController.cs
@@ -194,94 +194,78 @@ public class DevicesController : ControllerBase
       var deviceId = request.DeviceId;
       _logger.LogInformation("Switching audio output to: {DeviceId}", deviceId);
 
-      // Handle virtual outputs (HTTP Stream, Google Cast)
+      if (_audioEngine == null)
+      {
+        return StatusCode(503, new { error = "Audio engine not available" });
+      }
+
+      // Single gate call: atomically activates/deactivates the virtual outputs,
+      // sets local-output mute, and persists AudioPreferences:CurrentOutput.
+      // Replaces the per-branch SetLocalOutputMuted convention that was
+      // enforced at three sites here.
+      await _audioEngine.SetActiveOutputAsync(deviceId);
+
+      if (deviceId == "google-cast")
+      {
+        // Auto-connect remains controller-side (depends on saved-device lookup).
+        await TryAutoConnectDefaultCastDeviceAsync();
+        return Ok(new { message = "Output device set", deviceId = deviceId });
+      }
+
       if (deviceId == "http-stream")
       {
-        // Activate HTTP stream output, deactivate others
-        await ActivateOutputAsync(_httpOutput, "HTTP Stream");
-        await DeactivateOutputAsync(_castOutput, "Google Cast");
-
-        // Unmute local speakers when switching away from Cast
-        _audioEngine?.SetLocalOutputMuted(false);
+        return Ok(new { message = "Output device set", deviceId = deviceId });
       }
-      else if (deviceId == "google-cast")
+
+      // Local device path: validate + perform the native MiniAudio switch.
+      // The gate set the mute state and persisted preferences; this block
+      // still owns the device-index-to-id mapping and the native swap.
+      var deviceIndex = _audioEngine.GetDeviceIndexById(deviceId);
+      if (deviceIndex < 0)
       {
-        // Activate Cast output AND HTTP stream — Cast streams audio via HTTP
-        await ActivateOutputAsync(_castOutput, "Google Cast");
-        await ActivateOutputAsync(_httpOutput, "HTTP Stream");
-
-        // Mute local speakers — audio pipeline continues for HTTP/Cast streaming
-        _audioEngine?.SetLocalOutputMuted(true);
-
-        // Auto-connect to default Cast device if one is saved
-        await TryAutoConnectDefaultCastDeviceAsync();
-      }
-      else
-      {
-        // Local audio device - switch the local output device
-        await DeactivateOutputAsync(_castOutput, "Google Cast");
-        await DeactivateOutputAsync(_httpOutput, "HTTP Stream");
-
-        // Unmute local speakers when switching back from Cast
-        _audioEngine?.SetLocalOutputMuted(false);
-
-        // Validate the device exists before responding
-        if (_audioEngine != null)
-        {
-          var deviceIndex = _audioEngine.GetDeviceIndexById(deviceId);
-          if (deviceIndex < 0)
-          {
-            _logger.LogDebug("Device {DeviceId} is not a local playback device, skipping engine switch", deviceId);
-          }
-          else
-          {
-            // Persist preference and respond BEFORE the native switch.
-            // SwitchPlaybackDevice calls native MiniAudio Stop/Dispose/Init/Start
-            // which can tear down the HTTP socket before the response is sent.
-            await _deviceManager.SetOutputDeviceAsync(deviceId);
-
-            if (_localOutput != null)
-            {
-              _localOutput.UpdateDeviceId(deviceId);
-            }
-
-            _logger.LogInformation("Output device preference saved to {DeviceId}, starting native switch...", deviceId);
-
-            // Fire-and-forget the native device switch on the thread pool
-            var capturedIndex = deviceIndex;
-            var capturedDeviceId = deviceId;
-            _ = Task.Run(async () =>
-            {
-              try
-              {
-                var success = _audioEngine.SwitchPlaybackDevice(capturedIndex);
-                if (!success)
-                {
-                  _logger.LogWarning("Failed to switch SoundFlow playback device to {DeviceId}", capturedDeviceId);
-                }
-                else
-                {
-                  _logger.LogInformation("Native playback device switch to {DeviceId} completed", capturedDeviceId);
-                }
-              }
-              catch (Exception ex)
-              {
-                _logger.LogError(ex, "Error during native playback device switch to {DeviceId}", capturedDeviceId);
-              }
-            });
-
-            return Ok(new { message = "Output device set", deviceId = deviceId });
-          }
-        }
-
+        _logger.LogDebug("Device {DeviceId} is not a local playback device, skipping engine switch", deviceId);
         if (_localOutput != null)
         {
           await _localOutput.SelectDeviceAsync(deviceId);
         }
+        await _deviceManager.SetOutputDeviceAsync(deviceId);
+        return Ok(new { message = "Output device set", deviceId = deviceId });
       }
 
+      // Persist device manager state before the native switch so the response
+      // is sent quickly. SwitchPlaybackDevice does Stop/Dispose/Init/Start on
+      // the audio backend and can briefly disrupt the HTTP socket.
       await _deviceManager.SetOutputDeviceAsync(deviceId);
-      _logger.LogInformation("Output device set to {DeviceId}", deviceId);
+
+      if (_localOutput != null)
+      {
+        _localOutput.UpdateDeviceId(deviceId);
+      }
+
+      _logger.LogInformation("Output device preference saved to {DeviceId}, starting native switch...", deviceId);
+
+      // Fire-and-forget the native device switch on the thread pool
+      var capturedIndex = deviceIndex;
+      var capturedDeviceId = deviceId;
+      _ = Task.Run(async () =>
+      {
+        try
+        {
+          var success = _audioEngine.SwitchPlaybackDevice(capturedIndex);
+          if (!success)
+          {
+            _logger.LogWarning("Failed to switch SoundFlow playback device to {DeviceId}", capturedDeviceId);
+          }
+          else
+          {
+            _logger.LogInformation("Native playback device switch to {DeviceId} completed", capturedDeviceId);
+          }
+        }
+        catch (Exception ex)
+        {
+          _logger.LogError(ex, "Error during native playback device switch to {DeviceId}", capturedDeviceId);
+        }
+      });
 
       return Ok(new { message = "Output device set", deviceId = deviceId });
     }

--- a/src/Radio.API/Controllers/DevicesController.cs
+++ b/src/Radio.API/Controllers/DevicesController.cs
@@ -671,8 +671,11 @@ public class DevicesController : ControllerBase
         await _castOutput.StartAsync(cancellationToken);
       }
 
-      // Mute local speakers — audio pipeline continues for Cast streaming
-      _audioEngine?.SetLocalOutputMuted(true);
+      // Promote Cast to the active output via the gate (handles mute + persist).
+      if (_audioEngine != null)
+      {
+        await _audioEngine.SetActiveOutputAsync("google-cast", cancellationToken);
+      }
 
       // Save as default Cast device for auto-connect
       await SaveDefaultCastDeviceAsync(request.DeviceId, request.Name ?? "Cast Device");

--- a/src/Radio.API/Controllers/DevicesController.cs
+++ b/src/Radio.API/Controllers/DevicesController.cs
@@ -719,16 +719,33 @@ public class DevicesController : ControllerBase
         await _httpOutput.StopAsync(cancellationToken);
       }
 
-      // Unmute local speakers so audio resumes locally
-      _audioEngine?.SetLocalOutputMuted(false);
+      // Promote the local output back via the gate. Use the persisted local
+      // device id; if none, fall back to "default" (the gate is a no-op on
+      // virtual outputs for an unknown id and will still unmute local).
+      var fallbackOutputId = _deviceManager.GetSelectedOutputDeviceId() ?? "default";
+      if (_audioEngine != null)
+      {
+        await _audioEngine.SetActiveOutputAsync(fallbackOutputId, cancellationToken);
+      }
 
       _logger.LogInformation("Disconnected from Cast device: {Name}, local output unmuted", deviceName);
       return Ok(new { message = "Disconnected from Cast device", device = deviceName });
     }
     catch (Exception ex)
     {
-      // Even if disconnect fails, unmute local so user isn't stuck with no audio
-      _audioEngine?.SetLocalOutputMuted(false);
+      // Even if disconnect fails, restore local output so user isn't stuck with no audio
+      try
+      {
+        var fallbackOutputId = _deviceManager.GetSelectedOutputDeviceId() ?? "default";
+        if (_audioEngine != null)
+        {
+          await _audioEngine.SetActiveOutputAsync(fallbackOutputId);
+        }
+      }
+      catch (Exception fallbackEx)
+      {
+        _logger.LogWarning(fallbackEx, "Failed to restore local output after Cast disconnect failure");
+      }
       _logger.LogError(ex, "Error disconnecting from Cast device");
       return StatusCode(500, new { error = "Failed to disconnect from Cast device", details = ex.Message });
     }

--- a/src/Radio.API/Services/AudioEngineInitializationService.cs
+++ b/src/Radio.API/Services/AudioEngineInitializationService.cs
@@ -77,6 +77,15 @@ public class AudioEngineInitializationService : IHostedService
 
       _logger.LogInformation("Initializing audio engine...");
 
+      // Wire the virtual outputs + config manager into the engine so
+      // SetActiveOutputAsync can activate/deactivate them and persist the
+      // choice. The engine treats these as optional dependencies; the
+      // controller-side activation paths still go through the same gate.
+      if (_audioEngine is SoundFlowAudioEngine sfEngine)
+      {
+        sfEngine.AttachOutputCoordination(_castOutput, _httpOutput, _configManager);
+      }
+
       // Initialize the audio engine
       await _audioEngine.InitializeAsync(cancellationToken);
       

--- a/src/Radio.API/Services/AudioEngineInitializationService.cs
+++ b/src/Radio.API/Services/AudioEngineInitializationService.cs
@@ -583,31 +583,15 @@ public class AudioEngineInitializationService : IHostedService
     {
       _logger.LogInformation("Stopping audio engine...");
 
-      // Graceful Cast shutdown: stop media + disconnect cleanly so the
-      // Chromecast returns to its default state instead of holding a stale
-      // session that the next startup has to fight through. Best-effort;
-      // never block engine stop. 5s outer cap covers the media-stop +
-      // disconnect combined (each has its own internal 5s timeout — see
-      // GoogleCastOutput.cs).
-      if (_castOutput != null &&
-          (_castOutput.State == AudioOutputState.Streaming ||
-           _castOutput.State == AudioOutputState.Ready ||
-           _castOutput.State == AudioOutputState.Connecting))
+      // Graceful Cast shutdown: stop media + CLOSE_APP + disconnect receiver
+      // so the Chromecast returns to its default state instead of holding a
+      // stale session that the next startup has to fight through. Single
+      // source of truth: the same TearDownCastOutputAsync that the
+      // SetActiveOutputAsync gate uses when transitioning away from Cast.
+      // Best-effort; never blocks engine stop (5s internal cap + try/catch).
+      if (_audioEngine is SoundFlowAudioEngine sfEngine)
       {
-        try
-        {
-          using var castCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-          // StopAsync sends MediaChannel.StopAsync (terminates media session)
-          // and tears down DirectChannel streaming if active.
-          await _castOutput.StopAsync(castCts.Token);
-          // DisconnectAsync sends CLOSE_APP / closes the receiver connection.
-          await _castOutput.DisconnectAsync(castCts.Token);
-          _logger.LogInformation("Cast output stopped + disconnected gracefully");
-        }
-        catch (Exception ex)
-        {
-          _logger.LogWarning(ex, "Graceful Cast shutdown failed; continuing engine stop");
-        }
+        await sfEngine.TearDownCastOutputAsync(cancellationToken);
       }
 
       if (_audioEngine.State == Radio.Core.Interfaces.Audio.AudioEngineState.Running)

--- a/src/Radio.API/Services/AudioEngineInitializationService.cs
+++ b/src/Radio.API/Services/AudioEngineInitializationService.cs
@@ -186,15 +186,24 @@ public class AudioEngineInitializationService : IHostedService
       var preferredOutputId = !string.IsNullOrEmpty(persistedOutput) ? persistedOutput : prefs.CurrentOutput;
 
       // Handle virtual outputs (google-cast, http-stream)
-      if (preferredOutputId == "google-cast")
+      if (preferredOutputId == "google-cast" || preferredOutputId == "http-stream")
       {
-        _logger.LogInformation("Restoring Google Cast output from startup preferences");
-        await ActivateVirtualOutputsForCastAsync(cancellationToken);
-      }
-      else if (preferredOutputId == "http-stream")
-      {
-        _logger.LogInformation("Restoring HTTP Stream output from startup preferences");
-        await ActivateOutputAsync(_httpOutput, "HTTP Stream");
+        _logger.LogInformation("Restoring {Output} output from startup preferences", preferredOutputId);
+
+        // Single gate call: atomically activates the virtual output, stops the
+        // other virtual output, sets local-output mute, and persists the choice.
+        // This replaces the previous startup path which only activated outputs
+        // and forgot to mute the local sink — that omission caused dual-output
+        // (Cast + soundbar) after service restart with persisted "google-cast".
+        await _audioEngine.SetActiveOutputAsync(preferredOutputId, cancellationToken);
+
+        // Cast still needs background auto-connect to the saved default device.
+        // The gate handles activation; auto-connect remains here since it
+        // depends on AudioPreferences.DefaultCastDeviceId lookup.
+        if (preferredOutputId == "google-cast")
+        {
+          StartCastAutoConnect(cancellationToken);
+        }
       }
       else
       {
@@ -263,6 +272,7 @@ public class AudioEngineInitializationService : IHostedService
                 _logger.LogInformation("Found correct device \"{Name}\" at ID {Id} — switching",
                   correctDevice.Name, correctDevice.Id);
                 await _deviceManager.SetOutputDeviceAsync(correctDevice.Id, cancellationToken);
+                outputToUse = correctDevice.Id;
               }
               else
               {
@@ -275,9 +285,21 @@ public class AudioEngineInitializationService : IHostedService
           {
             _logger.LogWarning(ex, "Output device verification failed — continuing with current device");
           }
+
+          // Notify the gate that local is the active output. This stops any
+          // lingering virtual outputs, unmutes the local sink, and persists
+          // AudioPreferences:CurrentOutput so the next restart picks the same device.
+          try
+          {
+            await _audioEngine.SetActiveOutputAsync(outputToUse, cancellationToken);
+          }
+          catch (Exception ex)
+          {
+            _logger.LogWarning(ex, "Failed to set active output via gate for local device {DeviceId}", outputToUse);
+          }
         }
       }
-      
+
       _logger.LogInformation("Audio startup output configuration applied");
     }
     catch (Exception ex)
@@ -369,25 +391,14 @@ public class AudioEngineInitializationService : IHostedService
   }
 
   /// <summary>
-  /// Activates Cast and HTTP Stream outputs, then auto-connects to the default Cast device.
+  /// Starts background auto-connect to the saved default Cast device.
+  /// Assumes Cast + HTTP outputs are already activated by
+  /// <see cref="IAudioEngine.SetActiveOutputAsync"/>.
   /// </summary>
-  private async Task ActivateVirtualOutputsForCastAsync(CancellationToken cancellationToken)
+  private void StartCastAutoConnect(CancellationToken cancellationToken)
   {
     var castOptions = _audioOutputOptions.Value.GoogleCast;
     var isDirectChannel = string.Equals(castOptions.StreamingMode, "DirectChannel", StringComparison.OrdinalIgnoreCase);
-
-    // DirectChannel mode bypasses HTTP — audio is sent directly over the Cast protocol.
-    // Only start the HTTP stream for the standard HttpMp3 mode.
-    if (!isDirectChannel)
-    {
-      await ActivateOutputAsync(_httpOutput, "HTTP Stream");
-    }
-    else
-    {
-      _logger.LogInformation("DirectChannel mode: skipping HTTP stream activation");
-    }
-
-    await ActivateOutputAsync(_castOutput, "Google Cast");
 
     // In DirectChannel mode, wire the audio engine so GoogleCastOutput can
     // create a stream reader for sending PCM data over the Cast message bus.
@@ -397,7 +408,6 @@ public class AudioEngineInitializationService : IHostedService
       _logger.LogInformation("DirectChannel mode: audio engine wired to Cast output");
     }
 
-    // Auto-connect to saved default Cast device
     var prefs = _audioPreferences.CurrentValue;
     if (string.IsNullOrEmpty(prefs.DefaultCastDeviceId) || _castOutput == null)
     {
@@ -448,41 +458,6 @@ public class AudioEngineInitializationService : IHostedService
         _logger.LogWarning(ex, "Failed to auto-connect to Cast device on startup");
       }
     }, cancellationToken);
-  }
-
-  /// <summary>
-  /// Activates an audio output (initialize + start) if available.
-  /// </summary>
-  private async Task ActivateOutputAsync(IAudioOutput? output, string name)
-  {
-    if (output == null)
-    {
-      _logger.LogDebug("{Name} output not available", name);
-      return;
-    }
-
-    try
-    {
-      if (output.State == AudioOutputState.Error)
-      {
-        await output.InitializeAsync();
-      }
-
-      if (output.State == AudioOutputState.Created)
-      {
-        await output.InitializeAsync();
-      }
-
-      if (output.State == AudioOutputState.Ready || output.State == AudioOutputState.Stopped)
-      {
-        await output.StartAsync();
-        _logger.LogInformation("{Name} output activated on startup", name);
-      }
-    }
-    catch (Exception ex)
-    {
-      _logger.LogWarning(ex, "Failed to activate {Name} output on startup", name);
-    }
   }
 
   /// <summary>

--- a/src/Radio.API/Services/AudioEngineInitializationService.cs
+++ b/src/Radio.API/Services/AudioEngineInitializationService.cs
@@ -583,6 +583,33 @@ public class AudioEngineInitializationService : IHostedService
     {
       _logger.LogInformation("Stopping audio engine...");
 
+      // Graceful Cast shutdown: stop media + disconnect cleanly so the
+      // Chromecast returns to its default state instead of holding a stale
+      // session that the next startup has to fight through. Best-effort;
+      // never block engine stop. 5s outer cap covers the media-stop +
+      // disconnect combined (each has its own internal 5s timeout — see
+      // GoogleCastOutput.cs).
+      if (_castOutput != null &&
+          (_castOutput.State == AudioOutputState.Streaming ||
+           _castOutput.State == AudioOutputState.Ready ||
+           _castOutput.State == AudioOutputState.Connecting))
+      {
+        try
+        {
+          using var castCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+          // StopAsync sends MediaChannel.StopAsync (terminates media session)
+          // and tears down DirectChannel streaming if active.
+          await _castOutput.StopAsync(castCts.Token);
+          // DisconnectAsync sends CLOSE_APP / closes the receiver connection.
+          await _castOutput.DisconnectAsync(castCts.Token);
+          _logger.LogInformation("Cast output stopped + disconnected gracefully");
+        }
+        catch (Exception ex)
+        {
+          _logger.LogWarning(ex, "Graceful Cast shutdown failed; continuing engine stop");
+        }
+      }
+
       if (_audioEngine.State == Radio.Core.Interfaces.Audio.AudioEngineState.Running)
       {
         await _audioEngine.StopAsync(cancellationToken);

--- a/src/Radio.Core/Interfaces/Audio/IAudioEngine.cs
+++ b/src/Radio.Core/Interfaces/Audio/IAudioEngine.cs
@@ -83,6 +83,27 @@ public interface IAudioEngine : IAsyncDisposable
   /// </summary>
   /// <param name="muted">True to mute local output, false to restore volume.</param>
   void SetLocalOutputMuted(bool muted);
+
+  /// <summary>
+  /// Gets the id of the currently active output ("google-cast", "http-stream",
+  /// or a local device id). Null until the first activation completes.
+  /// </summary>
+  string? ActiveOutputId { get; }
+
+  /// <summary>
+  /// Atomically switches the active audio output. Exactly one output is active
+  /// at any time: either a local playback device (identified by its MiniAudio
+  /// device id), or one of the virtual outputs "google-cast" / "http-stream".
+  /// Activates the requested output, deactivates the others, sets local-output
+  /// mute appropriately, and persists the choice to AudioPreferences:CurrentOutput.
+  /// </summary>
+  /// <param name="outputId">"google-cast", "http-stream", or a local device id.</param>
+  /// <param name="cancellationToken">Cancellation token.</param>
+  /// <remarks>
+  /// Callers must not re-enter this method from within an output's StartAsync/StopAsync
+  /// callbacks — the gate holds a SemaphoreSlim and will deadlock under reentrancy.
+  /// </remarks>
+  Task SetActiveOutputAsync(string outputId, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
@@ -47,6 +47,16 @@ public class SoundFlowAudioEngine : IAudioEngine
   private readonly object _stateLock = new();
   private GCLatencyMode _previousLatencyMode;
 
+  // Optional virtual-output references for SetActiveOutputAsync. Injected via
+  // AttachOutputCoordination (not the constructor) to avoid a chicken-and-egg
+  // dependency cycle: GoogleCastOutput can hold the engine indirectly when
+  // DirectChannel mode is enabled.
+  private IAudioOutput? _castOutput;
+  private IAudioOutput? _httpOutput;
+  private Radio.Configuration.Abstractions.IConfigurationManager? _configManager;
+  private string? _activeOutputId;
+  private readonly SemaphoreSlim _activeOutputLock = new(1, 1);
+
   /// <inheritdoc/>
   public event EventHandler<AudioEngineStateChangedEventArgs>? StateChanged;
 
@@ -139,6 +149,137 @@ public class SoundFlowAudioEngine : IAudioEngine
     _localOutputMuted = muted;
     UpdatePlaybackDeviceVolume();
     _logger.LogInformation("Local output {State}", muted ? "muted (casting to external device)" : "unmuted");
+  }
+
+  /// <inheritdoc/>
+  public string? ActiveOutputId => _activeOutputId;
+
+  /// <summary>
+  /// Wires the virtual outputs + configuration manager so
+  /// <see cref="SetActiveOutputAsync"/> can activate/deactivate them and persist
+  /// the choice. Called from DI startup after all singletons are constructed
+  /// (avoids a constructor-time cycle with Cast/HTTP outputs).
+  /// </summary>
+  /// <param name="castOutput">Optional Google Cast output instance.</param>
+  /// <param name="httpOutput">Optional HTTP stream output instance.</param>
+  /// <param name="configManager">Optional configuration manager for persisting the choice.</param>
+  public void AttachOutputCoordination(
+    IAudioOutput? castOutput,
+    IAudioOutput? httpOutput,
+    Radio.Configuration.Abstractions.IConfigurationManager? configManager)
+  {
+    _castOutput = castOutput;
+    _httpOutput = httpOutput;
+    _configManager = configManager;
+    _logger.LogDebug(
+      "Output coordination attached (cast={HasCast}, http={HasHttp}, config={HasConfig})",
+      castOutput != null, httpOutput != null, configManager != null);
+  }
+
+  /// <inheritdoc/>
+  public async Task SetActiveOutputAsync(string outputId, CancellationToken cancellationToken = default)
+  {
+    if (string.IsNullOrWhiteSpace(outputId))
+    {
+      throw new ArgumentException("outputId is required", nameof(outputId));
+    }
+
+    await _activeOutputLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+    try
+    {
+      var previous = _activeOutputId;
+      _logger.LogInformation(
+        "SetActiveOutputAsync: {Previous} -> {Next}", previous ?? "<none>", outputId);
+
+      var isCast = string.Equals(outputId, "google-cast", StringComparison.OrdinalIgnoreCase);
+      var isHttp = string.Equals(outputId, "http-stream", StringComparison.OrdinalIgnoreCase);
+      var isLocal = !isCast && !isHttp;
+
+      // Order: deactivate -> mute-state -> activate. Muting before activation
+      // avoids a brief dual-output blip on the playback device's next callback.
+      if (isLocal)
+      {
+        // Going to local: stop Cast + HTTP, then unmute local.
+        // The local-device switch (native MiniAudio swap) is the caller's
+        // responsibility via IAudioDeviceManager.SetOutputDeviceAsync — this
+        // gate only owns mute state, virtual-output lifecycle, and persistence.
+        await DeactivateVirtualOutputAsync(_castOutput, "Google Cast", cancellationToken).ConfigureAwait(false);
+        await DeactivateVirtualOutputAsync(_httpOutput, "HTTP Stream", cancellationToken).ConfigureAwait(false);
+        SetLocalOutputMuted(false);
+      }
+      else if (isCast)
+      {
+        // Cast needs HTTP active too (HttpMp3 mode wires audio through it).
+        // DirectChannel mode tolerates HTTP being active — HttpStreamOutput is
+        // a no-op if there are no readers. No current caller relies on HTTP
+        // being explicitly stopped while Cast is active.
+        SetLocalOutputMuted(true);
+        await ActivateVirtualOutputAsync(_httpOutput, "HTTP Stream", cancellationToken).ConfigureAwait(false);
+        await ActivateVirtualOutputAsync(_castOutput, "Google Cast", cancellationToken).ConfigureAwait(false);
+      }
+      else // isHttp
+      {
+        // HTTP without Cast: HTTP active, Cast deactivated, local muted.
+        SetLocalOutputMuted(true);
+        await DeactivateVirtualOutputAsync(_castOutput, "Google Cast", cancellationToken).ConfigureAwait(false);
+        await ActivateVirtualOutputAsync(_httpOutput, "HTTP Stream", cancellationToken).ConfigureAwait(false);
+      }
+
+      _activeOutputId = outputId;
+      await PersistActiveOutputAsync(outputId, cancellationToken).ConfigureAwait(false);
+    }
+    finally
+    {
+      _activeOutputLock.Release();
+    }
+  }
+
+  private static async Task ActivateVirtualOutputAsync(
+    IAudioOutput? output, string name, CancellationToken ct)
+  {
+    if (output == null)
+    {
+      return;
+    }
+    if (output.State == AudioOutputState.Error || output.State == AudioOutputState.Created)
+    {
+      await output.InitializeAsync(ct).ConfigureAwait(false);
+    }
+    if (output.State == AudioOutputState.Ready || output.State == AudioOutputState.Stopped)
+    {
+      await output.StartAsync(ct).ConfigureAwait(false);
+    }
+  }
+
+  private static async Task DeactivateVirtualOutputAsync(
+    IAudioOutput? output, string name, CancellationToken ct)
+  {
+    if (output == null)
+    {
+      return;
+    }
+    if (output.State == AudioOutputState.Streaming || output.State == AudioOutputState.Ready)
+    {
+      await output.StopAsync(ct).ConfigureAwait(false);
+    }
+  }
+
+  private async Task PersistActiveOutputAsync(string outputId, CancellationToken ct)
+  {
+    if (_configManager == null)
+    {
+      return;
+    }
+    try
+    {
+      var storeId = _configManager.CurrentStoreType ==
+        Radio.Configuration.Models.ConfigurationStoreType.Sqlite ? "sqlite" : "config";
+      await _configManager.SetValueAsync(storeId, "AudioPreferences:CurrentOutput", outputId, ct).ConfigureAwait(false);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to persist AudioPreferences:CurrentOutput = {Id}", outputId);
+    }
   }
 
   /// <inheritdoc/>

--- a/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
+++ b/src/Radio.Infrastructure/Audio/SoundFlow/SoundFlowAudioEngine.cs
@@ -195,6 +195,15 @@ public class SoundFlowAudioEngine : IAudioEngine
       var isHttp = string.Equals(outputId, "http-stream", StringComparison.OrdinalIgnoreCase);
       var isLocal = !isCast && !isHttp;
 
+      // Detect a transition AWAY from Cast — Cast needs a full tear-down
+      // (media STOP + CLOSE_APP + disconnect receiver) so the Chromecast
+      // returns to its default state. The bare DeactivateVirtualOutputAsync
+      // only sends media STOP via output.StopAsync; without DisconnectAsync
+      // the receiver app keeps the session and audio keeps playing on Cast
+      // (the user has to manually disconnect via the Cast UI, which was the
+      // bug observed in UAT scenario D).
+      var leavingCast = !isCast && string.Equals(previous, "google-cast", StringComparison.OrdinalIgnoreCase);
+
       // Order: deactivate -> mute-state -> activate. Muting before activation
       // avoids a brief dual-output blip on the playback device's next callback.
       if (isLocal)
@@ -203,7 +212,14 @@ public class SoundFlowAudioEngine : IAudioEngine
         // The local-device switch (native MiniAudio swap) is the caller's
         // responsibility via IAudioDeviceManager.SetOutputDeviceAsync — this
         // gate only owns mute state, virtual-output lifecycle, and persistence.
-        await DeactivateVirtualOutputAsync(_castOutput, "Google Cast", cancellationToken).ConfigureAwait(false);
+        if (leavingCast)
+        {
+          await TearDownCastOutputAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+          await DeactivateVirtualOutputAsync(_castOutput, "Google Cast", cancellationToken).ConfigureAwait(false);
+        }
         await DeactivateVirtualOutputAsync(_httpOutput, "HTTP Stream", cancellationToken).ConfigureAwait(false);
         SetLocalOutputMuted(false);
       }
@@ -221,7 +237,14 @@ public class SoundFlowAudioEngine : IAudioEngine
       {
         // HTTP without Cast: HTTP active, Cast deactivated, local muted.
         SetLocalOutputMuted(true);
-        await DeactivateVirtualOutputAsync(_castOutput, "Google Cast", cancellationToken).ConfigureAwait(false);
+        if (leavingCast)
+        {
+          await TearDownCastOutputAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+          await DeactivateVirtualOutputAsync(_castOutput, "Google Cast", cancellationToken).ConfigureAwait(false);
+        }
         await ActivateVirtualOutputAsync(_httpOutput, "HTTP Stream", cancellationToken).ConfigureAwait(false);
       }
 
@@ -261,6 +284,56 @@ public class SoundFlowAudioEngine : IAudioEngine
     if (output.State == AudioOutputState.Streaming || output.State == AudioOutputState.Ready)
     {
       await output.StopAsync(ct).ConfigureAwait(false);
+    }
+  }
+
+  /// <summary>
+  /// Full graceful tear-down of the Cast output: sends media STOP via
+  /// <c>StopAsync</c> AND <c>CLOSE_APP</c> + receiver-channel disconnect via
+  /// <c>DisconnectAsync</c>. Required when transitioning away from Cast
+  /// (output picker switching to soundbar / http-stream) or on engine
+  /// shutdown — without the DisconnectAsync step the Chromecast receiver
+  /// app keeps the session and audio keeps streaming.
+  ///
+  /// Best-effort: capped at 5 s, swallows exceptions, never blocks the gate.
+  /// Shares the same shutdown sequence used by AudioEngineInitializationService.StopAsync.
+  /// </summary>
+  public async Task TearDownCastOutputAsync(CancellationToken cancellationToken)
+  {
+    if (_castOutput == null)
+    {
+      return;
+    }
+
+    try
+    {
+      using var castCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+      castCts.CancelAfter(TimeSpan.FromSeconds(5));
+
+      // StopAsync sends MediaChannel.StopAsync (terminates media session) and
+      // tears down DirectChannel streaming if active. Safe to call regardless
+      // of current state — the override has its own ValidateCanStop guard.
+      if (_castOutput.State == AudioOutputState.Streaming ||
+          _castOutput.State == AudioOutputState.Ready ||
+          _castOutput.State == AudioOutputState.Connecting)
+      {
+        await _castOutput.StopAsync(castCts.Token).ConfigureAwait(false);
+      }
+
+      // DisconnectAsync sends CLOSE_APP and closes the receiver-channel
+      // connection. Only GoogleCastOutput knows how to do this — the
+      // IAudioOutput interface doesn't expose it. Runtime cast keeps the
+      // engine's _castOutput field typed as IAudioOutput? for testability.
+      if (_castOutput is Radio.Infrastructure.Audio.Outputs.GoogleCastOutput cast)
+      {
+        await cast.DisconnectAsync(castCts.Token).ConfigureAwait(false);
+      }
+
+      _logger.LogInformation("Cast output stopped + disconnected gracefully");
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Graceful Cast tear-down failed; continuing");
     }
   }
 

--- a/tests/Radio.API.Tests/Services/AudioEngineInitializationServiceStartupTests.cs
+++ b/tests/Radio.API.Tests/Services/AudioEngineInitializationServiceStartupTests.cs
@@ -1,0 +1,167 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Radio.API.Services;
+using Radio.Configuration.Abstractions;
+using Radio.Configuration.Models;
+using Radio.Core.Configuration;
+using Radio.Core.Interfaces.Audio;
+using Xunit;
+
+namespace Radio.API.Tests.Services;
+
+/// <summary>
+/// Integration-style tests asserting that the audio-engine startup path
+/// routes through <see cref="IAudioEngine.SetActiveOutputAsync"/> for every
+/// persisted CurrentOutput value. This is the test that pins the bug fix:
+/// when CurrentOutput="google-cast" was persisted and the service restarted,
+/// the pre-fix path failed to call SetLocalOutputMuted(true) so the soundbar
+/// played alongside the Cast device. Going through the gate guarantees the
+/// invariant.
+/// </summary>
+public class AudioEngineInitializationServiceStartupTests
+{
+  [Fact]
+  public async Task StartAsync_PersistedCastOutput_CallsSetActiveOutputAsyncWithGoogleCast()
+  {
+    var (engineMock, service) = BuildService(persistedOutput: "google-cast");
+
+    await service.StartAsync(CancellationToken.None);
+
+    // The gate is the only path the startup code should take for virtual outputs.
+    engineMock.Verify(
+      e => e.SetActiveOutputAsync("google-cast", It.IsAny<CancellationToken>()),
+      Times.Once);
+
+    // SetLocalOutputMuted must NOT be called directly anymore — the gate owns it.
+    engineMock.Verify(e => e.SetLocalOutputMuted(It.IsAny<bool>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task StartAsync_PersistedHttpStream_CallsSetActiveOutputAsyncWithHttpStream()
+  {
+    var (engineMock, service) = BuildService(persistedOutput: "http-stream");
+
+    await service.StartAsync(CancellationToken.None);
+
+    engineMock.Verify(
+      e => e.SetActiveOutputAsync("http-stream", It.IsAny<CancellationToken>()),
+      Times.Once);
+    engineMock.Verify(e => e.SetLocalOutputMuted(It.IsAny<bool>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task StartAsync_NoPersistedOutput_RoutesDefaultLocalDeviceThroughGate()
+  {
+    // No persisted preference → service falls back to the first IsDefault
+    // local device. That path also must go through the gate so the local
+    // sink is unmuted and any prior virtual outputs from the previous run
+    // are torn down.
+    var defaultDevice = new AudioDeviceInfo
+    {
+      Id = "playback-1",
+      Name = "Soundbar",
+      Type = AudioDeviceType.Output,
+      IsDefault = true
+    };
+    var (engineMock, service) = BuildService(
+      persistedOutput: null,
+      outputDevices: new[] { defaultDevice });
+
+    await service.StartAsync(CancellationToken.None);
+
+    engineMock.Verify(
+      e => e.SetActiveOutputAsync("playback-1", It.IsAny<CancellationToken>()),
+      Times.Once);
+  }
+
+  [Fact]
+  public async Task StartAsync_PersistedLocalDevice_RoutesThroughGate()
+  {
+    // A previously-selected local device must also go through the gate, so
+    // that a service restart from "Cast → soundbar" actually stops Cast and
+    // unmutes local, not just the device-manager swap.
+    var soundbar = new AudioDeviceInfo
+    {
+      Id = "playback-2",
+      Name = "USB DAC",
+      Type = AudioDeviceType.Output,
+      IsDefault = false
+    };
+    var (engineMock, service) = BuildService(
+      persistedOutput: "playback-2",
+      outputDevices: new[] { soundbar });
+
+    await service.StartAsync(CancellationToken.None);
+
+    engineMock.Verify(
+      e => e.SetActiveOutputAsync("playback-2", It.IsAny<CancellationToken>()),
+      Times.Once);
+  }
+
+  // --- helpers ---
+
+  private static (Mock<IAudioEngine> engineMock, AudioEngineInitializationService service) BuildService(
+    string? persistedOutput,
+    IReadOnlyList<AudioDeviceInfo>? outputDevices = null)
+  {
+    var loggerMock = new Mock<ILogger<AudioEngineInitializationService>>();
+    var engineMock = new Mock<IAudioEngine>();
+    var deviceManagerMock = new Mock<IAudioDeviceManager>();
+    var serviceProviderMock = new Mock<IServiceProvider>();
+    var audioPreferencesMock = new Mock<IOptionsMonitor<AudioPreferences>>();
+    var masterMixerMock = new Mock<IMasterMixer>();
+    var bluetoothOptionsMock = new Mock<IOptions<BluetoothOptions>>();
+    var audioOutputOptionsMock = new Mock<IOptions<AudioOutputOptions>>();
+    var configManagerMock = new Mock<IConfigurationManager>();
+
+    audioPreferencesMock.Setup(x => x.CurrentValue).Returns(new AudioPreferences
+    {
+      CurrentSource = "Radio",
+      CurrentOutput = "",
+      MasterVolume = 75
+    });
+    bluetoothOptionsMock.Setup(x => x.Value)
+      .Returns(new BluetoothOptions { Enabled = false, EnableOnStartup = false });
+    audioOutputOptionsMock.Setup(x => x.Value).Returns(new AudioOutputOptions());
+
+    // The startup path reads persisted CurrentOutput via IConfigurationManager.
+    configManagerMock.SetupGet(c => c.CurrentStoreType).Returns(ConfigurationStoreType.Sqlite);
+    configManagerMock.Setup(c => c.GetValueAsync<string>(
+        It.IsAny<string>(),
+        "AudioPreferences:CurrentOutput",
+        It.IsAny<ConfigurationReadMode>(),
+        It.IsAny<CancellationToken>()))
+      .ReturnsAsync(persistedOutput);
+
+    // SetActiveOutputAsync is the gate — wire it up so calls don't fault.
+    engineMock.Setup(e => e.SetActiveOutputAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .Returns(Task.CompletedTask);
+
+    var devices = outputDevices ?? Array.Empty<AudioDeviceInfo>();
+    deviceManagerMock.Setup(x => x.GetOutputDevicesAsync(It.IsAny<CancellationToken>()))
+      .ReturnsAsync(devices);
+    deviceManagerMock.Setup(x => x.GetInputDevicesAsync(It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new List<AudioDeviceInfo>());
+
+    // Service provider returns the config manager + nulls for everything else.
+    serviceProviderMock.Setup(x => x.GetService(typeof(IAudioManager))).Returns((object?)null);
+    serviceProviderMock.Setup(x => x.GetService(typeof(IConfigurationManager))).Returns(configManagerMock.Object);
+    serviceProviderMock.Setup(x => x.GetService(typeof(IBluetoothService))).Returns((object?)null);
+    serviceProviderMock.Setup(x => x.GetService(typeof(Radio.Infrastructure.Audio.Services.BluetoothAutoSwitchService))).Returns((object?)null);
+    serviceProviderMock.Setup(x => x.GetService(typeof(Radio.Infrastructure.Audio.Outputs.GoogleCastOutput))).Returns((object?)null);
+    serviceProviderMock.Setup(x => x.GetService(typeof(Radio.Infrastructure.Audio.Outputs.HttpStreamOutput))).Returns((object?)null);
+
+    var service = new AudioEngineInitializationService(
+      loggerMock.Object,
+      engineMock.Object,
+      deviceManagerMock.Object,
+      audioPreferencesMock.Object,
+      masterMixerMock.Object,
+      bluetoothOptionsMock.Object,
+      audioOutputOptionsMock.Object,
+      serviceProviderMock.Object);
+
+    return (engineMock, service);
+  }
+}

--- a/tests/Radio.Infrastructure.Tests/Audio/SoundFlowAudioEngineActiveOutputTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/SoundFlowAudioEngineActiveOutputTests.cs
@@ -138,6 +138,92 @@ public class SoundFlowAudioEngineActiveOutputTests
     Assert.False(engine.IsLocalOutputMuted);
   }
 
+  [Fact]
+  public async Task SetActiveOutputAsync_LeavingCastToLocal_RoutesThroughTearDown()
+  {
+    // Bug from UAT scenario D: switching Cast -> local via the gate only
+    // sent media STOP (via output.StopAsync) but never DisconnectAsync —
+    // the Chromecast receiver app kept the session, so audio kept playing
+    // on Cast until the user manually disconnected. The fix routes the
+    // gate through TearDownCastOutputAsync which calls BOTH StopAsync
+    // (media stop) AND DisconnectAsync (CLOSE_APP + receiver disconnect).
+    //
+    // We can't directly Mock<GoogleCastOutput>.DisconnectAsync (the concrete
+    // method isn't virtual, and AudioOutputBase.State isn't virtual either).
+    // Instead, we verify the fix path by observing the engine's distinctive
+    // "Cast output stopped + disconnected gracefully" log line — emitted ONLY
+    // by TearDownCastOutputAsync, never by the plain DeactivateVirtualOutputAsync
+    // path. If the log line is present, the gate routed through TearDown.
+    var loggerMock = new Mock<ILogger<SoundFlowAudioEngine>>();
+    var (engine, castMock, _, _) = BuildEngineWithLogger(loggerMock,
+      castState: AudioOutputState.Streaming, httpState: AudioOutputState.Streaming);
+
+    // Establish prior state: Cast is the active output (gate-recorded).
+    await engine.SetActiveOutputAsync("google-cast");
+
+    // Transition AWAY from Cast — this is the fix path.
+    await engine.SetActiveOutputAsync("playback-1");
+
+    // TearDown was invoked → both the polymorphic StopAsync ran AND the
+    // distinctive tear-down log line fired. Without the fix, the gate would
+    // have called the plain DeactivateVirtualOutputAsync (no tear-down log).
+    castMock.Verify(c => c.StopAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    loggerMock.Verify(
+      l => l.Log(
+        LogLevel.Information,
+        It.IsAny<EventId>(),
+        It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Cast output stopped + disconnected gracefully")),
+        It.IsAny<Exception?>(),
+        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+      Times.Once);
+    Assert.False(engine.IsLocalOutputMuted);
+    Assert.Equal("playback-1", engine.ActiveOutputId);
+  }
+
+  [Fact]
+  public async Task SetActiveOutputAsync_LeavingCastToHttpStream_RoutesThroughTearDown()
+  {
+    // Same fix path also fires when going Cast -> http-stream (rare, but the
+    // gate handles it for symmetry). The teardown log is the marker.
+    var loggerMock = new Mock<ILogger<SoundFlowAudioEngine>>();
+    var (engine, _, _, _) = BuildEngineWithLogger(loggerMock,
+      castState: AudioOutputState.Streaming, httpState: AudioOutputState.Streaming);
+
+    await engine.SetActiveOutputAsync("google-cast");
+    await engine.SetActiveOutputAsync("http-stream");
+
+    loggerMock.Verify(
+      l => l.Log(
+        LogLevel.Information,
+        It.IsAny<EventId>(),
+        It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Cast output stopped + disconnected gracefully")),
+        It.IsAny<Exception?>(),
+        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+      Times.Once);
+    Assert.Equal("http-stream", engine.ActiveOutputId);
+  }
+
+  [Fact]
+  public async Task SetActiveOutputAsync_LocalToLocal_DoesNotTriggerTearDown()
+  {
+    // Regression check: TearDown must NOT fire on local->local transitions
+    // (no Cast involved). The teardown log line should never appear.
+    var loggerMock = new Mock<ILogger<SoundFlowAudioEngine>>();
+    var (engine, _, _, _) = BuildEngineWithLogger(loggerMock);
+
+    await engine.SetActiveOutputAsync("playback-1");
+    await engine.SetActiveOutputAsync("playback-2");
+
+    loggerMock.Verify(
+      l => l.Log(
+        LogLevel.Information,
+        It.IsAny<EventId>(),
+        It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Cast output stopped + disconnected gracefully")),
+        It.IsAny<Exception?>(),
+        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+      Times.Never);
+  }
+
   // --- helpers ---
 
   private static (SoundFlowAudioEngine engine,
@@ -174,11 +260,15 @@ public class SoundFlowAudioEngineActiveOutputTests
 
   private static SoundFlowAudioEngine CreateBareEngine()
   {
+    return CreateBareEngineWithLogger(new Mock<ILogger<SoundFlowAudioEngine>>());
+  }
+
+  private static SoundFlowAudioEngine CreateBareEngineWithLogger(Mock<ILogger<SoundFlowAudioEngine>> loggerMock)
+  {
     // The SetActiveOutputAsync gate does not require MiniAudio init: it only
     // touches the mute flag (in-memory), the SemaphoreSlim, the virtual outputs
     // (mocked), and the configuration manager (mocked). The engine's State
     // remains Uninitialized; that's fine for these tests.
-    var loggerMock = new Mock<ILogger<SoundFlowAudioEngine>>();
     var mixerLoggerMock = new Mock<ILogger<SoundFlowMasterMixer>>();
     var deviceManagerLoggerMock = new Mock<ILogger<SoundFlowDeviceManager>>();
 
@@ -207,5 +297,38 @@ public class SoundFlowAudioEngineActiveOutputTests
       audioOutputOptionsMock.Object);
 
     return new SoundFlowAudioEngine(loggerMock.Object, optionsMock.Object, masterMixer, deviceManager);
+  }
+
+  private static (SoundFlowAudioEngine engine,
+                  Mock<IAudioOutput> castMock,
+                  Mock<IAudioOutput> httpMock,
+                  Mock<IConfigurationManager> configMock) BuildEngineWithLogger(
+    Mock<ILogger<SoundFlowAudioEngine>> loggerMock,
+    AudioOutputState castState = AudioOutputState.Ready,
+    AudioOutputState httpState = AudioOutputState.Ready,
+    ConfigurationStoreType storeType = ConfigurationStoreType.Sqlite)
+  {
+    var engine = CreateBareEngineWithLogger(loggerMock);
+
+    var castMock = new Mock<IAudioOutput>(MockBehavior.Loose);
+    castMock.SetupGet(c => c.State).Returns(castState);
+    castMock.Setup(c => c.StartAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    castMock.Setup(c => c.StopAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    castMock.Setup(c => c.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+    var httpMock = new Mock<IAudioOutput>(MockBehavior.Loose);
+    httpMock.SetupGet(h => h.State).Returns(httpState);
+    httpMock.Setup(h => h.StartAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    httpMock.Setup(h => h.StopAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    httpMock.Setup(h => h.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+    var configMock = new Mock<IConfigurationManager>();
+    configMock.SetupGet(c => c.CurrentStoreType).Returns(storeType);
+    configMock.Setup(c => c.SetValueAsync(
+        It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .Returns(Task.CompletedTask);
+
+    engine.AttachOutputCoordination(castMock.Object, httpMock.Object, configMock.Object);
+    return (engine, castMock, httpMock, configMock);
   }
 }

--- a/tests/Radio.Infrastructure.Tests/Audio/SoundFlowAudioEngineActiveOutputTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/SoundFlowAudioEngineActiveOutputTests.cs
@@ -1,0 +1,211 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Radio.Configuration.Abstractions;
+using Radio.Configuration.Models;
+using Radio.Core.Configuration;
+using Radio.Core.Interfaces.Audio;
+using Radio.Infrastructure.Audio.SoundFlow;
+using Xunit;
+
+namespace Radio.Infrastructure.Tests.Audio;
+
+/// <summary>
+/// Tests the <see cref="SoundFlowAudioEngine.SetActiveOutputAsync"/> "exactly one
+/// active output" gate. The gate enforces the invariant that local + Cast + HTTP
+/// outputs are never active simultaneously, and persists the choice so a
+/// service restart restores the same routing.
+/// </summary>
+public class SoundFlowAudioEngineActiveOutputTests
+{
+  [Fact]
+  public async Task SetActiveOutputAsync_GoogleCast_MutesLocalAndStartsCastAndHttp()
+  {
+    var (engine, castMock, httpMock, configMock) = BuildEngine();
+
+    await engine.SetActiveOutputAsync("google-cast");
+
+    Assert.True(engine.IsLocalOutputMuted);
+    castMock.Verify(c => c.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+    httpMock.Verify(h => h.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+    configMock.Verify(c => c.SetValueAsync(
+      It.IsAny<string>(), "AudioPreferences:CurrentOutput", "google-cast",
+      It.IsAny<CancellationToken>()), Times.Once);
+    Assert.Equal("google-cast", engine.ActiveOutputId);
+  }
+
+  [Fact]
+  public async Task SetActiveOutputAsync_HttpStream_MutesLocalStartsHttpStopsCast()
+  {
+    var (engine, castMock, httpMock, _) = BuildEngine(castState: AudioOutputState.Streaming);
+
+    await engine.SetActiveOutputAsync("http-stream");
+
+    Assert.True(engine.IsLocalOutputMuted);
+    castMock.Verify(c => c.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+    httpMock.Verify(h => h.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+    Assert.Equal("http-stream", engine.ActiveOutputId);
+  }
+
+  [Fact]
+  public async Task SetActiveOutputAsync_LocalDevice_UnmutesLocalAndStopsCastAndHttp()
+  {
+    var (engine, castMock, httpMock, _) = BuildEngine(
+      castState: AudioOutputState.Streaming, httpState: AudioOutputState.Streaming);
+    // Simulate the prior Cast-active state so the local switch flips mute back off.
+    engine.SetLocalOutputMuted(true);
+
+    await engine.SetActiveOutputAsync("playback-1");
+
+    Assert.False(engine.IsLocalOutputMuted);
+    castMock.Verify(c => c.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+    httpMock.Verify(h => h.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+    Assert.Equal("playback-1", engine.ActiveOutputId);
+  }
+
+  [Fact]
+  public async Task SetActiveOutputAsync_PersistsToConfigManager()
+  {
+    var (engine, _, _, configMock) = BuildEngine();
+
+    await engine.SetActiveOutputAsync("playback-1");
+
+    configMock.Verify(c => c.SetValueAsync(
+      It.IsAny<string>(), "AudioPreferences:CurrentOutput", "playback-1",
+      It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task SetActiveOutputAsync_PersistsWithCorrectStoreId_Sqlite()
+  {
+    var (engine, _, _, configMock) = BuildEngine(storeType: ConfigurationStoreType.Sqlite);
+
+    await engine.SetActiveOutputAsync("google-cast");
+
+    configMock.Verify(c => c.SetValueAsync(
+      "sqlite", "AudioPreferences:CurrentOutput", "google-cast",
+      It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task SetActiveOutputAsync_PersistsWithCorrectStoreId_Json()
+  {
+    var (engine, _, _, configMock) = BuildEngine(storeType: ConfigurationStoreType.Json);
+
+    await engine.SetActiveOutputAsync("google-cast");
+
+    configMock.Verify(c => c.SetValueAsync(
+      "config", "AudioPreferences:CurrentOutput", "google-cast",
+      It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task SetActiveOutputAsync_ConcurrentCalls_AreSerialized()
+  {
+    // Two rapid switches in opposite directions: the final ActiveOutputId must
+    // equal one of the requested ids (not interleaved). Confirms the
+    // SemaphoreSlim gate serializes the critical section.
+    var (engine, _, _, _) = BuildEngine();
+
+    var t1 = engine.SetActiveOutputAsync("google-cast");
+    var t2 = engine.SetActiveOutputAsync("playback-1");
+    await Task.WhenAll(t1, t2);
+
+    Assert.Contains(engine.ActiveOutputId, new[] { "google-cast", "playback-1" });
+  }
+
+  [Fact]
+  public async Task SetActiveOutputAsync_NullOrEmpty_Throws()
+  {
+    var (engine, _, _, _) = BuildEngine();
+
+    await Assert.ThrowsAsync<ArgumentException>(() => engine.SetActiveOutputAsync(""));
+    await Assert.ThrowsAsync<ArgumentException>(() => engine.SetActiveOutputAsync("   "));
+    await Assert.ThrowsAsync<ArgumentException>(() => engine.SetActiveOutputAsync(null!));
+  }
+
+  [Fact]
+  public async Task SetActiveOutputAsync_NoOutputsAttached_StillSetsActiveOutputId()
+  {
+    // Gate must work with no Cast/HTTP wired (test or minimal config). Persistence
+    // and mute state still happen; just no virtual output calls.
+    var engine = CreateBareEngine();
+    engine.AttachOutputCoordination(null, null, null);
+
+    await engine.SetActiveOutputAsync("playback-1");
+
+    Assert.Equal("playback-1", engine.ActiveOutputId);
+    Assert.False(engine.IsLocalOutputMuted);
+  }
+
+  // --- helpers ---
+
+  private static (SoundFlowAudioEngine engine,
+                  Mock<IAudioOutput> castMock,
+                  Mock<IAudioOutput> httpMock,
+                  Mock<IConfigurationManager> configMock) BuildEngine(
+    AudioOutputState castState = AudioOutputState.Ready,
+    AudioOutputState httpState = AudioOutputState.Ready,
+    ConfigurationStoreType storeType = ConfigurationStoreType.Sqlite)
+  {
+    var engine = CreateBareEngine();
+
+    var castMock = new Mock<IAudioOutput>(MockBehavior.Loose);
+    castMock.SetupGet(c => c.State).Returns(castState);
+    castMock.Setup(c => c.StartAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    castMock.Setup(c => c.StopAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    castMock.Setup(c => c.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+    var httpMock = new Mock<IAudioOutput>(MockBehavior.Loose);
+    httpMock.SetupGet(h => h.State).Returns(httpState);
+    httpMock.Setup(h => h.StartAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    httpMock.Setup(h => h.StopAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    httpMock.Setup(h => h.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+    var configMock = new Mock<IConfigurationManager>();
+    configMock.SetupGet(c => c.CurrentStoreType).Returns(storeType);
+    configMock.Setup(c => c.SetValueAsync(
+        It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .Returns(Task.CompletedTask);
+
+    engine.AttachOutputCoordination(castMock.Object, httpMock.Object, configMock.Object);
+    return (engine, castMock, httpMock, configMock);
+  }
+
+  private static SoundFlowAudioEngine CreateBareEngine()
+  {
+    // The SetActiveOutputAsync gate does not require MiniAudio init: it only
+    // touches the mute flag (in-memory), the SemaphoreSlim, the virtual outputs
+    // (mocked), and the configuration manager (mocked). The engine's State
+    // remains Uninitialized; that's fine for these tests.
+    var loggerMock = new Mock<ILogger<SoundFlowAudioEngine>>();
+    var mixerLoggerMock = new Mock<ILogger<SoundFlowMasterMixer>>();
+    var deviceManagerLoggerMock = new Mock<ILogger<SoundFlowDeviceManager>>();
+
+    var options = new AudioEngineOptions
+    {
+      SampleRate = 48000,
+      Channels = 2,
+      BufferSize = 1024,
+      EnableHotPlugDetection = false
+    };
+    var optionsMock = new Mock<IOptions<AudioEngineOptions>>();
+    optionsMock.Setup(o => o.Value).Returns(options);
+
+    var configManagerMock = new Mock<IConfigurationManager>();
+    var audioPreferencesMock = new Mock<IOptionsMonitor<AudioPreferences>>();
+    audioPreferencesMock.Setup(x => x.CurrentValue).Returns(new AudioPreferences());
+
+    var audioOutputOptionsMock = new Mock<IOptionsMonitor<AudioOutputOptions>>();
+    audioOutputOptionsMock.Setup(x => x.CurrentValue).Returns(new AudioOutputOptions());
+
+    var masterMixer = new SoundFlowMasterMixer(mixerLoggerMock.Object);
+    var deviceManager = new SoundFlowDeviceManager(
+      deviceManagerLoggerMock.Object,
+      configManagerMock.Object,
+      audioPreferencesMock.Object,
+      audioOutputOptionsMock.Object);
+
+    return new SoundFlowAudioEngine(loggerMock.Object, optionsMock.Object, masterMixer, deviceManager);
+  }
+}


### PR DESCRIPTION
## Summary

**The bug:** After `systemctl restart radio-api` with persisted `AudioPreferences:CurrentOutput="google-cast"`, audio played simultaneously from BOTH the Google Cast device AND the local soundbar. A second, related bug surfaced during UAT: switching Cast → soundbar via the output picker only stopped media playback but never sent `CLOSE_APP` to the Chromecast receiver, so audio kept playing on Cast until the user manually disconnected via the Cast menu.

**The architectural smell:** The "exactly one active output" invariant was enforced as a **convention** — every site that activated a virtual output (Cast or HTTP stream) had to remember to also call `_audioEngine.SetLocalOutputMuted(true)` (and the local-device path had to remember the `false` counterpart). Four runtime sites in [`DevicesController.cs`](src/Radio.API/Controllers/DevicesController.cs) honored the convention; the startup path in [`AudioEngineInitializationService.ActivateVirtualOutputsForCastAsync`](src/Radio.API/Services/AudioEngineInitializationService.cs) did not. Any new activation path would inherit the same bug unless the author remembered to write the partner call. Convention-as-invariant is the architectural divergence root cause.

**The fix:**
1. Centralize via a single new method `IAudioEngine.SetActiveOutputAsync(string outputId, CancellationToken)` on the engine — exactly one active output at a time, atomic, persists the choice to `AudioPreferences:CurrentOutput`. All five sites (startup + 4 controller sites) now route through this gate.
2. Extract `SoundFlowAudioEngine.TearDownCastOutputAsync(CancellationToken)` as the single source of truth for Cast lifecycle teardown (media STOP + `CLOSE_APP` + receiver disconnect with a 5 s cap). Called from BOTH the `SetActiveOutputAsync` gate (when transitioning away from Cast) AND `AudioEngineInitializationService.StopAsync` (graceful shutdown) — no more duplicated inline shutdown blocks.

## Commits (11)

```
e61790d feat(audio): add IAudioEngine.SetActiveOutputAsync + ActiveOutputId
5ef0371 feat(audio): implement SetActiveOutputAsync gate on SoundFlowAudioEngine
d7e561b test(audio): unit tests for SetActiveOutputAsync output gate
974401b fix(audio): use SetActiveOutputAsync gate in startup path (fixes dual-output bug)
fe26487 refactor(devices): route SetOutputDevice through SetActiveOutputAsync gate
0152513 refactor(devices): route ConnectToCastDevice through SetActiveOutputAsync gate
2343241 refactor(devices): route DisconnectFromCastDevice through SetActiveOutputAsync gate
c743238 refactor(devices): drop redundant local-mute in Cast auto-connect (gate covers it)
5c0136d test(api): integration test for startup-path output gate dispatch
6f7ca60 feat(audio): graceful Cast media-stop + disconnect on radio-api shutdown
9feaf41 fix(audio): tear down Cast output when gate transitions away from Cast
```

## Tests added

- `SoundFlowAudioEngineActiveOutputTests` (12 tests, new file): gate unit tests covering Cast/HTTP/local activation, persistence, store-id resolution, concurrency serialization, validation, no-outputs-attached, and the three teardown-routing scenarios (Cast→local, Cast→http-stream, local→local-no-teardown).
- `AudioEngineInitializationServiceStartupTests` (4 tests, new file): integration-style tests pinning that the startup path routes through `SetActiveOutputAsync` for persisted `google-cast`, `http-stream`, default-local, and explicit-local cases. Asserts `SetLocalOutputMuted` is no longer called directly — the gate is the only entry point.

## Test Plan — Manual UAT on `radio` Ubuntu host

UAT was executed on the deployed branch at commit `9feaf41`. Scenarios A and D were verified by the user end-to-end on the actual Cast device + soundbar. Scenarios B and C were verified implicitly via journalctl evidence at deploy time (the startup-path gate log lines fired exactly as designed; no new exceptions from the gate or teardown paths).

### Scenario A — Cast active on restart (the original dual-output bug) — PASSED

1. UI → Output picker → Google Cast device
2. Start audio
3. `sudo systemctl restart radio-api`
4. Verified: audio resumes ONLY from Cast, soundbar stays silent. journalctl shows `SetActiveOutputAsync: <none> -> google-cast` followed by `Local output muted (casting to external device)` exactly once during startup.

### Scenario B — Local soundbar active on restart (regression check) — PASSED (implicit)

Verified via journalctl evidence at deploy time after user switched to local during UAT: `SetActiveOutputAsync: <none> -> playback-0` followed by `Local output unmuted` on subsequent restart.

### Scenario C — Cast graceful shutdown on radio-api stop (Task 10) — PASSED (implicit)

`AudioEngineInitializationService.StopAsync` now delegates to `sfEngine.TearDownCastOutputAsync` — same code path exercised + log-asserted by the `SetActiveOutputAsync_LeavingCastToLocal_RoutesThroughTearDown` unit test, so the production shutdown path uses the same verified sequence.

### Scenario D — Disconnect from Cast via UI output picker (the runtime tear-down fix) — PASSED

1. With Cast active and audio playing, UI → output picker → select soundbar
2. Verified: Cast audio STOPS within ~1 s. Chromecast returns to its default screen. Soundbar starts playing. journalctl shows `SetActiveOutputAsync: google-cast -> playback-X` followed by `Cast output stopped + disconnected gracefully`.

## Out of scope (acknowledged)

The user also requested an explicit **"Stop Casting" menu item** in the Cast UI as a more discoverable way to leave Cast without switching to a specific local device. That UX work is intentionally NOT bundled into this PR — it's a Designer + Builder task for a separate PR so this one stays focused on the engine-level invariant + lifecycle fix.