### PR TITLE
fix(sdr): eliminate per-batch allocation in FM stereo decimation path

### DIFF
--- a/src/RTLSDRCore/RadioReceiver.cs
+++ b/src/RTLSDRCore/RadioReceiver.cs
@@ -40,7 +40,8 @@ namespace RTLSDRCore;
       private float[] _demodBuffer = Array.Empty<float>();
       private float[] _stereoDemodBuffer = Array.Empty<float>(); // interleaved L,R at demod rate
       private float[] _decimBuffer = Array.Empty<float>();
-      private float[] _decimBufferRight = Array.Empty<float>(); // right channel decimation
+      private float[] _decimBufferRight = Array.Empty<float>(); // right channel demod (de-interleave + de-emphasis)
+      private float[] _decimBufferRightOut = Array.Empty<float>(); // right channel decimation output
       private IqSample[] _iqDecimBuffer = Array.Empty<IqSample>();
       // Pre-allocated silence buffer delivered when squelch closes or muted.
       // Keeps the downstream BufferedSoundGenerator fed at a consistent rate
@@ -865,11 +866,13 @@ namespace RTLSDRCore;
           {
               _stereoDemodBuffer = new float[maxDemodSamples * 2]; // interleaved L,R
               _decimBufferRight = new float[maxDemodSamples / (_audioDecimator?.Factor ?? 1) + 1];
+              _decimBufferRightOut = new float[maxDemodSamples / (_audioDecimator?.Factor ?? 1) + 1];
           }
           else
           {
               _stereoDemodBuffer = Array.Empty<float>();
               _decimBufferRight = Array.Empty<float>();
+              _decimBufferRightOut = Array.Empty<float>();
           }
 
           _agc.Reset();
@@ -1139,9 +1142,16 @@ namespace RTLSDRCore;
 
                   var leftDecimCount = _audioDecimator.Decimate(leftSpan, _decimBuffer);
 
-                  // We need a temp buffer for right decimation output
-                  var rightDecimBuf = new float[maxDecimOut]; // small, ~960 samples
-                  var rightDecimCount = _audioDecimatorRight.Decimate(rightSpan, rightDecimBuf);
+                  // Reuse pre-allocated right-channel decimation output buffer (avoid per-batch allocation).
+                  // Allocating a new float[] here per IQ batch (~200 Hz) previously produced ~131 GB of
+                  // garbage over a 2-day uptime test, causing GC storms (14M Gen0 in a single callback
+                  // interval) that starved MiniAudio's audio callback and caused PipeWire to drop the
+                  // stream. The radio reported "Playing" but produced no audio.
+                  if (_decimBufferRightOut.Length < maxDecimOut)
+                  {
+                      _decimBufferRightOut = new float[maxDecimOut];
+                  }
+                  var rightDecimCount = _audioDecimatorRight.Decimate(rightSpan, _decimBufferRightOut);
 
                   // 3d. Interleave decimated L,R into stereo output
                   var stereoCount = Math.Min(leftDecimCount, rightDecimCount);
@@ -1152,7 +1162,7 @@ namespace RTLSDRCore;
                   for (var i = 0; i < stereoCount; i++)
                   {
                       _stereoDemodBuffer[i * 2] = _decimBuffer[i];
-                      _stereoDemodBuffer[i * 2 + 1] = rightDecimBuf[i];
+                      _stereoDemodBuffer[i * 2 + 1] = _decimBufferRightOut[i];
                   }
                   outputCount = stereoCount * 2; // interleaved sample count
                   outputSamples = _stereoDemodBuffer;


### PR DESCRIPTION
## Summary

Production-critical GC-pressure fix originally identified March 2026 on `fix/sdr-gc-pressure-allocation`. Re-applied against current `main` because that branch was 62 commits behind and `src/RTLSDRCore/RadioReceiver.cs` accumulated unrelated RDS infrastructure that restructured the surrounding code — the original direct cherry-pick was no longer correct.

## Root cause

The stereo FM processing path allocated a fresh `new float[maxDecimOut]` (~960 samples) for the right-channel decimation output on every IQ batch (~200 Hz). Over multi-day uptime this produced ~131 GB of garbage and triggered escalating GC pressure:

- 14M Gen0 / 195K Gen1 / 32K Gen2 collections observed in a single callback interval
- RadioReceiver-DSP thread at 77% CPU after ~2 days uptime
- "Missed callback deadline" warnings from MiniAudio
- PipeWire dropped the audio stream after sustained xruns
- Radio reported `Playing` state via API but produced **no audio output**

## Fix

Introduce a new pre-allocated field `_decimBufferRightOut` dedicated to the right-channel decimation output. Resize it in the hot path only when the requested capacity grows (same pattern as `_decimBuffer` and `_stereoDemodBuffer`).

Why a new field instead of reusing `_decimBufferRight` (the original commit's approach)? On current `main`, `_decimBufferRight` has been repurposed by the RDS-era refactor as the right-channel de-interleave/de-emphasis buffer that is passed as the INPUT to `Decimate(rightSpan, ...)`. Using it as both input and output would alias `Decimate`'s spans — that happens to be safe in the current single-stage fast path, but it is fragile (multi-stage path uses `input.ToArray()` and would mask bugs). A dedicated output field keeps the contract clean and matches the existing buffer-per-stage idiom.

Initialization mirrors `_decimBufferRight` in `SetupSignalProcessing` (sized to `maxDemodSamples / Factor + 1` when stereo decoder present, `Array.Empty<float>()` otherwise).

## Original commit

- `55717b3` on `fix/sdr-gc-pressure-allocation`
- Concept preserved; mechanics adapted to drifted code.

## No new tests

The fix is "remove allocation, reuse pre-allocated field" — the test surface is "still produces correct output," which the existing 161 `RTLSDRCore.Tests` cover. The real verification is runtime: `dotnet-counters monitor` on `radio-api` after a 24h+ uptime should show Gen0/Gen1/Gen2 collection rates drop meaningfully versus the pre-fix baseline.

## Gates

- [x] `dotnet build --configuration Release` — 0 errors, 44 warnings (all pre-existing IDE0011 brace style, unrelated)
- [x] `dotnet test --configuration Release --filter "FullyQualifiedName~RTLSDRCore"` — 161/161 pass
- [x] Full test suite — only the 4 pre-existing Linux-only `SrcVariableResamplerTests` (libsamplerate.so.0 missing on Windows) fail, unrelated to this change

## Test plan (post-deploy, user)

- [ ] Deploy to Ubuntu radio host
- [ ] Tune FM stereo station, leave running 24h+
- [ ] Run `dotnet-counters monitor --process-id $(pgrep -f radio-api)` and confirm Gen0/Gen1 collection rates are dramatically lower than pre-fix baseline
- [ ] Confirm audio still playing after multi-day soak (the original failure mode was "Playing but silent")

## Refs

- `design/research/rotary-phone-arc-revival-survey.md` (item 1 of recommended sequence)
- Original commit `55717b3`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>