### PR TITLE
fix(web): RDS RT scrolls inline in PS slot (single-row layout)

### DIFF
--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -68,18 +68,21 @@
       }
 
       <!-- RDS card — mounted ABOVE the frequency well (handoff §P1·1 step 3).
-           Hosts the PS station name + PTY chip AND (post-fix) the
-           accumulating RT marquee on a second row inside the same card.
-           PR #414's first cut placed the marquee as a standalone block
-           BELOW the frequency well, which read as a doubled RDS surface
-           to the user — the bug fix consolidates all RDS info into this
-           single card under one "RDS" tag header so the RT data scrolls
-           inside the bar with the blue station-name text.
-           HANDOFF-rds-accumulating-scroll. -->
+           Single-row layout (post HANDOFF-rds-inline-scroll-revision): the
+           light-blue PS slot itself becomes the marquee surface when RT is
+           present, so PS identity + accumulating RT share one continuous
+           scroll string like "Eagles • Green Day · Hotel California".
+           Collapses the two-row card PR #416 shipped — that variant pushed
+           the frequency display + STEREO badge below the visible viewport
+           at 1920×720.
+           Separator is threaded from the SQLite-backed RdsScrollOptions so
+           the PS↔RT join visually matches the inter-chunk joins inside
+           the RT buffer. -->
       <RdsCard StationName="@_radioState.RdsStationName"
                ProgramType="@_radioState.RdsProgramType"
                RadioText="@_rdsBuffer.Text"
-               ScrollSpeedPxPerSec="@_rdsScrollOptions.RtScrollSpeedPxPerSec" />
+               ScrollSpeedPxPerSec="@_rdsScrollOptions.RtScrollSpeedPxPerSec"
+               Separator="@_rdsScrollOptions.RtChunkSeparator" />
 
       <!-- Frequency display -->
       <div class="rcp-freq-well">

--- a/src/Radio.Web/Components/Shared/RdsCard.razor
+++ b/src/Radio.Web/Components/Shared/RdsCard.razor
@@ -1,45 +1,59 @@
 @* RDS Card — single visual unit grouping the three RDS fields exposed by the
    tuner: the "RDS" label tag, the PS station name (blue), the optional PTY
-   chip, and (NEW) the accumulating RadioText (RT) marquee on a second row.
+   chip, and the accumulating RadioText (RT) marquee.
 
    Mounts above the frequency well in RadioControlPanel. PR 3 of the Radio
    Controller Polish arc (handoff §P1·1 step 3) introduced the original
-   PS/PTY-only form. PR #414 added the standalone <RdsScrollMarquee> BELOW
+   PS/PTY-only form. PR #414 added a standalone <RdsScrollMarquee> BELOW
    the frequency well, which read as a doubled RDS surface to the user
-   ("RDS data shown twice"). This card now hosts the marquee inline so all
-   RDS info lives in one card under the "RDS" tag with the blue text. *@
+   ("RDS data shown twice"). PR #416 then nested the marquee as a SECOND
+   row inside this card — which fixed the duplication but pushed the
+   frequency display + STEREO badge out of view at the project's 1920×720
+   viewport.
+
+   This revision (HANDOFF-rds-inline-scroll-revision.md, option (c))
+   collapses the card back to a single row: the light-blue PS slot itself
+   BECOMES the marquee surface. When RT is present, the track text is
+   "{PS} • {RT}" — station identity anchors the head, then accumulating
+   RT scrolls after a bullet separator. When RT is empty, render the
+   original static PS span (no animation). When PS is empty but RT is
+   present (transient tune-in), render the marquee with just RT (no
+   leading separator). When both are empty, the @if gate hides the card. *@
 
 @if (!string.IsNullOrEmpty(StationName) || !string.IsNullOrEmpty(RadioText))
 {
   <div class="rds-card">
-    <div class="rds-card-row">
-      <span class="rds-card-label">RDS</span>
-      @if (!string.IsNullOrEmpty(StationName))
-      {
-        <span class="rds-card-station">@StationName</span>
-      }
-      else
-      {
-        @* Spacer keeps the PTY chip pushed to the right when PS is missing
-           but RT is present — so the row geometry stays stable as PS comes
-           and goes during a tune. *@
-        <span class="rds-card-station-spacer"></span>
-      }
-      @if (!string.IsNullOrEmpty(ProgramType))
-      {
-        <span class="rds-card-pty">@ProgramType</span>
-      }
-    </div>
+    <span class="rds-card-label">RDS</span>
     @if (!string.IsNullOrEmpty(RadioText))
     {
-      @* Inline marquee — the same component PR #414 originally placed
-         standalone below the frequency well, now nested inside the RDS
-         card so it shares the "RDS" tag header and visual surround. The
-         marquee handles its own collapse-when-empty inside the
-         component, so passing through an empty string would render
-         nothing — but the @if above already gates on non-empty. *@
-      <RdsScrollMarquee Text="@RadioText"
+      @* Inline marquee fills the PS slot. Track text composition:
+         - PS + RT  → "{PS}{Separator}{RT}" (single continuous scroll string)
+         - PS empty → "{RT}" alone (no leading separator)
+         The CSS override .rds-card .rcp-rds-rt-track restyles the track
+         to inherit PS typography (blue 14 px 700) so the marquee reads
+         as the PS slot rather than as the dim 11 px standalone variant. *@
+      var trackText = string.IsNullOrEmpty(StationName)
+        ? RadioText
+        : $"{StationName}{Separator}{RadioText}";
+      <RdsScrollMarquee Text="@trackText"
                         ScrollSpeedPxPerSec="@ScrollSpeedPxPerSec" />
+    }
+    else if (!string.IsNullOrEmpty(StationName))
+    {
+      @* RT empty → static PS only. Preserves the pre-#414 behaviour:
+         single short station name should not scroll. *@
+      <span class="rds-card-station">@StationName</span>
+    }
+    else
+    {
+      @* Defensive — outer @if already rules out the both-empty case, but
+         keeping a spacer here mirrors the prior intent that the row
+         geometry remain stable if both fields are momentarily null. *@
+      <span class="rds-card-station-spacer"></span>
+    }
+    @if (!string.IsNullOrEmpty(ProgramType))
+    {
+      <span class="rds-card-pty">@ProgramType</span>
     }
   </div>
 }
@@ -49,8 +63,8 @@
   /// RDS Program Service station name (PS field, up to 8 characters). Optional
   /// — when null/empty AND <see cref="RadioText"/> is also null/empty the
   /// card renders nothing at all. When null/empty but RT is present, the
-  /// station-name slot is left blank and the card still renders so RT can
-  /// scroll on its own.
+  /// station-name slot is left blank and the marquee renders just the RT
+  /// (no leading separator).
   /// </summary>
   [Parameter] public string? StationName { get; set; }
 
@@ -62,9 +76,10 @@
 
   /// <summary>
   /// Accumulating RDS RadioText (RT) buffer text rendered as a scrolling
-  /// marquee on the second row of the card. Optional — when null/empty the
-  /// marquee row is omitted and the card renders only the PS/PTY row.
-  /// Caller passes the post-accumulation, post-dedup string from the
+  /// marquee in the PS slot (post-revision). Optional — when null/empty the
+  /// PS slot reverts to a static <c>&lt;span class="rds-card-station"&gt;</c>
+  /// and no marquee renders. Caller passes the post-accumulation, post-dedup
+  /// string from the
   /// <see cref="Radio.Web.Services.Rds.RdsAccumulatingScrollBuffer"/>.
   /// </summary>
   [Parameter] public string? RadioText { get; set; }
@@ -75,4 +90,14 @@
   /// that don't care about per-instance tuning can omit this parameter.
   /// </summary>
   [Parameter] public int ScrollSpeedPxPerSec { get; set; } = 40;
+
+  /// <summary>
+  /// Glyph inserted between the PS station name and the RT buffer when both
+  /// are present (e.g. <c>"Eagles • Green Day · Hotel California"</c>).
+  /// Defaults to <c>" • "</c> to match <see cref="Models.RdsScrollOptions.RtChunkSeparator"/>
+  /// so the PS↔RT join visually matches the inter-chunk joins inside the RT
+  /// buffer. <see cref="RadioControlPanel"/> threads the configured option
+  /// value through; tests can pass an explicit value to assert on it.
+  /// </summary>
+  [Parameter] public string Separator { get; set; } = " • ";
 }

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -3674,24 +3674,29 @@ body {
 }
 
 /* RDS Card — mounts above the frequency well. Hosts the RDS label tag, PS
-   station name (blue), optional PTY chip, AND (post-#414 hotfix) the
-   accumulating RT marquee as a second row inside the same card. Renders
-   when EITHER StationName OR RadioText is non-empty (component handles
-   the @if).
+   station name (blue), optional PTY chip, and the accumulating RT marquee.
+   Renders when EITHER StationName OR RadioText is non-empty (component
+   handles the @if).
 
-   Layout: flex column with two sub-rows.
-     1. .rds-card-row  — RDS label · station name · PTY chip (existing form)
-     2. .rcp-rds-rt-scroll — marquee, nested as the card's second child
+   Layout: SINGLE flex row (post HANDOFF-rds-inline-scroll-revision). The
+   PS slot itself is the marquee surface when RT is present:
+     [RDS label] [PS-or-marquee, flex:1] [PTY chip, pinned right]
+   The marquee track text is "{PS} • {RT}" when both are present, just
+   "{RT}" when PS is transient-null. When RT is empty, a static PS span
+   renders in the same slot (no animation).
 
-   Prior to the #414 hotfix, .rds-card was flex-row with only the
-   label/station/PTY children. The marquee was a sibling block below the
-   frequency well — which read as a duplicated RDS surface. Moving the
-   marquee inside the card gives the user a single visual unit under
-   the "RDS" tag. */
+   History: PR #414 added the RT marquee as a STANDALONE block below the
+   frequency well — read as a doubled RDS surface. PR #416 nested it as
+   a SECOND row inside this card to fix the duplication, but the extra
+   row pushed the frequency display + STEREO badge out of view at the
+   project's 1920×720 viewport. This revision collapses the two rows
+   back into one; the in-card .rcp-rds-rt-track override below restyles
+   the marquee to inherit PS typography so it reads as the PS slot. */
 .rds-card {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
   padding: 8px 12px;
   margin: 0 0 8px;
   background: var(--surface-elevated, rgba(255, 255, 255, 0.03));
@@ -3702,18 +3707,10 @@ body {
   box-sizing: border-box;
 }
 
-/* Top row of the RDS card — RDS label, station name, PTY chip. Mirrors the
-   pre-#414-hotfix flex-row layout that lived on .rds-card directly. */
-.rds-card-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
-}
-
-/* Spacer used when PS station name is missing but RT is present (transient
-   state during a tune-in). Keeps the PTY chip pushed to the right so the
-   row geometry stays stable as PS comes and goes. */
+/* Spacer used when PS station name is missing AND RT is also empty in the
+   same render — defensive only (the outer @if already gates the card on
+   either-present). Keeps the PTY chip pushed to the right so the row
+   geometry stays stable in any transient state. */
 .rds-card-station-spacer {
   flex: 1;
   min-width: 0;
@@ -3757,12 +3754,33 @@ body {
 }
 
 /* Marquee-nested-in-card adjustment — when the .rcp-rds-rt-scroll lives
-   inside an .rds-card, drop the standalone-block top margin and zero out
-   the max-width override so the marquee respects the card's inner padding
-   rather than punching out to the global 420 px ceiling. */
+   inside an .rds-card it fills the PS slot itself (post-revision). The
+   standalone variant's top margin and 420 px ceiling don't apply here; the
+   marquee takes whatever flex remainder sits between the RDS label and the
+   PTY pill. height:auto drops the standalone variant's 1.6em (which was
+   tuned for the 11 px standalone typography) so the marquee height tracks
+   the in-card 14 px PS typography from the override below. */
 .rds-card .rcp-rds-rt-scroll {
   margin-top: 0;
+  flex: 1;
+  min-width: 0;
   max-width: 100%;
+  height: auto;
+}
+
+/* In-card marquee typography override — when the marquee occupies the PS
+   slot it must read AS the PS slot, not as the dim 11 px standalone RT
+   line elsewhere. Inherits the same blue 14 px 700 mono treatment the
+   static <span class="rds-card-station"> uses, so the user's eye doesn't
+   notice the PS-vs-marquee swap when RT arrives. Standalone uses (.rcp-rds-rt-scroll
+   outside an .rds-card) keep their dim typography for future re-use. */
+.rds-card .rcp-rds-rt-track {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--accent-primary);
+  letter-spacing: 0.18em;
+  text-shadow: 0 0 8px color-mix(in srgb, var(--accent-primary) 40%, transparent);
 }
 
 /* RT (RadioText) line below the frequency well — one-line ellipsis */

--- a/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs
@@ -645,9 +645,11 @@ public class RadioControlPanelTests : TestContext
     // string" — but the scroll container also exposes the buffer via the
     // sr-only mirror for screen readers.
     //
-    // Post-#414-hotfix: the marquee now lives INSIDE .rds-card rather than
-    // as a standalone block below the frequency well. The .rcp-rds-rt-scroll
-    // selector still finds it (component-level selector unchanged).
+    // Post HANDOFF-rds-inline-scroll-revision: the marquee now lives in the
+    // PS slot of .rds-card and the track text is "{PS} • {RT}" so the user
+    // sees one continuous scroll string. The title attribute mirrors that
+    // composed string — that's what's actually scrolling, so the tooltip
+    // matches what the user is reading.
     var state = BuildState(
       rdsStationName: "WKQX",
       rdsRadioText: "Now playing: Pink Floyd — Wish You Were Here");
@@ -655,8 +657,11 @@ public class RadioControlPanelTests : TestContext
 
     var rt = cut.Find(".rcp-rds-rt-scroll");
     Assert.Contains("Pink Floyd", rt.TextContent);
-    // The title attribute carries the full buffer text — overflow tooltip + a11y
-    Assert.Equal("Now playing: Pink Floyd — Wish You Were Here", rt.GetAttribute("title"));
+    Assert.Contains("WKQX", rt.TextContent);
+    // Title carries the full composed track text — "{PS} • {RT}".
+    Assert.Equal(
+      "WKQX • Now playing: Pink Floyd — Wish You Were Here",
+      rt.GetAttribute("title"));
   }
 
   [Fact]
@@ -710,6 +715,97 @@ public class RadioControlPanelTests : TestContext
     marqueeInsideCard.Should().NotBeNull(
       "the marquee must live INSIDE .rds-card so the user sees a single " +
       "'RDS bar' containing both the blue station name and the scrolling RT");
+  }
+
+  // ─── HANDOFF-rds-inline-scroll-revision: single-row + empty-state matrix ──
+  //
+  // PR #416 nested the marquee as a SECOND row inside .rds-card, which fixed
+  // the duplication PR #414 introduced but pushed the frequency display +
+  // STEREO badge below the visible viewport at 1920×720. The revision
+  // collapses the card back to a single row: the PS slot itself becomes the
+  // marquee surface. These three tests pin the new layout + empty-state
+  // behaviour so a future regression can't sneak the second-row wrapper back.
+
+  [Fact]
+  public void RdsCard_RendersAsSingleRow_PSAndRtShareOneLine()
+  {
+    // PS + RT both present: the marquee track text must be "{PS} • {RT}" and
+    // the .rds-card must NOT contain a .rds-card-row wrapper (the PR #416
+    // two-row wrapper that this revision deletes). Exactly one marquee
+    // descendant. Tests RadioControlPanel-level wiring so the configured
+    // RtChunkSeparator threads through.
+    var state = BuildState(
+      rdsStationName: "Eagles",
+      rdsRadioText: "Green Day · Boulevard",
+      rdsProgramType: "ROCK");
+    var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
+
+    var card = cut.Find(".rds-card");
+
+    // The PR #416 two-row wrapper must be gone.
+    card.QuerySelector(".rds-card-row").Should().BeNull(
+      "the single-row revision deletes the .rds-card-row wrapper so the " +
+      "card stays one line tall and doesn't push the frequency display down");
+
+    // Exactly one marquee track, and its text contains both PS and RT joined
+    // by the default separator ` • ` (the configured RtChunkSeparator).
+    var tracks = cut.FindAll(".rcp-rds-rt-track");
+    tracks.Should().HaveCount(1,
+      "the marquee renders once in the PS slot; no second-row duplicate");
+    var trackText = tracks[0].TextContent;
+    trackText.Should().Contain("Eagles");
+    trackText.Should().Contain("Green Day · Boulevard");
+    trackText.Should().Contain(" • ",
+      "the configured RtChunkSeparator (' • ' default) joins PS and RT so " +
+      "the scroll reads as one continuous identity-plus-context string");
+  }
+
+  [Fact]
+  public void RdsCard_RtEmpty_RendersStaticStationOnly()
+  {
+    // PS present + RT empty: the card must fall back to the original static
+    // .rds-card-station span — no marquee, no animation, no scroll. This is
+    // the regression-prevention case from the handoff matrix: a single short
+    // station name should never scroll.
+    var state = BuildState(
+      rdsStationName: "Eagles",
+      rdsRadioText: null,
+      rdsProgramType: "ROCK");
+    var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
+
+    // Static PS renders.
+    var staticStation = cut.Find(".rds-card-station");
+    staticStation.TextContent.Trim().Should().Be("Eagles");
+
+    // No marquee surface anywhere.
+    cut.FindAll(".rcp-rds-rt-scroll").Should().BeEmpty(
+      "when RT is empty the card reverts to the static PS span; no marquee " +
+      "must render or the user would see a pointless scroll on a single name");
+    cut.FindAll(".rcp-rds-rt-track").Should().BeEmpty();
+  }
+
+  [Fact]
+  public void RdsCard_PsEmpty_RtPresent_RendersMarqueeWithoutLeadingSeparator()
+  {
+    // PS empty + RT present (transient tune-in): the marquee renders with
+    // just the RT text — NO leading " • " separator. The user must not see
+    // a stray bullet at the head of the scroll when station identity hasn't
+    // arrived yet.
+    var state = BuildState(
+      rdsStationName: null,
+      rdsRadioText: "Some RT");
+    var cut = RenderPanel(state, bands: new[] { BuildFmBand() });
+
+    var track = cut.Find(".rcp-rds-rt-track");
+    var trackText = track.TextContent.Trim();
+
+    trackText.Should().NotStartWith(" • ",
+      "when PS is empty the marquee must not lead with a separator — that " +
+      "would look like a dangling bullet at the head of the scroll");
+    trackText.Should().NotStartWith("•",
+      "no bullet glyph at the head either (covers separator variants)");
+    trackText.Should().Be("Some RT",
+      "track text is just the RT when PS is empty — no prefix, no separator");
   }
 
   [Fact]

--- a/tests/Radio.Web.Tests/Components/Shared/RdsCardTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/RdsCardTests.cs
@@ -11,9 +11,12 @@ namespace Radio.Web.Tests.Components.Shared;
 /// <summary>
 /// bUnit tests for the <see cref="RdsCard"/> widget introduced by PR 3 of the
 /// Radio Controller Polish arc. The card mounts above the frequency well in
-/// <c>RadioControlPanel</c>; it renders nothing at all when no station name is
-/// present (so the layout collapses gracefully on AM/SW or before RDS confirms
-/// the PS field), and renders the PTY chip only when supplied.
+/// <c>RadioControlPanel</c>. Renders when EITHER <c>StationName</c> OR
+/// <c>RadioText</c> is non-empty, and is hidden only when both are absent
+/// (post HANDOFF-rds-inline-scroll-revision — the RT marquee lives in the
+/// PS slot so the card stays useful during transient tune-in states where
+/// RT chunks arrive before PS confirms). PTY chip renders only when
+/// supplied.
 /// </summary>
 public class RdsCardTests : TestContext
 {
@@ -24,10 +27,17 @@ public class RdsCardTests : TestContext
   }
 
   [Fact]
-  public void RdsCard_RendersNothing_WhenStationNameNull()
+  public void RdsCard_RendersNothing_WhenBothStationNameAndRadioTextNull()
   {
+    // Post HANDOFF-rds-inline-scroll-revision the render gate is
+    // (!IsNullOrEmpty(StationName) || !IsNullOrEmpty(RadioText)). The
+    // card hides ONLY in the both-empty case — RadioText alone is now
+    // enough to keep the card on screen during transient tune-ins. Pass
+    // RadioText explicitly so the both-empty intent is obvious at the
+    // assertion level rather than relying on the parameter default.
     var cut = RenderComponent<RdsCard>(p => p
-      .Add(x => x.StationName, null));
+      .Add(x => x.StationName, null)
+      .Add(x => x.RadioText, null));
 
     // No .rds-card root in DOM — the card collapses entirely so the
     // surrounding layout doesn't have to skirt an empty box.
@@ -35,10 +45,13 @@ public class RdsCardTests : TestContext
   }
 
   [Fact]
-  public void RdsCard_RendersNothing_WhenStationNameEmpty()
+  public void RdsCard_RendersNothing_WhenBothStationNameAndRadioTextEmpty()
   {
+    // Empty-string variant of the both-absent gate — IsNullOrEmpty treats
+    // null and "" the same, so both forms must collapse the card.
     var cut = RenderComponent<RdsCard>(p => p
-      .Add(x => x.StationName, string.Empty));
+      .Add(x => x.StationName, string.Empty)
+      .Add(x => x.RadioText, string.Empty));
 
     Assert.Empty(cut.FindAll(".rds-card"));
   }


### PR DESCRIPTION
## Summary

User feedback on PR #416 — the second-row marquee pushed the frequency display + STEREO badge below the visible viewport at the project's 1920×720 production target. This PR collapses the RT scroll INTO the existing PS slot (Layout option (c) from the revision spec), so the card is a single row again and the frequency well + STEREO badge sit fully visible underneath.

> "I'd like the light blue RDS text to continuously scroll in the space it has with the latest RDS data. With the extra line for the additional RDS text, the data below the frequency is cut off (STEREO badge for example)."

Spec: [`docs/design-handoffs/HANDOFF-rds-inline-scroll-revision.md`](docs/design-handoffs/HANDOFF-rds-inline-scroll-revision.md)

## Layout decision — option (c)

The PS slot itself becomes the marquee surface. When RT is present, the track text is composed as `"{PS} • {RT}"` — station identity anchors the head of the scroll, then accumulating RT scrolls after a bullet separator. This was chosen over:

- (a) PS only — rejected: regresses RT visibility.
- (b) RT replaces PS — rejected: loses the station-identity anchor.
- (d) PS left-anchored + RT in a middle region — rejected: at 420 px max-width with a 14 px PS and a PTY pill, the middle region is often <120 px (too cramped).

Option (c) keeps "what station am I on?" the first thing the eye reads while still giving RT its continuous scroll.

## Empty-state matrix

| StationName | RadioText | Rendered |
|---|---|---|
| empty | empty | card hidden (existing `@if` gate) |
| present | empty | static `<span class="rds-card-station">` — no marquee, no scroll |
| empty | present | marquee with RT only — **no leading separator** |
| present | present | marquee with `"{PS} • {RT}"`, static-fit auto-engages on short text |

## CSS reverts

- `.rds-card` → `flex-direction: row` with `align-items: center; gap: 12px` (was `column` + `gap: 4px` from PR #416)
- `.rds-card-row` — wrapper rule **deleted** (the markup no longer emits this element)
- `.rds-card .rcp-rds-rt-scroll` — now `flex: 1; min-width: 0; height: auto` so the marquee fills the PS slot
- **New** `.rds-card .rcp-rds-rt-track` typography override — blue 14 px / 700 / `letter-spacing: 0.18em` matching the static PS span, so the in-card marquee reads as the PS slot (the standalone `.rcp-rds-rt-scroll` keeps its dim 11 px styling for future reuse)

## Tests

- **Preserved**: `RtLine_RendersExactlyOnce_InsideRdsCard_NoDuplicate` (load-bearing anti-duplicate guard from PR #416)
- **Updated**: `RtLine_RendersWithTitleAttribute_WhenPresent` — title attribute now mirrors the composed `"{PS} • {RT}"` track text (what the user sees scrolling)
- **New** `RdsCard_RendersAsSingleRow_PSAndRtShareOneLine` — asserts no `.rds-card-row` child, exactly one `.rcp-rds-rt-track`, track text contains PS + RT joined by ` • `
- **New** `RdsCard_RtEmpty_RendersStaticStationOnly` — asserts RT-empty falls back to static `.rds-card-station` with no marquee
- **New** `RdsCard_PsEmpty_RtPresent_RendersMarqueeWithoutLeadingSeparator` — asserts the marquee track text is just `"Some RT"` (no leading bullet)

All 594 Radio.Web tests pass. `RadioControlPanel` now threads the configured `RtChunkSeparator` option through to `RdsCard.Separator` so the PS↔RT join visually matches the inter-chunk joins inside the RT buffer.

## Affected files

- `src/Radio.Web/Components/Shared/RdsCard.razor` — single-row markup, `Separator` parameter, empty-state branches
- `src/Radio.Web/Components/Shared/RadioControlPanel.razor` — passes `RtChunkSeparator` through
- `src/Radio.Web/wwwroot/css/design-system.css` — `.rds-card` flex-row revert, `.rds-card-row` deleted, in-card `.rcp-rds-rt-track` typography override, `.rds-card .rcp-rds-rt-scroll` slot-fill rules
- `tests/Radio.Web.Tests/Components/Shared/RadioControlPanelTests.cs` — 3 new tests + 1 updated test

## Branch note

The original `fix/rds-inline-scroll-revision` branch on the remote was contaminated mid-session by an unrelated sleep-weather commit (`94a7b46`) pushed from a parallel worktree. This `-v2` branch carries only the two RDS-related commits cleanly stacked on `main`. The contaminated branch can be deleted once this PR is merged.

## Test plan

- [ ] Build green: `dotnet build --configuration Release` (verified locally, 0 errors)
- [ ] Tests green: `dotnet test` — all 594 Radio.Web tests pass; only the 4 pre-existing Linux-only `SrcVariableResamplerTests` failures remain (expected, ignored per workflow contract)
- [ ] **UAT (browser, after deploy):** tune to an RDS station with active RT broadcast
  - [ ] RDS card renders as a single row (one line tall)
  - [ ] PS station name anchors the left side, scrolling continuously with RT after a ` • ` separator
  - [ ] PTY badge stays pinned to the right edge
  - [ ] STEREO badge below the frequency is no longer cut off
  - [ ] Frequency display + signal meter sit fully visible at 1920×720
- [ ] **UAT — RT-empty station:** confirm the card shows a static PS name only (no scroll animation)
- [ ] **UAT — PS-empty transient:** during a tune-in where RT arrives before PS, confirm the marquee shows RT without a leading bullet

🤖 Generated with [Claude Code](https://claude.com/claude-code)