### PR TITLE
fix(web): sleep weather icons render as glyphs (Material Symbols class)

### DIFF
--- a/src/Radio.Web/Components/App.razor
+++ b/src/Radio.Web/Components/App.razor
@@ -9,6 +9,13 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%235CD4E8'><path d='M20 6H8.3l8.26-3.34L15.88 1 3.24 6.15C2.51 6.43 2 7.17 2 8v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2zM7 20c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm13-8h-2v-2h-2v2H4V8h16v4z'/></svg>" />
   <title>Radio Console</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Orbitron:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <!-- Material Symbols Rounded (variable font) — required by SleepForecastPane and any
+       future component that emits an icon glyph via the .material-symbols-rounded class.
+       Without this link the spans render their icon-key text as literal words
+       (e.g. "foggy", "thunderstorm") because the ligature-substitution font is not
+       loaded. The opsz / wght / FILL / GRAD axes mirror the variation settings used in
+       design-system.css so the variable font can resolve at any requested style. -->
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
   <!-- Radzen theme: served as a static <link> so the dark theme applies on first paint,
        independent of Blazor circuit hydration. Resolves to the same asset that
        <RadzenTheme Theme="material-dark"> would emit, but without the HeadOutlet/prerender

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -2953,6 +2953,29 @@ body {
  * See HANDOFF-sleep-weather-visual-redesign.md §3–§7 for the geometry,
  * §4 for typography, §6 for the color budget.
  * ─────────────────────────────────────────────────────────────────────────── */
+
+/* Base font-family for any Material Symbols Rounded glyph in the app.
+   Google Fonts also injects this declaration via the <link> in App.razor;
+   pinning it here makes the dependency grep-discoverable and survives a
+   network blip on the Google Fonts CDN as long as the font is locally
+   cached. Without a font-family resolving to "Material Symbols Rounded",
+   the ligature-substitution font never engages and spans render their
+   icon-key text as literal words (e.g. "foggy", "thunderstorm"). */
+.material-symbols-rounded {
+  font-family: 'Material Symbols Rounded';
+  font-weight: normal;
+  font-style: normal;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+}
+
 .sleep-forecast-pane {
   display: flex;
   flex-direction: column;

--- a/tests/Radio.Web.Tests/Components/Shared/SleepForecastPaneTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/SleepForecastPaneTests.cs
@@ -473,6 +473,113 @@ public class SleepForecastPaneTests : TestContext
     pane.GetAttribute("aria-label").Should().Contain("stale");
   }
 
+  // ── Material Symbols Rounded font wiring (regression pin) ──────────────
+  //
+  // These tests pin the two pieces required for the icon spans on the sleep
+  // pane to render as actual glyphs instead of as literal text:
+  //
+  //   1. App.razor MUST <link> the Material Symbols Rounded stylesheet from
+  //      Google Fonts. Without it, the font is never loaded and the
+  //      ligature-substitution that turns "foggy" / "thunderstorm" into
+  //      glyphs never engages.
+  //   2. design-system.css MUST declare a base .material-symbols-rounded
+  //      rule with font-family: 'Material Symbols Rounded'. This is the
+  //      defensive companion to the <link>: if the Google Fonts CDN is
+  //      momentarily unavailable but the user has the font locally cached
+  //      or installed, the spans still resolve correctly.
+  //
+  // Visual UAT after PR #418 caught the icons rendering as literal text
+  // ("foggy", "thunderstorm" overlapping the temperature numerals). These
+  // tests would have failed in that state.
+
+  [Fact]
+  public void AppRazor_LinksMaterialSymbolsRoundedStylesheet()
+  {
+    var appRazor = File.ReadAllText(LocateAppRazor());
+    appRazor.Should().Contain(
+      "Material+Symbols+Rounded",
+      "App.razor must <link> the Material Symbols Rounded font from Google Fonts; "
+      + "without it, the .material-symbols-rounded spans render their icon-key text "
+      + "as literal words (e.g. \"foggy\", \"thunderstorm\") instead of as glyphs");
+  }
+
+  [Fact]
+  public void DesignSystemCss_DeclaresMaterialSymbolsRoundedFontFamily()
+  {
+    var css = File.ReadAllText(LocateDesignSystemCss());
+
+    // Match the base .material-symbols-rounded rule body (not the more
+    // specific descendant selectors like .sleep-forecast-card-icon
+    // .material-symbols-rounded which only set font-size / color).
+    var baseRule = Regex.Match(
+      css,
+      @"^\s*\.material-symbols-rounded\s*\{([^}]*)\}",
+      RegexOptions.Multiline | RegexOptions.Singleline);
+
+    baseRule.Success.Should().BeTrue(
+      "design-system.css must declare a base .material-symbols-rounded rule "
+      + "so the icon font resolves even if the Google Fonts CDN is briefly "
+      + "unavailable; without a font-family declaration, icon spans render "
+      + "their icon-key text as literal words");
+    baseRule.Groups[1].Value.Should().Contain(
+      "font-family: 'Material Symbols Rounded'",
+      "the base rule must point at the Material Symbols Rounded font family");
+  }
+
+  [Fact]
+  public void Pane_PrimaryIcon_SpanCarriesMaterialSymbolsRoundedClass()
+  {
+    // Without this class the icon-key text ("foggy", "thunderstorm", etc.)
+    // renders as plain words instead of as the Material Symbol glyph.
+    // Pins the class on the PRIMARY block icon specifically.
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var primaryIconSpan = cut.Find(".sleep-forecast-primary-icon span");
+    primaryIconSpan.ClassList.Should().Contain(
+      "material-symbols-rounded",
+      "the primary icon span must carry the icon-font class so its text "
+      + "content is replaced by the corresponding Material Symbol glyph");
+  }
+
+  [Fact]
+  public void Pane_EveryForecastCardIcon_SpanCarriesMaterialSymbolsRoundedClass()
+  {
+    // Same regression pin, applied to every card icon (1–3 cards depending
+    // on day count) so a future refactor of the card markup can't silently
+    // drop the class on one card while leaving it on the others.
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var cards = cut.FindAll(".sleep-forecast-card");
+    cards.Should().HaveCount(3);
+    foreach (var card in cards)
+    {
+      var iconSpan = card.QuerySelector(".sleep-forecast-card-icon span");
+      iconSpan.Should().NotBeNull("each card must render an icon span");
+      iconSpan!.ClassList.Should().Contain(
+        "material-symbols-rounded",
+        "every card icon span must carry the icon-font class");
+    }
+  }
+
+  [Fact]
+  public void Pane_StaleIconSpan_CarriesMaterialSymbolsRoundedClass()
+  {
+    // The sub-line's sync_problem glyph (rendered only in the stale state)
+    // is the third icon surface on the pane. Pin it for completeness.
+    var cut = RenderComponent<SleepForecastPane>(p => p
+      .Add(x => x.Forecast, BuildForecast(3, isStale: true))
+      .Add(x => x.TemperatureUnit, "F"));
+
+    var staleIcon = cut.Find(".sleep-forecast-stale-icon");
+    staleIcon.ClassList.Should().Contain(
+      "material-symbols-rounded",
+      "the stale-state sync_problem icon span must carry the icon-font class");
+  }
+
   // ── Helpers ─────────────────────────────────────────────────────────────
 
   /// <summary>
@@ -494,5 +601,24 @@ public class SleepForecastPaneTests : TestContext
       dir = Path.GetDirectoryName(dir);
     }
     throw new FileNotFoundException("design-system.css not found by walking up from test base dir");
+  }
+
+  /// <summary>
+  /// Locate the App.razor source file (companion to <see cref="LocateDesignSystemCss"/>).
+  /// Same upward walk strategy; the source isn't copied into the test output.
+  /// </summary>
+  private static string LocateAppRazor()
+  {
+    var dir = AppContext.BaseDirectory;
+    for (var i = 0; i < 10 && dir != null; i++)
+    {
+      var candidate = Path.Combine(dir, "src", "Radio.Web", "Components", "App.razor");
+      if (File.Exists(candidate))
+      {
+        return candidate;
+      }
+      dir = Path.GetDirectoryName(dir);
+    }
+    throw new FileNotFoundException("App.razor not found by walking up from test base dir");
   }
 }


### PR DESCRIPTION
## Summary

Visual UAT after PR #418 (`feat(web): redesigned sleep-mode weather layout`)
caught the icon `<span>` elements on `/sleep` rendering their icon-key text
(e.g. `foggy`, `thunderstorm`) as **literal words** instead of as Material
Symbol glyphs. The words were visible overlapping the LED temperature
numerals — see `uat-sleep-waited35.png`. Fix: wire up the Material Symbols
Rounded font that the spans were expecting.

## Root cause

`SleepForecastPane` emits `<span class="material-symbols-rounded">@key</span>`
relying on the font's **ligature substitution** to replace the icon-key text
with the corresponding glyph. That only works when a font-family resolves to
`Material Symbols Rounded`. In production, neither side of the wiring was in
place:

1. `App.razor` only linked Inter + Orbitron from Google Fonts — no Material
   Symbols stylesheet, so no `@font-face` for the variable font was ever loaded.
2. `design-system.css` declared only descendant rules
   (`.sleep-forecast-primary-icon .material-symbols-rounded`,
   `.sleep-forecast-card-icon .material-symbols-rounded`) that set
   `font-size` / `color` / `font-variation-settings`, with **no
   `font-family`**. Nothing told the browser which font to use.

Result: the spans rendered as plain text in the inherited Inter font.

The spans themselves were correct — they had the right `class` and they
emitted the right icon-key strings (`foggy`, `thunderstorm`, `sunny`, etc.)
which are valid Material Symbols Rounded ligature names. The user's
initial bug report hypothesized a missing class, but inspection showed the
class WAS present everywhere it needed to be; the font itself was simply
never loaded — exactly the "less likely" possibility #3 from the report.
(The handoff's "Orbitron is rendering fine, so font loading must be OK"
heuristic was misleading: Orbitron loads via the existing Inter+Orbitron
`<link>`; nothing in that link covers Material Symbols.)

## Investigation

- `grep -r material-symbols src/Radio.Web` → only 2 files mention it:
  `SleepForecastPane.razor` (the consumer) and `design-system.css` (descendant
  rules). No other component in the app uses raw Material Symbols Rounded —
  topbar / queue / dialogs all use Radzen's `<RadzenIcon>`, which is a
  different icon set served by Radzen's own theme bundle.
  → there was no "working convention" elsewhere to copy; the spans were the
  first and only consumer, and the font-loading piece was simply omitted.
- `grep font-family.*[Mm]aterial src/Radio.Web/wwwroot` → zero hits.
- `Sleep.razor` uses `EmptyLayout`, but the `<head>` is in `App.razor` and is
  shared across all layouts, so the issue isn't layout-specific — the font
  is missing for every page; only the sleep pane happens to use it.

## Fix (defense in depth)

1. **`src/Radio.Web/Components/App.razor`** — add the Google Fonts `<link>`
   for `Material Symbols Rounded` with the `opsz` / `wght` / `FILL` / `GRAD`
   axes that match `font-variation-settings` in `design-system.css`.
2. **`src/Radio.Web/wwwroot/css/design-system.css`** — add a base
   `.material-symbols-rounded { font-family: 'Material Symbols Rounded'; ... }`
   rule. Google Fonts injects this declaration itself via the CDN CSS, but
   pinning it locally makes the dependency grep-discoverable and survives a
   transient CDN blip when the font is locally cached/installed.

## Affected files

- `src/Radio.Web/Components/App.razor` — added `<link>` for Material Symbols
  Rounded (+7 lines)
- `src/Radio.Web/wwwroot/css/design-system.css` — added base
  `.material-symbols-rounded` rule with `font-family` (+23 lines)
- `tests/Radio.Web.Tests/Components/Shared/SleepForecastPaneTests.cs` —
  five new regression tests (+126 lines)

## Regression tests

Five new tests in `SleepForecastPaneTests`:

- `AppRazor_LinksMaterialSymbolsRoundedStylesheet` — pins the Google Fonts
  `<link>` in `App.razor`
- `DesignSystemCss_DeclaresMaterialSymbolsRoundedFontFamily` — pins the
  base `.material-symbols-rounded { font-family: ... }` rule in
  `design-system.css`
- `Pane_PrimaryIcon_SpanCarriesMaterialSymbolsRoundedClass` — pins the
  class on the 96 px primary-block icon span
- `Pane_EveryForecastCardIcon_SpanCarriesMaterialSymbolsRoundedClass` —
  pins the class on every forecast-card icon span
- `Pane_StaleIconSpan_CarriesMaterialSymbolsRoundedClass` — pins the
  class on the sub-line `sync_problem` glyph

Together these would have failed CI in the pre-fix state and will catch any
future PR that removes either the `<link>`, the base CSS rule, or the class
on any of the three icon surfaces.

## Test plan

Gates (local):

- [x] `dotnet build --configuration Release` — 0 errors (44 pre-existing
      IDE0011 warnings unchanged)
- [x] `dotnet test --configuration Release` — all Web tests pass (29/29 in
      `SleepForecastPaneTests`, 623/623 in `Radio.Web.Tests`); the only
      failures are the 4 pre-existing Linux-only `SrcVariableResamplerTests`
      that DllNotFound on Windows for `libsamplerate.so.0` — unrelated to
      this PR.

UAT (post-merge):

- [ ] Deploy to Ubuntu, navigate to `http://radio:5002/sleep`, wait for the
      forecast pane to swap in (~60 s alternation cadence with the clock)
- [ ] Verify the 96 px primary icon renders as the correct glyph (cloud /
      sun / thunderstorm / fog / etc.) — NOT as the literal word
- [ ] Verify each of the 3 forecast-card icons renders as a glyph
- [ ] Verify the stale-state `sync_problem` icon renders as a glyph when
      the forecast is stale (>12 h old)

## Operator note

Adds one extra Google Fonts request on first load of any page. Cached
aggressively by the browser; no recurring cost. Material Symbols Rounded
variable-font subset weights ~290 KB before the kiosk caches it.