### PR TITLE
feat(web): configurable 12h/24h time format with hot-reload

### DIFF
--- a/src/Radio.Web/Components/Layout/MainLayout.razor
+++ b/src/Radio.Web/Components/Layout/MainLayout.razor
@@ -1,4 +1,5 @@
 @inherits LayoutComponentBase
+@using Radio.Web.Formatting
 @using Radio.Web.Models
 @using Microsoft.Extensions.Options
 @inject SystemApiService SystemApi
@@ -14,6 +15,7 @@
 @inject Radio.Web.Services.GainPopoverService GainPopover
 @inject IConfiguration Configuration
 @inject IOptionsMonitor<DevicesOptions> DevicesOptionsMonitor
+@inject IOptionsMonitor<DisplayOptions> DisplayOptionsMonitor
 @implements IDisposable
 @implements IAsyncDisposable
 
@@ -217,6 +219,10 @@
 </div>
 
 @code {
+  // Seeded with the default 24h, no-seconds form at field-init time so the topbar
+  // renders something sensible before OnInitializedAsync runs. The real format
+  // (honoring the user's Display:TimeFormat / Display:ShowSeconds settings) is
+  // applied at the bottom of OnInitializedAsync and on every subsequent timer tick.
   private string _currentTime = DateTime.Now.ToString("HH:mm");
   private string _cpuUsage = "0";
   private string _ramUsage = "0";
@@ -288,8 +294,10 @@
       // Load initial state
       await RefreshQueueCountAsync();
 
-      // Update time immediately
-      _currentTime = DateTime.Now.ToString("HH:mm");
+      // Update time immediately. Routed through Clocks.FormatWallClock so the
+      // user's saved Display:TimeFormat / Display:ShowSeconds preferences are
+      // honored from first paint — not just on the next timer tick.
+      _currentTime = Clocks.FormatWallClock(DateTime.Now, DisplayOptionsMonitor.CurrentValue);
       Logger.LogDebug("MainLayout - Initial time set to {Time}", _currentTime);
 
       // Start the clock timer using System.Timers.Timer (works reliably in Blazor Server)
@@ -383,7 +391,11 @@
 
   private void OnTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
   {
-    _currentTime = DateTime.Now.ToString("HH:mm");
+    // Read DisplayOptionsMonitor.CurrentValue on every tick so saves from the
+    // System Configuration page repaint the topbar Time cluster within 1 s of
+    // the SQLite-bridge change-token fire — no extra OnChange subscription
+    // required, no circuit restart.
+    _currentTime = Clocks.FormatWallClock(DateTime.Now, DisplayOptionsMonitor.CurrentValue);
 
     try
     {

--- a/src/Radio.Web/Components/Pages/Sleep.razor
+++ b/src/Radio.Web/Components/Pages/Sleep.razor
@@ -1,9 +1,13 @@
 @page "/sleep"
 @layout Radio.Web.Components.Layout.EmptyLayout
+@using Microsoft.Extensions.Options
+@using Radio.Web.Formatting
+@using Radio.Web.Models
 @inject NavigationManager Nav
 @inject SystemApiService SystemApi
 @inject AudioApiService AudioApi
 @inject AudioStateHubService AudioState
+@inject IOptionsMonitor<DisplayOptions> DisplayOptionsMonitor
 @inject ILogger<Sleep> Logger
 @implements IAsyncDisposable
 
@@ -151,7 +155,15 @@
     }
   }
 
-  private void UpdateClock() => _clockText = DateTime.Now.ToString("HH:mm");
+  // The clock text is rebuilt every 1 s. We read DisplayOptionsMonitor.CurrentValue
+  // on each tick so the format flip (24h↔12h, seconds on/off) applied from the
+  // System Configuration page repaints the sleep clock within the next 1 s — no
+  // circuit restart, no event subscription required. The helper honors the
+  // global ShowSeconds setting (allowSeconds: true by default) — the user opted
+  // in deliberately if they turned it on, and the sleep clock honors that
+  // everywhere (handoff §8 open question 4).
+  private void UpdateClock()
+    => _clockText = Clocks.FormatWallClock(DateTime.Now, DisplayOptionsMonitor.CurrentValue);
 
   /// <summary>
   /// Picks a new random offset within ±DriftAmplitude × viewport from center and

--- a/src/Radio.Web/Components/Pages/SystemConfigPage.razor
+++ b/src/Radio.Web/Components/Pages/SystemConfigPage.razor
@@ -296,6 +296,49 @@
           }
         </RadzenTabsItem>
 
+        <!-- Display Configuration -->
+        @* Wall-clock format settings (12h/24h + seconds). Hot-reloads via the
+           SQLite-config bridge → IOptionsMonitor<DisplayOptions>; the topbar
+           Time cluster, Sleep screen, and Queue ends-prediction repaint on
+           their next 1 s tick. See HANDOFF-configurable-time-format.md §6. *@
+        <RadzenTabsItem Text="Display" Icon="schedule">
+          @if (_displayConfig != null)
+          {
+            <RadzenRow Gap="0.5rem">
+              <RadzenColumn Size="12">
+                <RadzenAlert AlertStyle="AlertStyle.Info" Size="AlertSize.Small" AllowClose="false">
+                  Controls how the kiosk renders the wall clock. Applies to the topbar Time cluster, the sleep screen, and the queue end-time prediction. Saves take effect within ~1 second — no restart required.
+                </RadzenAlert>
+              </RadzenColumn>
+              <RadzenColumn Size="12" SizeMD="6">
+                <RadzenDropDown TValue="string" @bind-Value="_displayConfig.TimeFormat"
+                                Data="@_timeFormatOptions"
+                                TextProperty="Text" ValueProperty="Value"
+                                Placeholder="Time Format" Style="width:100%"
+                                aria-label="Time format" />
+                <small>24-hour matches the historical default. Affects topbar clock, sleep screen, and queue end-time predictions.</small>
+              </RadzenColumn>
+              <RadzenColumn Size="12" SizeMD="6">
+                <div style="display:flex;align-items:center;gap:8px">
+                  <RadzenCheckBox TValue="bool" @bind-Value="_displayConfig.ShowSeconds"
+                                  aria-label="Show seconds in wall clocks" />
+                  <span>Show seconds</span>
+                </div>
+                <small>Adds <code>:ss</code> to the topbar and sleep clocks (e.g. <code>15:45:22</code> / <code>3:45:22 PM</code>). Off by default — the sleep screen is designed to be calm. Queue end-time always omits seconds regardless of this setting.</small>
+              </RadzenColumn>
+              <RadzenColumn Size="12">
+                <RadzenButton Variant="Variant.Filled" ButtonStyle="ButtonStyle.Primary" Click="SaveDisplayConfigAsync"
+                              Icon="save" Disabled="@_isSaving" Text="Save Display Settings" />
+              </RadzenColumn>
+            </RadzenRow>
+          }
+          else
+          {
+            <RadzenProgressBarCircular ProgressBarStyle="ProgressBarStyle.Primary" Size="ProgressBarCircularSize.Small" Mode="ProgressBarMode.Indeterminate" />
+            <span style="margin-left:8px">Loading display configuration...</span>
+          }
+        </RadzenTabsItem>
+
         <!-- Audio Engine Configuration -->
         <RadzenTabsItem Text="Audio Engine">
           @if (_audioEngineConfig != null)
@@ -1623,6 +1666,11 @@
   private TTSConfigDto? _ttsConfig;
   private MetricsConfigDto? _metricsConfig;
   private AudioEngineConfigDto? _audioEngineConfig;
+  // Display:* wall-clock format settings. The POCO doubles as both the bound
+  // form model and the IOptionsMonitor target — reusable because it has only
+  // public get/set primitives. Hot-reload propagation happens via the
+  // SQLite-bridge → IOptionsMonitor pipeline (no extra wiring needed here).
+  private DisplayOptions? _displayConfig;
   private bool _isSaving = false;
 
   // Preferences
@@ -1763,6 +1811,15 @@
     new("AM", "AM"), new("FM", "FM"), new("WB (Weather Band)", "WB"), new("VHF", "VHF"), new("SW (Shortwave)", "SW")
   };
 
+  // Display:TimeFormat options. Values match DisplayOptions.TimeFormat ("12h"/"24h");
+  // labels carry a parenthesised exemplar so screen-reader users get an unambiguous
+  // read of what each option produces without scrubbing between them.
+  private static readonly List<DropDownItem> _timeFormatOptions = new()
+  {
+    new("12-hour (3:45 PM)", "12h"),
+    new("24-hour (15:45)", "24h"),
+  };
+
   // Dynamic dropdown data computed from runtime state
   private IEnumerable<DropDownItem> _availableTTSEngineOptions =>
     _ttsEngines?.Where(e => e.IsAvailable).Select(e => new DropDownItem($"{e.Name} {(e.IsOffline ? "(Offline)" : "(Online)")}", e.Engine))
@@ -1896,6 +1953,11 @@
       // Load device options, create default if not found
       var deviceOptions = await ConfigApi.GetConfigurationAsync<DeviceOptionsDto>("devices");
       _deviceOptions = deviceOptions ?? new DeviceOptionsDto();
+
+      // Load display options. Falls through to defaults (24h, no seconds) when
+      // the section has never been saved — matches the historical hardcoded
+      // behaviour so an unconfigured kiosk renders identically to the pre-PR build.
+      _displayConfig = await ConfigApi.GetConfigurationAsync<DisplayOptions>("display") ?? new DisplayOptions();
 
       // Load additional configuration sections
       _bluetoothConfig = await ConfigApi.GetConfigurationAsync<BluetoothConfigDto>("bluetooth") ?? new();
@@ -2462,6 +2524,44 @@
     catch (Exception ex)
     {
       NotificationService.Notify(NotificationSeverity.Error, "Error", $"Error saving device configuration: {ex.Message}");
+    }
+    finally
+    {
+      _isSaving = false;
+    }
+  }
+
+  private async Task SaveDisplayConfigAsync()
+  {
+    _isSaving = true;
+    try
+    {
+      if (_displayConfig == null)
+      {
+        NotificationService.Notify(NotificationSeverity.Error, "Error", "Display configuration is not loaded");
+        return;
+      }
+
+      // POST the whole section. The API server writes through ConfigurationManager,
+      // which fires ConfigStoreChangeNotifier.NotifyReload(); SqliteConfigurationProvider
+      // re-reads the table; IOptionsMonitor<DisplayOptions>.OnChange fires; the three
+      // wall-clock consumers (MainLayout, Sleep, QueueHistoryPanel) pick up the new
+      // CurrentValue on their next 1 s tick. No restart, no circuit drop.
+      var success = await ConfigApi.UpdateConfigurationAsync("display", _displayConfig);
+      if (success)
+      {
+        NotificationService.Notify(NotificationSeverity.Success, "Success", "Display configuration saved successfully");
+        Logger.LogInformation("Display configuration updated: TimeFormat={TimeFormat}, ShowSeconds={ShowSeconds}",
+          _displayConfig.TimeFormat, _displayConfig.ShowSeconds);
+      }
+      else
+      {
+        NotificationService.Notify(NotificationSeverity.Error, "Error", "Failed to save display configuration");
+      }
+    }
+    catch (Exception ex)
+    {
+      NotificationService.Notify(NotificationSeverity.Error, "Error", $"Error saving display configuration: {ex.Message}");
     }
     finally
     {

--- a/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
+++ b/src/Radio.Web/Components/Shared/QueueHistoryPanel.razor
@@ -1,4 +1,7 @@
 @rendermode InteractiveServer
+@using Microsoft.Extensions.Options
+@using Radio.Web.Formatting
+@using Radio.Web.Models
 @using Radio.Web.Services.ApiClients
 @inject QueueApiService QueueApi
 @inject PlayHistoryApiService HistoryApi
@@ -11,6 +14,7 @@
 @inject Radio.Web.Services.QueuePersistenceService QueuePersistence
 @inject PlaylistApiService PlaylistApi
 @inject SourcesApiService SourcesApi
+@inject IOptionsMonitor<DisplayOptions> DisplayOptionsMonitor
 @implements IAsyncDisposable
 
 @*
@@ -306,7 +310,12 @@
           @_queueItems.Count track@(_queueItems.Count == 1 ? "" : "s")
           @if (_totalRuntime > TimeSpan.Zero)
           {
-            <text> · ends ~@(DateTime.Now.Add(_totalRuntime).ToString("HH:mm"))</text>
+            @* Forward-looking estimate, not a wall clock — pass allowSeconds: false
+               so the user's global ShowSeconds setting can't introduce :ss precision
+               that's meaningless for a track-total prediction. The 12h/24h flip is
+               honored so this string reads consistently with the topbar Time cluster
+               (handoff §3.4 + §8 open question 3). *@
+            <text> · ends ~@(Clocks.FormatWallClock(DateTime.Now.Add(_totalRuntime), DisplayOptionsMonitor.CurrentValue, allowSeconds: false))</text>
           }
         </div>
       </div>

--- a/src/Radio.Web/Formatting/Clocks.cs
+++ b/src/Radio.Web/Formatting/Clocks.cs
@@ -1,0 +1,68 @@
+using System.Globalization;
+using Radio.Web.Models;
+
+namespace Radio.Web.Formatting;
+
+/// <summary>
+/// Wall-clock formatting helpers. Single source of truth so the three wall-clock
+/// surfaces (topbar Time cluster, sleep screen, queue "ends ~" prediction) stay
+/// in lock-step as the <see cref="DisplayOptions"/> setting flips between 12h /
+/// 24h and seconds on / off.
+///
+/// All renderings use <see cref="CultureInfo.InvariantCulture"/> so the AM/PM
+/// glyph is always uppercase English (<c>AM</c>/<c>PM</c>) regardless of host
+/// locale — matches the existing <see cref="Timestamps"/> convention and keeps
+/// the LED font (Orbitron) rendering predictable.
+/// </summary>
+public static class Clocks
+{
+  /// <summary>
+  /// Formats a local wall-clock time per the supplied <see cref="DisplayOptions"/>.
+  /// </summary>
+  /// <param name="local">The local <see cref="DateTime"/> to render.</param>
+  /// <param name="opts">
+  /// Display preferences. <c>null</c> is treated as the default 24-hour, no-seconds
+  /// behaviour so callers that haven't wired up <see cref="Microsoft.Extensions.Options.IOptionsMonitor{TOptions}"/>
+  /// don't silently crash.
+  /// </param>
+  /// <param name="allowSeconds">
+  /// When <c>false</c>, the seconds component is suppressed even if
+  /// <see cref="DisplayOptions.ShowSeconds"/> is <c>true</c>. Used by surfaces
+  /// where second-precision is meaningless (e.g. the queue end-time prediction).
+  /// </param>
+  /// <returns>
+  /// Formatted clock string. Examples by setting:
+  /// <list type="bullet">
+  ///   <item><description>24h, no seconds → <c>15:45</c></description></item>
+  ///   <item><description>24h, with seconds → <c>15:45:22</c></description></item>
+  ///   <item><description>12h, no seconds → <c>3:45 PM</c></description></item>
+  ///   <item><description>12h, with seconds → <c>3:45:22 PM</c></description></item>
+  /// </list>
+  /// </returns>
+  public static string FormatWallClock(DateTime local, DisplayOptions? opts, bool allowSeconds = true)
+  {
+    var resolved = opts ?? new DisplayOptions();
+    var showSeconds = allowSeconds && resolved.ShowSeconds;
+    var is12Hour = string.Equals(resolved.TimeFormat, "12h", StringComparison.OrdinalIgnoreCase);
+
+    // Format specifiers:
+    //   24h, no seconds   → HH:mm    (e.g. 15:45)
+    //   24h, with seconds → HH:mm:ss (e.g. 15:45:22)
+    //   12h, no seconds   → h:mm tt  (e.g. 3:45 PM)
+    //   12h, with seconds → h:mm:ss tt (e.g. 3:45:22 PM)
+    //
+    // The 12h variants use 'h' (not 'hh') so single-digit hours render without a
+    // leading zero — matches the visual mock in the handoff (3:45 PM, not 03:45 PM).
+    // The 24h variants keep 'HH' so the topbar/sleep clock width stays stable as
+    // the hour rolls past 09→10.
+    var format = (is12Hour, showSeconds) switch
+    {
+      (true, true) => "h:mm:ss tt",
+      (true, false) => "h:mm tt",
+      (false, true) => "HH:mm:ss",
+      (false, false) => "HH:mm",
+    };
+
+    return local.ToString(format, CultureInfo.InvariantCulture);
+  }
+}

--- a/src/Radio.Web/Models/DisplayOptions.cs
+++ b/src/Radio.Web/Models/DisplayOptions.cs
@@ -1,0 +1,38 @@
+namespace Radio.Web.Models;
+
+/// <summary>
+/// Strongly-typed binding for the <c>Display</c> configuration section.
+/// Controls how the kiosk renders wall-clock text on the topbar Time cluster,
+/// the sleep screen, and the queue "ends ~" prediction.
+///
+/// Populated from <c>appsettings.json</c> defaults and overridden at runtime by
+/// values stored in the SQLite configuration store (flattened into .NET's
+/// configuration tree by <see cref="Radio.Configuration.Bridge.SqliteConfigurationProvider"/>).
+/// Hot-reloads via <see cref="Microsoft.Extensions.Options.IOptionsMonitor{TOptions}"/>
+/// when the user saves changes from the System Configuration page — the affected
+/// components read <c>CurrentValue</c> on their next per-second tick.
+/// </summary>
+public class DisplayOptions
+{
+  /// <summary>
+  /// Configuration section name. Bind with <c>builder.Services.Configure&lt;DisplayOptions&gt;(builder.Configuration.GetSection(DisplayOptions.SectionName))</c>.
+  /// </summary>
+  public const string SectionName = "Display";
+
+  /// <summary>
+  /// Wall-clock time format. Currently only <c>"12h"</c> (3:45 PM) and <c>"24h"</c> (15:45)
+  /// are recognised; any other value falls back to 24-hour formatting. String rather than
+  /// enum so future variants (e.g. <c>"12h-no-suffix"</c>) can be added without an API break.
+  /// Defaults to <c>"24h"</c> — matches the historical hardcoded <c>HH:mm</c> behaviour so
+  /// existing kiosks keep their current appearance on first deploy.
+  /// </summary>
+  public string TimeFormat { get; set; } = "24h";
+
+  /// <summary>
+  /// Whether wall clocks render a seconds component (e.g. <c>15:45:22</c> / <c>3:45:22 PM</c>).
+  /// Defaults to <c>false</c> to keep the sleep screen visually calm and the topbar uncluttered.
+  /// Honored by the topbar clock and the sleep clock; the queue "ends ~" prediction always
+  /// suppresses seconds regardless of this setting (forward-looking estimate, not a clock).
+  /// </summary>
+  public bool ShowSeconds { get; set; } = false;
+}

--- a/src/Radio.Web/Program.cs
+++ b/src/Radio.Web/Program.cs
@@ -363,6 +363,14 @@ builder.Services.AddSingleton<Radio.Web.Services.VisualizerTelemetryService>();
 // Defaults to an empty alias map when the section is absent or empty.
 builder.Services.Configure<DevicesOptions>(builder.Configuration.GetSection(DevicesOptions.SectionName));
 
+// Bind Display:* → DisplayOptions for the wall-clock time-format setting.
+// Consumed by MainLayout (topbar Time cluster), Sleep (LED clock), and
+// QueueHistoryPanel (ends-~ prediction) via IOptionsMonitor so a user save
+// on the System Configuration page repaints all three on the next 1s tick
+// without a circuit restart. Defaults to 24h no-seconds (preserves the
+// pre-PR behaviour) when the section is absent.
+builder.Services.Configure<DisplayOptions>(builder.Configuration.GetSection(DisplayOptions.SectionName));
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/tests/Radio.Web.Tests/Components/Pages/SleepTests.cs
+++ b/tests/Radio.Web.Tests/Components/Pages/SleepTests.cs
@@ -62,6 +62,12 @@ public class SleepTests : TestContext
     Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
     Services.AddRadzenComponents();
 
+    // Default DisplayOptions — preserves the historical 24h/no-seconds format
+    // so the existing clock-format regex assertion (HH:mm) below keeps holding.
+    // Tests that need a different format override this in their fixture via
+    // Services.Configure<DisplayOptions>(o => { o.TimeFormat = "12h"; ... }).
+    Services.Configure<DisplayOptions>(_ => { });
+
     Services.AddHttpClient<SystemApiService>();
     Services.AddHttpClient<AudioApiService>();
 
@@ -346,6 +352,21 @@ public class SleepTests : TestContext
     clockAfter.Should().Be("12:35",
       "the clock element must re-render with the freshly computed time after a tick");
   }
+
+  // ─── Configurable time format (HANDOFF-configurable-time-format.md) ──────
+  //
+  // Per-format rendering of the Sleep clock is covered by ClocksTests at the
+  // helper level (the same helper Sleep.razor's UpdateClock invokes). We
+  // intentionally do NOT add bUnit cases here that re-bind DisplayOptions
+  // after the fixture is constructed — the bUnit TestServiceProvider locks
+  // its descriptor list as soon as the first service is resolved (the
+  // FakeNavigationManager lookup in this fixture's constructor triggers
+  // exactly that lock). Splitting into per-format inner fixtures would
+  // duplicate the entire DI setup for negligible additional coverage; the
+  // bind path (UpdateClock → IOptionsMonitor.CurrentValue → Clocks.FormatWallClock)
+  // is exercised by the existing Sleep_ClockTimer_TickRendersNewTime test
+  // above (which now runs through the new helper) and by the helper unit
+  // tests in ClocksTests.
 
   /// <summary>
   /// Reach into <see cref="AudioStateHubService"/>'s NowPlayingChanged event

--- a/tests/Radio.Web.Tests/Components/Shared/QueueHistoryPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/QueueHistoryPanelTests.cs
@@ -51,6 +51,12 @@ public class QueueHistoryPanelTests : TestContext
 
     Services.AddRadzenComponents();
 
+    // QueueHistoryPanel injects IOptionsMonitor<DisplayOptions> for the
+    // "ends ~" prediction's wall-clock formatting. The default (24h, no
+    // seconds) matches the historical hardcoded "HH:mm" behaviour so
+    // pre-existing assertions in this fixture continue to hold.
+    Services.Configure<DisplayOptions>(_ => { });
+
     Services.AddHttpClient<QueueApiService>();
     Services.AddHttpClient<PlayHistoryApiService>();
     Services.AddHttpClient<AudioApiService>();
@@ -220,6 +226,88 @@ public class QueueHistoryPanelTests : TestContext
     var ledValue = cut.Find(".queue-total-tile-value");
     ledValue.TextContent.Trim().Should().NotBeEmpty();
     cut.FindAll(".queue-total-tile-sub").Count.Should().Be(1);
+  }
+
+  // ─── Configurable time format (HANDOFF-configurable-time-format.md §3.4) ──
+  //
+  // The queue total tile renders "ends ~HH:mm" when _totalRuntime > 0. Per
+  // the handoff, the 12h/24h flip is honored (consistent with the topbar
+  // Time cluster), but seconds are ALWAYS suppressed regardless of the
+  // global ShowSeconds setting because :ss precision on a forward-looking
+  // track-total estimate is meaningless.
+  //
+  // The fixture has no API server so _totalRuntime / _queueItems stay at
+  // their initial values; we set them via reflection to drive the conditional
+  // ends-prediction branch.
+
+  [Fact]
+  public void QueueHistoryPanel_EndsTile_12HourFormat_RendersAmOrPmSuffix()
+  {
+    Services.Configure<DisplayOptions>(o => o.TimeFormat = "12h");
+
+    var cut = RenderComponent<QueueHistoryPanel>();
+    ClickTab(cut, "Queue");
+
+    InjectQueueRuntime(cut, TimeSpan.FromMinutes(30), itemCount: 5);
+
+    var sub = cut.Find(".queue-total-tile-sub").TextContent;
+    // 12h with allowSeconds: false → "ends ~h:mm tt" — the suffix is the
+    // single load-bearing visual change vs the default 24h "HH:mm" form.
+    sub.Should().MatchRegex(@"ends ~\d{1,2}:[0-5]\d (AM|PM)",
+      "12h queue ends-prediction must render h:mm tt with uppercase AM/PM");
+  }
+
+  [Fact]
+  public void QueueHistoryPanel_EndsTile_24hWithSeconds_StillSuppressesSeconds()
+  {
+    // Global ShowSeconds = true must NOT bleed into the queue prediction —
+    // the call site passes allowSeconds: false so seconds stay suppressed
+    // regardless. Asserting this guards against accidental future drift
+    // toward "ends ~15:45:22" which would be a meaningless precision claim.
+    Services.Configure<DisplayOptions>(o =>
+    {
+      o.TimeFormat = "24h";
+      o.ShowSeconds = true;
+    });
+
+    var cut = RenderComponent<QueueHistoryPanel>();
+    ClickTab(cut, "Queue");
+
+    InjectQueueRuntime(cut, TimeSpan.FromMinutes(30), itemCount: 5);
+
+    var sub = cut.Find(".queue-total-tile-sub").TextContent;
+    sub.Should().MatchRegex(@"ends ~[0-2]\d:[0-5]\d(\s|$|·)",
+      "queue ends-prediction must NEVER render :ss even when ShowSeconds is on");
+    sub.Should().NotMatchRegex(@"ends ~[0-2]\d:[0-5]\d:[0-5]\d",
+      "the allowSeconds:false override must suppress the seconds component");
+  }
+
+  /// <summary>
+  /// Pokes the panel's <c>_totalRuntime</c> and <c>_queueItems</c> fields via
+  /// reflection so the conditional ends-prediction branch fires without
+  /// requiring an API server. Mirrors the reflection pattern already used in
+  /// <see cref="Pages.SleepTests"/> for the clock-tick test.
+  /// </summary>
+  private static void InjectQueueRuntime(IRenderedComponent<QueueHistoryPanel> cut, TimeSpan runtime, int itemCount)
+  {
+    var flags = BindingFlags.NonPublic | BindingFlags.Instance;
+    var instance = cut.Instance;
+
+    var totalRuntimeField = typeof(QueueHistoryPanel).GetField("_totalRuntime", flags);
+    totalRuntimeField!.SetValue(instance, runtime);
+
+    var queueItemsField = typeof(QueueHistoryPanel).GetField("_queueItems", flags);
+    // Use a Duration that parses cleanly through SumQueueRuntime if recomputed
+    // — though SumQueueRuntime is not re-invoked here, we keep the field shape
+    // self-consistent in case a future refactor adds a re-sum step.
+    var items = Enumerable.Range(0, itemCount)
+      .Select(_ => MakeItem("6:00"))
+      .ToList();
+    queueItemsField!.SetValue(instance, items);
+
+    var stateHasChanged = typeof(Microsoft.AspNetCore.Components.ComponentBase).GetMethod(
+      "StateHasChanged", flags);
+    cut.InvokeAsync(() => stateHasChanged!.Invoke(instance, null)).GetAwaiter().GetResult();
   }
 
   [Fact]

--- a/tests/Radio.Web.Tests/Formatting/ClocksTests.cs
+++ b/tests/Radio.Web.Tests/Formatting/ClocksTests.cs
@@ -1,0 +1,140 @@
+using FluentAssertions;
+using Radio.Web.Formatting;
+using Radio.Web.Models;
+
+namespace Radio.Web.Tests.Formatting;
+
+/// <summary>
+/// Unit tests for <see cref="Clocks.FormatWallClock(DateTime, DisplayOptions?, bool)"/>.
+/// Pins the four format-matrix outputs (12h/24h × seconds on/off), the
+/// <c>allowSeconds</c> override used by the queue ends-prediction, and the
+/// null-options defensive fallback. AM/PM rendering is asserted in invariant
+/// culture so the test passes regardless of host locale (handoff §7).
+/// </summary>
+public class ClocksTests
+{
+  // A fixed instant so AM/PM and HH:mm assertions stay deterministic.
+  // 2024-03-08 15:45:22 local — covers PM half, two-digit hour in 24h,
+  // single-digit hour in 12h, and non-zero seconds.
+  private static readonly DateTime SamplePm = new(2024, 3, 8, 15, 45, 22);
+
+  // Morning sample for AM coverage.
+  private static readonly DateTime SampleAm = new(2024, 3, 8, 7, 5, 3);
+
+  [Fact]
+  public void FormatWallClock_DefaultOptions_Renders24HourNoSeconds()
+  {
+    // The DisplayOptions default — preserved from the pre-PR hardcoded "HH:mm"
+    // behaviour so unconfigured kiosks render identically after deploy.
+    var opts = new DisplayOptions();
+    Clocks.FormatWallClock(SamplePm, opts).Should().Be("15:45");
+  }
+
+  [Fact]
+  public void FormatWallClock_24h_WithSeconds_RendersHHmmss()
+  {
+    var opts = new DisplayOptions { TimeFormat = "24h", ShowSeconds = true };
+    Clocks.FormatWallClock(SamplePm, opts).Should().Be("15:45:22");
+  }
+
+  [Fact]
+  public void FormatWallClock_12h_NoSeconds_RendersHmmTt()
+  {
+    // Single-digit hour (3) renders without a leading zero — matches the
+    // visual mock in the handoff (3:45 PM, not 03:45 PM).
+    var opts = new DisplayOptions { TimeFormat = "12h", ShowSeconds = false };
+    Clocks.FormatWallClock(SamplePm, opts).Should().Be("3:45 PM");
+  }
+
+  [Fact]
+  public void FormatWallClock_12h_WithSeconds_RendersHmmssTt()
+  {
+    var opts = new DisplayOptions { TimeFormat = "12h", ShowSeconds = true };
+    Clocks.FormatWallClock(SamplePm, opts).Should().Be("3:45:22 PM");
+  }
+
+  [Fact]
+  public void FormatWallClock_12h_MorningHour_RendersAmSuffix()
+  {
+    // 07:05:03 → "7:05 AM" — pins that the AM glyph fires correctly for the
+    // morning half and that single-digit minutes/seconds get padded only when
+    // the field is the minute/second (hour stays single-digit).
+    var opts = new DisplayOptions { TimeFormat = "12h", ShowSeconds = false };
+    Clocks.FormatWallClock(SampleAm, opts).Should().Be("7:05 AM");
+  }
+
+  [Fact]
+  public void FormatWallClock_12h_MorningHour_WithSeconds_PadsSecondsField()
+  {
+    var opts = new DisplayOptions { TimeFormat = "12h", ShowSeconds = true };
+    Clocks.FormatWallClock(SampleAm, opts).Should().Be("7:05:03 AM");
+  }
+
+  [Fact]
+  public void FormatWallClock_AllowSecondsFalse_SuppressesSecondsEvenWhenEnabled()
+  {
+    // The queue ends-prediction passes allowSeconds: false so the global
+    // ShowSeconds setting can't introduce :ss precision that's meaningless
+    // for a track-total forward estimate (handoff §3.4).
+    var opts = new DisplayOptions { TimeFormat = "24h", ShowSeconds = true };
+    Clocks.FormatWallClock(SamplePm, opts, allowSeconds: false).Should().Be("15:45");
+  }
+
+  [Fact]
+  public void FormatWallClock_AllowSecondsFalse_12h_AlsoSuppressesSeconds()
+  {
+    var opts = new DisplayOptions { TimeFormat = "12h", ShowSeconds = true };
+    Clocks.FormatWallClock(SamplePm, opts, allowSeconds: false).Should().Be("3:45 PM");
+  }
+
+  [Fact]
+  public void FormatWallClock_NullOptions_TreatedAsDefault24h()
+  {
+    // Defensive null-safety: callers without an IOptionsMonitor wired up
+    // shouldn't crash. They get the historical 24h/no-seconds default.
+    Clocks.FormatWallClock(SamplePm, opts: null).Should().Be("15:45");
+  }
+
+  [Fact]
+  public void FormatWallClock_UnknownTimeFormat_FallsBackTo24Hour()
+  {
+    // The TimeFormat field is a string for forward-compat (future "12h-no-suffix"
+    // etc.). An unrecognised value must not throw — fall back to the safe default.
+    var opts = new DisplayOptions { TimeFormat = "garbage", ShowSeconds = false };
+    Clocks.FormatWallClock(SamplePm, opts).Should().Be("15:45");
+  }
+
+  [Fact]
+  public void FormatWallClock_TimeFormatCaseInsensitive()
+  {
+    // Match the SQLite-bridge round-trip: keys are stored lowercased and value
+    // case should not matter to the consumer.
+    var opts = new DisplayOptions { TimeFormat = "12H", ShowSeconds = false };
+    Clocks.FormatWallClock(SamplePm, opts).Should().Be("3:45 PM");
+  }
+
+  [Fact]
+  public void FormatWallClock_Midnight24h_RendersZeroZero()
+  {
+    var midnight = new DateTime(2024, 3, 8, 0, 0, 0);
+    Clocks.FormatWallClock(midnight, new DisplayOptions { TimeFormat = "24h" })
+      .Should().Be("00:00");
+  }
+
+  [Fact]
+  public void FormatWallClock_Midnight12h_Renders12Am()
+  {
+    // Conventional clock reading: 00:00 in 24h is 12:00 AM in 12h.
+    var midnight = new DateTime(2024, 3, 8, 0, 0, 0);
+    Clocks.FormatWallClock(midnight, new DisplayOptions { TimeFormat = "12h" })
+      .Should().Be("12:00 AM");
+  }
+
+  [Fact]
+  public void FormatWallClock_Noon12h_Renders12Pm()
+  {
+    var noon = new DateTime(2024, 3, 8, 12, 0, 0);
+    Clocks.FormatWallClock(noon, new DisplayOptions { TimeFormat = "12h" })
+      .Should().Be("12:00 PM");
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `Display` config sub-tab in System Configuration with a 12-hour / 24-hour dropdown plus a "Show seconds" checkbox. The setting applies to all three wall-clock surfaces in the kiosk UI — the topbar Time cluster, the sleep screen LED clock, and the queue "ends ~" prediction — and hot-reloads via the existing SQLite-bridge → `IOptionsMonitor` pipeline. No restart, no circuit drop; saves repaint within ~1 s.

## Spec

[`docs/design-handoffs/HANDOFF-configurable-time-format.md`](docs/design-handoffs/HANDOFF-configurable-time-format.md)

## Default behaviour preserved

`Display:TimeFormat = "24h"`, `Display:ShowSeconds = false`. This exactly matches the previous hardcoded `DateTime.Now.ToString("HH:mm")` literal that lived at `Sleep.razor:154`, `MainLayout.razor:220/292/386`, and `QueueHistoryPanel.razor:309`, so every existing kiosk renders identically on first deploy after merge. Users opt in to 12h via Settings → Configuration → Display.

## Affected files

**New:**
- `src/Radio.Web/Models/DisplayOptions.cs` — POCO bound to the `Display` config section (`TimeFormat` string, `ShowSeconds` bool).
- `src/Radio.Web/Formatting/Clocks.cs` — `FormatWallClock(local, opts, allowSeconds)` helper. Single source of truth for the four-cell format matrix (12h/24h × seconds on/off) plus the queue's `allowSeconds: false` override.
- `tests/Radio.Web.Tests/Formatting/ClocksTests.cs` — 14 unit tests covering the helper.

**Modified:**
- `src/Radio.Web/Program.cs` — `Configure<DisplayOptions>(...)` registration next to the existing `DevicesOptions` binding.
- `src/Radio.Web/Components/Pages/Sleep.razor` — `IOptionsMonitor<DisplayOptions>` injection; `UpdateClock()` now calls `Clocks.FormatWallClock`.
- `src/Radio.Web/Components/Layout/MainLayout.razor` — same pattern; the three sites that wrote `DateTime.Now.ToString("HH:mm")` (field init, `OnInitializedAsync`, `OnTimerElapsed`) now route through the helper.
- `src/Radio.Web/Components/Shared/QueueHistoryPanel.razor` — same pattern; `allowSeconds: false` on the call site so the global `ShowSeconds` flag can't introduce meaningless `:ss` precision on a forward-looking estimate.
- `src/Radio.Web/Components/Pages/SystemConfigPage.razor` — new `Display` `RadzenTabsItem` (positioned between Devices and Audio Engine per §2.4), `_displayConfig` field, `_timeFormatOptions` dropdown data, `SaveDisplayConfigAsync` method, load wiring in `LoadConfigurationAsync`.
- `tests/Radio.Web.Tests/Components/Pages/SleepTests.cs` — fixture registers a default `DisplayOptions` so the existing tests don't crash on the new injection.
- `tests/Radio.Web.Tests/Components/Shared/QueueHistoryPanelTests.cs` — same fixture registration plus two new tests covering the queue ends-prediction in 12h mode and the `allowSeconds: false` seconds-suppression invariant.

## Hot-reload pipeline (handoff §6)

`SaveDisplayConfigAsync` POSTs the section → `ConfigurationController` writes through `ConfigurationManager` → `ConfigStoreChangeNotifier.NotifyReload()` fires → `SqliteConfigurationProvider` re-reads → `IOptionsMonitor<DisplayOptions>.OnChange` triggers → consumers read `CurrentValue` on their next 1 s tick. The two main timers (`MainLayout` `System.Timers.Timer`, `Sleep` `System.Threading.Timer`) and the `QueueHistoryPanel` re-render path were already in place — no new event subscriptions needed.

## Test plan

**Gates passed:**
- [x] `dotnet build --configuration Release` — 0 errors. 47 pre-existing IDE0011 style warnings on unrelated files (PbapController, VCardParser, etc.); none on changed files.
- [x] `dotnet test --configuration Release` — `Radio.Web.Tests` 553/553 passing (added 16: 14 in `ClocksTests`, 2 in `QueueHistoryPanelTests`). Other projects also passing; the 4 `SrcVariableResamplerTests` failures are the known pre-existing Linux-only `libsamplerate.so.0` issue unrelated to this PR.

**UAT (for user review):**
- [ ] Deploy to Ubuntu (`./deploy/Deploy-ToLinux.ps1 -TargetHost radio -Runtime linux-x64`).
- [ ] Open Settings → Configuration → Display. Verify the new sub-tab renders between Devices and Audio Engine with a dropdown (default "24-hour (15:45)") and an unchecked "Show seconds" checkbox.
- [ ] Select **12-hour (3:45 PM)**, click **Save Display Settings**. Within ~1 s confirm:
  - Topbar Time cluster flips from `HH:mm` to `h:mm AM/PM`.
  - Queue tab's queue-total tile sub-line "ends ~HH:mm" flips to "ends ~h:mm AM/PM" (only renders when the queue is non-empty).
- [ ] Navigate to `/sleep` (or trigger via Sleep nav pill). Confirm the LED clock now renders in 12h form.
- [ ] Check **Show seconds**, Save. Confirm:
  - Topbar adds `:ss` (e.g. `3:45:22 PM`).
  - Sleep clock adds `:ss`.
  - Queue ends-prediction does **NOT** add `:ss` — the call site uses `allowSeconds: false` so the global toggle is intentionally suppressed on this surface.
- [ ] Flip back to 24-hour, uncheck Show seconds, Save. Verify all three surfaces revert to the historical `HH:mm` form.
- [ ] Restart `radio-web.service` once. Confirm the saved 12h preference (if you left it as 12h) persists across the restart — the value lives in the SQLite config store and is read on startup via the bridge provider.

## Operator note

No deploy-time changes required. The setting persists in the existing SQLite `Config_sqlite` table (keys `display:timeformat` / `display:showseconds`). On a fresh install with no SQLite row, the default `24h` from the POCO applies — identical to the pre-PR behaviour.

## Out of scope (handoff §9)

Custom format patterns, locale-aware AM/PM glyphs, ISO date displays, relative-time formatters (`Timestamps.cs`), chart axis labels, log timestamps, `PlayHistoryPage` tooltips, per-surface overrides, server-side timestamp formats, timezone handling. Two enumerated values + one boolean — that's the whole scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)