### PR TITLE
feat(web): explicit "Stop Casting" row in Cast popover

### DIFF
--- a/docs/design-handoffs/HANDOFF-stop-casting-menu-item.md
+++ b/docs/design-handoffs/HANDOFF-stop-casting-menu-item.md
@@ -1,0 +1,180 @@
+# HANDOFF — Explicit "Stop Casting" menu item in Cast popover
+
+**Component:** `src/Radio.Web/Components/Shared/CastDeviceDropdown.razor`
+**Surface:** Topbar → "Cast" pill → popover
+**Status:** `[PENDING REVIEW]` — ready for Builder
+**Relationship to existing handoffs:**
+- **Follows** `docs/design-handoffs/design_handoff_radio_console/` (token system, popover chrome, Radzen-icon vocabulary).
+- **Extends** the existing popover with a new dedicated action row. No deviation from established visual language.
+- **Path note:** Existing handoffs live under `docs/design-handoffs/`. This one was written to `design/design-handoffs/` per the explicit request; if Builder prefers, move to `docs/design-handoffs/` to keep the canonical location consistent.
+
+---
+
+## 1. Problem + context
+
+When Cast is active, the only ways to stop casting today are (a) the small inline `Disconnect` Danger button tucked inside the green "connected device" banner at the top of the Cast popover, or (b) implicitly switching to a local output via the `Out` picker. Both are easy to miss: the inline button reads more like an "X" affordance on a banner than a primary action, and the Out-picker route never says the word "Cast." User feedback (2026-05-23) was specifically: "there should be an explicit 'Stop Casting' selection from the Cast menu to make this action explicit." The fix is a clearly-labelled list-style action row at the bottom of the device list — same visual weight as a device row, so the popover scans as "pick a device OR stop casting."
+
+---
+
+## 2. Visual mockup (ASCII)
+
+### Before — Cast popover when a device is connected (today)
+
+```
+┌─────────────────────────────────────────┐
+│ Cast Devices                        [↻] │  header (rescan)
+├─────────────────────────────────────────┤
+│ [cast_connected]  Living Room      [Disconnect] │  ← small Danger button (low discoverability)
+├─────────────────────────────────────────┤
+│ [speaker]  Living Room    Live          │  device list (selected row is opacity-0.5,
+│ [tv]       Bedroom TV     Cached        │   pointer-events:none — see line 58)
+│ [speaker]  Kitchen Hub    Cached        │
+└─────────────────────────────────────────┘
+```
+
+### After — same popover with new "Stop Casting" row
+
+```
+┌─────────────────────────────────────────┐
+│ Cast Devices                        [↻] │  header (rescan)
+├─────────────────────────────────────────┤
+│ [cast_connected]  Living Room           │  banner: device name only,
+│                                         │  no inline Disconnect button (removed)
+├─────────────────────────────────────────┤
+│ [speaker]  Living Room    Live          │  active row stays dimmed (existing behavior)
+│ [tv]       Bedroom TV     Cached        │
+│ [speaker]  Kitchen Hub    Cached        │
+├─────────────────────────────────────────┤ ← separator (border-top, same color
+│ [cast_off]  Stop Casting                │   as inter-row dividers)
+└─────────────────────────────────────────┘
+```
+
+### After — same popover when NO device is connected
+
+```
+┌─────────────────────────────────────────┐
+│ Cast Devices                        [↻] │
+├─────────────────────────────────────────┤
+│ [speaker]  Living Room    Live          │  (no banner, no Stop Casting row —
+│ [tv]       Bedroom TV     Cached        │   visibility rule hides it)
+│ [speaker]  Kitchen Hub    Cached        │
+└─────────────────────────────────────────┘
+```
+
+### After — disconnect in progress
+
+```
+┌─────────────────────────────────────────┐
+│ Cast Devices                        [↻] │
+├─────────────────────────────────────────┤
+│ [cast_connected]  Living Room           │
+├─────────────────────────────────────────┤
+│ [speaker]  Living Room    Live          │  (rows still rendered but
+│ [tv]       Bedroom TV     Cached        │   container has opacity:0.6,
+│ [speaker]  Kitchen Hub    Cached        │   pointer-events:none)
+├─────────────────────────────────────────┤
+│ [○ spin]  Stopping…                     │  ← icon swaps to inline spinner,
+└─────────────────────────────────────────┘   label changes, row is aria-busy
+```
+
+---
+
+## 3. Interaction spec
+
+### Visibility rule
+- Render the row **iff** `_connectedDevice != null` (same condition that gates the existing connected-device banner at line 34).
+- When no Cast device is connected, the row is omitted from the DOM entirely (not just hidden) so Tab order is clean.
+
+### Click handler
+- Wire `@onclick="StopCastingAsync"`. Reuse the existing `DisconnectAsync()` private method body — just rename to `StopCastingAsync` (more explicit) OR add a thin wrapper that calls `DisconnectAsync`. Internally it must:
+  1. Set `_isDisconnecting = true` and `StateHasChanged()`.
+  2. `await DevicesApi.DisconnectFromCastDeviceAsync()` (already routes to `DevicesController.DisconnectFromCastDevice` at `DevicesController.cs:714`, which after PR #409 goes through `SetActiveOutputAsync` and unmutes local output automatically).
+  3. On success: `_connectedDevice = null`, invoke `OnDisconnect`, then `await Close()`.
+  4. On exception: log, set `_disconnectError = true`, keep popover open, surface inline error (see Error state).
+  5. `finally`: clear `_isDisconnecting`, `StateHasChanged()`.
+
+### Loading state (during disconnect)
+- The row's leading icon swaps from `cast_off` to a small inline `RadzenProgressBarCircular` (same `Size="ButtonSize.Small"` pattern used in the header rescan spinner at lines 22–24).
+- Label text changes: `"Stop Casting"` → `"Stopping…"`.
+- Row gets `aria-busy="true"` and `pointer-events: none` to block double-clicks.
+- Device list above is dimmed (`opacity: 0.6; pointer-events: none`) so user can't initiate a conflicting connect-while-disconnecting.
+- Header rescan button also disables during this window.
+
+### Success state (post-disconnect)
+- Popover closes (existing `Close()` helper). Topbar returns to its non-Cast state via the existing `OnCastDeviceDisconnected` handler in `MainLayout.razor:866` which clears the default Cast device and re-renders.
+- No toast / no banner needed — the disappearance of the Cast pill's "connecting" dot + the topbar `Out` cluster reverting to the local output name is sufficient feedback.
+
+### Error state (network failure during disconnect)
+- Keep popover open.
+- Replace the "Stop Casting" row content with a small inline error: `[error_outline] Couldn't stop. Try again.` using `color: var(--rz-danger)` (matches the existing inline Danger button color). The row stays clickable so the user can retry.
+- After 5s of idle, auto-revert the row label back to `Stop Casting` so the popover doesn't get stuck in error state.
+- Log via `Logger?.LogError` (matches existing `DisconnectAsync` catch at line 254).
+
+### Keyboard nav
+- The row is a `<button type="button">` (not a `<div>` — the existing device rows use `<div @onclick>` which is non-ideal but out of scope here; the new action row should be a real button so it lands in Tab order naturally).
+- Tab order: header rescan → connected banner (no interactive child now) → each device row in order → **Stop Casting button** → click-away closes.
+- `Enter` and `Space` activate the button (native button behavior).
+- `Esc` while popover is open closes it (existing behavior; verify still works after the change).
+- Focus ring: rely on Radzen / browser default focus outline; do not suppress.
+
+---
+
+## 4. Copy
+
+| Element | Exact string | Notes |
+|---|---|---|
+| Default label | `Stop Casting` | Two words, title case. Matches Cast button vocabulary ("Cast", "Cast Devices"). |
+| Loading label | `Stopping…` | Single ellipsis char `…` not three dots. |
+| Error label | `Couldn't stop. Try again.` | Lowercase second sentence is intentional — matches conversational micro-copy elsewhere in the popover ("No Cast devices found", "Searching..."). |
+| Tooltip (`title=`) | `Disconnect from Living Room` (interpolated with `_connectedDevice.Name`); fall back to `Disconnect from Cast device` if name is null/empty. |
+| `aria-label` | Same as tooltip — `Disconnect from {device name}` or `Disconnect from Cast device`. |
+| Confirmation prompt | **None.** Cast disconnect is non-destructive (audio routes back to local speakers immediately) and the user can reconnect with one click. |
+
+---
+
+## 5. Styling notes
+
+- **Row container:** mirror the existing `.cast-device-row` pattern (lines 56–78) but distinguish as an action row:
+  - `display: flex; align-items: center; gap: 8px; padding: 8px 12px;` (same as device rows but `padding: 8px 12px` not `6px 12px` to give the action slightly more visual weight).
+  - `border-top: 1px solid rgba(255,255,255,0.1);` — separator above so it visually detaches from the device list. Same color as the header `border-bottom` at line 18 for consistency.
+  - `background: rgba(0,0,0,0.2);` — subtle dark tint (matches the existing connecting-state strip at line 98) so the action zone reads as distinct from the device list.
+  - Hover: `background: rgba(255,255,255,0.06);` — same hover as `.cast-device-row` so the family resemblance holds.
+  - `cursor: pointer;`
+- **Icon:** `cast_off` (Material Symbols name — confirmed available in the same set as `cast`, `cast_connected`). Size 18px, `color: var(--text-medium)`. Matches device-row icon sizing.
+- **Label text:** `font-size: 12px; color: var(--text-high);` — same scale as device-row primary text.
+- **Color choice — neutral, not danger:** Use `var(--text-high)` for the label, NOT `var(--rz-danger)`. Rationale: Stop Casting is non-destructive (audio simply re-routes locally) and is the standard "exit" affordance for the popover. Danger red would over-signal risk. The old inline `Disconnect` button used Danger because it was buried in a green banner and needed contrast; the new dedicated row gets that affordance from its position + separator instead.
+- **Remove old inline button:** Delete the `<RadzenButton ... Text="Disconnect" />` inside the green banner (lines 42–44). The banner becomes display-only: icon + device name, no action. This is the discoverability fix — one canonical way to stop casting, not two competing ones.
+- **No new CSS tokens.** Everything uses existing `--text-high`, `--text-medium`, `--text-low`, `--rz-danger` (error state only), and the same `rgba(...)` literals already in this file.
+
+---
+
+## 6. Accessibility
+
+- Element: `<button type="button" class="cast-stop-row" aria-label="..." title="...">`.
+- `aria-busy="true"` during the disconnect loading state.
+- During loading, also set `aria-disabled="true"` (visual block via `pointer-events: none` is paired with semantic block).
+- Focus visible by default (do not set `outline: none`).
+- The icon should NOT be focusable/announced separately; it's decorative. Either omit aria entirely or set `aria-hidden="true"` on the `<RadzenIcon>`.
+- Screen-reader flow when the popover opens with a device connected: "Cast Devices, rescan button, Living Room connected, [device list…], Disconnect from Living Room, button."
+- Color contrast: `var(--text-high)` on `rgba(0,0,0,0.2)` over `rgba(30,30,30,0.95)` clears WCAG AA at 12px (existing pattern, no change).
+
+---
+
+## 7. Non-goals
+
+Explicitly NOT in scope for this spec — flag any of these to the user before expanding:
+
+1. **No confirmation modal.** Disconnect is one-click. (Aligns with feedback: user wants this MORE explicit / easier, not gated behind a second click.)
+2. **No undo / toast.** Reconnecting is one click in the same popover; classic undo isn't needed.
+3. **No multi-device disconnect.** Cast is single-device today; no group-cast logic.
+4. **No new icon design.** Using stock `cast_off` Material glyph. If Material doesn't render this name in the current Radzen icon font, fall back to `stop_circle` or `power_settings_new`; Builder should verify visually after deploy.
+5. **No topbar-level affordance.** The "Stop Casting" action lives only inside the popover. The Cast pill itself keeps its current single-click behavior (open popover).
+6. **No keyboard shortcut.** Not adding `Ctrl+Shift+C` or similar; the existing popover Tab order is sufficient.
+7. **No telemetry event.** If we later want a "stop_cast_explicit" metric to compare against implicit-via-Out-picker stops, that's a separate spec.
+8. **Banner re-styling beyond removing the inline button.** The green banner stays — it still confirms "this is the device you're connected to." Only the inline `Disconnect` Radzen button inside it is removed.
+
+---
+
+## Hand-off summary for Planner / Builder
+
+One new action row at the bottom of the `CastDeviceDropdown` popover device list, visible only when a device is connected, labeled `Stop Casting`, neutral color, icon `cast_off`, calls the existing `DisconnectAsync` flow. The old inline `Disconnect` Danger button inside the green banner gets removed in the same change so there's exactly one canonical way to stop casting. No new tokens, no new API, no new component — single-file edit to `CastDeviceDropdown.razor` plus possibly a rename of the private method for clarity.

--- a/src/Radio.Web/Components/Shared/CastDeviceDropdown.razor
+++ b/src/Radio.Web/Components/Shared/CastDeviceDropdown.razor
@@ -39,14 +39,12 @@
         <span style="flex: 1; font-size: 12px; color: #4caf50; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
           @_connectedDevice.Name
         </span>
-        <RadzenButton Size="ButtonSize.Small" Variant="Variant.Text" ButtonStyle="ButtonStyle.Danger"
-                      Click="DisconnectAsync" Style="font-size: 11px; text-transform: none; min-width: auto; padding: 0 6px;"
-                      Text="Disconnect" />
       </div>
     }
 
     <!-- Device list -->
-    <div style="max-height: 200px; overflow-y: auto;">
+    <div style="max-height: 200px; overflow-y: auto;
+                @(_isDisconnecting ? "opacity: 0.6; pointer-events: none;" : "")">
       @if (_devices != null && _devices.Count > 0)
       {
         @foreach (var device in _devices)
@@ -102,11 +100,54 @@
         <span style="font-size: 11px; color: var(--text-medium);">Connecting...</span>
       </div>
     }
+
+    <!-- Stop Casting action row (only when a device is connected) -->
+    @if (_connectedDevice != null)
+    {
+      var stopLabel = _disconnectError
+        ? "Couldn't stop. Try again."
+        : (_isDisconnecting ? "Stopping…" : "Stop Casting");
+      var stopAriaLabel = string.IsNullOrEmpty(_connectedDevice.Name)
+        ? "Disconnect from Cast device"
+        : $"Disconnect from {_connectedDevice.Name}";
+      var stopColor = _disconnectError ? "var(--rz-danger)" : "var(--text-high)";
+
+      <button type="button"
+              class="cast-stop-row"
+              aria-label="@stopAriaLabel"
+              title="@stopAriaLabel"
+              aria-busy="@(_isDisconnecting ? "true" : "false")"
+              aria-disabled="@(_isDisconnecting ? "true" : "false")"
+              @onclick="StopCastingAsync"
+              style="@($"display: flex; align-items: center; gap: 8px; padding: 8px 12px; width: 100%; " +
+                      $"border: none; border-top: 1px solid rgba(255,255,255,0.1); " +
+                      $"background: rgba(0,0,0,0.2); color: {stopColor}; cursor: pointer; text-align: left; " +
+                      $"font-family: inherit; font-size: 12px; transition: background 0.15s;" +
+                      (_isDisconnecting ? " pointer-events: none;" : ""))">
+        @if (_isDisconnecting)
+        {
+          <RadzenProgressBarCircular Size="ProgressBarCircularSize.Small" Mode="ProgressBarMode.Indeterminate"
+                                     ProgressBarStyle="ProgressBarStyle.Primary"
+                                     Style="width: 14px; height: 14px;" aria-hidden="true" />
+        }
+        else
+        {
+          var stopIcon = _disconnectError ? "error_outline" : "cast_off";
+          <RadzenIcon Icon="@stopIcon"
+                      Style="@($"font-size: 18px; color: {stopColor};")"
+                      aria-hidden="true" />
+        }
+        <span style="flex: 1;">@stopLabel</span>
+      </button>
+    }
   </div>
 }
 
 <style>
   .cast-device-row:hover {
+    background: rgba(255,255,255,0.06);
+  }
+  .cast-stop-row:hover {
     background: rgba(255,255,255,0.06);
   }
 </style>
@@ -126,8 +167,17 @@
   private bool _isScanning;
   private bool _scanCompleted;
   private bool _isConnecting;
+  private bool _isDisconnecting;
+  private bool _disconnectError;
   private bool _initialized;
   private CancellationTokenSource? _scanCts;
+  private CancellationTokenSource? _errorRevertCts;
+
+  // Auto-revert window for the error state on the Stop Casting row.
+  // Spec §3 Error state: after 5s of idle, label snaps back to "Stop Casting"
+  // so the popover doesn't get stuck in error state. Exposed (internal) so
+  // bUnit tests don't have to wait the wall-clock 5s.
+  internal TimeSpan ErrorRevertDelay { get; set; } = TimeSpan.FromSeconds(5);
 
   protected override void OnParametersSet()
   {
@@ -241,11 +291,35 @@
     }
   }
 
-  private async Task DisconnectAsync()
+  /// <summary>
+  /// Handles the "Stop Casting" action row click. Mirrors the discoverability
+  /// goal called out in the spec (HANDOFF-stop-casting-menu-item.md §1):
+  /// one canonical, explicit way to stop casting. Internally routes to the
+  /// existing DevicesController.DisconnectFromCastDevice endpoint, which
+  /// post-PR #409 goes through SetActiveOutputAsync and unmutes local output.
+  /// </summary>
+  private async Task StopCastingAsync()
   {
+    if (_isDisconnecting) return;
+
+    // Cancel any pending error auto-revert — user is retrying.
+    _errorRevertCts?.Cancel();
+    _errorRevertCts = null;
+
+    _isDisconnecting = true;
+    _disconnectError = false;
+    StateHasChanged();
+
     try
     {
-      await DevicesApi.DisconnectFromCastDeviceAsync();
+      var success = await DevicesApi.DisconnectFromCastDeviceAsync();
+      if (!success)
+      {
+        // DevicesApiService swallows transport exceptions and returns false;
+        // treat that as a user-visible failure so the row surfaces the retry
+        // affordance described in the spec.
+        throw new InvalidOperationException("Cast disconnect endpoint returned an unsuccessful status");
+      }
       _connectedDevice = null;
       await OnDisconnect.InvokeAsync();
       await Close();
@@ -253,13 +327,40 @@
     catch (Exception ex)
     {
       Logger?.LogError(ex, "Error disconnecting from Cast device");
+      _disconnectError = true;
+      // Schedule auto-revert: per spec §3 Error state, after 5s of idle revert
+      // the label back to "Stop Casting" so the popover doesn't get stuck.
+      _errorRevertCts = new CancellationTokenSource();
+      _ = ScheduleErrorRevertAsync(_errorRevertCts.Token);
+    }
+    finally
+    {
+      _isDisconnecting = false;
+      StateHasChanged();
+    }
+  }
+
+  private async Task ScheduleErrorRevertAsync(CancellationToken token)
+  {
+    try
+    {
+      await Task.Delay(ErrorRevertDelay, token);
+      if (token.IsCancellationRequested) return;
+      _disconnectError = false;
+      await InvokeAsync(StateHasChanged);
+    }
+    catch (OperationCanceledException)
+    {
+      // Cancelled — either a retry or the popover closed; nothing to do.
     }
   }
 
   private async Task Close()
   {
     _scanCts?.Cancel();
+    _errorRevertCts?.Cancel();
     _isScanning = false;
+    _disconnectError = false;
     await IsOpenChanged.InvokeAsync(false);
   }
 

--- a/tests/Radio.Web.Tests/Components/Shared/CastDeviceDropdownTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/CastDeviceDropdownTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Radzen;
+using Radio.Web.Components.Shared;
+using Radio.Web.Models;
+using Radio.Web.Services.ApiClients;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for <see cref="CastDeviceDropdown"/> — specifically the new
+/// explicit "Stop Casting" action row added per
+/// <c>docs/design-handoffs/HANDOFF-stop-casting-menu-item.md</c>.
+///
+/// The component is mostly presentational + drives DevicesApiService for
+/// scan/connect/disconnect. We give it a real DevicesApiService backed by a
+/// stub HttpMessageHandler so:
+/// <list type="bullet">
+///   <item>scans return an empty cached + discovery list (no Cast devices
+///         leak into the row count, keeping assertions tight),</item>
+///   <item>the disconnect call can be observed (success vs. failure) and
+///         delayed so we can assert the loading state mid-flight.</item>
+/// </list>
+///
+/// Radzen + JS interop pattern matches <see cref="OutputPickerDropdownTests"/>:
+/// register Radzen components and put the JSRuntime in Loose mode (same gotcha
+/// MEMORY documents for MudBlazor).
+/// </summary>
+public class CastDeviceDropdownTests : TestContext
+{
+  public CastDeviceDropdownTests()
+  {
+    Services.AddRadzenComponents();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+  }
+
+  /// <summary>
+  /// When no Cast device is connected, the Stop Casting action row must NOT
+  /// render — the visibility rule (spec §3) gates it on
+  /// <c>_connectedDevice != null</c> so the popover only shows the action
+  /// when there's actually something to stop.
+  /// </summary>
+  [Fact]
+  public void StopCastingRow_NotRendered_WhenNoDeviceConnected()
+  {
+    var handler = new StubCastDevicesHandler();
+    var api = BuildApi(handler);
+
+    var cut = RenderComponent<CastDeviceDropdown>(p => p
+      .Add(c => c.IsOpen, true)
+      .Add(c => c.DevicesApi, api)
+      .Add(c => c.ConnectedDevice, null));
+
+    Assert.Empty(cut.FindAll("button.cast-stop-row"));
+    // Sanity: the old inline Disconnect button was removed, so no
+    // "Disconnect" text should appear when no device is connected either.
+    Assert.DoesNotContain("Disconnect", cut.Markup);
+  }
+
+  /// <summary>
+  /// When a Cast device is connected, the Stop Casting row IS rendered,
+  /// labelled "Stop Casting", with the cast_off icon, and an aria-label
+  /// that names the connected device (per spec §4 Copy table).
+  /// </summary>
+  [Fact]
+  public void StopCastingRow_Rendered_WhenDeviceConnected()
+  {
+    var handler = new StubCastDevicesHandler();
+    var api = BuildApi(handler);
+    var device = new CastDeviceDto("device-1", "Living Room", "10.0.0.5", 8009, "Speaker");
+
+    var cut = RenderComponent<CastDeviceDropdown>(p => p
+      .Add(c => c.IsOpen, true)
+      .Add(c => c.DevicesApi, api)
+      .Add(c => c.ConnectedDevice, device));
+
+    var stopRows = cut.FindAll("button.cast-stop-row");
+    Assert.Single(stopRows);
+    Assert.Contains("Stop Casting", stopRows[0].TextContent);
+    // aria-label should name the device for screen readers.
+    Assert.Equal("Disconnect from Living Room", stopRows[0].GetAttribute("aria-label"));
+    // Default state: not busy.
+    Assert.Equal("false", stopRows[0].GetAttribute("aria-busy"));
+  }
+
+  /// <summary>
+  /// Clicking the Stop Casting row must invoke the DevicesApiService disconnect
+  /// flow — verified via the stub handler observing the POST to
+  /// /api/devices/cast/disconnect. On success the row also clears the
+  /// connected-device banner and fires the OnDisconnect EventCallback.
+  /// </summary>
+  [Fact]
+  public void StopCastingRow_Click_InvokesDisconnectAndFiresCallback()
+  {
+    var handler = new StubCastDevicesHandler();
+    var api = BuildApi(handler);
+    var device = new CastDeviceDto("device-1", "Living Room", "10.0.0.5", 8009, "Speaker");
+    var disconnectCallbackCount = 0;
+
+    var cut = RenderComponent<CastDeviceDropdown>(p => p
+      .Add(c => c.IsOpen, true)
+      .Add(c => c.DevicesApi, api)
+      .Add(c => c.ConnectedDevice, device)
+      .Add(c => c.OnDisconnect, Microsoft.AspNetCore.Components.EventCallback.Factory.Create(
+        this, () => disconnectCallbackCount++)));
+
+    cut.Find("button.cast-stop-row").Click();
+
+    // Stub handler observed the disconnect call.
+    Assert.True(handler.DisconnectCallCount >= 1,
+      "Expected DevicesApiService to POST /api/devices/cast/disconnect at least once.");
+    Assert.Equal(1, disconnectCallbackCount);
+  }
+
+  /// <summary>
+  /// While the disconnect HTTP request is pending the row must show the
+  /// loading state: label flips to "Stopping…" (with the ellipsis char,
+  /// not three dots — spec §4) and aria-busy goes to true. The stub
+  /// handler holds the disconnect response open so we can observe the
+  /// in-flight render before completion.
+  /// </summary>
+  [Fact]
+  public async Task StopCastingRow_LoadingState_ShowsStoppingLabelWhilePending()
+  {
+    var pendingTcs = new TaskCompletionSource<HttpResponseMessage>();
+    var handler = new StubCastDevicesHandler { PendingDisconnect = pendingTcs.Task };
+    var api = BuildApi(handler);
+    var device = new CastDeviceDto("device-1", "Living Room", "10.0.0.5", 8009, "Speaker");
+
+    var cut = RenderComponent<CastDeviceDropdown>(p => p
+      .Add(c => c.IsOpen, true)
+      .Add(c => c.DevicesApi, api)
+      .Add(c => c.ConnectedDevice, device));
+
+    // Click — InvokeAsync so bUnit's renderer dispatches without awaiting
+    // the disconnect call (which is parked on pendingTcs).
+    _ = cut.InvokeAsync(() => cut.Find("button.cast-stop-row").Click());
+
+    // The component sets _isDisconnecting=true then awaits the HTTP call.
+    // Wait until the row reflects the loading state.
+    cut.WaitForAssertion(() =>
+    {
+      var row = cut.Find("button.cast-stop-row");
+      Assert.Contains("Stopping", row.TextContent);
+      Assert.Equal("true", row.GetAttribute("aria-busy"));
+    });
+
+    // Release the disconnect — let the component finish.
+    pendingTcs.SetResult(new HttpResponseMessage(HttpStatusCode.OK));
+    await Task.Yield();
+  }
+
+  private static DevicesApiService BuildApi(HttpMessageHandler handler)
+  {
+    var client = new HttpClient(handler)
+    {
+      BaseAddress = new Uri("http://localhost:5000")
+    };
+    return new DevicesApiService(client, NullLogger<DevicesApiService>.Instance);
+  }
+
+  /// <summary>
+  /// Minimal stub of the Cast endpoints the dropdown calls during OnParametersSet
+  /// (GET cached + discovery) and the explicit disconnect button. Returns empty
+  /// device lists so the device list stays empty (keeps assertions on the
+  /// Stop Casting row clean) and lets tests inject a pending Task for the
+  /// disconnect call to observe the loading state.
+  /// </summary>
+  private sealed class StubCastDevicesHandler : HttpMessageHandler
+  {
+    public int DisconnectCallCount { get; private set; }
+    /// <summary>
+    /// When non-null, the disconnect response will be deferred until this
+    /// Task completes — lets a test observe mid-flight UI state.
+    /// </summary>
+    public Task<HttpResponseMessage>? PendingDisconnect { get; set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+      HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+      var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+      if (path.EndsWith("/api/devices/cast/disconnect"))
+      {
+        DisconnectCallCount++;
+        if (PendingDisconnect != null)
+        {
+          return await PendingDisconnect.WaitAsync(cancellationToken);
+        }
+        return new HttpResponseMessage(HttpStatusCode.OK);
+      }
+
+      if (path.EndsWith("/api/devices/cast/cached") || path.EndsWith("/api/devices/cast"))
+      {
+        // Empty list — no Cast devices for these tests.
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+          Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+        };
+      }
+
+      // Default: 404 — not under test, just don't blow up.
+      return new HttpResponseMessage(HttpStatusCode.NotFound);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

User feedback (2026-05-23): the only way to stop Cast was implicit (pick a local output from the Out picker, which never says the word "Cast") OR a small inline "Disconnect" Danger button tucked inside the green connected-device banner — that button read more like an X affordance on a banner than a primary action. This PR makes Stop-Casting a first-class, discoverable action with its own labelled row at the bottom of the Cast popover device list.

The row:
- Renders only when a Cast device is connected (`_connectedDevice != null`)
- Uses the `cast_off` Material icon + neutral `--text-high` label (not Danger red — disconnect is non-destructive; audio re-routes to local speakers via the `SetActiveOutputAsync` gate that landed in PR #409)
- Is a real `<button type="button">` so it lands in Tab order naturally
- Shows a `"Stopping…"` label + inline spinner while pending; dims the device list above to block a conflicting connect mid-disconnect
- Surfaces inline retry on error (`"Couldn't stop. Try again."`) with a 5s auto-revert

Backend is unchanged — the existing `DevicesController.DisconnectFromCastDevice` endpoint is already correct post-PR-#409.

## Design decision (please flag if you want it changed)

The Designer chose to **REPLACE** the existing inline "Disconnect" Danger button (lines 42–44 of `CastDeviceDropdown.razor` pre-change) with the new dedicated row — giving exactly one canonical Stop-Casting action. Reasoning: the user's feedback was about discoverability; adding a more discoverable action without removing the inline one would leave two ways to do the same thing.

**If you'd prefer to keep BOTH the inline button AND the new row, say so and I'll restore the button in a follow-up commit.**

## Spec

`docs/design-handoffs/HANDOFF-stop-casting-menu-item.md` (moved from `design/design-handoffs/` to the canonical handoffs location in the first commit).

## Files changed

- `src/Radio.Web/Components/Shared/CastDeviceDropdown.razor` — additive row + targeted deletion of the inline `Disconnect` Radzen button; new private `StopCastingAsync` wrapper around the existing disconnect call adds loading + error state handling
- `tests/Radio.Web.Tests/Components/Shared/CastDeviceDropdownTests.cs` — new file, 4 bUnit cases
- `docs/design-handoffs/HANDOFF-stop-casting-menu-item.md` — spec, moved to canonical location

## Test plan

**Automated (passing):**
- [x] `dotnet build --configuration Release` — 0 errors, 47 warnings (all pre-existing IDE0011 in unrelated files)
- [x] `dotnet test --filter "FullyQualifiedName~CastDeviceDropdown"` — 4/4 passing
- [x] Full `dotnet test` — Radio.Web.Tests 537/537 passing. Pre-existing flakes only: 4 Linux-only `SrcVariableResamplerTests` (libsamplerate native binding missing on Windows) + 1 `CoverArtPipelineIntegrationTests` (upstream 500 from coverartarchive.org).

**UAT — for you to run on return:** with audio actively playing on a Cast device:
- [ ] Open Cast popover → click "Stop Casting" → Cast stops, local soundbar resumes within ~1s, popover closes
- [ ] Re-cast, then click "Stop Casting" again → same flow, no stuck loading state
- [ ] Disconnect the Cast device's network mid-stream, open popover → click "Stop Casting" → inline error `"Couldn't stop. Try again."` appears, label auto-reverts after ~5s, retry works once network is back

This exercises the same backend path that PR #409's `SetActiveOutputAsync` + `TearDownCastOutputAsync` already validate, so the risk surface is small.

## Operator note

None — UI-only change, no config/deploy steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)