### PR TITLE
fix(bt): re-enable fingerprinting after BT capture pipeline recovery

### DIFF
--- a/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
+++ b/src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs
@@ -356,6 +356,11 @@ public class BluetoothAudioSource : USBAudioSourceBase
   private void OnCaptureStreamRecovered(object? sender, EventArgs e)
   {
     Logger.LogInformation("BluetoothAudioSource: capture stream recovered by pipeline monitor");
+    // Re-enable fingerprinting lookup — OnDeviceDisconnected cleared it, and a recovered
+    // capture means we have a fresh post-disconnect session that needs SongRec to run for
+    // album-art enrichment. Without this, no track on the recovered session gets identified
+    // until the service restarts.
+    NeedsFingerprintingLookup = true;
     _ = TryAcquireAudioCaptureAsync();
   }
 

--- a/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
+++ b/src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs
@@ -41,7 +41,7 @@ public sealed class MockBluetoothService : IBluetoothService
         public event EventHandler<BluetoothPlaybackStatus>? PlaybackStatusChanged;
         public event EventHandler<TimeSpan>? PositionChanged { add { } remove { } }
         public event EventHandler<BluetoothVolumeChangedEventArgs>? VolumeChanged { add { } remove { } }
-        public event EventHandler? CaptureStreamRecovered { add { } remove { } }
+        public event EventHandler? CaptureStreamRecovered;
         public event EventHandler<CaptureStreamStalledEventArgs>? CaptureStreamStalled { add { } remove { } }
         // Mock never raises CaptureNodeAvailable — the platform manages capture-node visibility.
         public event EventHandler<CaptureNodeAvailableEventArgs>? CaptureNodeAvailable { add { } remove { } }
@@ -165,5 +165,11 @@ public sealed class MockBluetoothService : IBluetoothService
         {
             ConnectedDevice = null;
             DeviceDisconnected?.Invoke(this, new BluetoothDeviceDisconnectedEventArgs { Device = device, UserInitiated = userInitiated });
+        }
+
+        // Mock helper to simulate the BT capture pipeline monitor raising recovery after a stall.
+        public void SimulateCaptureStreamRecovered()
+        {
+            CaptureStreamRecovered?.Invoke(this, EventArgs.Empty);
         }
 }

--- a/tests/Radio.Infrastructure.Tests/Audio/BluetoothAudioSourceTests.cs
+++ b/tests/Radio.Infrastructure.Tests/Audio/BluetoothAudioSourceTests.cs
@@ -127,6 +127,33 @@ public class BluetoothAudioSourceTests : IAsyncDisposable
   }
 
   [Fact]
+  public void CaptureStreamRecovered_AfterDisconnect_ReenablesFingerprintingLookup()
+  {
+    // Regression for: after a BT capture pipeline recovery event, SongRec stops being
+    // triggered for new tracks indefinitely (no album art). Root cause: OnDeviceDisconnected
+    // clears NeedsFingerprintingLookup, and OnCaptureStreamRecovered did not re-set it —
+    // so BackgroundIdentificationService's gate stayed false until service restart.
+    var device = new BluetoothDeviceInfo
+    {
+      Address = "AA:BB:CC:DD:EE:FF",
+      Name = "My Speaker",
+      IsPaired = true,
+      IsConnected = true
+    };
+
+    _mockBluetooth.SimulateConnection(device);
+    Assert.True(_source.NeedsFingerprintingLookup);
+
+    _mockBluetooth.SimulateDisconnection(device);
+    Assert.False(_source.NeedsFingerprintingLookup);
+
+    // Pipeline monitor reports recovery — capture stream is re-established.
+    _mockBluetooth.SimulateCaptureStreamRecovered();
+
+    Assert.True(_source.NeedsFingerprintingLookup);
+  }
+
+  [Fact]
   public async Task InitializeAsync_WhenNoCaptureDevice_SetsReadyState()
   {
     // MockBluetoothService returns "mock-capture-endpoint" (string, not AudioCaptureDevice)


### PR DESCRIPTION
## Summary

Pre-existing bug surfaced during PR #410 UAT — after a BT capture stream recovery event (`BT pipeline recovery successful`), SongRec stops being triggered for all subsequent tracks, so album art never appears for those tracks until the service is restarted.

## Root cause

The `NeedsFingerprintingLookup` flag on `BluetoothAudioSource` is cleared by `OnDeviceDisconnected` (line 657) but never re-set by `OnCaptureStreamRecovered` (lines 354-358). The mirror handler `OnDeviceConnected` (line 348) DOES set it, which is why initial connections work fine. `BackgroundIdentificationService:260-264` consults this flag as the gate for whether to run SongRec — so once cleared, all identifications are silently skipped.

## Fix

Add `NeedsFingerprintingLookup = true` in `OnCaptureStreamRecovered`, mirroring the `OnDeviceConnected:348` pattern exactly.

## Investigation credit

Debugger investigation identified this with file:line evidence. My initial hypothesis (FingerprintTap modifier not re-attached) was falsified during investigation — the tap is attached to the MasterMixer (not per-generator) and works correctly; the gate was the actual mechanism.

## Tests

- New regression test `CaptureStreamRecovered_AfterDisconnect_ReenablesFingerprintingLookup` in `BluetoothAudioSourceTests`.
- Supporting `MockBluetoothService.SimulateCaptureStreamRecovered()` helper (also converted the previously stubbed event accessor to a real backing event so the test can raise it).
- Full suite passes (`Radio.Infrastructure.Tests`: 877 passed, only the 4 pre-existing `SrcVariableResamplerTests` Linux-only `libsamplerate.so.0` failures on Windows).

## Test Plan (PASSED)

User verified on `radio` host with the deployed `915fd53` build by toggling phone BT to trigger a real `BT pipeline recovery successful` event, then confirming the next new track was identified by SongRec and album art appeared.

- [x] With BT source active and a track playing, album art appears within ~15s (SongRec identifying).
- [x] Toggle phone BT to trigger `BT pipeline recovery successful — capture stream re-established` log line.
- [x] After recovery, play a NEW track on the phone.
- [x] Within ~15s, the new track is identified by SongRec and album art appears (`SongRec recognized: '...'`, `Cover art found for '...'`).
- [x] Regression check: subsequent track changes also identified within ~15s.

## Files changed (3)

- `src/Radio.Infrastructure/Audio/Sources/Primary/BluetoothAudioSource.cs` — the 1-line fix
- `src/Radio.Infrastructure/Platform/Bluetooth/MockBluetoothService.cs` — added `SimulateCaptureStreamRecovered()` helper for the test
- `tests/Radio.Infrastructure.Tests/Audio/BluetoothAudioSourceTests.cs` — new regression test