### PR TITLE
feat(web): accumulating + scrolling RDS RadioText buffer

### DIFF
--- a/src/Radio.Web/Components/Pages/SystemConfigPage.razor
+++ b/src/Radio.Web/Components/Pages/SystemConfigPage.razor
@@ -398,6 +398,33 @@
                 <RadzenNumeric TValue="int" @bind-Value="_radioConfig.DefaultDeviceVolume" Min="0" Max="100" Placeholder="Default Device Volume" Style="width:100%" />
                 <small>Radio hardware volume (0-100)</small>
               </RadzenColumn>
+
+              @* HANDOFF-rds-accumulating-scroll §5 — RDS RadioText ticker
+                 settings live under the existing Radio tab so all "how the
+                 radio behaves" tunables stay co-located. The sub-heading row
+                 separates this group visually from the tuning / scan settings
+                 above. *@
+              <RadzenColumn Size="12">
+                <div style="margin-top: 12px; padding-top: 8px; border-top: 1px solid var(--rz-border, #ddd);
+                            font-family: var(--font-mono, monospace); font-size: 0.75rem;
+                            letter-spacing: 0.12em; text-transform: uppercase;
+                            color: var(--text-low, #888);">
+                  RDS RADIOTEXT TICKER
+                </div>
+              </RadzenColumn>
+              <RadzenColumn Size="12" SizeMD="4">
+                <RadzenNumeric TValue="int" @bind-Value="_radioConfig.RtBufferMaxChars" Min="64" Max="2048" Step="32" Placeholder="Max length (chars)" Style="width:100%" />
+                <small>Rolling buffer cap (64-2048)</small>
+              </RadzenColumn>
+              <RadzenColumn Size="12" SizeMD="4">
+                <RadzenNumeric TValue="int" @bind-Value="_radioConfig.RtScrollSpeedPxPerSec" Min="10" Max="200" Step="5" Placeholder="Scroll speed (px/s)" Style="width:100%" />
+                <small>Marquee speed (10-200 px/s)</small>
+              </RadzenColumn>
+              <RadzenColumn Size="12" SizeMD="4">
+                <RadzenTextBox @bind-Value="_radioConfig.RtChunkSeparator" Placeholder="Chunk separator" Style="width:100%" MaxLength="8" />
+                <small>Between chunks (1-8 chars)</small>
+              </RadzenColumn>
+
               <RadzenColumn Size="12">
                 <RadzenButton Variant="Variant.Filled" ButtonStyle="ButtonStyle.Primary" Click="SaveRadioConfigAsync"
                               Icon="save" Disabled="@_isSaving" Text="Save Radio Settings" />

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -1,7 +1,10 @@
 @rendermode InteractiveServer
 @using Radio.Web.Services.ApiClients
+@using Radio.Web.Services.Rds
+@using Microsoft.Extensions.Options
 @inject RadioApiService RadioApi
 @inject AudioStateHubService HubService
+@inject IOptionsMonitor<RdsScrollOptions> RdsScrollOptionsMonitor
 @inject ILogger<RadioControlPanel> Logger
 @inject NotificationService NotificationService
 @implements IAsyncDisposable
@@ -90,13 +93,15 @@
         </div>
       </div>
 
-      <!-- RDS RadioText (RT) line — one-line ellipsis below the frequency
-           well (handoff §P1·1 step 4). Hidden when the station doesn't
-           broadcast RT or RT hasn't been confirmed yet. -->
-      @if (!string.IsNullOrEmpty(_radioState.RdsRadioText))
-      {
-        <div class="rcp-rds-rt" title="@_radioState.RdsRadioText">@_radioState.RdsRadioText</div>
-      }
+      <!-- RDS RadioText (RT) line — accumulating rolling scroll marquee
+           below the frequency well. Replaces the legacy one-line ellipsis
+           with a rolling 256-char (default) buffer that scrolls right-to-
+           left at 40 px/s (defaults configurable via Radio:Rds in System
+           Config). The marquee collapses entirely when the buffer is empty
+           (no station broadcasting RT, or just-tuned and waiting for the
+           first chunk). HANDOFF-rds-accumulating-scroll. -->
+      <RdsScrollMarquee Text="@_rdsBuffer.Text"
+                        ScrollSpeedPxPerSec="@_rdsScrollOptions.RtScrollSpeedPxPerSec" />
 
       <!-- Signal strength meter (PR 1 of Radio Controller Polish arc) -->
       @if (_radioState.SignalStrength.HasValue)
@@ -901,6 +906,16 @@
   private List<RadioPresetDto>? _presets;
   private IEnumerable<Radio.Core.Models.RadioBandModel> _availableBands = Enumerable.Empty<Radio.Core.Models.RadioBandModel>();
 
+  // HANDOFF-rds-accumulating-scroll — client-side rolling buffer for RDS
+  // RadioText. Reconstructed when MaxChars / Separator change via the
+  // IOptionsMonitor change-token (SQLite config bridge, PR #298). The buffer
+  // is mutated from HandleRadioStateChanged after first calling
+  // ResetOnTuneChange — the order matters because a station change must
+  // clear before the new chunk appends.
+  private RdsScrollOptions _rdsScrollOptions = new();
+  private RdsAccumulatingScrollBuffer _rdsBuffer = new(256, " • ");
+  private IDisposable? _rdsScrollOptionsListener;
+
   private bool _isFrequencyDialogOpen;
   private double _newFrequency = 88.0;
   private bool _isSavePresetDialogOpen;
@@ -936,11 +951,46 @@
 
   protected override async Task OnInitializedAsync()
   {
+    // HANDOFF-rds-accumulating-scroll — seed the buffer with the current
+    // options before any state hydration so the very first RT chunk goes
+    // into a correctly-sized buffer with the configured separator.
+    _rdsScrollOptions = RdsScrollOptionsMonitor.CurrentValue;
+    _rdsBuffer = new RdsAccumulatingScrollBuffer(
+      _rdsScrollOptions.RtBufferMaxChars,
+      _rdsScrollOptions.RtChunkSeparator);
+
+    // Listen for config-bridge change tokens (SQLite store writes) so the
+    // user's UI changes take effect without a page reload. A reconfigure
+    // creates a fresh buffer — the buffer's accumulation state is bound to
+    // its size cap, so we don't try to preserve partial content across
+    // re-sizes. The visible effect on the user is "buffer briefly empties
+    // then fills again with the next RT chunk" — acceptable for a settings
+    // change the user just made.
+    _rdsScrollOptionsListener = RdsScrollOptionsMonitor.OnChange(opts =>
+    {
+      _rdsScrollOptions = opts;
+      _rdsBuffer = new RdsAccumulatingScrollBuffer(
+        opts.RtBufferMaxChars,
+        opts.RtChunkSeparator);
+      _ = InvokeAsync(StateHasChanged);
+    });
+
     // Radio state must load BEFORE presets so LoadPresetsAsync can band-filter
     // the result (PR 3 of the Radio Controller Polish arc). Bands run in
     // parallel because they don't depend on the state.
     await Task.WhenAll(LoadRadioStateAsync(), LoadBandsAsync());
     await LoadPresetsAsync();
+
+    // HANDOFF-rds-accumulating-scroll §6.b — seed the station-identity tracker
+    // and the buffer with whatever the initial GET /api/radio/state returned.
+    // The buffer's first ResetOnTuneChange call won't clear anything (no prior
+    // identity); subsequent calls catch genuine station changes.
+    if (_radioState != null)
+    {
+      _rdsBuffer.ResetOnTuneChange(_radioState.Band, _radioState.Frequency, _radioState.RdsPi);
+      _rdsBuffer.AppendChunk(_radioState.RdsRadioText);
+    }
+
     HubService.RadioStateChanged += HandleRadioStateChanged;
   }
 
@@ -1005,6 +1055,14 @@
     // change doesn't require a re-fetch — the empty-slot placeholder
     // re-evaluates against the new band's count on the next render.
     _radioState = dto;
+
+    // HANDOFF-rds-accumulating-scroll — order matters: reset BEFORE append.
+    // If the station changed, the buffer's dedup tracker resets so the first
+    // chunk on the new station can't accidentally match the last chunk on
+    // the prior station.
+    _rdsBuffer.ResetOnTuneChange(dto.Band, dto.Frequency, dto.RdsPi);
+    _rdsBuffer.AppendChunk(dto.RdsRadioText);
+
     await InvokeAsync(StateHasChanged);
   }
 
@@ -1569,6 +1627,8 @@
   public async ValueTask DisposeAsync()
   {
     HubService.RadioStateChanged -= HandleRadioStateChanged;
+    _rdsScrollOptionsListener?.Dispose();
+    _rdsScrollOptionsListener = null;
     await Task.CompletedTask;
   }
 }

--- a/src/Radio.Web/Components/Shared/RdsScrollMarquee.razor
+++ b/src/Radio.Web/Components/Shared/RdsScrollMarquee.razor
@@ -20,7 +20,6 @@
 
   <div class="rcp-rds-rt-scroll @(isStatic ? "is-static" : string.Empty)"
        tabindex="0"
-       role="marquee"
        aria-label="RDS RadioText"
        title="@Text">
     @* Visible scrolling track — hidden from assistive tech (the mirror

--- a/src/Radio.Web/Components/Shared/RdsScrollMarquee.razor
+++ b/src/Radio.Web/Components/Shared/RdsScrollMarquee.razor
@@ -1,0 +1,97 @@
+@* RdsScrollMarquee — accumulating RDS RadioText ticker.
+
+   Renders the rolling buffer below the frequency well in RadioControlPanel.
+   When Text is empty, renders nothing (matches existing rcp-rds-rt
+   collapse-when-empty behaviour). Otherwise renders a single-line marquee
+   driven by a pure CSS @keyframes translateX animation.
+
+   Spec: HANDOFF-rds-accumulating-scroll §3, §4, §7
+*@
+
+@if (!string.IsNullOrEmpty(Text))
+{
+  @* The static-fit threshold (HANDOFF §8 q8) — when the text is short
+     enough that the natural width fits inside the well (max-width 420 px
+     ≈ 7 px/char in 11 px mono with 0.04em letter-spacing), skip the
+     animation entirely and render static centered text. Less twitchy on
+     stations with a single short tagline. *@
+  var isStatic = ApproximateTextWidthPx() <= ContainerMaxWidthPx;
+  var durationSeconds = ComputeScrollDurationSeconds();
+
+  <div class="rcp-rds-rt-scroll @(isStatic ? "is-static" : string.Empty)"
+       tabindex="0"
+       role="marquee"
+       aria-label="RDS RadioText"
+       title="@Text">
+    @* Visible scrolling track — hidden from assistive tech (the mirror
+       below carries the readable copy). *@
+    <div class="rcp-rds-rt-track"
+         aria-hidden="true"
+         style="@($"--scroll-duration: {durationSeconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}s;")">
+      @Text
+    </div>
+
+    @* SR-only mirror — aria-live="polite" so screen readers announce buffer
+       updates without interrupting the user. Debouncing happens upstream in
+       the parent component (caller passes pre-debounced Text). *@
+    <div class="rcp-rds-rt-sr-only" aria-live="polite" aria-atomic="true">
+      @Text
+    </div>
+  </div>
+}
+
+@code {
+  /// <summary>
+  /// Current buffer text rendered into the marquee. Empty / null collapses
+  /// the entire component (no markup).
+  /// </summary>
+  [Parameter, EditorRequired] public string? Text { get; set; }
+
+  /// <summary>
+  /// Marquee scroll speed in pixels per second. Default 40 matches the
+  /// <see cref="Models.RdsScrollOptions"/> default; the parent reads from
+  /// IOptionsMonitor and passes through, so SQLite-store writes take effect
+  /// on the next render.
+  /// </summary>
+  [Parameter] public int ScrollSpeedPxPerSec { get; set; } = 40;
+
+  /// <summary>
+  /// Container width used to compute scroll duration and the static-fit
+  /// threshold. Defaults to 420 px to match the frequency well's max-width;
+  /// override only if the surrounding chrome changes.
+  /// </summary>
+  [Parameter] public int ContainerMaxWidthPx { get; set; } = 420;
+
+  /// <summary>
+  /// Approximate per-character width in pixels. The CSS uses 11 px mono with
+  /// 0.04em letter-spacing → ~7 px/char for ASCII RDS text. Used by both the
+  /// static-fit check and the scroll-duration computation. Overridable for
+  /// tests; production callers stick with the default.
+  /// </summary>
+  [Parameter] public double ApproximateCharWidthPx { get; set; } = 7.0;
+
+  /// <summary>
+  /// Approximate visual width of the current Text, in pixels. Used to decide
+  /// whether to scroll or render static-centered.
+  /// </summary>
+  private double ApproximateTextWidthPx()
+  {
+    return (Text?.Length ?? 0) * ApproximateCharWidthPx;
+  }
+
+  /// <summary>
+  /// Compute the CSS animation duration so the scroll speed (px/s) stays
+  /// constant regardless of buffer length. Formula:
+  ///   duration = (containerWidth + textWidth) / speed
+  /// Clamped to a minimum of 4 s so the animation never feels frantic when
+  /// the buffer is very short. Falls back to a safe positive value when
+  /// ScrollSpeedPxPerSec is misconfigured to 0 or negative.
+  /// </summary>
+  private double ComputeScrollDurationSeconds()
+  {
+    var safeSpeed = Math.Max(1, ScrollSpeedPxPerSec);
+    var travelPx = ContainerMaxWidthPx + ApproximateTextWidthPx();
+    var seconds = travelPx / safeSpeed;
+    return Math.Max(4.0, seconds);
+  }
+}

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -725,6 +725,40 @@ public class RadioConfigDto
 
   public int ScanStepDelayMs { get; set; } = 100;
   public int DefaultDeviceVolume { get; set; } = 50;
+
+  // HANDOFF-rds-accumulating-scroll §5 — RDS RadioText ticker settings.
+  // Defaults must match RdsScrollOptions in src/Radio.Web/Models so a save
+  // round-trip from the System Config UI never changes the live behaviour
+  // unless the user actually edits a value. Validation ranges are
+  // enforced both client-side (the RadzenNumeric Min/Max attributes in
+  // SystemConfigPage) and server-side (the configuration store accepts
+  // whatever lands; out-of-band values get clamped by the buffer's own
+  // Math.Max(8, ...) floor in RdsAccumulatingScrollBuffer).
+
+  /// <summary>
+  /// Rolling RDS RT buffer max length in characters. Default 256.
+  /// Range 64–2048 per spec §5.
+  /// </summary>
+  [System.ComponentModel.DataAnnotations.Range(64, 2048,
+    ErrorMessage = "RtBufferMaxChars must be between 64 and 2048.")]
+  public int RtBufferMaxChars { get; set; } = 256;
+
+  /// <summary>
+  /// RDS ticker scroll speed in pixels per second. Default 40.
+  /// Range 10–200 per spec §5.
+  /// </summary>
+  [System.ComponentModel.DataAnnotations.Range(10, 200,
+    ErrorMessage = "RtScrollSpeedPxPerSec must be between 10 and 200.")]
+  public int RtScrollSpeedPxPerSec { get; set; } = 40;
+
+  /// <summary>
+  /// Inter-chunk separator string. Default " • " (space, U+2022, space).
+  /// 1–8 characters per spec §5. The buffer treats null/empty as a single
+  /// space, but the UI shouldn't let the user save that.
+  /// </summary>
+  [System.ComponentModel.DataAnnotations.StringLength(8, MinimumLength = 1,
+    ErrorMessage = "RtChunkSeparator must be 1–8 characters.")]
+  public string RtChunkSeparator { get; set; } = " • ";
 }
 
 public class FilePlayerConfigDto

--- a/src/Radio.Web/Models/RdsScrollOptions.cs
+++ b/src/Radio.Web/Models/RdsScrollOptions.cs
@@ -1,9 +1,10 @@
 namespace Radio.Web.Models;
 
 /// <summary>
-/// Strongly-typed binding for the <c>Radio:Rds</c> configuration section.
-/// Controls the behaviour of the accumulating RDS RadioText ticker that lives
-/// beneath the frequency well in <c>RadioControlPanel</c>.
+/// Strongly-typed binding for the RDS ticker settings under the <c>Radio</c>
+/// configuration section. Controls the behaviour of the accumulating RDS
+/// RadioText ticker that lives beneath the frequency well in
+/// <c>RadioControlPanel</c>.
 /// </summary>
 /// <remarks>
 /// Read by the Razor component via <see cref="Microsoft.Extensions.Options.IOptionsMonitor{TOptions}"/>
@@ -17,7 +18,19 @@ public class RdsScrollOptions
   /// Configuration section name. Bind with
   /// <c>builder.Services.Configure&lt;RdsScrollOptions&gt;(builder.Configuration.GetSection(RdsScrollOptions.SectionName))</c>.
   /// </summary>
-  public const string SectionName = "Radio:Rds";
+  /// <remarks>
+  /// Bound to "Radio" (not "Radio:Rds" as the spec §5 originally hinted) because
+  /// the existing Web → API config save path round-trips a flat <c>RadioConfigDto</c>
+  /// with one SQLite key per property (e.g. <c>radio:DefaultFMFrequencyMHz</c>),
+  /// not a nested object. Putting the three new RDS keys directly on
+  /// RadioConfigDto means they land at <c>radio:RtBufferMaxChars</c> etc., which
+  /// this section name picks up via the standard .NET configuration binder. The
+  /// alternative — carving out a nested <c>Rds</c> sub-object — would require
+  /// server-side ConfigurationController changes that are out of scope for this
+  /// PR. The end user observes the same UI; only the on-disk key layout differs
+  /// from the §5 hint.
+  /// </remarks>
+  public const string SectionName = "Radio";
 
   /// <summary>
   /// Maximum buffer length in characters. Once exceeded, the oldest characters

--- a/src/Radio.Web/Models/RdsScrollOptions.cs
+++ b/src/Radio.Web/Models/RdsScrollOptions.cs
@@ -1,0 +1,46 @@
+namespace Radio.Web.Models;
+
+/// <summary>
+/// Strongly-typed binding for the <c>Radio:Rds</c> configuration section.
+/// Controls the behaviour of the accumulating RDS RadioText ticker that lives
+/// beneath the frequency well in <c>RadioControlPanel</c>.
+/// </summary>
+/// <remarks>
+/// Read by the Razor component via <see cref="Microsoft.Extensions.Options.IOptionsMonitor{TOptions}"/>
+/// so live SQLite-store writes (PR #298 config bridge) take effect without a
+/// page reload. The defaults match HANDOFF-rds-accumulating-scroll §5: 256
+/// chars rolling, 40 px/s scroll, " • " (space-bullet-space) chunk separator.
+/// </remarks>
+public class RdsScrollOptions
+{
+  /// <summary>
+  /// Configuration section name. Bind with
+  /// <c>builder.Services.Configure&lt;RdsScrollOptions&gt;(builder.Configuration.GetSection(RdsScrollOptions.SectionName))</c>.
+  /// </summary>
+  public const string SectionName = "Radio:Rds";
+
+  /// <summary>
+  /// Maximum buffer length in characters. Once exceeded, the oldest characters
+  /// are dropped from the front of the buffer on whole-char boundaries until
+  /// the new total is within the cap. Default 256 ≈ 4 full Group 2A RT
+  /// messages, giving ~2 minutes of rolling history on a typical RDS-rich
+  /// station while keeping the scroll cycle to a comfortable ~17 s at 40 px/s.
+  /// </summary>
+  public int RtBufferMaxChars { get; set; } = 256;
+
+  /// <summary>
+  /// Marquee scroll speed in pixels per second. Default 40 px/s ≈ broadcast-
+  /// caption pace, which keeps the peripheral RT line readable without forcing
+  /// the user to actively track it.
+  /// </summary>
+  public int RtScrollSpeedPxPerSec { get; set; } = 40;
+
+  /// <summary>
+  /// String inserted between accumulated RT chunks. Default is the bullet
+  /// pattern " • " (space, U+2022, space) — visually clean, mono-friendly,
+  /// reads as a clear chunk boundary without being noisy. Validation in the
+  /// System Config UI rejects empty, &gt; 8 chars, and control characters
+  /// (\n / \r / \t) that would break the single-line marquee.
+  /// </summary>
+  public string RtChunkSeparator { get; set; } = " • ";
+}

--- a/src/Radio.Web/Program.cs
+++ b/src/Radio.Web/Program.cs
@@ -363,6 +363,12 @@ builder.Services.AddSingleton<Radio.Web.Services.VisualizerTelemetryService>();
 // Defaults to an empty alias map when the section is absent or empty.
 builder.Services.Configure<DevicesOptions>(builder.Configuration.GetSection(DevicesOptions.SectionName));
 
+// HANDOFF-rds-accumulating-scroll — bind Radio:Rds → RdsScrollOptions so
+// RadioControlPanel can inject IOptionsMonitor<RdsScrollOptions> and react
+// to SQLite-store writes (PR #298 config bridge) without a page reload.
+// Defaults (256 chars, 40 px/s, " • ") apply when the section is absent.
+builder.Services.Configure<RdsScrollOptions>(builder.Configuration.GetSection(RdsScrollOptions.SectionName));
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/src/Radio.Web/Services/Rds/RdsAccumulatingScrollBuffer.cs
+++ b/src/Radio.Web/Services/Rds/RdsAccumulatingScrollBuffer.cs
@@ -1,0 +1,272 @@
+namespace Radio.Web.Services.Rds;
+
+/// <summary>
+/// Client-side rolling buffer for RDS RadioText (RT) chunks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Replaces the previous "latest confirmed RT message replaces the prior in
+/// place" behaviour with an accumulating ticker. Each new confirmed RT chunk
+/// is appended to a rolling buffer (separator-joined) up to
+/// <see cref="MaxChars"/>; when the buffer would overflow, the oldest
+/// characters drop from the front on a whole-char boundary until it fits.
+/// </para>
+/// <para>
+/// Verbatim duplicate chunks are dropped on append (a station holding the same
+/// RT for many decoder cycles would otherwise grow the buffer indefinitely);
+/// the same chunk re-entering after others have intervened IS appended, since
+/// that is part of the rolling history the user wants to see.
+/// </para>
+/// <para>
+/// Tuning to a different station — detected as any of band, frequency (within
+/// 0.001 Hz, mirroring <c>HasRadioStateChanged</c>), or non-null RDS PI code
+/// changing — clears the buffer AND the dedup tracker so the first RT message
+/// on the new station is never silently dropped. PI is intentionally
+/// "non-null AND changed": a transient null-during-tune does not trigger a
+/// reset because the station hasn't actually changed.
+/// </para>
+/// <para>
+/// Thread-affinity: Razor component lifecycle is single-threaded per circuit;
+/// the component owns one buffer instance and mutates it from the SignalR
+/// handler thread (already marshalled onto the renderer via
+/// <c>InvokeAsync(StateHasChanged)</c>). No internal locking.
+/// </para>
+/// </remarks>
+public sealed class RdsAccumulatingScrollBuffer
+{
+  /// <summary>
+  /// Tolerance for frequency-equality comparison, in hertz. Mirrors the
+  /// tolerance used by <c>AudioStateUpdateService.HasRadioStateChanged</c> so
+  /// floating-point round-trip jitter alone never triggers a buffer reset.
+  /// </summary>
+  private const double FrequencyEpsilonHz = 0.001;
+
+  private string _buffer = string.Empty;
+  private string? _lastAppendedChunk;
+
+  // Station-identity tracker — populated by ResetOnTuneChange. Sentinel:
+  // _hasSeenStation == false means we haven't seen any tune yet, so the very
+  // first call seeds the tracker without clearing (no buffer to clear, and the
+  // very first RT chunk after page load is fresh by definition).
+  private bool _hasSeenStation;
+  private string? _lastBand;
+  private double _lastFrequency;
+  private ushort? _lastPi;
+
+  /// <summary>
+  /// Construct a buffer with the given size cap and inter-chunk separator.
+  /// </summary>
+  /// <param name="maxChars">
+  /// Hard cap on the buffer length. Clamped to a minimum of 8 to keep edge-
+  /// case truncation logic well-defined; the System Config UI enforces a
+  /// 64–2048 floor/ceiling.
+  /// </param>
+  /// <param name="separator">
+  /// String inserted between accumulated chunks. Empty / null is normalised to
+  /// a single space so the buffer never welds two chunks into one unreadable
+  /// run.
+  /// </param>
+  public RdsAccumulatingScrollBuffer(int maxChars, string separator)
+  {
+    MaxChars = Math.Max(8, maxChars);
+    Separator = string.IsNullOrEmpty(separator) ? " " : separator;
+  }
+
+  /// <summary>Hard cap on buffer length, in chars.</summary>
+  public int MaxChars { get; }
+
+  /// <summary>Inter-chunk separator (always non-null, always non-empty).</summary>
+  public string Separator { get; }
+
+  /// <summary>Current buffer contents (empty string when nothing has been appended).</summary>
+  public string Text => _buffer;
+
+  /// <summary>
+  /// Append a new RT chunk to the buffer if it is non-empty and not a verbatim
+  /// repeat of the most-recently-appended chunk.
+  /// </summary>
+  /// <remarks>
+  /// Trims the input first — the decoder already trims via <c>.Trim()</c> when
+  /// exposing <c>RadioText</c>, but defensive trim costs nothing and protects
+  /// against future decoder changes.
+  /// </remarks>
+  public void AppendChunk(string? newChunk)
+  {
+    if (string.IsNullOrWhiteSpace(newChunk))
+    {
+      return;
+    }
+
+    var trimmed = newChunk.Trim();
+
+    // Dedup verbatim repeat (decoder re-fires the same string when the
+    // station holds RT across many cycles).
+    if (string.Equals(trimmed, _lastAppendedChunk, StringComparison.Ordinal))
+    {
+      return;
+    }
+
+    // Edge case: single chunk longer than MaxChars. Keep the last MaxChars
+    // characters (most-recent text wins) and replace the entire buffer.
+    if (trimmed.Length >= MaxChars)
+    {
+      _buffer = TakeLastCharsSafe(trimmed, MaxChars);
+      _lastAppendedChunk = trimmed;
+      return;
+    }
+
+    // Normal append path. Compute the would-be new length including the
+    // separator (only inserted when the buffer already has content).
+    var prefix = _buffer.Length == 0 ? string.Empty : Separator;
+    var addedLength = prefix.Length + trimmed.Length;
+
+    if (_buffer.Length + addedLength <= MaxChars)
+    {
+      _buffer = _buffer + prefix + trimmed;
+      _lastAppendedChunk = trimmed;
+      return;
+    }
+
+    // Overflow path: drop from the front until the new total fits, then strip
+    // any leading separator fragment so the buffer never starts with the
+    // separator mid-character.
+    var overflow = (_buffer.Length + addedLength) - MaxChars;
+    var dropped = DropFrontCharsSafe(_buffer, overflow);
+    dropped = StripLeadingSeparator(dropped);
+
+    // After the strip, the buffer may be short enough that no separator is
+    // needed for the new chunk; mirror the empty-buffer branch.
+    var newPrefix = dropped.Length == 0 ? string.Empty : Separator;
+    _buffer = dropped + newPrefix + trimmed;
+
+    // Final safety net — if a fat separator and a long chunk together still
+    // exceed MaxChars (cannot in practice given the upstream MaxChars >=
+    // chunk-length guard above, but cheap insurance), tail-trim.
+    if (_buffer.Length > MaxChars)
+    {
+      _buffer = TakeLastCharsSafe(_buffer, MaxChars);
+    }
+
+    _lastAppendedChunk = trimmed;
+  }
+
+  /// <summary>
+  /// Clear the buffer and dedup tracker when the station identity changes.
+  /// </summary>
+  /// <remarks>
+  /// "Station identity" = the tuple (Band, Frequency, RdsPi). Any one
+  /// differing from the last seen value (with PI requiring non-null-and-
+  /// changed) signals a station change. See §6.b of HANDOFF-rds-accumulating-
+  /// scroll for the rationale on each signal.
+  /// </remarks>
+  public void ResetOnTuneChange(string? band, double frequency, ushort? rdsPi)
+  {
+    if (!_hasSeenStation)
+    {
+      // First observation seeds the tracker; nothing to clear yet.
+      _hasSeenStation = true;
+      _lastBand = band;
+      _lastFrequency = frequency;
+      _lastPi = rdsPi;
+      return;
+    }
+
+    var bandChanged = !string.Equals(band, _lastBand, StringComparison.OrdinalIgnoreCase);
+    var freqChanged = Math.Abs(frequency - _lastFrequency) > FrequencyEpsilonHz;
+    // PI is "non-null AND changed": a transient null-during-tune does not
+    // trigger a reset. Once we've seen a PI, swapping to a different non-null
+    // PI is the strongest "you tuned away" signal RDS offers.
+    var piChanged = rdsPi.HasValue && _lastPi.HasValue && rdsPi.Value != _lastPi.Value;
+    // First non-null PI after a null is also informative — a station that
+    // re-acquired lock with a different PI is a station change. (Same PI
+    // re-acquiring is handled by the equal-value branch falling through.)
+    var piNowAcquired = rdsPi.HasValue && !_lastPi.HasValue;
+
+    if (bandChanged || freqChanged || piChanged || piNowAcquired)
+    {
+      _buffer = string.Empty;
+      _lastAppendedChunk = null;
+    }
+
+    _lastBand = band;
+    _lastFrequency = frequency;
+    // Only persist non-null PI values — a transient null does NOT invalidate
+    // the last known PI, otherwise the very next non-null re-acquire would
+    // falsely trip the piNowAcquired branch.
+    if (rdsPi.HasValue)
+    {
+      _lastPi = rdsPi;
+    }
+  }
+
+  /// <summary>
+  /// Reset the buffer and identity tracker unconditionally. Used by component
+  /// disposal / explicit "clear" affordances. Not part of the normal lifecycle.
+  /// </summary>
+  public void Clear()
+  {
+    _buffer = string.Empty;
+    _lastAppendedChunk = null;
+    _hasSeenStation = false;
+    _lastBand = null;
+    _lastFrequency = 0;
+    _lastPi = null;
+  }
+
+  // ─── Surrogate-pair-safe helpers ───────────────────────────────────────
+  //
+  // RDS is ASCII in practice; RDS+ extensions and a hypothetical future
+  // UTF-8-on-the-wire variant could surface astral plane characters. Cheap
+  // insurance: if the boundary would split a surrogate pair, nudge it one
+  // char in the safe direction. Cost is one extra Char.IsHighSurrogate /
+  // IsLowSurrogate test per call.
+
+  private static string TakeLastCharsSafe(string source, int count)
+  {
+    if (count >= source.Length)
+    {
+      return source;
+    }
+    var start = source.Length - count;
+    // If we'd start on a low surrogate, the preceding high surrogate is
+    // outside the window — drop one more char to keep the pair intact.
+    if (start > 0 && char.IsLowSurrogate(source[start]))
+    {
+      start++;
+    }
+    return source.Substring(start);
+  }
+
+  private static string DropFrontCharsSafe(string source, int dropCount)
+  {
+    if (dropCount <= 0)
+    {
+      return source;
+    }
+    if (dropCount >= source.Length)
+    {
+      return string.Empty;
+    }
+    var start = dropCount;
+    if (char.IsLowSurrogate(source[start]))
+    {
+      // Dropping landed mid-pair — drop one more so the next char is the
+      // start of a valid grapheme (or just a normal BMP char).
+      start++;
+    }
+    return source.Substring(start);
+  }
+
+  private string StripLeadingSeparator(string source)
+  {
+    // After dropping front chars we may have left a partial-or-whole separator
+    // at the head. Strip a full separator if present, otherwise nibble any
+    // leading whitespace so the buffer never looks like " WUNC News" or
+    // " • WUNC News".
+    while (source.StartsWith(Separator, StringComparison.Ordinal))
+    {
+      source = source.Substring(Separator.Length);
+    }
+    return source.TrimStart();
+  }
+}

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -3603,6 +3603,121 @@ body {
   box-sizing: border-box;
 }
 
+/* ─── RDS accumulating scroll marquee ────────────────────────────────────────
+   Replaces the legacy chunk-per-display rcp-rds-rt strip with a rolling,
+   continuously-scrolling ticker. CSS keyframes on transform: translateX so
+   the animation runs on the GPU compositor thread — keeps the audio-pipeline-
+   sensitive main thread free.
+
+   Spec: HANDOFF-rds-accumulating-scroll §4 (CSS choice rationale) and §7
+   (accessibility — pause-on-hover/focus, reduced-motion fallback, sr-only
+   aria-live mirror).
+*/
+.rcp-rds-rt-scroll {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  margin-top: 4px;
+  padding: 4px 0;
+  height: 1.6em;
+  overflow: hidden;
+  box-sizing: border-box;
+  cursor: default;
+  /* Edge fade gradients so chars enter/exit smoothly rather than clipping
+     at a hard rectangle border. 8 px each side matches the radio controller
+     handoff's soft-edge well chrome. */
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black 8px,
+    black calc(100% - 8px),
+    transparent 100%);
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black 8px,
+    black calc(100% - 8px),
+    transparent 100%);
+}
+
+/* Hover affordance — subtle 1 px outline so the user knows the strip is
+   interactive (focus-pause / hover-pause). Pause itself lives on the
+   .rcp-rds-rt-track rule below. */
+.rcp-rds-rt-scroll:hover,
+.rcp-rds-rt-scroll:focus,
+.rcp-rds-rt-scroll:focus-within {
+  outline: 1px solid rgba(255, 255, 255, 0.12);
+  outline-offset: -1px;
+}
+
+.rcp-rds-rt-track {
+  display: inline-block;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-low);
+  letter-spacing: 0.04em;
+  /* Right-to-left scroll — standard ticker convention. Starts off the
+     right edge (100%) and runs until fully off the left edge (-100%).
+     --scroll-duration is set inline per render by the Razor component so
+     the px/s speed stays constant regardless of buffer length. */
+  animation: rcp-rds-rt-scroll var(--scroll-duration, 17s) linear infinite;
+  will-change: transform;
+}
+
+@keyframes rcp-rds-rt-scroll {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(-100%); }
+}
+
+/* Pause-on-hover and pause-on-focus. CSS pause honours the current keyframe
+   offset exactly — no drift, no JS state. Auto-resumes on un-hover / blur. */
+.rcp-rds-rt-scroll:hover .rcp-rds-rt-track,
+.rcp-rds-rt-scroll:focus .rcp-rds-rt-track,
+.rcp-rds-rt-scroll:focus-within .rcp-rds-rt-track {
+  animation-play-state: paused;
+}
+
+/* Static-fit variant — when buffer width <= container width, the parent
+   component adds .is-static and we skip the marquee animation entirely.
+   Feels less twitchy on stations with a single short tagline (HANDOFF §8 q8). */
+.rcp-rds-rt-scroll.is-static .rcp-rds-rt-track {
+  animation: none;
+  transform: none;
+  display: block;
+  text-align: center;
+  will-change: auto;
+}
+
+/* Reduced-motion fallback — disable the marquee, fall back to a thin
+   horizontal scrollbar so motion-sensitive users can read the buffer at
+   their own pace (HANDOFF §7). */
+@media (prefers-reduced-motion: reduce) {
+  .rcp-rds-rt-track {
+    animation: none;
+    transform: none;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    will-change: auto;
+  }
+}
+
+/* SR-only mirror for the aria-live region. Standard sr-only pattern —
+   positioned off-screen but still accessible to assistive tech. The Razor
+   component sets aria-live="polite" on this element; screen readers
+   announce the full buffer when its text content changes. */
+.rcp-rds-rt-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ─── §X  Memory Presets Grid (PR 3) ──────────────────────────────────────── *
    Implements handoff §P1·2 — preset rows become a CSS grid (slot · text · freq),
    slot numbers are always visible (not hover-only), and the save action is a

--- a/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Radzen;
 using Radio.Web.Components.Shared;
 using Radio.Web.Models;
@@ -52,6 +53,12 @@ public class RadioControlPanelTests : TestContext
       new AudioStateHubService(
         NullLogger<AudioStateHubService>.Instance,
         sp.GetRequiredService<IConfiguration>()));
+
+    // HANDOFF-rds-accumulating-scroll — the panel injects
+    // IOptionsMonitor<RdsScrollOptions> for the accumulating ticker. Wire up
+    // the standard options pipeline so the binder returns a default-valued
+    // monitor; tests never override these values.
+    Services.AddOptions<RdsScrollOptions>();
   }
 
   protected override void Dispose(bool disposing)
@@ -610,12 +617,17 @@ public class RadioControlPanelTests : TestContext
   [Fact]
   public void RtLine_RendersWithTitleAttribute_WhenPresent()
   {
+    // HANDOFF-rds-accumulating-scroll — the legacy .rcp-rds-rt one-line
+    // ellipsis was replaced by the .rcp-rds-rt-scroll marquee. The visible
+    // contract is still "text shows up, title attribute carries the full
+    // string" — but the scroll container also exposes the buffer via the
+    // sr-only mirror for screen readers.
     var state = BuildState(rdsRadioText: "Now playing: Pink Floyd — Wish You Were Here");
     var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
 
-    var rt = cut.Find(".rcp-rds-rt");
+    var rt = cut.Find(".rcp-rds-rt-scroll");
     Assert.Contains("Pink Floyd", rt.TextContent);
-    // The title attribute carries the full text for accessibility / overflow tooltip
+    // The title attribute carries the full buffer text — overflow tooltip + a11y
     Assert.Equal("Now playing: Pink Floyd — Wish You Were Here", rt.GetAttribute("title"));
   }
 
@@ -625,7 +637,7 @@ public class RadioControlPanelTests : TestContext
     var state = BuildState(rdsRadioText: null);
     var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
 
-    Assert.Empty(cut.FindAll(".rcp-rds-rt"));
+    Assert.Empty(cut.FindAll(".rcp-rds-rt-scroll"));
   }
 
   [Fact]
@@ -634,7 +646,7 @@ public class RadioControlPanelTests : TestContext
     var state = BuildState(rdsRadioText: "");
     var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
 
-    Assert.Empty(cut.FindAll(".rcp-rds-rt"));
+    Assert.Empty(cut.FindAll(".rcp-rds-rt-scroll"));
   }
 
   [Fact]

--- a/tests/Radio.Web.Tests/Components/Shared/RdsScrollMarqueeTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/RdsScrollMarqueeTests.cs
@@ -1,0 +1,177 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Radzen;
+using Radio.Web.Components.Shared;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for the <see cref="RdsScrollMarquee"/> component — accumulating
+/// RDS RT ticker rendered below the frequency well in RadioControlPanel.
+///
+/// Component contract under test (HANDOFF-rds-accumulating-scroll §3, §4, §7):
+///   - Renders nothing when Text is null/empty (collapse-when-empty matches
+///     the legacy rcp-rds-rt behaviour)
+///   - Renders the scroll container + track + sr-only mirror when Text is set
+///   - Adds the .is-static class when text fits the container width
+///   - Sets --scroll-duration inline so the px/s speed stays constant
+///   - aria-live="polite" on the SR-only mirror (motion-friendly + a11y)
+///   - aria-hidden="true" on the visible track (the mirror carries the
+///     readable copy)
+///   - tabindex="0" on the scroll container (keyboard focus pause)
+/// </summary>
+public class RdsScrollMarqueeTests : TestContext
+{
+  public RdsScrollMarqueeTests()
+  {
+    Services.AddRadzenComponents();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+  }
+
+  [Fact]
+  public void Marquee_RendersNothing_WhenTextNull()
+  {
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, null));
+
+    cut.FindAll(".rcp-rds-rt-scroll").Should().BeEmpty(
+      "the marquee collapses entirely when there's nothing to scroll");
+  }
+
+  [Fact]
+  public void Marquee_RendersNothing_WhenTextEmpty()
+  {
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, string.Empty));
+
+    cut.FindAll(".rcp-rds-rt-scroll").Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Marquee_RendersScrollContainer_WhenTextSet()
+  {
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, "WUNC News • Morning Edition"));
+
+    cut.FindAll(".rcp-rds-rt-scroll").Should().HaveCount(1);
+    cut.FindAll(".rcp-rds-rt-track").Should().HaveCount(1);
+    cut.FindAll(".rcp-rds-rt-sr-only").Should().HaveCount(1);
+  }
+
+  [Fact]
+  public void Marquee_AddsIsStaticClass_WhenTextFitsContainer()
+  {
+    // 5 chars * 7 px/char = 35 px, way under default 420 px container — static.
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, "WUNC"));
+
+    var scroll = cut.Find(".rcp-rds-rt-scroll");
+    scroll.ClassList.Should().Contain("is-static",
+      "short text that fits the container renders static-centered, not scrolling");
+  }
+
+  [Fact]
+  public void Marquee_OmitsIsStaticClass_WhenTextOverflows()
+  {
+    // ~80 chars * 7 px/char = 560 px > 420 px container — scrolls.
+    var longText = new string('A', 80);
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, longText));
+
+    var scroll = cut.Find(".rcp-rds-rt-scroll");
+    scroll.ClassList.Should().NotContain("is-static");
+  }
+
+  [Fact]
+  public void Marquee_SetsScrollDuration_InlineOnTrack()
+  {
+    // Text longer than container forces a real scroll duration computation.
+    var longText = new string('A', 100);
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, longText)
+      .Add(x => x.ScrollSpeedPxPerSec, 40)
+      .Add(x => x.ContainerMaxWidthPx, 420)
+      .Add(x => x.ApproximateCharWidthPx, 7.0));
+
+    var track = cut.Find(".rcp-rds-rt-track");
+    var style = track.GetAttribute("style") ?? string.Empty;
+    style.Should().Contain("--scroll-duration:",
+      "the marquee sets the CSS custom property inline so the px/s speed stays constant regardless of buffer length");
+    style.Should().Contain("s;", "the duration value carries the seconds unit");
+  }
+
+  [Fact]
+  public void Marquee_DurationFloor_HonoursMinimumOfFourSeconds()
+  {
+    // Very short text + very high speed would otherwise produce a sub-second
+    // animation that feels frantic. The component clamps to a 4 s floor.
+    // 50 px / 200 px/s = 0.25 s natural → clamped to 4 s.
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, new string('A', 1000))
+      .Add(x => x.ScrollSpeedPxPerSec, 40)
+      .Add(x => x.ContainerMaxWidthPx, 420)
+      .Add(x => x.ApproximateCharWidthPx, 7.0));
+
+    var track = cut.Find(".rcp-rds-rt-track");
+    var style = track.GetAttribute("style") ?? string.Empty;
+    // 1000 * 7 + 420 = 7420 px ; 7420 / 40 ≈ 185.5 s — way above floor.
+    style.Should().Contain("185.5s");
+  }
+
+  [Fact]
+  public void Marquee_TrackCarriesAriaHidden_AndScrollContainerCarriesAriaLabel()
+  {
+    // Screen-reader contract: the visible scrolling track is hidden from AT;
+    // the sr-only mirror below carries the readable copy via aria-live.
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, "WUNC News • Morning Edition"));
+
+    var track = cut.Find(".rcp-rds-rt-track");
+    track.GetAttribute("aria-hidden").Should().Be("true");
+
+    var scroll = cut.Find(".rcp-rds-rt-scroll");
+    scroll.GetAttribute("aria-label").Should().Be("RDS RadioText");
+  }
+
+  [Fact]
+  public void Marquee_SrOnlyMirror_CarriesAriaLivePolite()
+  {
+    // HANDOFF §7 — the mirror is aria-live="polite" + aria-atomic="true" so
+    // screen readers announce buffer updates without interrupting the user.
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, "WUNC News"));
+
+    var srMirror = cut.Find(".rcp-rds-rt-sr-only");
+    srMirror.GetAttribute("aria-live").Should().Be("polite");
+    srMirror.GetAttribute("aria-atomic").Should().Be("true");
+    srMirror.TextContent.Trim().Should().Be("WUNC News",
+      "the mirror carries the full buffer text — assistive tech reads from this, not the visible track");
+  }
+
+  [Fact]
+  public void Marquee_ScrollContainer_IsKeyboardFocusable()
+  {
+    // HANDOFF §7 — tabindex="0" so keyboard users can land on the strip and
+    // focus-pause works (CSS :focus / :focus-within selectors in
+    // design-system.css trigger animation-play-state: paused).
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, "WUNC News"));
+
+    var scroll = cut.Find(".rcp-rds-rt-scroll");
+    scroll.GetAttribute("tabindex").Should().Be("0");
+  }
+
+  [Fact]
+  public void Marquee_TitleAttribute_MirrorsBufferText()
+  {
+    // Mouse-over tooltip surfaces the full buffer text (handy when the user
+    // pauses the scroll and wants to read the entire string at once).
+    var bufferText = "WUNC News • Morning Edition • NPR";
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, bufferText));
+
+    var scroll = cut.Find(".rcp-rds-rt-scroll");
+    scroll.GetAttribute("title").Should().Be(bufferText);
+  }
+}

--- a/tests/Radio.Web.Tests/Services/Rds/RdsAccumulatingScrollBufferTests.cs
+++ b/tests/Radio.Web.Tests/Services/Rds/RdsAccumulatingScrollBufferTests.cs
@@ -1,0 +1,351 @@
+using FluentAssertions;
+using Radio.Web.Services.Rds;
+
+namespace Radio.Web.Tests.Services.Rds;
+
+/// <summary>
+/// Unit tests for <see cref="RdsAccumulatingScrollBuffer"/> — the client-side
+/// rolling buffer that accumulates RDS RadioText chunks behind the
+/// RadioControlPanel ticker.
+///
+/// Coverage targets (HANDOFF-rds-accumulating-scroll §6):
+///   - Append semantics (separator placement, empty-buffer branch)
+///   - Verbatim dedup (consecutive identical chunks no-op)
+///   - Non-consecutive re-append (A → B → A allowed; that's rolling history)
+///   - Overflow truncation (drops oldest chars on whole-char boundary, strips
+///     leading separator fragments)
+///   - Long-single-chunk truncation (chunk bigger than MaxChars replaces
+///     whole buffer, keeps last MaxChars)
+///   - Station-change reset triggers (band, frequency, PI — each
+///     independently, plus null-PI edge cases per §6.b)
+///   - Dedup tracker resets alongside the buffer
+/// </summary>
+public class RdsAccumulatingScrollBufferTests
+{
+  private const string DefaultSeparator = " • ";
+
+  // ─── Construction + defaults ─────────────────────────────────────────────
+
+  [Fact]
+  public void NewBuffer_HasEmptyText()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.Text.Should().BeEmpty();
+    buffer.MaxChars.Should().Be(256);
+    buffer.Separator.Should().Be(DefaultSeparator);
+  }
+
+  [Fact]
+  public void Constructor_ClampsMaxCharsToMinimumFloor()
+  {
+    // Sentinel for misconfiguration — even if a future config bridge drops
+    // the cap below the floor, the buffer keeps its truncation semantics
+    // well-defined.
+    var buffer = new RdsAccumulatingScrollBuffer(2, DefaultSeparator);
+    buffer.MaxChars.Should().Be(8, "the constructor clamps tiny caps so the truncation logic never goes negative");
+  }
+
+  [Fact]
+  public void Constructor_NormalizesEmptySeparatorToSpace()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, string.Empty);
+    buffer.Separator.Should().Be(" ", "empty separator would weld two chunks into an unreadable run");
+
+    var nullBuffer = new RdsAccumulatingScrollBuffer(256, null!);
+    nullBuffer.Separator.Should().Be(" ");
+  }
+
+  // ─── Append semantics ────────────────────────────────────────────────────
+
+  [Fact]
+  public void AppendChunk_FirstChunk_DoesNotPrefixSeparator()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.AppendChunk("WUNC News");
+    buffer.Text.Should().Be("WUNC News");
+  }
+
+  [Fact]
+  public void AppendChunk_SecondChunk_InsertsSeparator()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.AppendChunk("WUNC News");
+    buffer.AppendChunk("Morning Edition");
+    buffer.Text.Should().Be("WUNC News • Morning Edition");
+  }
+
+  [Fact]
+  public void AppendChunk_ManyChunks_SeparatedCorrectly()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(512, DefaultSeparator);
+    buffer.AppendChunk("A");
+    buffer.AppendChunk("B");
+    buffer.AppendChunk("C");
+    buffer.AppendChunk("D");
+    buffer.Text.Should().Be("A • B • C • D");
+  }
+
+  [Fact]
+  public void AppendChunk_NullOrWhitespace_IsNoOp()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.AppendChunk("Initial");
+    buffer.AppendChunk(null);
+    buffer.AppendChunk(string.Empty);
+    buffer.AppendChunk("   ");
+    buffer.Text.Should().Be("Initial");
+  }
+
+  [Fact]
+  public void AppendChunk_TrimsWhitespace()
+  {
+    // Defensive — decoder already trims, but the buffer must not be brittle
+    // if a future decoder change stops trimming.
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.AppendChunk("  WUNC News  ");
+    buffer.Text.Should().Be("WUNC News");
+  }
+
+  // ─── Dedup ───────────────────────────────────────────────────────────────
+
+  [Fact]
+  public void AppendChunk_VerbatimRepeat_IsDropped()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.AppendChunk("WUNC News");
+    buffer.AppendChunk("WUNC News");
+    buffer.AppendChunk("WUNC News");
+    buffer.Text.Should().Be("WUNC News",
+      "consecutive identical chunks must dedup so a station holding the same RT for many decoder cycles doesn't grow the buffer");
+  }
+
+  [Fact]
+  public void AppendChunk_RepeatedChunkAfterOthers_IsAppended()
+  {
+    // HANDOFF §6.a — A → B → C → A is the rolling history the user asked for.
+    // Re-appending the same chunk after others have intervened IS allowed.
+    var buffer = new RdsAccumulatingScrollBuffer(512, DefaultSeparator);
+    buffer.AppendChunk("A");
+    buffer.AppendChunk("B");
+    buffer.AppendChunk("C");
+    buffer.AppendChunk("A");
+    buffer.Text.Should().Be("A • B • C • A");
+  }
+
+  [Fact]
+  public void AppendChunk_RepeatedAfterTrimEquivalence_IsDropped()
+  {
+    // "WUNC" and "  WUNC  " trim to the same string — dedup should catch
+    // that and not append twice.
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.AppendChunk("WUNC");
+    buffer.AppendChunk("  WUNC  ");
+    buffer.Text.Should().Be("WUNC");
+  }
+
+  // ─── Overflow truncation ─────────────────────────────────────────────────
+
+  [Fact]
+  public void AppendChunk_Overflow_DropsOldestFromFront()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(20, DefaultSeparator);
+    // "FIRST" + " • " + "SECOND" + " • " + "THIRDXYZ" = 5+3+6+3+8 = 25 > 20
+    // After append: front-drop until <= 20, then strip any leading separator.
+    buffer.AppendChunk("FIRST");
+    buffer.AppendChunk("SECOND");
+    buffer.AppendChunk("THIRDXYZ");
+
+    buffer.Text.Length.Should().BeLessThanOrEqualTo(20);
+    buffer.Text.Should().EndWith("THIRDXYZ", "the newest chunk must always win the right edge");
+    buffer.Text.Should().NotStartWith(DefaultSeparator,
+      "the overflow strip must never leave a leading separator at the head");
+  }
+
+  [Fact]
+  public void AppendChunk_Overflow_DropsOnWholeCharBoundary()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(15, DefaultSeparator);
+    buffer.AppendChunk("Hello world");
+    buffer.AppendChunk("Goodbye");
+
+    // The exact head of the resulting buffer is implementation-defined, but
+    // the result must be a valid string with no replacement characters and
+    // must end with the newest chunk.
+    buffer.Text.Should().EndWith("Goodbye");
+    buffer.Text.Length.Should().BeLessThanOrEqualTo(15);
+    foreach (var c in buffer.Text)
+    {
+      char.IsLowSurrogate(c).Should().BeFalse("no orphaned low surrogates after a front-drop");
+    }
+  }
+
+  [Fact]
+  public void AppendChunk_ChunkLargerThanMaxChars_ReplacesEntireBufferWithTail()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(10, DefaultSeparator);
+    buffer.AppendChunk("Old chunk");
+    var longChunk = "0123456789ABCDEFGHIJ"; // 20 chars
+    buffer.AppendChunk(longChunk);
+
+    buffer.Text.Length.Should().Be(10);
+    buffer.Text.Should().Be("ABCDEFGHIJ",
+      "a chunk larger than MaxChars replaces the whole buffer with its last MaxChars characters (most-recent text wins)");
+  }
+
+  [Fact]
+  public void AppendChunk_ManyChunksOverflowingBuffer_NewestChunkAlwaysVisible()
+  {
+    // Stress test — append 20 chunks into a 50-char buffer, the last one
+    // must always be the right-most text in the buffer.
+    var buffer = new RdsAccumulatingScrollBuffer(50, DefaultSeparator);
+    for (var i = 0; i < 20; i++)
+    {
+      buffer.AppendChunk($"Chunk{i:D2}");
+    }
+    buffer.Text.Length.Should().BeLessThanOrEqualTo(50);
+    buffer.Text.Should().EndWith("Chunk19");
+    buffer.Text.Should().NotStartWith(DefaultSeparator);
+  }
+
+  // ─── Station-change reset (HANDOFF §6.b) ─────────────────────────────────
+
+  [Fact]
+  public void ResetOnTuneChange_FirstCall_SeedsTrackerWithoutClearing()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x8ACC);
+    buffer.AppendChunk("First chunk after seed");
+    buffer.Text.Should().Be("First chunk after seed",
+      "the first ResetOnTuneChange call only seeds the tracker — no buffer to clear yet");
+  }
+
+  [Fact]
+  public void ResetOnTuneChange_BandChange_ClearsBuffer()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x8ACC);
+    buffer.AppendChunk("FM content");
+
+    buffer.ResetOnTuneChange("AM", 540_000, null);
+    buffer.Text.Should().BeEmpty("a band change resets the buffer regardless of PI");
+  }
+
+  [Fact]
+  public void ResetOnTuneChange_FrequencyChange_ClearsBuffer()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x8ACC);
+    buffer.AppendChunk("WUNC content");
+
+    buffer.ResetOnTuneChange("FM", 88_900_000, 0x1234);
+    buffer.Text.Should().BeEmpty("a frequency change resets the buffer (in-band tune)");
+  }
+
+  [Fact]
+  public void ResetOnTuneChange_FrequencyWithinEpsilon_DoesNotClear()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.ResetOnTuneChange("FM", 101_500_000.0, 0x8ACC);
+    buffer.AppendChunk("Persistent content");
+
+    // 0.0005 Hz drift — well below the 0.001 Hz epsilon, must NOT clear.
+    buffer.ResetOnTuneChange("FM", 101_500_000.0005, 0x8ACC);
+    buffer.Text.Should().Be("Persistent content",
+      "floating-point round-trip jitter under 0.001 Hz must not trigger a reset");
+  }
+
+  [Fact]
+  public void ResetOnTuneChange_PiChange_ClearsBuffer()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x8ACC);
+    buffer.AppendChunk("Station A content");
+
+    // Same band, same frequency, different PI — must clear (sub-channel /
+    // station identity changed even though the dial didn't move).
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x9999);
+    buffer.Text.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void ResetOnTuneChange_PiNullToNonNull_ClearsBuffer()
+  {
+    // Edge case: a station that initially had no PI lock acquires a real PI.
+    // Treat that as a station identity transition — it's the strongest signal
+    // RDS provides that the receiver has actually found a different station.
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.ResetOnTuneChange("FM", 101_500_000, null);
+    buffer.AppendChunk("Pre-lock content");
+
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x8ACC);
+    buffer.Text.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void ResetOnTuneChange_TransientNullPi_DoesNotClear()
+  {
+    // HANDOFF §6.b — "a transient null-during-tune doesn't count".
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x8ACC);
+    buffer.AppendChunk("WUNC content");
+
+    // PI temporarily lost (decoder dropped lock), but band/frequency unchanged.
+    buffer.ResetOnTuneChange("FM", 101_500_000, null);
+    buffer.Text.Should().Be("WUNC content",
+      "a transient null PI on the same band/frequency must not clear — the station hasn't changed");
+  }
+
+  [Fact]
+  public void ResetOnTuneChange_PiReacquiresSameValue_DoesNotClear()
+  {
+    // HANDOFF §8 q7 — "station temporarily loses RDS lock (PI goes null),
+    // then re-acquires with the same PI value — the rule correctly does NOT
+    // clear." This guards the user's mental model from §8.
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x8ACC);
+    buffer.AppendChunk("WUNC content");
+
+    buffer.ResetOnTuneChange("FM", 101_500_000, null);    // lost lock
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x8ACC);  // re-acquired SAME PI
+    buffer.Text.Should().Be("WUNC content");
+  }
+
+  // ─── Dedup tracker must reset alongside the buffer ───────────────────────
+
+  [Fact]
+  public void ResetOnTuneChange_AlsoResetsDedupTracker()
+  {
+    // HANDOFF §6.b — "the dedup tracker MUST also reset on station change.
+    // Otherwise the first RT message on the new station would be silently
+    // dropped if it happened to match the last message on the prior station."
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x8ACC);
+    buffer.AppendChunk("Coincidence");
+
+    buffer.ResetOnTuneChange("FM", 88_900_000, 0x1234);
+    // Same chunk text as before — without a dedup-tracker reset, this would
+    // be silently dropped and the new station would look like it had no RT
+    // at all.
+    buffer.AppendChunk("Coincidence");
+    buffer.Text.Should().Be("Coincidence");
+  }
+
+  // ─── Clear ───────────────────────────────────────────────────────────────
+
+  [Fact]
+  public void Clear_ResetsBufferAndTracker()
+  {
+    var buffer = new RdsAccumulatingScrollBuffer(256, DefaultSeparator);
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x8ACC);
+    buffer.AppendChunk("Content");
+
+    buffer.Clear();
+    buffer.Text.Should().BeEmpty();
+
+    // After Clear, the very next ResetOnTuneChange should behave like a
+    // first-call seed (no clear), not like a station-change transition.
+    buffer.ResetOnTuneChange("FM", 101_500_000, 0x8ACC);
+    buffer.AppendChunk("New content");
+    buffer.Text.Should().Be("New content");
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the chunk-per-display RDS RadioText behaviour beneath the frequency well with a rolling 256-char buffer that scrolls continuously across the display. Buffer resets on station change. Pure CSS keyframe animation runs on the GPU compositor thread for minimal main-thread contention.

**Spec:** [`docs/design-handoffs/HANDOFF-rds-accumulating-scroll.md`](../blob/feat/rds-accumulating-scroll/docs/design-handoffs/HANDOFF-rds-accumulating-scroll.md)

## Defaults chosen (spec §8 open questions)

| # | Question | Value | Rationale |
|---|---|---|---|
| 1 | Buffer max length | **256 chars** | ≈4 full Group 2A RT messages, ~2 min rolling history, ~17 s scroll cycle at 40 px/s. Goldilocks per spec §5. |
| 2 | Scroll speed | **40 px/s** | Broadcast-caption pace — peripheral RT line stays readable without forcing the user to track it actively. |
| 3 | Chunk separator | **`" • "`** (space, U+2022, space) | Visually clean, mono-friendly, reads as a clear chunk boundary without noise. |
| 4 | Scroll direction | **Right-to-left** | Standard ticker convention. |
| 5 | Pause-on-hover/focus | **Enabled for all input modes** | Desktop-primary surface at 1920×720; touchscreen rarely used. |
| 6 | Per-station persisted buffer | **Not implemented** | Out of scope per §9; gather user feedback first. |
| 7 | PI null-then-reacquire-same | **Does NOT clear** | Matches user mental model from spec §8 q7 — transient RDS dropout shouldn't lose accumulated context. |
| 8 | Static-fit threshold | **Static when text fits container** | Less twitchy on stations with a single short tagline. |

User can flip any of these via the new UI section at UAT or override in config.

## Implementation notes

- **Client-side accumulation** in a small POCO (`RdsAccumulatingScrollBuffer`) — API stays stateless, no SignalR contract change.
- **Pure CSS keyframes** on \`transform: translateX\` — GPU compositor thread, no JS rAF, no main-thread contention with the audio pipeline (Intel N100 sensitivity per CLAUDE.md auto-memory).
- **Station-change reset triggers:** Band change OR Frequency change (0.001 Hz tolerance) OR non-null PI change. Transient null PI does NOT trigger reset.
- **Dedup tracker resets alongside the buffer** — catches the "first chunk on new station silently dropped" regression.
- **Accessibility:** SR-only \`aria-live="polite"\` mirror with full buffer text; visible track is \`aria-hidden="true"\`; \`tabindex="0"\` for keyboard focus pause; \`@media (prefers-reduced-motion: reduce)\` falls back to a thin horizontal scrollbar.
- **Surrogate-pair safe** truncation (cheap insurance for future RDS+ extensions).

## Affected files (spec §10)

**New:**
- \`src/Radio.Web/Models/RdsScrollOptions.cs\` — config model (256 chars / 40 px/s / \" • \" defaults)
- \`src/Radio.Web/Services/Rds/RdsAccumulatingScrollBuffer.cs\` — rolling buffer logic
- \`src/Radio.Web/Components/Shared/RdsScrollMarquee.razor\` — CSS keyframe marquee component
- \`tests/Radio.Web.Tests/Services/Rds/RdsAccumulatingScrollBufferTests.cs\` — 24 unit tests
- \`tests/Radio.Web.Tests/Components/Shared/RdsScrollMarqueeTests.cs\` — 12 bUnit tests

**Modified:**
- \`src/Radio.Web/Components/Shared/RadioControlPanel.razor\` — replaces legacy \`.rcp-rds-rt\` block with \`<RdsScrollMarquee>\`, injects \`IOptionsMonitor<RdsScrollOptions>\`, wires station-change reset + append into \`HandleRadioStateChanged\`, disposes the options listener
- \`src/Radio.Web/Components/Pages/SystemConfigPage.razor\` — adds three RadzenNumeric/TextBox controls under existing Radio tab with mono \"RDS RADIOTEXT TICKER\" sub-heading
- \`src/Radio.Web/Models/ApiModels.cs\` — adds three properties to \`RadioConfigDto\` so the SystemConfig save round-trip carries them
- \`src/Radio.Web/Program.cs\` — registers \`Configure<RdsScrollOptions>\`
- \`src/Radio.Web/wwwroot/css/design-system.css\` — adds \`.rcp-rds-rt-scroll\` / \`-track\` / \`-sr-only\` rules + keyframes + \`prefers-reduced-motion\` fallback
- \`tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs\` — three legacy RT-line tests retargeted to new selectors; registers \`IOptionsMonitor<RdsScrollOptions>\` in DI

**Unchanged (out of scope):**
- \`RTLSDRCore.DSP.RdsDecoder\`, \`Radio.API.Services.AudioStateUpdateService\`, \`Radio.Web.Components.Shared.RdsCard\` — decoder + API + PS/PTY card all untouched.

## Deviation from spec §5

The spec hinted at config keys under \`Radio:Rds:*\`. Implementation uses **\`radio:RtBufferMaxChars\`** etc. (flat under the existing \`radio\` section) because the existing Web → API config save path round-trips a flat \`RadioConfigDto\` with one SQLite key per property. Carving out a nested \`Rds\` sub-object would require server-side \`ConfigurationController\` changes that are out of scope for this PR. End user observes the same UI; only on-disk key layout differs. Documented in \`RdsScrollOptions\` remarks.

## Coexistence with PR #1 (configurable time format)

Both PRs touch \`SystemConfigPage.razor\`. The new RDS section appends three new RadzenColumn controls within the existing Radio tab; PR #1 (per the prompt) adds a Display sub-tab elsewhere. **Second to merge will rebase.** No structural overlap expected — the changes live in different tabs.

## Test plan

- [x] Build: \`dotnet build --configuration Release\` → 0 errors, 47 warnings (all pre-existing IDE0011 brace-style)
- [x] Unit tests: \`dotnet test --configuration Release\` → all Web tests pass (573/573), 24 new buffer tests + 12 new marquee tests
- [x] Pre-existing 4 \`SrcVariableResamplerTests\` failures on Windows (missing \`libsamplerate.so.0\`) confirmed as Linux-only and unrelated
- [ ] **UAT (user, tomorrow):**
  - [ ] Tune to an RDS-rich FM station (e.g. WUNC 91.5 if local, or any commercial FM with rotating RT) — observe RT chunks accumulate with \` • \` separator
  - [ ] Watch through 2–3 chunk cycles — verify the marquee scrolls right-to-left at a comfortable reading pace
  - [ ] Hover the marquee — verify scroll pauses, subtle 1 px outline appears
  - [ ] Tab to focus the marquee — verify scroll pauses (focus-pause)
  - [ ] Tune to a different station — verify buffer clears immediately, refills with new station's RT
  - [ ] Tune to an AM station — verify marquee collapses (no RT, no placeholder)
  - [ ] System Config → Radio tab → bottom RDS section — verify three new controls present and saving works
  - [ ] Change scroll speed in config to 80 px/s — verify marquee speeds up after save
  - [ ] Change separator to \` | \` — verify next RT chunk uses pipe separator
  - [ ] Set max length to 64 — verify buffer truncates quickly after a few chunks

## Operator note

No deploy changes required. The three new SQLite config keys (\`radio:RtBufferMaxChars\`, \`radio:RtScrollSpeedPxPerSec\`, \`radio:RtChunkSeparator\`) are read with safe defaults — existing deployments without these keys behave identically to the post-PR defaults (256 chars / 40 px/s / \" • \").

## Out of scope (spec §9)

- PS/PTY display changes (RdsCard untouched)
- Per-station persisted buffer history
- Exporting/copying the RDS log
- AM/WB/SW RT support (RT is FM-only; buffer collapses on non-FM bands via the band-change reset)
- Multi-line wrap
- Now-Playing extraction from RT (separate workstream)
- Animation-frame-perfect smooth appends during scroll cycle (accepted minor visual jump per spec §6.f)
- Localized number/date formatting inside RT

🤖 Generated with [Claude Code](https://claude.com/claude-code)