### PR TITLE
fix(bt): cache AVRCP album art URL + remove deprecated MusicBrainz cover lookup

### DIFF
--- a/src/Radio.Fingerprinting/Services/BackgroundIdentificationService.cs
+++ b/src/Radio.Fingerprinting/Services/BackgroundIdentificationService.cs
@@ -16,7 +16,7 @@ namespace Radio.Fingerprinting.Services;
 /// All source types (radio, file, vinyl, USB) use the same SongRec capture-and-recognize path.
 /// Exposes real-time status via <see cref="GetStatus"/> and <see cref="StatusChanged"/>.
 /// </summary>
-public sealed class BackgroundIdentificationService : BackgroundService
+public class BackgroundIdentificationService : BackgroundService
 {
   private readonly ILogger<BackgroundIdentificationService> _logger;
   private readonly IServiceProvider _serviceProvider;
@@ -148,6 +148,17 @@ public sealed class BackgroundIdentificationService : BackgroundService
     {
       // Timer already disposed, ignore
     }
+  }
+
+  /// <summary>
+  /// Internal test hook: raises the <see cref="TrackIdentified"/> event without
+  /// running a real SongRec identification cycle. Used by Infrastructure.Tests
+  /// to verify downstream subscribers (e.g., BluetoothAudioSource's
+  /// OnTrackIdentified handler) without spinning up the full audio pipeline.
+  /// </summary>
+  internal void RaiseTrackIdentifiedForTesting(TrackIdentifiedEventArgs e)
+  {
+    TrackIdentified?.Invoke(this, e);
   }
 
   /// <inheritdoc/>

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -33,9 +33,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
   private readonly IOptionsMonitor<FingerprintingOptions>? _fingerprintingOptionsMonitor;
   private readonly SoundFlowPlaybackService? _playbackService;
   private readonly SemaphoreSlim _routeLock = new(1, 1);
-  private readonly HashSet<string> _failedArtLookups = new();
   private string? _playbackId;
-  private string? _lastCoverArtLookupKey;
   private AudioCaptureDevice? _captureDevice;
   private BufferedSoundGenerator<float>? _captureGenerator;
   private TimeSpan _btPosition;
@@ -660,7 +658,6 @@ public class BluetoothAudioSource : USBAudioSourceBase
       _hasMediaPlayer = false;
       _btPosition = TimeSpan.Zero;
       _btDuration = null;
-      _lastCoverArtLookupKey = null;
 
       // Remove capture from mixer and clear capture state so reconnect starts fresh
       if (_playbackId != null && _playbackService != null)
@@ -760,30 +757,20 @@ public class BluetoothAudioSource : USBAudioSourceBase
           e.AlbumArtUrl);
       }
     }
-    else
-    {
-      _lastCoverArtLookupKey = null;
-    }
 
     // If metadata is incomplete (no title or artist), request fingerprinting.
     // When UseShazamForAllSources is enabled, always fingerprint — SongRec provides
     // higher-quality cover art (Apple Music CDN) and more accurate metadata.
+    //
+    // SongRec is the only cover-art fallback for BT (MusicBrainz has been removed
+    // project-wide); when AVRCP has no art and SongRec doesn't identify the track,
+    // the UI shows the fallback icon — accepted UX.
     var hasIncompleteMetadata = string.IsNullOrEmpty(e.Title) || string.IsNullOrEmpty(e.Artist);
     NeedsFingerprintingLookup = hasIncompleteMetadata || FpOptions.UseShazamForAllSources;
 
     if (NeedsFingerprintingLookup)
     {
       _identificationService?.RequestImmediateIdentification();
-    }
-    else if (string.IsNullOrEmpty(e.AlbumArtUrl) && _serviceScopeFactory != null)
-    {
-      // AVRCP rarely provides album art — look it up via MusicBrainz text search
-      var lookupKey = $"{e.Title}|{e.Artist}";
-      if (lookupKey != _lastCoverArtLookupKey && !_failedArtLookups.Contains(lookupKey))
-      {
-        _lastCoverArtLookupKey = lookupKey;
-        _ = LookupCoverArtAsync(e.Title, e.Artist, e.Album);
-      }
     }
   }
 
@@ -827,73 +814,17 @@ public class BluetoothAudioSource : USBAudioSourceBase
       return;
     }
 
-    // Use fingerprint-identified cover art if we don't already have art
+    // Use fingerprint-identified cover art if we don't already have art.
+    // SongRec provides Apple Music CDN URLs which are HTTPS and cache cleanly.
+    // If SongRec didn't provide a CoverArtUrl, leave art absent (UI fallback);
+    // MusicBrainz CAA / release-ID lookup is no longer used for BT (deprecated
+    // project-wide in favor of SongRec).
     var hasArt = MetadataInternal.TryGetValue(StandardMetadataKeys.AlbumArtUrl, out var existingArt)
       && existingArt is string artStr && !string.IsNullOrEmpty(artStr);
 
-    if (!hasArt && _serviceScopeFactory != null)
+    if (!hasArt && !string.IsNullOrEmpty(e.Track.CoverArtUrl) && _serviceScopeFactory != null)
     {
-      if (!string.IsNullOrEmpty(e.Track.CoverArtUrl))
-      {
-        // Fingerprint pipeline already found cover art — cache it locally
-        _ = CacheAndSetCoverArtAsync(e.Track.CoverArtUrl, e.Track.Title, e.Track.Artist);
-      }
-      else if (!string.IsNullOrEmpty(e.Track.MusicBrainzReleaseId))
-      {
-        // Have a release ID but no art yet — query Cover Art Archive directly
-        _ = LookupCoverArtByReleaseIdAsync(e.Track.MusicBrainzReleaseId, e.Track.Title, e.Track.Artist);
-      }
-      else if (!string.IsNullOrEmpty(e.Track.Title) && !string.IsNullOrEmpty(e.Track.Artist))
-      {
-        // Fingerprint gave us better metadata — retry text search with it
-        var lookupKey = $"{e.Track.Title}|{e.Track.Artist}";
-        if (lookupKey != _lastCoverArtLookupKey && !_failedArtLookups.Contains(lookupKey))
-        {
-          _lastCoverArtLookupKey = lookupKey;
-          _ = LookupCoverArtAsync(e.Track.Title, e.Track.Artist, e.Track.Album);
-        }
-      }
-    }
-  }
-
-  private async Task LookupCoverArtAsync(string title, string artist, string? album)
-  {
-    try
-    {
-      Logger.LogInformation("Looking up cover art for '{Title}' by '{Artist}' (Album: '{Album}')", title, artist, album);
-
-      using var scope = _serviceScopeFactory!.CreateScope();
-      var lookupService = scope.ServiceProvider.GetService<IMetadataLookupService>();
-      if (lookupService == null)
-      {
-        Logger.LogWarning("IMetadataLookupService not available — cannot look up cover art");
-        return;
-      }
-
-      var coverArtUrl = await lookupService.SearchCoverArtByTextAsync(title, artist, album);
-
-      // If album was specified but no results, retry without album constraint —
-      // streaming services append edition info that may not match MusicBrainz
-      if (string.IsNullOrEmpty(coverArtUrl) && !string.IsNullOrEmpty(album))
-      {
-        Logger.LogDebug("Retrying cover art search without album for '{Title}' by '{Artist}'", title, artist);
-        coverArtUrl = await lookupService.SearchCoverArtByTextAsync(title, artist);
-      }
-
-      if (!string.IsNullOrEmpty(coverArtUrl))
-      {
-        await CacheAndSetCoverArtUrlAsync(coverArtUrl, title, artist);
-      }
-      else
-      {
-        // Track this failure to avoid re-querying for the same track
-        _failedArtLookups.Add($"{title}|{artist}");
-        Logger.LogInformation("No cover art found for '{Title}' by '{Artist}'", title, artist);
-      }
-    }
-    catch (Exception ex)
-    {
-      Logger.LogWarning(ex, "Cover art lookup failed for '{Title}' by '{Artist}'", title, artist);
+      _ = CacheAndSetCoverArtAsync(e.Track.CoverArtUrl, e.Track.Title, e.Track.Artist);
     }
   }
 
@@ -939,37 +870,6 @@ public class BluetoothAudioSource : USBAudioSourceBase
     catch (Exception ex)
     {
       Logger.LogWarning(ex, "Failed to cache AVRCP album art for '{Title}' by '{Artist}'", title, artist);
-    }
-  }
-
-  private async Task LookupCoverArtByReleaseIdAsync(string releaseId, string title, string artist)
-  {
-    try
-    {
-      Logger.LogInformation(
-        "Looking up cover art by release ID {ReleaseId} for '{Title}' by '{Artist}'",
-        releaseId, title, artist);
-
-      using var scope = _serviceScopeFactory!.CreateScope();
-      var lookupService = scope.ServiceProvider.GetService<IMetadataLookupService>();
-      if (lookupService == null)
-      {
-        return;
-      }
-
-      var coverArtUrl = await lookupService.GetCoverArtByReleaseIdAsync(releaseId);
-      if (!string.IsNullOrEmpty(coverArtUrl))
-      {
-        await CacheAndSetCoverArtUrlAsync(coverArtUrl, title, artist);
-      }
-      else
-      {
-        Logger.LogDebug("No cover art at Cover Art Archive for release {ReleaseId}", releaseId);
-      }
-    }
-    catch (Exception ex)
-    {
-      Logger.LogWarning(ex, "Cover art lookup by release ID failed for '{Title}' by '{Artist}'", title, artist);
     }
   }
 

--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -28,7 +28,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
   private readonly IBluetoothService _bluetoothService;
   private readonly BackgroundIdentificationService? _identificationService;
   private readonly IServiceScopeFactory? _serviceScopeFactory;
-  private readonly AlbumArtCacheService? _albumArtCache;
+  private readonly IAlbumArtCacheService? _albumArtCache;
   private readonly IOptionsMonitor<BluetoothOptions> _options;
   private readonly IOptionsMonitor<FingerprintingOptions>? _fingerprintingOptionsMonitor;
   private readonly SoundFlowPlaybackService? _playbackService;
@@ -63,7 +63,7 @@ public class BluetoothAudioSource : USBAudioSourceBase
     IMetricsCollector? metricsCollector = null,
     SoundFlowPlaybackService? playbackService = null,
     IServiceScopeFactory? serviceScopeFactory = null,
-    AlbumArtCacheService? albumArtCache = null,
+    IAlbumArtCacheService? albumArtCache = null,
     IOptionsMonitor<FingerprintingOptions>? fingerprintingOptions = null)
     : base(logger, deviceManager, identificationService, metricsCollector)
   {
@@ -737,13 +737,31 @@ public class BluetoothAudioSource : USBAudioSourceBase
     // Always clear stale art from the previous song — PlayHistoryTracker reads
     // AlbumArtUrl from source metadata when creating entries, so leftover art
     // from the previous song would leak into the new song's history entry.
+    //
+    // AVRCP ArtUrl is usually a file:///data/data/com.android.<player>/cache/...
+    // URI on the PHONE'S local filesystem, which the browser cannot fetch. Route
+    // every URL through the album-art cache: it downloads the bytes (for http(s)://)
+    // or returns null (for file:// — HttpClient throws NotSupportedException,
+    // caught inside SaveFromUrlAsync). On null we leave AlbumArtUrl absent so the
+    // UI shows the fallback icon; SongRec, if it later identifies the track via
+    // OnTrackIdentified, will populate the art then.
+    MetadataInternal.Remove(StandardMetadataKeys.AlbumArtUrl);
     if (!string.IsNullOrEmpty(e.AlbumArtUrl))
     {
-      MetadataInternal[StandardMetadataKeys.AlbumArtUrl] = e.AlbumArtUrl;
+      if (_albumArtCache != null && _serviceScopeFactory != null)
+      {
+        _ = CacheAvrcpArtAsync(e.AlbumArtUrl, e.Title, e.Artist);
+      }
+      else
+      {
+        Logger.LogWarning(
+          "AVRCP delivered ArtUrl '{Url}' but album-art cache or scope factory is null — " +
+          "BT album art will not appear. Check DI registration of IAlbumArtCacheService.",
+          e.AlbumArtUrl);
+      }
     }
     else
     {
-      MetadataInternal.Remove(StandardMetadataKeys.AlbumArtUrl);
       _lastCoverArtLookupKey = null;
     }
 
@@ -888,6 +906,39 @@ public class BluetoothAudioSource : USBAudioSourceBase
     catch (Exception ex)
     {
       Logger.LogWarning(ex, "Failed to cache cover art from fingerprint for '{Title}' by '{Artist}'", title, artist);
+    }
+  }
+
+  /// <summary>
+  /// Downloads the AVRCP-supplied album art URL into the local cache and
+  /// sets <see cref="StandardMetadataKeys.AlbumArtUrl"/> to the resulting
+  /// /api/albumart/... path. If the cache returns null (file:// URLs,
+  /// network errors, etc.) metadata is left without AlbumArtUrl and the
+  /// UI falls back to the default icon.
+  /// </summary>
+  private async Task CacheAvrcpArtAsync(string artUrl, string title, string artist)
+  {
+    try
+    {
+      var localUrl = await _albumArtCache!.SaveFromUrlAsync(artUrl);
+      if (string.IsNullOrEmpty(localUrl))
+      {
+        Logger.LogDebug(
+          "AVRCP art URL not cacheable for '{Title}' by '{Artist}' (URL: {Url}); waiting for SongRec",
+          title, artist, artUrl);
+        return;
+      }
+
+      MetadataInternal[StandardMetadataKeys.AlbumArtUrl] = localUrl;
+      Logger.LogInformation(
+        "Cached AVRCP album art for '{Title}' by '{Artist}': {LocalUrl}",
+        title, artist, localUrl);
+
+      await UpdateRecentPlayHistoryCoverArtAsync(localUrl, title, artist);
+    }
+    catch (Exception ex)
+    {
+      Logger.LogWarning(ex, "Failed to cache AVRCP album art for '{Title}' by '{Artist}'", title, artist);
     }
   }
 

--- a/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
@@ -140,13 +140,14 @@ public sealed class MockBluetoothService : IBluetoothService
         }
         
         // Mock helper to simulate metadata
-        public void SimulateMetadataChange(string title, string artist)
+        public void SimulateMetadataChange(string title, string artist, string? albumArtUrl = null)
         {
-            MetadataChanged?.Invoke(this, new BluetoothPlaybackMetadata 
-            { 
-               Title = title, 
+            MetadataChanged?.Invoke(this, new BluetoothPlaybackMetadata
+            {
+               Title = title,
                Artist = artist,
-               Album = "Mock Album"
+               Album = "Mock Album",
+               AlbumArtUrl = albumArtUrl
             });
         }
 

--- a/tests/Radio.Infrastructure.Tests/Audio/BluetoothAudioSourceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/BluetoothAudioSourceTests.cs
@@ -1,11 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Radio.Core.Configuration;
+using Radio.Core.Events;
 using Radio.Core.Interfaces;
 using Radio.Fingerprinting;
 using Radio.Core.Interfaces.Audio;
 using Radio.Core.Models.Audio;
+using Radio.Fingerprinting.Services;
 using Radio.Infrastructure.Audio.Sources.Primary;
 using Radio.Infrastructure.Platform.Bluetooth;
 using Radio.Metrics;
@@ -278,5 +281,214 @@ public class BluetoothAudioSourceTests : IAsyncDisposable
 
     // Assert — should NOT request fingerprinting because toggle is OFF and metadata is complete
     Assert.False(_source.NeedsFingerprintingLookup);
+  }
+
+  // -----------------------------------------------------------------------
+  // BT album-art tests — verify AVRCP fast path + SongRec fallback routing.
+  //
+  // Bug A regression: file:// AVRCP URLs (the common Spotify/YouTube Music
+  // case on Android) must not be propagated raw to the browser. The fix
+  // routes every AVRCP ArtUrl through AlbumArtCacheService.SaveFromUrlAsync,
+  // which returns null for file:// (HttpClient throws NotSupportedException,
+  // caught internally) and a /api/albumart/{hash}.{ext} URL for http(s)://.
+  // -----------------------------------------------------------------------
+
+  /// <summary>
+  /// Minimal IServiceScopeFactory for tests: the scope it produces has no
+  /// IPlayHistoryRepository / ITrackMetadataRepository registered, so
+  /// UpdateRecentPlayHistoryCoverArtAsync no-ops cleanly via its null guards.
+  /// </summary>
+  private static IServiceScopeFactory BuildScopeFactory()
+  {
+    var services = new ServiceCollection();
+    return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+  }
+
+  /// <summary>
+  /// Builds a real BackgroundIdentificationService (no SongRec, no audio
+  /// capture) suitable for raising TrackIdentified via the internal
+  /// RaiseTrackIdentifiedForTesting hook.
+  /// </summary>
+  private static BackgroundIdentificationService BuildIdentificationServiceForTests()
+  {
+    var services = new ServiceCollection();
+    var sp = services.BuildServiceProvider();
+    var optionsMonitor = new Mock<IOptionsMonitor<FingerprintingOptions>>();
+    optionsMonitor.Setup(o => o.CurrentValue).Returns(new FingerprintingOptions());
+    var logger = new Mock<ILogger<BackgroundIdentificationService>>().Object;
+    return new BackgroundIdentificationService(logger, sp, optionsMonitor.Object);
+  }
+
+  [Fact]
+  public async Task MetadataChanged_WithFileSchemeArtUrl_DoesNotStoreRawUrlInMetadata()
+  {
+    // Arrange — cache mock returns null for file:// (simulating HttpClient
+    // NotSupportedException caught inside SaveFromUrlAsync).
+    var cacheMock = new Mock<IAlbumArtCacheService>();
+    cacheMock
+      .Setup(c => c.SaveFromUrlAsync(It.Is<string>(u => u.StartsWith("file://"))))
+      .ReturnsAsync((string?)null);
+
+    await _source.DisposeAsync();
+    _source = new BluetoothAudioSource(
+      _loggerMock.Object,
+      _deviceManagerMock.Object,
+      _mockBluetooth,
+      _options,
+      identificationService: null,
+      metricsCollector: _metricsMock.Object,
+      serviceScopeFactory: BuildScopeFactory(),
+      albumArtCache: cacheMock.Object);
+
+    // Act — simulate AVRCP metadata with a phone-local file:// URI (the
+    // common case from Spotify/YouTube Music on Android — Track.ArtUrl
+    // points to the phone's app cache directory, unreachable from the browser).
+    _mockBluetooth.SimulateMetadataChange(
+      "Song", "Artist",
+      albumArtUrl: "file:///data/data/com.android.spotify/cache/art.jpg");
+
+    // Allow the fire-and-forget CacheAvrcpArtAsync task to complete.
+    await Task.Delay(200);
+
+    // Assert — AlbumArtUrl must NOT be set to the raw file:// URL. It must
+    // be either absent or empty (UI then falls back to the default-art icon).
+    var hasArt = _source.Metadata.TryGetValue(StandardMetadataKeys.AlbumArtUrl, out var art);
+    Assert.False(
+      hasArt && art is string s && s.StartsWith("file://"),
+      "Raw file:// AVRCP URL must not be propagated to metadata");
+
+    // And the cache was invoked exactly once for the file:// URL — we route
+    // every URL through the cache (rather than scheme-filtering up front) so
+    // future schemes (data:, embedded http://localhost servers) work
+    // automatically once the cache learns to handle them.
+    cacheMock.Verify(c => c.SaveFromUrlAsync(It.Is<string>(u => u.StartsWith("file://"))), Times.Once);
+  }
+
+  [Fact]
+  public async Task MetadataChanged_WithHttpsArtUrl_StoresCachedRelativeUrl()
+  {
+    // Arrange — cache mock returns a cached /api/albumart URL.
+    var cacheMock = new Mock<IAlbumArtCacheService>();
+    cacheMock
+      .Setup(c => c.SaveFromUrlAsync("https://example.com/art.jpg"))
+      .ReturnsAsync("/api/albumart/abc123.jpg");
+
+    await _source.DisposeAsync();
+    _source = new BluetoothAudioSource(
+      _loggerMock.Object,
+      _deviceManagerMock.Object,
+      _mockBluetooth,
+      _options,
+      identificationService: null,
+      metricsCollector: _metricsMock.Object,
+      serviceScopeFactory: BuildScopeFactory(),
+      albumArtCache: cacheMock.Object);
+
+    // Act — AVRCP metadata with an https:// art URL (rare from phones, common
+    // from local-music players that expose art via MPRIS).
+    _mockBluetooth.SimulateMetadataChange(
+      "Song", "Artist",
+      albumArtUrl: "https://example.com/art.jpg");
+    await Task.Delay(200);  // let the fire-and-forget CacheAvrcpArtAsync complete
+
+    // Assert — metadata holds the cache's relative URL (browser-fetchable).
+    Assert.True(_source.Metadata.TryGetValue(StandardMetadataKeys.AlbumArtUrl, out var art));
+    Assert.Equal("/api/albumart/abc123.jpg", art);
+    cacheMock.Verify(c => c.SaveFromUrlAsync("https://example.com/art.jpg"), Times.Once);
+  }
+
+  [Fact]
+  public async Task TrackIdentified_AfterEmptyAvrcp_CachesSongRecCoverArtUrl()
+  {
+    // Arrange — cache mock returns a /api/albumart URL when called with the
+    // SongRec CDN URL. SongRec provides Apple Music CDN URLs which are HTTPS.
+    var cacheMock = new Mock<IAlbumArtCacheService>();
+    cacheMock
+      .Setup(c => c.SaveFromUrlAsync("https://itunes.apple.com/some-art.jpg"))
+      .ReturnsAsync("/api/albumart/songrec-abc.jpg");
+
+    var identificationService = BuildIdentificationServiceForTests();
+
+    await _source.DisposeAsync();
+    _source = new BluetoothAudioSource(
+      _loggerMock.Object,
+      _deviceManagerMock.Object,
+      _mockBluetooth,
+      _options,
+      identificationService: identificationService,
+      metricsCollector: _metricsMock.Object,
+      serviceScopeFactory: BuildScopeFactory(),
+      albumArtCache: cacheMock.Object);
+
+    // AVRCP delivers only Title (Spotify/YouTube-style: Artist empty) — this
+    // sets NeedsFingerprintingLookup = true and the SongRec path engages.
+    _mockBluetooth.SimulateMetadataChange("Some Song", "", albumArtUrl: null);
+    Assert.True(_source.NeedsFingerprintingLookup);
+
+    // Act — SongRec identifies the track later.
+    identificationService.RaiseTrackIdentifiedForTesting(new TrackIdentifiedEventArgs(
+      new TrackMetadata
+      {
+        Id = Guid.NewGuid().ToString(),
+        Title = "Some Song",
+        Artist = "Real Artist",
+        CoverArtUrl = "https://itunes.apple.com/some-art.jpg",
+        Source = MetadataSource.Shazam,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow
+      },
+      confidence: 0.95));
+    await Task.Delay(200);
+
+    // Assert — metadata holds the cached SongRec art URL.
+    Assert.True(_source.Metadata.TryGetValue(StandardMetadataKeys.AlbumArtUrl, out var art));
+    Assert.Equal("/api/albumart/songrec-abc.jpg", art);
+  }
+
+  [Fact]
+  public async Task TrackIdentified_WithNoCoverArtUrl_LeavesAlbumArtUrlAbsent()
+  {
+    // Arrange — cache mock should NEVER be called (no URL to download).
+    var cacheMock = new Mock<IAlbumArtCacheService>(MockBehavior.Strict);
+
+    var identificationService = BuildIdentificationServiceForTests();
+
+    await _source.DisposeAsync();
+    _source = new BluetoothAudioSource(
+      _loggerMock.Object,
+      _deviceManagerMock.Object,
+      _mockBluetooth,
+      _options,
+      identificationService: identificationService,
+      metricsCollector: _metricsMock.Object,
+      serviceScopeFactory: BuildScopeFactory(),
+      albumArtCache: cacheMock.Object);
+
+    _mockBluetooth.SimulateMetadataChange("Mystery Song", "", albumArtUrl: null);
+
+    // Act — SongRec identifies but has no cover art (track not on Apple Music
+    // CDN, or SongRec returned partial metadata).
+    identificationService.RaiseTrackIdentifiedForTesting(new TrackIdentifiedEventArgs(
+      new TrackMetadata
+      {
+        Id = Guid.NewGuid().ToString(),
+        Title = "Mystery Song",
+        Artist = "Mystery Artist",
+        CoverArtUrl = null,
+        Source = MetadataSource.Shazam,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow
+      },
+      confidence: 0.7));
+    await Task.Delay(200);
+
+    // Assert — AlbumArtUrl must be absent (UI shows fallback icon — accepted UX).
+    var hasArt = _source.Metadata.TryGetValue(StandardMetadataKeys.AlbumArtUrl, out var art);
+    Assert.False(
+      hasArt && art is string s && !string.IsNullOrEmpty(s),
+      "AlbumArtUrl must remain absent when neither AVRCP nor SongRec provides art");
+
+    // And the cache was never touched (MockBehavior.Strict throws on any unset call).
+    cacheMock.VerifyNoOtherCalls();
   }
 }


### PR DESCRIPTION
## Summary

Two bugs in BT album art display:

- **Bug A:** The AVRCP fast path in BluetoothAudioSource.OnMetadataChanged stored the raw e.AlbumArtUrl from BlueZ MPRIS directly into the source metadata. For mainstream phone players (Spotify, YouTube Music, Apple Music) this URL is typically file:///data/data/com.android.PLAYER/cache/art.jpg - a path on the PHONES local filesystem. The browser cannot fetch file:// URLs over the network, so img.onerror fired and the UI swapped to the default-art icon.
- **Bug B:** When AVRCP delivered no art, OnMetadataChanged and OnTrackIdentified fell back to the MusicBrainz Cover Art Archive via IMetadataLookupService.SearchCoverArtByTextAsync and GetCoverArtByReleaseIdAsync. Per project direction, **MusicBrainz has been deprecated** in favor of SongRec for cover-art resolution. The MB fallback path was both no longer aligned with project policy and had several latent failure modes.

## Fix scope

- **Route AVRCP e.AlbumArtUrl through _albumArtCache.SaveFromUrlAsync.** HttpClient throws NotSupportedException for file:// (caught inside the cache) so the cache returns null; we leave AlbumArtUrl absent and SongRec - if it identifies the track - populates the art via OnTrackIdentified. For http(s):// URLs the cache downloads the bytes, content-addresses them on disk, and returns the browser-fetchable /api/albumart/{hash}.{ext} path. Future-proofs against data: URIs and http://localhost:PORT/... schemes some players use, without scheme-filtering up front.
- **Remove MusicBrainz fallback paths from BluetoothAudioSource only.** Deleted the else-if MB text-search branch in OnMetadataChanged, the MB release-ID and text-search retry branches in OnTrackIdentified, the two helper methods (LookupCoverArtAsync, LookupCoverArtByReleaseIdAsync), and the dead state fields (_failedArtLookups, _lastCoverArtLookupKey) plus their reset site in OnDeviceDisconnected.
- **SongRec wiring unchanged.** Audit (Task 4 in the plan) confirmed TrackIdentified += OnTrackIdentified is wired, NeedsFingerprintingLookup is set + RequestImmediateIdentification invoked when AVRCP metadata is incomplete, and OnTrackIdentified routes e.Track.CoverArtUrl through CacheAndSetCoverArtAsync. BackgroundIdentificationService is DI-registered as singleton + hosted service via FingerprintingServiceExtensions.cs.
- **Accepted UX:** if AVRCP does not provide art AND SongRec does not identify the track, the now-playing card shows the default-album-art icon (no broken img). Confirmed by user direction.
- **Refactor:** BluetoothAudioSource ctor param AlbumArtCacheService? -> IAlbumArtCacheService?. DI registration at AudioServiceExtensions.cs:189 already exposes both; the concrete is implicitly assignable to the interface, so AudioSourceFactory and WindowsBluetoothService (which still hold the concrete reference) need no changes. The interface change enables mock-based cache testing without touching the filesystem (avoids the Environment.CurrentDirectory-mutating helper the plans fallback path would have required).
- **Defensive log:** OnMetadataChanged now emits a LogWarning when AVRCP delivers a non-empty ArtUrl but _albumArtCache or _serviceScopeFactory is null. Without this, a DI regression would silently re-trigger Bug As symptom.

## Commits

- 2868825 - fix(bt): route AVRCP album-art URL through cache (avoid raw file:// to browser)
- d704ea9 - refactor(bt): remove deprecated MusicBrainz cover-art fallback paths
- 61b31b3 - test(bt): regression tests for BT album-art (AVRCP + SongRec routing)

## Tests

4 new tests in BluetoothAudioSourceTests:

- MetadataChanged_WithFileSchemeArtUrl_DoesNotStoreRawUrlInMetadata - Bug A regression: AVRCP file:// URL goes through the cache, cache returns null, and AlbumArtUrl stays absent (never propagated raw).
- MetadataChanged_WithHttpsArtUrl_StoresCachedRelativeUrl - AVRCP https:// URL goes through the cache and the resulting /api/albumart/{hash}.jpg is stored.
- TrackIdentified_AfterEmptyAvrcp_CachesSongRecCoverArtUrl - when AVRCP arrives empty and SongRec later identifies the track with a CoverArtUrl, the SongRec URL is cached.
- TrackIdentified_WithNoCoverArtUrl_LeavesAlbumArtUrlAbsent - when AVRCP is empty AND SongRec returns no CoverArtUrl, AlbumArtUrl stays absent and the cache is never called (verified via MockBehavior.Strict).

Supporting test infrastructure:

- MockBluetoothService.SimulateMetadataChange gains an optional albumArtUrl parameter (default null preserves all existing call sites).
- BackgroundIdentificationService unsealed + gained an `internal void RaiseTrackIdentifiedForTesting(TrackIdentifiedEventArgs)` hook so the event can be raised from tests without spinning up the full audio capture + SongRec pipeline. Visible only within the assembly + 3 test assemblies via existing InternalsVisibleTo.

Gate: `dotnet build --configuration Release` - 0 errors. Full `dotnet test --configuration Release` - all tests green except the 4 pre-existing SrcVariableResamplerTests that need libsamplerate.so.0 (Linux-only, unrelated to this PR).

## Test Plan

The 4 UAT scenarios from section 5 of design/plans/PLAN-fix-bt-album-art.md were verified on the radio Ubuntu host with the c82ec22 deploy (pre-rebase, BT album art fix in isolation):

- [x] **Scenario A - Phone player without AVRCP art (Spotify / YT Music / Apple Music).** Album art resolves via SongRec OR shows default icon. DevTools Network shows /api/albumart/{hash}.jpg, never file://. journalctl shows the "AVRCP art URL not cacheable; waiting for SongRec" debug line followed by "Cover art found ...: /api/albumart/..." when SongRec resolves.
- [x] **Scenario B - Phone player with AVRCP http(s):// art (local-music player, podcast apps).** Album art appears within ~1s (cached AVRCP path, no SongRec wait). journalctl shows "Cached AVRCP album art ...: /api/albumart/{hash}.jpg".
- [x] **Scenario C - Track change leaks no art from previous track.** Skipping to next track briefly shows fallback icon, then resolves to new art (or stays on fallback if SongRec does not match).
- [x] **Scenario D - Source switch away from BT and back.** Album art re-resolves correctly on return to BT.

Pass criteria met: zero file:// URLs for album art in DevTools Network across the session; no ERROR lines in journalctl mentioning AlbumArtCache.

Combined deploy (61b31b3 = ca6db78 from PR #409 + 3 rebased BT commits) also verified active on radio: both services healthy, PR #409s SetActiveOutputAsync gate firing at startup, BT source initialized normally, zero errors in the new process.

## Known limitation surfaced during combined deploy UAT (NOT addressed in this PR)

After a BT capture stream recovery event ("BT pipeline recovery successful"), SongRec stops being triggered for new tracks, so album art does not appear for tracks following the recovery. **This is a pre-existing bug in the capture-recovery path - FingerprintTap is not re-attached to the mixer after StopCoreAsync + PlayCoreAsync in OnGeneratorStalled.** Tracked separately for a follow-up PR. Does NOT affect this PRs correctness - once SongRec resumes, the cached-URL flow works correctly.

## Out of scope

- Removal of IMetadataLookupService interface or Radio.Fingerprinting.Services.MetadataLookupService implementation (separate PR - wider blast radius; needs an audit of all consumers beyond BluetoothAudioSource).
- Time-bounding _failedArtLookups (made irrelevant - the field is deleted).
- Web -> API album-art proxy changes (debug investigation confirmed it works).
- Capture-recovery FingerprintTap re-attach (separate pre-existing bug, separate PR).
- Changes to AlbumArtCacheService itself (TTL, cache size limits, eviction policy, data: URI scheme handling).

Generated with [Claude Code](https://claude.com/claude-code)
