### PR TITLE
fix(web): RDS RadioText renders once in existing display bar (was duplicated post-#414)

### DIFF
--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -67,9 +67,19 @@
         </div>
       }
 
-      <!-- RDS card — mounted ABOVE the frequency well (handoff §P1·1 step 3) -->
+      <!-- RDS card — mounted ABOVE the frequency well (handoff §P1·1 step 3).
+           Hosts the PS station name + PTY chip AND (post-fix) the
+           accumulating RT marquee on a second row inside the same card.
+           PR #414's first cut placed the marquee as a standalone block
+           BELOW the frequency well, which read as a doubled RDS surface
+           to the user — the bug fix consolidates all RDS info into this
+           single card under one "RDS" tag header so the RT data scrolls
+           inside the bar with the blue station-name text.
+           HANDOFF-rds-accumulating-scroll. -->
       <RdsCard StationName="@_radioState.RdsStationName"
-               ProgramType="@_radioState.RdsProgramType" />
+               ProgramType="@_radioState.RdsProgramType"
+               RadioText="@_rdsBuffer.Text"
+               ScrollSpeedPxPerSec="@_rdsScrollOptions.RtScrollSpeedPxPerSec" />
 
       <!-- Frequency display -->
       <div class="rcp-freq-well">
@@ -92,16 +102,6 @@
           }
         </div>
       </div>
-
-      <!-- RDS RadioText (RT) line — accumulating rolling scroll marquee
-           below the frequency well. Replaces the legacy one-line ellipsis
-           with a rolling 256-char (default) buffer that scrolls right-to-
-           left at 40 px/s (defaults configurable via Radio:Rds in System
-           Config). The marquee collapses entirely when the buffer is empty
-           (no station broadcasting RT, or just-tuned and waiting for the
-           first chunk). HANDOFF-rds-accumulating-scroll. -->
-      <RdsScrollMarquee Text="@_rdsBuffer.Text"
-                        ScrollSpeedPxPerSec="@_rdsScrollOptions.RtScrollSpeedPxPerSec" />
 
       <!-- Signal strength meter (PR 1 of Radio Controller Polish arc) -->
       @if (_radioState.SignalStrength.HasValue)

--- a/src/Radio.Web/Components/Shared/RdsCard.razor
+++ b/src/Radio.Web/Components/Shared/RdsCard.razor
@@ -1,29 +1,78 @@
-@* RDS Card — renders only when StationName is non-empty. Mounted above the
-   frequency well in RadioControlPanel. PR 3 of the Radio Controller Polish
-   arc (handoff §P1·1 step 3). *@
+@* RDS Card — single visual unit grouping the three RDS fields exposed by the
+   tuner: the "RDS" label tag, the PS station name (blue), the optional PTY
+   chip, and (NEW) the accumulating RadioText (RT) marquee on a second row.
 
-@if (!string.IsNullOrEmpty(StationName))
+   Mounts above the frequency well in RadioControlPanel. PR 3 of the Radio
+   Controller Polish arc (handoff §P1·1 step 3) introduced the original
+   PS/PTY-only form. PR #414 added the standalone <RdsScrollMarquee> BELOW
+   the frequency well, which read as a doubled RDS surface to the user
+   ("RDS data shown twice"). This card now hosts the marquee inline so all
+   RDS info lives in one card under the "RDS" tag with the blue text. *@
+
+@if (!string.IsNullOrEmpty(StationName) || !string.IsNullOrEmpty(RadioText))
 {
   <div class="rds-card">
-    <span class="rds-card-label">RDS</span>
-    <span class="rds-card-station">@StationName</span>
-    @if (!string.IsNullOrEmpty(ProgramType))
+    <div class="rds-card-row">
+      <span class="rds-card-label">RDS</span>
+      @if (!string.IsNullOrEmpty(StationName))
+      {
+        <span class="rds-card-station">@StationName</span>
+      }
+      else
+      {
+        @* Spacer keeps the PTY chip pushed to the right when PS is missing
+           but RT is present — so the row geometry stays stable as PS comes
+           and goes during a tune. *@
+        <span class="rds-card-station-spacer"></span>
+      }
+      @if (!string.IsNullOrEmpty(ProgramType))
+      {
+        <span class="rds-card-pty">@ProgramType</span>
+      }
+    </div>
+    @if (!string.IsNullOrEmpty(RadioText))
     {
-      <span class="rds-card-pty">@ProgramType</span>
+      @* Inline marquee — the same component PR #414 originally placed
+         standalone below the frequency well, now nested inside the RDS
+         card so it shares the "RDS" tag header and visual surround. The
+         marquee handles its own collapse-when-empty inside the
+         component, so passing through an empty string would render
+         nothing — but the @if above already gates on non-empty. *@
+      <RdsScrollMarquee Text="@RadioText"
+                        ScrollSpeedPxPerSec="@ScrollSpeedPxPerSec" />
     }
   </div>
 }
 
 @code {
   /// <summary>
-  /// RDS Program Service station name (PS field, up to 8 characters). Required
-  /// in the contract sense — when null/empty the card renders nothing at all.
+  /// RDS Program Service station name (PS field, up to 8 characters). Optional
+  /// — when null/empty AND <see cref="RadioText"/> is also null/empty the
+  /// card renders nothing at all. When null/empty but RT is present, the
+  /// station-name slot is left blank and the card still renders so RT can
+  /// scroll on its own.
   /// </summary>
-  [Parameter, EditorRequired] public string? StationName { get; set; }
+  [Parameter] public string? StationName { get; set; }
 
   /// <summary>
   /// RDS Program Type name (PTY field, e.g. "Rock", "News"). Optional — when
   /// null/empty the PTY chip is omitted but the station name still renders.
   /// </summary>
   [Parameter] public string? ProgramType { get; set; }
+
+  /// <summary>
+  /// Accumulating RDS RadioText (RT) buffer text rendered as a scrolling
+  /// marquee on the second row of the card. Optional — when null/empty the
+  /// marquee row is omitted and the card renders only the PS/PTY row.
+  /// Caller passes the post-accumulation, post-dedup string from the
+  /// <see cref="Radio.Web.Services.Rds.RdsAccumulatingScrollBuffer"/>.
+  /// </summary>
+  [Parameter] public string? RadioText { get; set; }
+
+  /// <summary>
+  /// Marquee scroll speed in pixels per second. Threaded through to the
+  /// nested <see cref="RdsScrollMarquee"/>; matches its default so callers
+  /// that don't care about per-instance tuning can omit this parameter.
+  /// </summary>
+  [Parameter] public int ScrollSpeedPxPerSec { get; set; } = 40;
 }

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -3673,12 +3673,25 @@ body {
   color: color-mix(in srgb, var(--signal-amber) 70%, var(--text-low));
 }
 
-/* RDS Card — mounts above the frequency well. Renders only when StationName
-   is non-empty (component handles the @if). */
+/* RDS Card — mounts above the frequency well. Hosts the RDS label tag, PS
+   station name (blue), optional PTY chip, AND (post-#414 hotfix) the
+   accumulating RT marquee as a second row inside the same card. Renders
+   when EITHER StationName OR RadioText is non-empty (component handles
+   the @if).
+
+   Layout: flex column with two sub-rows.
+     1. .rds-card-row  — RDS label · station name · PTY chip (existing form)
+     2. .rcp-rds-rt-scroll — marquee, nested as the card's second child
+
+   Prior to the #414 hotfix, .rds-card was flex-row with only the
+   label/station/PTY children. The marquee was a sibling block below the
+   frequency well — which read as a duplicated RDS surface. Moving the
+   marquee inside the card gives the user a single visual unit under
+   the "RDS" tag. */
 .rds-card {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  flex-direction: column;
+  gap: 4px;
   padding: 8px 12px;
   margin: 0 0 8px;
   background: var(--surface-elevated, rgba(255, 255, 255, 0.03));
@@ -3687,6 +3700,23 @@ body {
   width: 100%;
   max-width: 420px;
   box-sizing: border-box;
+}
+
+/* Top row of the RDS card — RDS label, station name, PTY chip. Mirrors the
+   pre-#414-hotfix flex-row layout that lived on .rds-card directly. */
+.rds-card-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+/* Spacer used when PS station name is missing but RT is present (transient
+   state during a tune-in). Keeps the PTY chip pushed to the right so the
+   row geometry stays stable as PS comes and goes. */
+.rds-card-station-spacer {
+  flex: 1;
+  min-width: 0;
 }
 
 .rds-card-label {
@@ -3724,6 +3754,15 @@ body {
   border-radius: 999px;
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+/* Marquee-nested-in-card adjustment — when the .rcp-rds-rt-scroll lives
+   inside an .rds-card, drop the standalone-block top margin and zero out
+   the max-width override so the marquee respects the card's inner padding
+   rather than punching out to the global 420 px ceiling. */
+.rds-card .rcp-rds-rt-scroll {
+  margin-top: 0;
+  max-width: 100%;
 }
 
 /* RT (RadioText) line below the frequency well — one-line ellipsis */

--- a/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
@@ -606,12 +606,34 @@ public class RadioControlPanelTests : TestContext
   }
 
   [Fact]
-  public void RdsCard_Hidden_WhenStationNameNull()
+  public void RdsCard_Hidden_WhenStationNameNullAndRadioTextNull()
   {
-    var state = BuildState(rdsStationName: null);
+    // Post-#414-hotfix: the card now renders when EITHER StationName OR
+    // RadioText is present (because RT lives inside the card). When BOTH
+    // are null the card collapses entirely — same as the pre-hotfix
+    // contract for the station-only case.
+    var state = BuildState(rdsStationName: null, rdsRadioText: null);
     var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
 
     Assert.Empty(cut.FindAll(".rds-card"));
+  }
+
+  [Fact]
+  public void RdsCard_Renders_WhenRadioTextPresentButStationNameNull()
+  {
+    // Post-#414-hotfix: transient state during a tune-in where RT chunks
+    // arrive before PS is confirmed. The card must still render so the
+    // RT marquee has a home — otherwise we'd regress the prior PR #414
+    // behaviour where RT could show without PS.
+    var state = BuildState(rdsStationName: null, rdsRadioText: "Tuning in...");
+    var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
+
+    var card = cut.Find(".rds-card");
+    Assert.NotNull(card);
+    // Station-name slot must be absent (no PS yet); marquee inside card.
+    Assert.Empty(cut.FindAll(".rds-card-station"));
+    var rt = cut.Find(".rcp-rds-rt-scroll");
+    Assert.Contains("Tuning in", rt.TextContent);
   }
 
   [Fact]
@@ -622,7 +644,13 @@ public class RadioControlPanelTests : TestContext
     // contract is still "text shows up, title attribute carries the full
     // string" — but the scroll container also exposes the buffer via the
     // sr-only mirror for screen readers.
-    var state = BuildState(rdsRadioText: "Now playing: Pink Floyd — Wish You Were Here");
+    //
+    // Post-#414-hotfix: the marquee now lives INSIDE .rds-card rather than
+    // as a standalone block below the frequency well. The .rcp-rds-rt-scroll
+    // selector still finds it (component-level selector unchanged).
+    var state = BuildState(
+      rdsStationName: "WKQX",
+      rdsRadioText: "Now playing: Pink Floyd — Wish You Were Here");
     var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
 
     var rt = cut.Find(".rcp-rds-rt-scroll");
@@ -634,7 +662,7 @@ public class RadioControlPanelTests : TestContext
   [Fact]
   public void RtLine_Hidden_WhenRadioTextNull()
   {
-    var state = BuildState(rdsRadioText: null);
+    var state = BuildState(rdsStationName: "WKQX", rdsRadioText: null);
     var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
 
     Assert.Empty(cut.FindAll(".rcp-rds-rt-scroll"));
@@ -643,10 +671,45 @@ public class RadioControlPanelTests : TestContext
   [Fact]
   public void RtLine_Hidden_WhenRadioTextEmpty()
   {
-    var state = BuildState(rdsRadioText: "");
+    var state = BuildState(rdsStationName: "WKQX", rdsRadioText: "");
     var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
 
     Assert.Empty(cut.FindAll(".rcp-rds-rt-scroll"));
+  }
+
+  [Fact]
+  public void RtLine_RendersExactlyOnce_InsideRdsCard_NoDuplicate()
+  {
+    // Regression guard against the bug PR #414 shipped: the new accumulating
+    // marquee was added as a NEW standalone element below the frequency well
+    // instead of replacing the existing static RT line, causing the RT to
+    // render twice in the panel (user-reported: "RDS data doubled up").
+    //
+    // The fix consolidates the marquee into a single location INSIDE
+    // .rds-card. This test pins that contract:
+    //   1. Exactly ONE .rcp-rds-rt-scroll element renders for non-empty RT.
+    //   2. That single element is a descendant of .rds-card (i.e. lives
+    //      inside the RDS bar with the blue station-name text, NOT as a
+    //      standalone sibling).
+    var state = BuildState(
+      rdsStationName: "WUNC",
+      rdsProgramType: "News",
+      rdsRadioText: "Morning Edition with Steve Inskeep");
+    var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
+
+    var marquees = cut.FindAll(".rcp-rds-rt-scroll");
+    marquees.Should().HaveCount(1,
+      "PR #414's first cut rendered the RT marquee twice (standalone below " +
+      "freq well + would-be-replacement intended for inside the RDS bar) — " +
+      "the hotfix consolidates to a single render location inside .rds-card");
+
+    // The single marquee must be a descendant of the RDS card so all
+    // RDS data lives in one visual unit under the "RDS" tag header.
+    var card = cut.Find(".rds-card");
+    var marqueeInsideCard = card.QuerySelector(".rcp-rds-rt-scroll");
+    marqueeInsideCard.Should().NotBeNull(
+      "the marquee must live INSIDE .rds-card so the user sees a single " +
+      "'RDS bar' containing both the blue station name and the scrolling RT");
   }
 
   [Fact]


### PR DESCRIPTION
## Summary

PR #414's accumulating-scroll marquee was added as a NEW element BELOW the existing RDS bar instead of replacing the static RT rendering inside it. User reported the RT text rendering twice on http://radio:5002 — once as the existing RDS card surface above the frequency well, once as the new standalone marquee below. This PR consolidates to a single render location inside the existing `.rds-card` so all RDS info lives under one "RDS" tag header with the blue station-name text.

## Root cause

PR #414's implementation added `<RdsScrollMarquee>` as a sibling block below the frequency well in `RadioControlPanel.razor`, while leaving the `RdsCard` (RDS tag + blue PS station name + PTY chip) above the frequency well untouched. The intent was a single RT display surface; the result was two visually-related RDS surfaces flanking the frequency well — the user perceived this as "doubled-up" data even though only one was actually rendering RT text.

## Approach taken

**Approach A** (per the prompt — the cleaner option here): nest the marquee INSIDE the existing `.rds-card` as a second sub-row, so the card becomes:

```
┌─────────────────────────────────────────────┐
│ RDS  |  WUNC  (blue, large)        | News  │   ← top row (PS / PTY)
│ Morning Edition with Steve Inskeep …       │   ← bottom row (scrolling RT)
└─────────────────────────────────────────────┘
```

This keeps the existing visual chrome (border, surround, "RDS" tag, blue station-name aesthetic) exactly as the user described and routes the RT through the marquee component inside the same box. The standalone marquee block below the frequency well is removed entirely.

**Why not Approach B (keep marquee below freq well, remove RdsCard surface):** the user explicitly said "I want the RDS data to scroll in the bar already created for it (with the blue text after the RDS tag)". The user wants the existing `.rds-card` bar to be the host, not a separately-styled marquee. Approach A is the only read that lands the RT in the bar the user is pointing at.

### Layout / CSS changes

- `.rds-card` flips from `flex-row` to `flex-direction: column` with a 4px gap between sub-rows
- New `.rds-card-row` wraps the original `RDS label | station | PTY` flex-row layout as the card's first sub-row (no visual change to that row in isolation)
- New `.rds-card .rcp-rds-rt-scroll` overrides drop the standalone-block top margin and max-width override so the nested marquee respects the card's inner padding
- New `.rds-card-station-spacer` keeps the PTY chip right-aligned during the transient tune-in state when PS is absent but RT is present

### Component contract changes

`RdsCard.razor` gains two new optional parameters:
- `RadioText` (string?) — the accumulating buffer text; renders the marquee row when non-empty
- `ScrollSpeedPxPerSec` (int, default 40) — threaded to the nested `<RdsScrollMarquee>`

Render condition widens from `StationName non-empty` to `StationName OR RadioText non-empty` so the marquee can scroll during the transient state where RT chunks arrive before PS is confirmed. When both are null/empty the card still collapses entirely (matches the prior contract for the station-only case).

`RdsScrollMarquee` and `RdsAccumulatingScrollBuffer` are untouched. Only the placement of the marquee changes.

## Tests

`tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs`:

- **New**: `RtLine_RendersExactlyOnce_InsideRdsCard_NoDuplicate` — regression guard pinning the contract this hotfix delivers. Asserts (1) exactly ONE `.rcp-rds-rt-scroll` element renders for non-empty RT, and (2) that single element is a descendant of `.rds-card`. If a future change re-introduces the duplicate or moves the marquee back outside the card, this test trips immediately.
- **New**: `RdsCard_Renders_WhenRadioTextPresentButStationNameNull` — covers the transient tune-in state where RT arrives before PS.
- **Renamed**: `RdsCard_Hidden_WhenStationNameNull` → `RdsCard_Hidden_WhenStationNameNullAndRadioTextNull` to reflect the new render-if-either semantics; passes both nulls.
- **Updated**: `RtLine_RendersWithTitleAttribute_WhenPresent` now seeds `RdsStationName` alongside `RdsRadioText` so the test exercises the production coexistence path (PS + RT both present in the same card). The `.rcp-rds-rt-scroll` selector still finds the nested marquee — component-level selector is unchanged.

`RdsCardTests.cs` unchanged — the standalone component contract still holds (renders nothing when both StationName and RadioText are empty; cyan station-name colour rule on `.rds-card-station` unchanged).

## Files changed

- `src/Radio.Web/Components/Shared/RdsCard.razor` — new params, nest marquee, render-if-either
- `src/Radio.Web/Components/Shared/RadioControlPanel.razor` — thread RT + speed into `<RdsCard>`, remove standalone `<RdsScrollMarquee>` block below freq well
- `src/Radio.Web/wwwroot/css/design-system.css` — `.rds-card` flex-column, new `.rds-card-row`, nested-marquee overrides
- `tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs` — regression guard + render-if-either coverage

## Test plan

- [x] `dotnet build --configuration Release` — 0 errors (44 warnings, all pre-existing IDE0011 brace-style)
- [x] `dotnet test --configuration Release` — 591/591 Web tests pass including the new regression guard; full solution passes except the 4 pre-existing Linux-only `SrcVariableResamplerTests` failures (unrelated)
- [ ] **User UAT on http://radio:5002**: tune to an RDS station (e.g. WUNC 91.5 FM). Verify the RT text appears EXACTLY ONCE inside the existing RDS bar (with the blue station-name text after the RDS tag) and scrolls continuously right-to-left. Verify NO duplicate RT block appears below the frequency well.
- [ ] **User UAT — empty-RT station**: tune to a station that doesn't broadcast RT. Verify the RDS card still shows the PS station name + PTY chip in the top row, with no empty marquee row underneath.
- [ ] **User UAT — RT-only transient**: optional — observe behaviour during tune-in. If RT chunks arrive before PS, verify the card renders with the marquee row but no station-name slot above (PTY chip stays right-aligned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)