### PR TITLE
feat(web): redesigned sleep-mode weather layout (two-region with primary block + forecast cards)

### DIFF
--- a/src/Radio.Web/Components/Shared/SleepForecastPane.razor
+++ b/src/Radio.Web/Components/Shared/SleepForecastPane.razor
@@ -1,15 +1,40 @@
 @*
-  Sleep-mode 3-day weather forecast pane (HANDOFF-sleep-mode-weather-forecast.md §2).
+  Sleep-mode weather forecast pane — v2 visual redesign.
 
-  Rides inside the existing .sleep-screen-drift wrapper on alternate drift cycles,
-  inheriting the same anti-burn-in translate without adding new motion. Single
-  emissive color (dim amber 35% — same as .sleep-screen-clock) and a single
-  passive color (--text-low) preserves the "stereo's off-state" sleep aesthetic.
+  Implements HANDOFF-sleep-weather-visual-redesign.md (supersedes the v1
+  "wall of three coequal cards" treatment from HANDOFF-sleep-mode-weather-
+  forecast.md §2). Composition:
 
-  Null / zero-day forecasts MUST be caught upstream — this component assumes a
-  non-null Forecast with at least one day. The Sleep page guards by simply not
-  rendering this component when Forecast is null (per ADR §2.3 failure-mode
-  contract: null = hide the forecast pane).
+    Region 1 (primary block, 880×180):
+      [96px Material Symbol icon] [96px Orbitron LED current temp + °]
+      [small F·C unit indicator]  [24px condition text]
+                                  [28px LED today H/L]
+
+    Sub-line (14px mono, --text-medium):
+      "<City> · <Day> <Time>"     — or "<icon> <City> · yesterday at HH:mm"
+                                    when IsStale
+
+    Region 2 (forecast row, omitted when Days.Count < 2):
+      3 (or 2) cards, 32px gaps, whitespace-only separation
+      Each card: 48px icon + 14px mono day label + 28px LED high + 20px LED low
+
+  All emissive elements share a single color:
+    color-mix(in srgb, var(--signal-amber) 35%, #050507)
+
+  The primary temperature numeral uses the same font / size / weight /
+  color / text-shadow recipe as .sleep-screen-clock so it reads as the same
+  amber "instrument" as the wall clock.
+
+  Rides inside the existing .sleep-screen-drift wrapper; alternation cadence,
+  anti-burn-in math, NWS fetch, and config UI are all unchanged from v1
+  (handoff §10 "out of scope").
+
+  Null / zero-day forecasts MUST be caught upstream — this component assumes
+  a non-null Forecast with at least one day. Sleep.razor guards via
+  `_forecast.Days.Count > 0`. For a single-day forecast the pane DOES render:
+  the primary block + sub-line are the entire output and Region 2 is omitted
+  (v2 spec §3 State D — a single forecast card duplicating today's data has
+  no comparative value).
 
   All state is supplied via parameters; the pane is purely presentational.
 *@
@@ -17,101 +42,161 @@
 @using Radio.Core.Models
 @using System.Globalization
 
-<div class="sleep-forecast-pane @(Forecast.IsStale ? "is-stale" : null)"
+<div class="sleep-forecast-pane @(Forecast.IsStale ? "is-stale" : null) @(IsBoth ? "unit-both" : null)"
      role="region"
      aria-live="polite"
      aria-atomic="true"
      aria-label="@_ariaLabel">
-  <div class="sleep-forecast-cards">
-    @foreach (var day in Forecast.Days)
-    {
-      <div class="sleep-forecast-card">
-        <div class="sleep-forecast-day">@day.DayName</div>
-        <div class="sleep-forecast-icon">
-          <span class="material-symbols-rounded">@IconKeyToSymbol(day.IconKey)</span>
-        </div>
-        <div class="sleep-forecast-condition">@day.ConditionShort</div>
-        @* Temperature rendering — F / C / both. The both case shrinks the
-           type to 28/20px so the dual numeric fits on one line per
-           Designer §2 State E. *@
-        @if (string.Equals(TemperatureUnit, "both", StringComparison.OrdinalIgnoreCase))
-        {
-          <div class="sleep-forecast-temp sleep-forecast-temp-both sleep-forecast-temp-high">
-            @day.HighF°F<span class="sleep-forecast-temp-sep"> · </span>@day.HighC°C
-          </div>
-          <div class="sleep-forecast-temp sleep-forecast-temp-both sleep-forecast-temp-low">
-            @day.LowF°F<span class="sleep-forecast-temp-sep"> · </span>@day.LowC°C
-          </div>
-        }
-        else if (string.Equals(TemperatureUnit, "C", StringComparison.OrdinalIgnoreCase))
-        {
-          <div class="sleep-forecast-temp sleep-forecast-temp-high">@day.HighC°</div>
-          <div class="sleep-forecast-temp sleep-forecast-temp-low">@day.LowC°</div>
-        }
-        else
-        {
-          @* "F" or any other value falls through to Fahrenheit — matches
-             WeatherDisplayOptions default. *@
-          <div class="sleep-forecast-temp sleep-forecast-temp-high">@day.HighF°</div>
-          <div class="sleep-forecast-temp sleep-forecast-temp-low">@day.LowF°</div>
-        }
+
+  @* Region 1 — primary current-weather block *@
+  <div class="sleep-forecast-primary">
+    <div class="sleep-forecast-primary-icon">
+      <span class="material-symbols-rounded">@IconKeyToSymbol(Today.IconKey)</span>
+    </div>
+    <div class="sleep-forecast-primary-temp">
+      @CurrentTempDisplay<span class="sleep-forecast-primary-degree">°</span>
+    </div>
+    <div class="sleep-forecast-primary-unit" aria-hidden="true">
+      <span class="@(IsCelsius ? "is-inactive" : "is-active")">F</span><span class="sleep-forecast-primary-unit-sep">·</span><span class="@(IsCelsius ? "is-active" : "is-inactive")">C</span>
+    </div>
+    <div class="sleep-forecast-primary-right">
+      <div class="sleep-forecast-primary-condition">@Today.ConditionShort</div>
+      <div class="sleep-forecast-primary-hl">
+        <span class="sleep-forecast-primary-high">@TodayHigh</span><span class="sleep-forecast-primary-hl-sep">/</span><span class="sleep-forecast-primary-low">@TodayLow</span>
       </div>
-    }
+    </div>
   </div>
-  <div class="sleep-forecast-footer">
+
+  @* Sub-line — location · day · time (with optional stale indicator) *@
+  <div class="sleep-forecast-subline">
     @if (Forecast.IsStale)
     {
       <span class="sleep-forecast-stale-icon material-symbols-rounded" aria-hidden="true">sync_problem</span>
     }
-    <span class="sleep-forecast-footer-text">@Forecast.LocationName · @_footerTimestamp</span>
+    <span class="sleep-forecast-subline-text">@_subLineText</span>
   </div>
+
+  @* Region 2 — forecast row. Omitted entirely when only one day is
+     available (the primary block already carries today's data; a single
+     duplicate card adds no comparative value — see spec §3 State D). *@
+  @if (Forecast.Days.Count >= 2)
+  {
+    <div class="sleep-forecast-cards">
+      @foreach (var day in Forecast.Days)
+      {
+        <div class="sleep-forecast-card">
+          <div class="sleep-forecast-card-icon">
+            <span class="material-symbols-rounded">@IconKeyToSymbol(day.IconKey)</span>
+          </div>
+          <div class="sleep-forecast-card-day">@day.DayName</div>
+          @* Card temperature — F / C / both. The "both" path keeps v1's
+             dual-numeric line on a single row at smaller type so the card
+             column still reads cleanly (spec §3 State F). *@
+          @if (IsBoth)
+          {
+            <div class="sleep-forecast-card-temp sleep-forecast-card-temp-both sleep-forecast-card-temp-high">
+              @day.HighF°F<span class="sleep-forecast-card-temp-sep"> · </span>@day.HighC°C
+            </div>
+            <div class="sleep-forecast-card-temp sleep-forecast-card-temp-both sleep-forecast-card-temp-low">
+              @day.LowF°F<span class="sleep-forecast-card-temp-sep"> · </span>@day.LowC°C
+            </div>
+          }
+          else if (IsCelsius)
+          {
+            <div class="sleep-forecast-card-temp sleep-forecast-card-temp-high">@day.HighC°</div>
+            <div class="sleep-forecast-card-temp sleep-forecast-card-temp-low">@day.LowC°</div>
+          }
+          else
+          {
+            @* "F" or any other value falls through to Fahrenheit — matches
+               WeatherDisplayOptions default. *@
+            <div class="sleep-forecast-card-temp sleep-forecast-card-temp-high">@day.HighF°</div>
+            <div class="sleep-forecast-card-temp sleep-forecast-card-temp-low">@day.LowF°</div>
+          }
+        </div>
+      }
+    </div>
+  }
 </div>
 
 @code {
   /// <summary>The forecast to render. MUST be non-null and have at least one day.</summary>
   [Parameter, EditorRequired] public WeatherForecast Forecast { get; set; } = default!;
 
-  /// <summary>"F", "C", or "both" — controls which temperature field renders per card.</summary>
+  /// <summary>"F", "C", or "both" — controls which temperature field renders.</summary>
   [Parameter, EditorRequired] public string TemperatureUnit { get; set; } = "F";
 
   /// <summary>
-  /// Optional time-format string for the footer "as of HH:mm" stamp.
-  /// When null, defaults to invariant 24-hour. Wired to PR #1's
-  /// Clocks.FormatWallClock by the parent.
+  /// Optional time-format string for the sub-line "<Day> HH:mm" stamp.
+  /// When null, defaults to invariant 24-hour. Wired to
+  /// <c>Clocks.FormatWallClock</c> by the parent so the wall-clock setting
+  /// (12h/24h) governs both surfaces in lock-step.
   /// </summary>
   [Parameter] public Func<DateTime, string>? FormatClock { get; set; }
 
   private string _ariaLabel = string.Empty;
-  private string _footerTimestamp = string.Empty;
+  private string _subLineText = string.Empty;
   private string? _lastAnnouncedSignature;
+
+  // ── Computed display helpers ────────────────────────────────────────────
+  // These mirror the v2 spec's "Builder note" code-behind additions (§9).
+  // Today is always Days[0] — the service guarantees chronological order.
+
+  private WeatherDay Today => Forecast.Days[0];
+
+  private bool IsCelsius =>
+    string.Equals(TemperatureUnit, "C", StringComparison.OrdinalIgnoreCase);
+
+  private bool IsBoth =>
+    string.Equals(TemperatureUnit, "both", StringComparison.OrdinalIgnoreCase);
+
+  /// <summary>
+  /// Primary-block current-temperature numeral. In single-unit mode this is
+  /// the per-unit field directly; in "both" mode we fall back to Fahrenheit
+  /// per spec §3 State F (the 96 px "60°F · 16°C" string would blow the
+  /// column budget at 480 px — the user explicitly opted into "both" for the
+  /// cards, not for the primary readout).
+  /// </summary>
+  private int CurrentTempDisplay => IsCelsius ? Today.HighC : Today.HighF;
+
+  private int TodayHigh => IsCelsius ? Today.HighC : Today.HighF;
+  private int TodayLow => IsCelsius ? Today.LowC : Today.LowF;
 
   protected override void OnParametersSet()
   {
-    // Footer timestamp — show "as of HH:mm" for fresh data, add the
-    // "yesterday" / "N days ago" qualifier for stale data older than 12h
-    // (Designer §11 open question 3 — 12h threshold).
+    // Compose the sub-line. Fresh data: "<City> · <Day> <Time>". Stale data
+    // (>12h old) prepends a relative qualifier per the v1 stale rules —
+    // "<City> · yesterday at HH:mm" or "<City> · N days ago at HH:mm".
     var localGenerated = Forecast.GeneratedAtUtc.LocalDateTime;
     var hoursOld = (DateTime.Now - localGenerated).TotalHours;
-    var clockString = FormatClock?.Invoke(localGenerated) ?? localGenerated.ToString("HH:mm", CultureInfo.InvariantCulture);
+    var clockString = FormatClock?.Invoke(localGenerated)
+      ?? localGenerated.ToString("HH:mm", CultureInfo.InvariantCulture);
+    var locationDisplay = ShortLocation(Forecast.LocationName);
 
     if (hoursOld < 12)
     {
-      _footerTimestamp = $"as of {clockString}";
+      // Use today's full weekday name for the sub-line. The forecast cards
+      // still use 3-letter abbreviations (DayName from the API) because
+      // horizontal width matters there — the sub-line has its own slot.
+      var dayName = DateTime.Now.ToString("dddd", CultureInfo.InvariantCulture);
+      _subLineText = $"{locationDisplay} · {dayName} {clockString}";
     }
     else if (hoursOld < 36)
     {
-      _footerTimestamp = $"as of {clockString} yesterday";
+      _subLineText = $"{locationDisplay} · yesterday at {clockString}";
     }
     else
     {
       var daysOld = (int)Math.Floor(hoursOld / 24.0);
-      _footerTimestamp = $"as of {clockString}, {daysOld} days ago";
+      _subLineText = $"{locationDisplay} · {daysOld} days ago at {clockString}";
     }
 
     // Aria-live label — single sentence the screen reader can read end-to-end.
     // Regenerate only on data change to avoid spamming the SR on every swap-in
     // (per Designer §8 caching). The signature folds in everything visible.
-    var signature = $"{Forecast.Zip}|{Forecast.GeneratedAtUtc.Ticks}|{Forecast.IsStale}|{TemperatureUnit}|{Forecast.Days.Count}";
+    // v2: include Today.IconKey so a same-day icon change retriggers the
+    // announcement (spec §9 "_lastAnnouncedSignature" note).
+    var signature = $"{Forecast.Zip}|{Forecast.GeneratedAtUtc.Ticks}|{Forecast.IsStale}|{TemperatureUnit}|{Forecast.Days.Count}|{Today.IconKey}";
     if (_lastAnnouncedSignature != signature)
     {
       _lastAnnouncedSignature = signature;
@@ -119,24 +204,37 @@
     }
   }
 
+  /// <summary>
+  /// Strips ", &lt;state&gt;" from a location string when present (e.g.
+  /// "Pittsboro, NC" → "Pittsboro") so the sub-line stays short. Strings
+  /// without a comma fall through verbatim — state-only / city-only forms
+  /// don't need post-processing.
+  /// </summary>
+  private static string ShortLocation(string locationName)
+  {
+    if (string.IsNullOrWhiteSpace(locationName)) return locationName;
+    var commaIdx = locationName.IndexOf(',');
+    return commaIdx > 0 ? locationName[..commaIdx].Trim() : locationName;
+  }
+
   private string BuildAriaLabel()
   {
     var sb = new System.Text.StringBuilder();
     if (Forecast.IsStale)
     {
-      var localGenerated = Forecast.GeneratedAtUtc.LocalDateTime;
-      sb.Append($"Forecast data is stale, last updated {_footerTimestamp}. ");
+      sb.Append($"Forecast data is stale. ");
     }
-    sb.Append($"{Forecast.Days.Count}-day forecast for {Forecast.LocationName}. ");
+
+    // v2: lead with the current condition + temperature so the SR description
+    // mirrors the visual layout (primary block first, then the day-by-day
+    // breakdown). Same Fahrenheit-default rule as the visible primary block
+    // applies in "both" mode — the SR string stays compact.
+    var unit = IsCelsius ? "Celsius" : "Fahrenheit";
+    sb.Append($"Currently {CurrentTempDisplay} degrees {unit}, {Today.ConditionShort} in {Forecast.LocationName}. ");
 
     foreach (var d in Forecast.Days)
     {
-      var (high, low, unit) = string.Equals(TemperatureUnit, "C", StringComparison.OrdinalIgnoreCase)
-        ? (d.HighC, d.LowC, "Celsius")
-        : (d.HighF, d.LowF, "Fahrenheit");
-      // "Both" reads as Fahrenheit in the SR string to keep the announcement
-      // compact — the visible UI shows both numerics, but the SR description
-      // is one or the other.
+      var (high, low) = IsCelsius ? (d.HighC, d.LowC) : (d.HighF, d.LowF);
       sb.Append($"{d.DayName} {d.ConditionShort}, high {high} {unit}, low {low} {unit}. ");
     }
     return sb.ToString();
@@ -144,10 +242,11 @@
 
   /// <summary>
   /// Resolves a stable IconKey (produced by NwsIconMapper) to a Material
-  /// Symbols Rounded name. The mapping is pinned by HANDOFF §4 — the left
-  /// column is what NwsIconMapper emits, the right column is what we render.
-  /// Unknown keys (including the explicit "unknown" fallback) resolve to
-  /// cloud_off so the pane never renders a blank icon slot.
+  /// Symbols Rounded name. The mapping is pinned by v1 HANDOFF §4 and
+  /// referenced verbatim by the v2 spec §5 — the same Material Symbol name
+  /// renders at 96 px in the primary block and at 48 px in today's card.
+  /// Unknown keys resolve to cloud_off so the pane never renders a blank
+  /// icon slot.
   /// </summary>
   private static string IconKeyToSymbol(string iconKey) => iconKey switch
   {

--- a/src/Radio.Web/Components/Shared/SleepForecastPane.razor
+++ b/src/Radio.Web/Components/Shared/SleepForecastPane.razor
@@ -127,7 +127,7 @@
   [Parameter, EditorRequired] public string TemperatureUnit { get; set; } = "F";
 
   /// <summary>
-  /// Optional time-format string for the sub-line "<Day> HH:mm" stamp.
+  /// Optional time-format string for the sub-line "&lt;Day&gt; HH:mm" stamp.
   /// When null, defaults to invariant 24-hour. Wired to
   /// <c>Clocks.FormatWallClock</c> by the parent so the wall-clock setting
   /// (12h/24h) governs both surfaces in lock-step.

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -2924,98 +2924,310 @@ body {
 }
 
 
-/* ─── §P·6  Sleep-mode 3-day weather forecast pane ──────────────────────────
+/* ─── §P·6  Sleep-mode weather forecast pane (v2 — visual redesign) ─────────
  *
  * Lives inside .sleep-screen-drift (alongside or alternated with the LED
- * clock cluster). All emissive elements use the SAME dim-amber 35 % as the
- * sleep clock so the screen has exactly one emissive color; the icons
- * therefore convey condition by SHAPE, not color. Stale data is signaled
- * by opacity: 0.7 on the pane root + a small sync_problem glyph in the
- * footer — no per-element style change, so we don't introduce a second
- * token. See HANDOFF-sleep-mode-weather-forecast.md §2 for the visual.
+ * clock cluster). Two-region composition:
+ *   Region 1 — primary readout: 96px Material Symbol icon + 96px Orbitron
+ *     LED current temperature (byte-identical to .sleep-screen-clock so the
+ *     temp reads as the same "amber instrument") + small mono F·C unit
+ *     indicator + 24px condition text + 28px LED today H/L.
+ *   Sub-line — single mono line beneath Region 1 carrying location, day,
+ *     and time (formatted via Clocks.FormatWallClock by the parent). When
+ *     stale, prepends a sync_problem glyph.
+ *   Region 2 — 3-card forecast row at 160px per card (200px in "both" mode);
+ *     omitted entirely when Days.Count < 2 (a single card duplicating today
+ *     has no comparative value).
  *
- * Cards are 200 px each; pane is 640 px total (1 / 2 / 3 cards fit
- * comfortably inside the ±384 px drift safe area on the 1920 px kiosk).
- * Card widens to 220 px for TemperatureUnit="both" so the F·C numerics
- * fit on a single line per Designer §2 State E.
+ * All emissive elements share a single color
+ *   color-mix(in srgb, var(--signal-amber) 35 %, #050507)
+ * — the same dim amber as .sleep-screen-clock. Icons convey condition by
+ * SHAPE, not color. Stale data is signaled by opacity: 0.7 on the pane
+ * root + the sync_problem glyph on the sub-line — no per-element overrides,
+ * no new tokens.
+ *
+ * Total pane bounding box: 880×360 (920×380 in "both" mode). Fits inside
+ * the ±384 px horizontal × ±144 px vertical drift safe area on the 1920×720
+ * kiosk with ≥ 100 px of bezel clearance at worst-case drift offset.
+ *
+ * See HANDOFF-sleep-weather-visual-redesign.md §3–§7 for the geometry,
+ * §4 for typography, §6 for the color budget.
  * ─────────────────────────────────────────────────────────────────────────── */
 .sleep-forecast-pane {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 28px;
   /* Allow the SR-only aria-live region to be picked up regardless of
      positioning; the pane is otherwise inert visually for screen readers
-     because each card's content is decorative (and announced via the
+     because the visible content is decorative (and announced via the
      parent's aria-label). */
   position: relative;
 }
 
 .sleep-forecast-pane.is-stale {
-  /* Single dimming knob — the footer's sync_problem glyph + relative
+  /* Single dimming knob — the sub-line's sync_problem glyph + relative
      "yesterday" / "N days ago" text carry the semantics. */
   opacity: 0.7;
 }
 
-.sleep-forecast-cards {
+/* ── Region 1 — primary current-weather block ─────────────────────────── */
+
+.sleep-forecast-primary {
   display: flex;
   flex-direction: row;
-  gap: 20px;
-  align-items: stretch;
-}
-
-.sleep-forecast-card {
-  width: 200px;
-  display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 6px;
-  padding: 8px 4px;
+  justify-content: center;
+  gap: 24px;
+  /* 96 px is the dominant baseline (icon + temp). Right column's two
+     stacked lines + the unit indicator vertically center against it. */
+  min-height: 96px;
 }
 
-.sleep-forecast-day {
-  font-family: var(--font-mono);
-  font-size: 14px;
-  color: var(--text-medium);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
+.sleep-forecast-primary-icon {
+  /* 96 px icon column — paired with the 96 px LED temp on the same baseline.
+     Width fixed so the row keeps its three-column rhythm regardless of which
+     Material Symbol glyph renders (some are wider than others). */
+  width: 120px;
+  height: 96px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sleep-forecast-primary-icon .material-symbols-rounded {
+  font-size: 96px;
+  color: color-mix(in srgb, var(--signal-amber) 35%, #050507);
+  /* FILL=1 keeps the icon as a solid silhouette — same convention as the
+     card icons. opsz 48 is the largest standard Material Symbols optical
+     axis; the variable font scales 48 → 96 cleanly without geometry
+     artifacts at the bigger size. NO text-shadow on the icon — the glow
+     is reserved for LED numerals; on a 96 px filled silhouette it reads
+     as a smudge (see spec §5). */
+  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 48;
   line-height: 1;
 }
 
-.sleep-forecast-icon {
-  /* 40 px target per Designer §2 card geometry. Material Symbols Rounded
-     scales cleanly as a variable font; we set font-size on the .material-
-     symbols-rounded child rather than the wrapper so transforms (none in
-     this build) don't blur the glyph. */
+.sleep-forecast-primary-temp {
+  /* Byte-identical to .sleep-screen-clock — same font, size, weight,
+     color-mix recipe, text-shadow, letter-spacing, line-height. The user's
+     mental model on this surface is "this is the amber readout of my
+     radio"; the wall clock and the current temperature are the same
+     instrument doing two jobs (spec §4 "Why the temp numerals match the
+     clock byte-for-byte"). */
+  font-family: var(--font-led);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-size: 96px;
+  color: color-mix(in srgb, var(--signal-amber) 35%, #050507);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--signal-amber) 15%, transparent);
+  letter-spacing: 0.02em;
+  line-height: 1;
+  /* Inline-flex so the degree symbol can nest inside the numeral baseline. */
+  display: inline-flex;
+  align-items: flex-start;
+}
+
+.sleep-forecast-primary-degree {
+  /* Smaller superscript-style degree symbol so the "60°" reads as a single
+     glyph cluster rather than equal-weight characters. Aligned to the top
+     of the numerals. Inherits the dim-amber color + text-shadow from its
+     parent .sleep-forecast-primary-temp. */
+  font-size: 40px;
+  font-weight: 700;
+  line-height: 1;
+  margin-left: 2px;
+  /* Lift the degree to sit near the top of the 96 px numeral cap-height.
+     The numeral's effective ascender lives ~80 px above the baseline; the
+     degree's 40 px box gets nudged up so its visual center lands ~10 px
+     below the numeral cap. */
+  margin-top: 4px;
+  align-self: flex-start;
+}
+
+.sleep-forecast-primary-unit {
+  /* "F·C" stamp on the temperature. Display only — no click target, no
+     hover state. 18 px mono matches the sub-line's mono treatment; the
+     active letter is the only emissive piece here. */
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 400;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  /* Vertical-align on the temp baseline — sit centered on the 96 px row. */
+  min-height: 96px;
+  /* Small horizontal slot between the temp and the right column. */
+  min-width: 32px;
+}
+
+.sleep-forecast-primary-unit .is-active {
+  color: color-mix(in srgb, var(--signal-amber) 35%, #050507);
+}
+
+.sleep-forecast-primary-unit .is-inactive {
+  color: var(--text-low);
+}
+
+.sleep-forecast-primary-unit-sep {
+  color: var(--text-low);
+  font-weight: 400;
+  /* Tighten the cluster — F · C with the dot a thin marker rather than a
+     full-letter slot. */
+  font-size: 12px;
+  line-height: 1;
+}
+
+/* "both" mode: both glyphs are active (the user explicitly opted into
+   dual-unit display). The separator stays --text-low. */
+.sleep-forecast-pane.unit-both .sleep-forecast-primary-unit .is-active,
+.sleep-forecast-pane.unit-both .sleep-forecast-primary-unit .is-inactive {
+  color: color-mix(in srgb, var(--signal-amber) 35%, #050507);
+}
+
+.sleep-forecast-primary-right {
+  /* Two stacked rows: condition above today H/L, left-aligned within a
+     200 px slot. Vertically centered against the 96 px temp baseline. */
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 12px;
+  width: 200px;
+  min-height: 96px;
+}
+
+.sleep-forecast-primary-condition {
+  /* Reads as "tag/label" not "readout" — using --text-medium prevents the
+     200×30 px slab from competing with the big temp for visual weight
+     (see spec §4 "Why condition text is --text-medium and not dim amber").
+     Source string is WeatherDay.ConditionShort verbatim; NWS labels are
+     already capitalised ("Partly Sunny"), so no text-transform here. */
+  font-family: var(--font-mono);
+  font-size: 24px;
+  font-weight: 400;
+  color: var(--text-medium);
+  letter-spacing: 0.02em;
+  line-height: 1.1;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sleep-forecast-primary-hl {
+  /* Today's H/L — same recipe as the big temp so the two numerals read as
+     the same instrument family. Slash separator is --text-low so the
+     numerals dominate. */
+  font-family: var(--font-led);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-size: 28px;
+  color: color-mix(in srgb, var(--signal-amber) 35%, #050507);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--signal-amber) 15%, transparent);
+  letter-spacing: 0.02em;
+  line-height: 1;
+}
+
+.sleep-forecast-primary-hl-sep {
+  color: var(--text-low);
+  font-weight: 400;
+  /* No text-shadow on the separator — keep the glow on the numerals only. */
+  text-shadow: none;
+  margin: 0 4px;
+}
+
+.sleep-forecast-primary-low {
+  /* Same emissive color as the high — both numerals are "readout" on the
+     today row. (The low only de-emphasises in the card row where the
+     comparison-by-day relationship makes the low a supporting datum.) */
+  color: color-mix(in srgb, var(--signal-amber) 35%, #050507);
+}
+
+/* ── Sub-line — location · day · time ─────────────────────────────────── */
+
+.sleep-forecast-subline {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--text-medium);
+  letter-spacing: 0.12em;
+  /* Tighten the gap to Region 1 — the parent's gap: 28 px would otherwise
+     push the sub-line further from the primary than it belongs. Spec §7:
+     12 px top margin to Region 1, 28 px bottom to Region 2 (the latter
+     supplied by the parent .sleep-forecast-pane gap rule, since the cards
+     are the next sibling). */
+  margin-top: -16px;
+}
+
+.sleep-forecast-stale-icon {
+  font-size: 16px;
+  color: var(--text-low);
+  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 20;
+  /* Inherits the pane's opacity: 0.7 because it lives inside .is-stale. */
+  line-height: 1;
+}
+
+/* ── Region 2 — forecast row of cards ─────────────────────────────────── */
+
+.sleep-forecast-cards {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 32px;
+}
+
+.sleep-forecast-card {
+  width: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 6px;
+  padding: 12px 4px;
+}
+
+.sleep-forecast-card-icon {
+  /* 48 px icon — sized between the 96 px primary and v1's 40 px cards so
+     the row reads as discrete units without competing with the primary
+     block (spec §5). */
   height: 56px;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.sleep-forecast-icon .material-symbols-rounded {
-  font-size: 40px;
+.sleep-forecast-card-icon .material-symbols-rounded {
+  font-size: 48px;
   color: color-mix(in srgb, var(--signal-amber) 35%, #050507);
-  /* Variable-font axes — set 'fill' so the icon reads as a solid shape
-     rather than the default outline; matches the silhouette aesthetic of
-     a dim LED. */
-  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 40;
+  /* opsz 48 — the natural Material Symbols size axis at 48 px (no scaling
+     stretch). FILL=1 to match the primary icon's silhouette aesthetic. */
+  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 48;
+  line-height: 1;
 }
 
-.sleep-forecast-condition {
+.sleep-forecast-card-day {
+  /* Identical typography to the sub-line so the two share a visual rhythm. */
   font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-low);
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--text-medium);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: center;
+  letter-spacing: 0.12em;
+  line-height: 1;
+  margin-top: 2px;
 }
 
-.sleep-forecast-temp {
+.sleep-forecast-card-temp {
   font-family: var(--font-led);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
@@ -3023,43 +3235,33 @@ body {
   letter-spacing: 0.02em;
 }
 
-.sleep-forecast-temp-high {
-  font-size: 36px;
+.sleep-forecast-card-temp-high {
+  font-size: 28px;
   color: color-mix(in srgb, var(--signal-amber) 35%, #050507);
   text-shadow: 0 0 12px color-mix(in srgb, var(--signal-amber) 15%, transparent);
+  margin-top: 4px;
 }
 
-.sleep-forecast-temp-low {
-  font-size: 24px;
+.sleep-forecast-card-temp-low {
+  /* The low in the cards is --text-low (not amber) — deliberate hierarchy
+     step (spec §6 color table): high = "the answer", low = "the supporting
+     datum". */
+  font-size: 20px;
   color: var(--text-low);
 }
 
-/* The "both" path renders F·C on a single line — shrink the type so the
-   two numerics + middle dot fit comfortably inside the 220 px card. */
-.sleep-forecast-temp-both.sleep-forecast-temp-high { font-size: 28px; }
-.sleep-forecast-temp-both.sleep-forecast-temp-low  { font-size: 20px; }
-.sleep-forecast-pane.unit-both .sleep-forecast-card { width: 220px; }
+/* "both" path — cards render F·C on a single line. Type shrinks so the
+   two numerics + middle dot fit; card column widens to 200 px so the line
+   still reads cleanly. Total pane grows from 880 → 920 px (still inside
+   the safe area — spec §7 bounding-box table). */
+.sleep-forecast-card-temp-both.sleep-forecast-card-temp-high { font-size: 22px; }
+.sleep-forecast-card-temp-both.sleep-forecast-card-temp-low  { font-size: 16px; }
+.sleep-forecast-pane.unit-both .sleep-forecast-card { width: 200px; }
 
-.sleep-forecast-temp-sep {
+.sleep-forecast-card-temp-sep {
   color: var(--text-low);
   font-weight: 400;
-}
-
-.sleep-forecast-footer {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 6px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-low);
-  letter-spacing: 0.08em;
-}
-
-.sleep-forecast-stale-icon {
-  font-size: 14px;
-  color: var(--text-low);
-  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+  text-shadow: none;
 }
 
 

--- a/tests/Radio.Web.Tests/Components/Shared/SleepForecastPaneTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/SleepForecastPaneTests.cs
@@ -1,0 +1,498 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Radzen;
+using Radio.Core.Models;
+using Radio.Web.Components.Shared;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for <see cref="SleepForecastPane"/> — v2 visual redesign
+/// (HANDOFF-sleep-weather-visual-redesign.md).
+///
+/// Locks the two-region structure (primary block + sub-line + optional
+/// 3-card forecast row), the byte-identical wall-clock typography on the
+/// primary temperature numeral, the partial-day cases (3/2/1), and the
+/// stale-state affordance. The v1 fixture was structural enough that the
+/// new selectors required a near-total rewrite — Designer's spec §9 calls
+/// out the selector renames (.sleep-forecast-day → .sleep-forecast-card-day,
+/// .sleep-forecast-footer → .sleep-forecast-subline, etc.).
+/// </summary>
+public class SleepForecastPaneTests : TestContext
+{
+  public SleepForecastPaneTests()
+  {
+    Services.AddRadzenComponents();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  /// <summary>
+  /// Build a fresh test forecast with N days. Day 0 is Sunday with the
+  /// reference-image data (60/77/66, "Partly Sunny") so the assertions stay
+  /// easy to read.
+  /// </summary>
+  private static WeatherForecast BuildForecast(int dayCount, bool isStale = false)
+  {
+    var days = new List<WeatherDay>
+    {
+      new(new DateOnly(2026, 5, 24), "Today", 77, 66, 25, 19, "Partly Sunny",
+          "Partly sunny with a high near 77.", 20, "partly-cloudy", null),
+      new(new DateOnly(2026, 5, 25), "Mon", 76, 68, 24, 20, "Cloudy",
+          "Mostly cloudy.", 30, "cloudy", null),
+      new(new DateOnly(2026, 5, 26), "Tue", 80, 66, 27, 19, "Sunny",
+          "Sunny.", 5, "sunny", null),
+    };
+
+    return new WeatherForecast(
+      Zip: "27312",
+      LocationName: "Pittsboro, NC",
+      // Fresh: 1 hour old; Stale: 25 hours old so the "yesterday at HH:mm"
+      // sub-line branch fires.
+      GeneratedAtUtc: DateTime.UtcNow.AddHours(isStale ? -25 : -1),
+      FetchedAtUtc: DateTime.UtcNow.AddMinutes(-1),
+      IsStale: isStale,
+      Days: days.Take(dayCount).ToList());
+  }
+
+  // ── Region 1 — primary block contract ───────────────────────────────────
+
+  [Fact]
+  public void Pane_RendersPrimaryBlock_WithIconTempUnitAndRightColumn()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    // The four primary-block children must all render — this is the
+    // load-bearing structural contract for the new layout.
+    cut.Find(".sleep-forecast-primary").Should().NotBeNull();
+    cut.Find(".sleep-forecast-primary-icon").Should().NotBeNull();
+    cut.Find(".sleep-forecast-primary-temp").Should().NotBeNull();
+    cut.Find(".sleep-forecast-primary-unit").Should().NotBeNull();
+    cut.Find(".sleep-forecast-primary-right").Should().NotBeNull();
+    cut.Find(".sleep-forecast-primary-condition").Should().NotBeNull();
+    cut.Find(".sleep-forecast-primary-hl").Should().NotBeNull();
+  }
+
+  [Fact]
+  public void Pane_PrimaryTemp_RendersTodayHighInFahrenheit_WhenUnitIsF()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var temp = cut.Find(".sleep-forecast-primary-temp");
+    // Today.HighF=77 — the spec uses today's high as the current-temp
+    // display (no separate "current" field in the data model; §9 code-
+    // behind: CurrentTempDisplay = Today.HighF or HighC).
+    temp.TextContent.Should().Contain("77");
+    temp.TextContent.Should().Contain("°");
+  }
+
+  [Fact]
+  public void Pane_PrimaryTemp_RendersTodayHighInCelsius_WhenUnitIsC()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "C"));
+
+    var temp = cut.Find(".sleep-forecast-primary-temp");
+    temp.TextContent.Should().Contain("25"); // Today.HighC
+  }
+
+  [Fact]
+  public void Pane_PrimaryTemp_FallsBackToFahrenheit_WhenUnitIsBoth()
+  {
+    // Spec §3 State F + §9: in "both" mode the 96 px primary block keeps a
+    // single unit (the 480 px-wide "60°F · 16°C" string would blow the
+    // column budget). Fahrenheit is the fallback to match the v1 default.
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "both"));
+
+    var temp = cut.Find(".sleep-forecast-primary-temp");
+    temp.TextContent.Should().Contain("77"); // HighF
+    temp.TextContent.Should().NotContain("25"); // HighC — not on the primary
+  }
+
+  [Fact]
+  public void Pane_UnitIndicator_MarksFActive_WhenUnitIsF()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var unit = cut.Find(".sleep-forecast-primary-unit");
+    // F is the first <span> child; with F active the first letter gets
+    // .is-active, the second .is-inactive.
+    var letters = unit.QuerySelectorAll("span.is-active, span.is-inactive");
+    letters.Should().HaveCount(2);
+    letters[0].ClassList.Should().Contain("is-active");
+    letters[0].TextContent.Trim().Should().Be("F");
+    letters[1].ClassList.Should().Contain("is-inactive");
+    letters[1].TextContent.Trim().Should().Be("C");
+  }
+
+  [Fact]
+  public void Pane_UnitIndicator_MarksCActive_WhenUnitIsC()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "C"));
+
+    var unit = cut.Find(".sleep-forecast-primary-unit");
+    var letters = unit.QuerySelectorAll("span.is-active, span.is-inactive");
+    letters[0].ClassList.Should().Contain("is-inactive");
+    letters[1].ClassList.Should().Contain("is-active");
+  }
+
+  [Fact]
+  public void Pane_PrimaryCondition_RendersTodayShortConditionVerbatim()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var cond = cut.Find(".sleep-forecast-primary-condition");
+    // NWS labels are already capitalised — no text-transform applied; the
+    // string round-trips verbatim per spec §4.
+    cond.TextContent.Trim().Should().Be("Partly Sunny");
+  }
+
+  [Fact]
+  public void Pane_PrimaryHL_RendersTodayHighAndLow_WithSeparator()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var hl = cut.Find(".sleep-forecast-primary-hl");
+    hl.QuerySelector(".sleep-forecast-primary-high")!.TextContent.Trim()
+      .Should().Be("77");
+    hl.QuerySelector(".sleep-forecast-primary-low")!.TextContent.Trim()
+      .Should().Be("66");
+    hl.QuerySelector(".sleep-forecast-primary-hl-sep")!.TextContent.Trim()
+      .Should().Be("/");
+  }
+
+  // ── Region 1 — wall-clock typography parity (load-bearing) ──────────────
+
+  [Fact]
+  public void Pane_PrimaryTempRule_UsesSameLedFontAndDimAmber_AsSleepScreenClock()
+  {
+    // The spec's load-bearing aesthetic decision: the primary temperature
+    // numeral must read as the SAME amber instrument as the wall clock.
+    // bUnit can't fully resolve CSS variables on getComputedStyle, so we
+    // pin BOTH the component contract (the temp span carries the
+    // .sleep-forecast-primary-temp class) AND the design-system rule (the
+    // class binds to the same recipe as .sleep-screen-clock).
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var temp = cut.Find(".sleep-forecast-primary-temp");
+    temp.ClassList.Should().Contain("sleep-forecast-primary-temp",
+      "the temp span must carry the class the byte-identical rule targets");
+
+    var cssPath = LocateDesignSystemCss();
+    var css = File.ReadAllText(cssPath);
+
+    // Match the .sleep-forecast-primary-temp body and assert every
+    // load-bearing typography property mirrors .sleep-screen-clock per
+    // spec §4 ("byte-identical to .sleep-screen-clock").
+    var primaryBlockMatch = Regex.Match(
+      css,
+      @"\.sleep-forecast-primary-temp\s*\{([^}]*)\}",
+      RegexOptions.Singleline);
+    primaryBlockMatch.Success.Should().BeTrue(
+      "the .sleep-forecast-primary-temp rule must exist");
+    var body = primaryBlockMatch.Groups[1].Value;
+
+    body.Should().Contain("font-family: var(--font-led)",
+      "primary temp must use the LED font (matches .sleep-screen-clock)");
+    body.Should().Contain("font-weight: 700",
+      "primary temp must be 700 weight (matches .sleep-screen-clock)");
+    body.Should().Contain("font-size: 96px",
+      "primary temp must be 96 px (matches .sleep-screen-clock)");
+    body.Should().Contain("color: color-mix(in srgb, var(--signal-amber) 35%, #050507)",
+      "primary temp must use the dim-amber 35 % color-mix (matches .sleep-screen-clock)");
+    body.Should().Contain("text-shadow: 0 0 12px color-mix(in srgb, var(--signal-amber) 15%, transparent)",
+      "primary temp must use the same text-shadow recipe as .sleep-screen-clock");
+    body.Should().Contain("font-variant-numeric: tabular-nums",
+      "primary temp must use tabular-nums (matches .sleep-screen-clock)");
+    body.Should().Contain("letter-spacing: 0.02em",
+      "primary temp must use the same letter-spacing as .sleep-screen-clock");
+  }
+
+  // ── Sub-line contract ───────────────────────────────────────────────────
+
+  [Fact]
+  public void Pane_SubLine_RendersWithLocationDayAndTime_WhenFresh()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var subline = cut.Find(".sleep-forecast-subline");
+    var text = subline.TextContent.Trim();
+
+    // Location with the state stripped (spec §3 ShortLocation rule).
+    text.Should().Contain("Pittsboro");
+    text.Should().NotContain("Pittsboro, NC",
+      "the comma-and-state slice must be stripped for the sub-line");
+
+    // The middle-dot separator is rendered as a literal "·" inside the
+    // text node — verifies the format string is wired correctly.
+    text.Should().Contain("·");
+  }
+
+  [Fact]
+  public void Pane_SubLine_RendersFullWeekdayName_NotAbbreviation()
+  {
+    // Spec §3: the sub-line uses the full weekday name ("Sunday") rather
+    // than the 3-letter abbreviation; abbreviations live only in the
+    // forecast cards. Compute the expected weekday for "today" so the test
+    // doesn't drift over time.
+    var expectedDay = DateTime.Now.ToString("dddd",
+      System.Globalization.CultureInfo.InvariantCulture);
+
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    cut.Find(".sleep-forecast-subline").TextContent.Should().Contain(expectedDay);
+  }
+
+  // ── Stale state contract ────────────────────────────────────────────────
+
+  [Fact]
+  public void Pane_IsStale_AppliesOpacityClassAndShowsSyncProblemIcon()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3, isStale: true))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    // Single dimming knob — the .is-stale class on the root.
+    cut.Find(".sleep-forecast-pane").ClassList.Should().Contain("is-stale");
+
+    // sync_problem glyph lives on the sub-line in v2 (was the footer in v1).
+    var staleIcon = cut.Find(".sleep-forecast-stale-icon");
+    staleIcon.TextContent.Trim().Should().Be("sync_problem");
+    staleIcon.GetAttribute("aria-hidden").Should().Be("true");
+  }
+
+  [Fact]
+  public void Pane_IsStale_SubLineRendersRelativeQualifier()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3, isStale: true))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    // 25h-old forecast (BuildForecast stale path) — sub-line prepends
+    // "yesterday at HH:mm" per spec §3 State B.
+    var subline = cut.Find(".sleep-forecast-subline");
+    subline.TextContent.Should().Contain("yesterday at");
+  }
+
+  [Fact]
+  public void Pane_Fresh_DoesNotRenderStaleIcon()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3, isStale: false))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    cut.FindAll(".sleep-forecast-stale-icon").Should().BeEmpty();
+    cut.Find(".sleep-forecast-pane").ClassList.Should().NotContain("is-stale");
+  }
+
+  // ── Region 2 — forecast cards: partial-day matrix ───────────────────────
+
+  [Fact]
+  public void Pane_3Days_RendersThreeCards()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    cut.FindAll(".sleep-forecast-card").Should().HaveCount(3);
+  }
+
+  [Fact]
+  public void Pane_2Days_RendersTwoCards()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(2))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    // Spec §3 State C — 2-day case shows 2 cards centered (CSS handles the
+    // centering via justify-content). The card count is what we assert at
+    // the component level.
+    cut.FindAll(".sleep-forecast-card").Should().HaveCount(2);
+    cut.Find(".sleep-forecast-cards").Should().NotBeNull();
+  }
+
+  [Fact]
+  public void Pane_1Day_OmitsForecastRowEntirely()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(1))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    // Spec §3 State D — Region 2 is omitted entirely when only today is
+    // available; a single forecast card duplicating today's data has no
+    // comparative value. The primary block + sub-line carry all the
+    // information.
+    cut.FindAll(".sleep-forecast-cards").Should().BeEmpty();
+    cut.FindAll(".sleep-forecast-card").Should().BeEmpty();
+
+    // Primary block + sub-line still render — they're the entire output.
+    cut.Find(".sleep-forecast-primary").Should().NotBeNull();
+    cut.Find(".sleep-forecast-subline").Should().NotBeNull();
+  }
+
+  // ── Region 2 — card structure ───────────────────────────────────────────
+
+  [Fact]
+  public void Pane_Card_RendersIconDayHighAndLow_InFahrenheit()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var firstCard = cut.FindAll(".sleep-forecast-card")[0];
+    firstCard.QuerySelector(".sleep-forecast-card-icon").Should().NotBeNull();
+    firstCard.QuerySelector(".sleep-forecast-card-day")!.TextContent.Trim()
+      .Should().Be("Today");
+    firstCard.QuerySelector(".sleep-forecast-card-temp-high")!.TextContent
+      .Should().Contain("77");
+    firstCard.QuerySelector(".sleep-forecast-card-temp-low")!.TextContent
+      .Should().Contain("66");
+  }
+
+  [Fact]
+  public void Pane_Card_RendersCelsius_WhenUnitIsC()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "C"));
+
+    var firstCard = cut.FindAll(".sleep-forecast-card")[0];
+    firstCard.QuerySelector(".sleep-forecast-card-temp-high")!.TextContent
+      .Should().Contain("25");
+    firstCard.QuerySelector(".sleep-forecast-card-temp-low")!.TextContent
+      .Should().Contain("19");
+  }
+
+  [Fact]
+  public void Pane_Card_RendersBothNumerics_WhenUnitIsBoth_AndPaneCarriesUnitBothClass()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "both"));
+
+    // .unit-both modifier triggers the wider card column (spec §3 State F).
+    cut.Find(".sleep-forecast-pane").ClassList.Should().Contain("unit-both");
+
+    var firstCard = cut.FindAll(".sleep-forecast-card")[0];
+    // Both F and C numerics appear on the card's high row.
+    var high = firstCard.QuerySelector(".sleep-forecast-card-temp-high")!;
+    high.ClassList.Should().Contain("sleep-forecast-card-temp-both");
+    high.TextContent.Should().Contain("77");
+    high.TextContent.Should().Contain("25");
+  }
+
+  // ── Icon mapping (preserved verbatim from v1) ───────────────────────────
+
+  [Fact]
+  public void Pane_Card_RendersMaterialSymbolForIconKey()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    // First card = today = "partly-cloudy" iconKey → "partly_cloudy_day".
+    // Third card = Tuesday = "sunny" → "sunny".
+    var cards = cut.FindAll(".sleep-forecast-card");
+    cards[0].QuerySelector(".sleep-forecast-card-icon .material-symbols-rounded")!
+      .TextContent.Trim().Should().Be("partly_cloudy_day");
+    cards[2].QuerySelector(".sleep-forecast-card-icon .material-symbols-rounded")!
+      .TextContent.Trim().Should().Be("sunny");
+  }
+
+  [Fact]
+  public void Pane_PrimaryIcon_MatchesTodayCardIconSymbol()
+  {
+    // Spec §5: the same Material Symbol name MUST render at 96 px in the
+    // primary block and at 48 px in today's card. The IconKeyToSymbol
+    // helper is the single source of truth for both renderings.
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var primary = cut.Find(".sleep-forecast-primary-icon .material-symbols-rounded")
+      .TextContent.Trim();
+    var todayCard = cut.FindAll(".sleep-forecast-card")[0]
+      .QuerySelector(".sleep-forecast-card-icon .material-symbols-rounded")!
+      .TextContent.Trim();
+
+    primary.Should().Be(todayCard);
+  }
+
+  // ── Aria-live label ─────────────────────────────────────────────────────
+
+  [Fact]
+  public void Pane_AriaLabel_LeadsWithCurrentConditionAndTemperature()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var pane = cut.Find(".sleep-forecast-pane");
+    var ariaLabel = pane.GetAttribute("aria-label")!;
+
+    // v2: the SR string mirrors the visual layout — primary block first,
+    // then the day-by-day breakdown (spec §9).
+    ariaLabel.Should().StartWith("Currently 77 degrees Fahrenheit");
+    ariaLabel.Should().Contain("Partly Sunny");
+    ariaLabel.Should().Contain("Pittsboro");
+  }
+
+  [Fact]
+  public void Pane_AriaLabel_FlaggsStaleData_WhenStale()
+  {
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3, isStale: true))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var pane = cut.Find(".sleep-forecast-pane");
+    pane.GetAttribute("aria-label").Should().Contain("stale");
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  /// <summary>
+  /// Locate the design-system.css source file by walking up from the test
+  /// binary directory until we find the Radio.Web/wwwroot/css folder. The
+  /// stylesheet isn't copied into the test output, so a relative path
+  /// lookup is the load-bearing piece.
+  /// </summary>
+  private static string LocateDesignSystemCss()
+  {
+    var dir = AppContext.BaseDirectory;
+    for (var i = 0; i < 10 && dir != null; i++)
+    {
+      var candidate = Path.Combine(dir, "src", "Radio.Web", "wwwroot", "css", "design-system.css");
+      if (File.Exists(candidate))
+      {
+        return candidate;
+      }
+      dir = Path.GetDirectoryName(dir);
+    }
+    throw new FileNotFoundException("design-system.css not found by walking up from test base dir");
+  }
+}


### PR DESCRIPTION
## Summary

User feedback on PR #415 (the v1 sleep-mode weather pane): _"For the weather info in sleep mode, I expected to see something more stylish than a wall of text. Something like this, but styled in a way that matches the current aesthetic."_ The user provided a reference image showing a two-region composition — a primary block (large icon + current temperature + condition + today H/L) above a row of small forecast cards.

This PR implements the redesign in the radio's amber/LED aesthetic. Spec: [`docs/design-handoffs/HANDOFF-sleep-weather-visual-redesign.md`](docs/design-handoffs/HANDOFF-sleep-weather-visual-redesign.md).

## What changed

**Two-region composition replacing v1's flat row of three coequal cards:**

- **Region 1 — primary current-weather block** (880×180):
  - 96px Material Symbol icon (left)
  - 96px Orbitron LED current temperature with the same recipe as `.sleep-screen-clock` (same font, size, weight, color-mix, text-shadow) so the temp reads as the same amber "instrument" as the wall clock
  - Small mono `F·C` unit indicator (read-only display from config)
  - Right column: 24px condition text + 28px today H/L stacked
- **Sub-line** (14px mono, `--text-medium`): `"<City> · <Day> HH:mm"` via `Clocks.FormatWallClock` so 12h/24h preference governs in lock-step with the wall clock; state stripped from the location; full weekday name (sub-line has only one date, so the 3-letter abbreviation has no reason to live here)
- **Region 2 — forecast row** (3 days): 160×140 cards, 32px gaps, whitespace-only separation; each card is 48px icon + 14px mono day label + 28px LED high + 20px low

**Visual decisions preserved:**
- Single emissive color `color-mix(in srgb, var(--signal-amber) 35%, #050507)` across both regions
- No new design tokens
- Stale state verbatim from v1: `opacity: 0.7` on the outer pane + `sync_problem` glyph on the sub-line
- Bounding box: 880×360 px (3-day, single unit) — clears the ±384×144 px drift safe area with ≥ 100 px bezel margin at worst-case drift offset

**Partial-day rules:**
- 3 days → 3 cards
- 2 days → 2 cards centered
- 1 day → Region 2 omitted entirely (today's data already lives in the primary block; a single duplicate card has no comparative value)
- 0 / null → pane doesn't render (unchanged Sleep.razor guard)

**`both` temperature unit:** primary block falls back to F (the 96 px `60°F · 16°C` string would blow the column budget); cards keep v1's dual-numeric line, row widens 880 → 920 px (still inside safe area).

## What's unchanged

Per spec §10 "out of scope":
- Alternation cadence with `_driftTimer` (Sleep.razor)
- Anti-burn-in `.sleep-screen-drift` wrapper
- Accessibility surface (`aria-live=polite`, SR caching, wake behavior)
- Config UI/keys
- NWS data fetch and refresh interval
- `IconKeyToSymbol` mapping (preserved verbatim — same helper renders the primary 96 px icon and today's 48 px card icon)
- `OnParametersSet` timestamp logic (repurposed into the sub-line composition, but the math is identical)

## Affected files

- `src/Radio.Web/Components/Shared/SleepForecastPane.razor` — markup rewrite + new computed properties (`Today`, `IsBoth`, `IsCelsius`, `CurrentTempDisplay`, `TodayHigh`, `TodayLow`, `_subLineText`)
- `src/Radio.Web/wwwroot/css/design-system.css` §P·6 — rules replaced (kept the section-header comment block, updated body)
- `tests/Radio.Web.Tests/Components/Shared/SleepForecastPaneTests.cs` — net-new bUnit fixture (24 tests covering the v2 contract)

No backend changes; no config additions; no new tokens.

## Test plan

- [x] `dotnet build --configuration Release` — 0 errors
- [x] `dotnet test tests/Radio.Web.Tests` — 615/615 passing (24 new sleep-pane tests)
- [ ] **UAT (browser):** on `radio`, enter sleep mode; observe forecast pane alternating with clock on the 60 s drift cycle. Verify:
  - Primary block: 96 px icon (left), 96 px temp + `°` (center), small `F·C` unit indicator, 24 px condition text + 28 px today H/L (right)
  - Sub-line: `Pittsboro · <Day> HH:mm` with `·` separators in `--text-low`
  - Forecast row: 3 cards with 48 px icons, 14 px mono day, 28 px high, 20 px low
  - Primary temperature reads as the same amber instrument as the wall clock (same brightness, same glow, same font)
  - Stale state (force by stopping the API): outer pane dims to 70%, `sync_problem` glyph appears at the start of the sub-line, sub-line text becomes `"<City> · yesterday at HH:mm"` (or `N days ago`)
- [ ] **UAT (configured units):** flip `Display:Weather:TemperatureUnit` to `C` then `both`; verify primary temp switches to Celsius (single unit) or falls back to F (in `both` mode), and forecast cards render dual numerics with the widened card column in `both` mode
- [ ] **UAT (partial days):** if NWS returns 2 days, verify Region 2 centers two cards; if 1 day, verify Region 2 is omitted entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)