### PR TITLE
feat(web): Phone page left-rail shell + Status Hero + Dev Tray (PR-1)

### DIFF
--- a/src/Radio.Web/Components/Layout/MainLayout.razor
+++ b/src/Radio.Web/Components/Layout/MainLayout.razor
@@ -31,7 +31,7 @@
     <div class="topbar-primary">
 
       <!-- Time cluster -->
-      <div class="cluster">
+      <div class="cluster cluster-time">
         <span class="cluster-label">Time</span>
         <span class="cluster-value"><span class="font-led">@_currentTime</span></span>
       </div>

--- a/src/Radio.Web/Components/Pages/PhoneContactsPanel.razor
+++ b/src/Radio.Web/Components/Pages/PhoneContactsPanel.razor
@@ -1,0 +1,148 @@
+@using Radio.Web.Models
+
+<div class="phone-contacts">
+  @* Action bar: Sync dropdown + Add Contact *@
+  <div class="contacts-header">
+    <h3 class="card-title">Contacts</h3>
+    <div style="display:flex; gap:8px; align-items:center; position:relative">
+      @* Sync from Phone dropdown *@
+      <div style="position:relative">
+        <RadzenButton Text="@(IsSyncing ? "Syncing..." : "Sync from Phone")"
+          Icon="@(IsSyncing ? "" : "smartphone")"
+          Click="@(() => ShowSyncDropdownChanged.InvokeAsync(!ShowSyncDropdown))"
+          ButtonStyle="ButtonStyle.Info" Size="ButtonSize.Small"
+          Disabled="@IsSyncing">
+          @if (IsSyncing)
+          {
+            <RadzenProgressBarCircular Size="ProgressBarCircularSize.Small"
+              Mode="ProgressBarMode.Indeterminate" Style="margin-right:4px" />
+          }
+        </RadzenButton>
+        @if (ShowSyncDropdown && BtStatus != null)
+        {
+          @* Click-away overlay *@
+          <div style="position:fixed; top:0; left:0; right:0; bottom:0; z-index:99"
+               @onclick="@(() => ShowSyncDropdownChanged.InvokeAsync(false))"
+               @onclick:stopPropagation="true"></div>
+          <div style="position:absolute; top:100%; right:0; margin-top:4px; background:var(--rz-base-800);
+                      border:1px solid var(--rz-base-600); border-radius:6px; padding:4px;
+                      min-width:240px; z-index:100; box-shadow:0 4px 12px rgba(0,0,0,0.5)">
+            <div style="padding:6px 12px; font-size:0.75rem; color:var(--text-low);
+                        border-bottom:1px solid var(--rz-base-700)">Select device to sync:</div>
+            @if (BtStatus.ConnectedDevice != null)
+            {
+              <div style="padding:8px 12px; font-size:0.85rem; cursor:pointer; border-radius:4px;
+                          background:var(--rz-info-lighter, rgba(21,101,192,0.2))"
+                   @onclick="@(() => OnSyncFromDevice.InvokeAsync(BtStatus.ConnectedDevice.Address))"
+                   @onclick:stopPropagation="true">
+                @BtStatus.ConnectedDevice.Name
+                <span style="color:var(--rz-success); font-size:0.7rem">(connected)</span>
+              </div>
+            }
+            @foreach (var device in (BtStatus.PairedDevices ?? []).Where(d => !d.IsConnected))
+            {
+              <div style="padding:8px 12px; font-size:0.85rem; color:var(--text-low);
+                          cursor:pointer; border-radius:4px"
+                   @onclick="@(() => OnSyncFromDevice.InvokeAsync(device.Address))"
+                   @onclick:stopPropagation="true">
+                @device.Name
+                <span style="font-size:0.7rem">(paired)</span>
+              </div>
+            }
+          </div>
+        }
+      </div>
+      <RadzenButton Text="Add Contact" Icon="person_add"
+        Click="@OnAddContact"
+        ButtonStyle="ButtonStyle.Primary" Size="ButtonSize.Small" />
+    </div>
+  </div>
+
+  @* Sync status bar *@
+  @if (ConnectedDeviceSyncInfo != null)
+  {
+    var syncInfo = ConnectedDeviceSyncInfo;
+    <div style="background:var(--rz-base-800); border-radius:4px; padding:8px 12px;
+                display:flex; justify-content:space-between; align-items:center; font-size:0.8rem; margin-bottom:8px">
+      <span style="color:var(--text-low)">
+        Last synced from @(syncInfo.DeviceName ?? syncInfo.DeviceAddress):
+        @(syncInfo.LastSynced.HasValue ? FormatTimeAgo(syncInfo.LastSynced.Value) : "never")
+        — @syncInfo.ContactCount contacts
+      </span>
+      <RadzenBadge Text="@(syncInfo.IsStale ? "Stale" : "Fresh")"
+        BadgeStyle="@(syncInfo.IsStale ? BadgeStyle.Warning : BadgeStyle.Success)"
+        IsPill="true" />
+    </div>
+  }
+
+  @* Merged contacts grid *@
+  <RadzenDataGrid Data="@MergedContacts" TItem="MergedContact"
+    AllowSorting="true" AllowFiltering="true" FilterMode="FilterMode.Simple"
+    class="contacts-grid">
+    <Columns>
+      <RadzenDataGridColumn TItem="MergedContact" Property="Name" Title="Name" Width="200px" />
+      <RadzenDataGridColumn TItem="MergedContact" Property="Phone" Title="Phone" Width="160px">
+        <Template Context="contact">
+          <span class="phone-number">@contact.Phone</span>
+        </Template>
+      </RadzenDataGridColumn>
+      <RadzenDataGridColumn TItem="MergedContact" Property="Email" Title="Email" />
+      <RadzenDataGridColumn TItem="MergedContact" Property="Source" Title="Source" Width="100px"
+        Sortable="true" Filterable="true">
+        <Template Context="contact">
+          @if (contact.Source == "PBAP")
+          {
+            <RadzenBadge Text="PBAP" BadgeStyle="BadgeStyle.Info" IsPill="true"
+              Style="font-size:0.7rem" />
+          }
+          else
+          {
+            <RadzenBadge Text="Manual" BadgeStyle="BadgeStyle.Light" IsPill="true"
+              Style="font-size:0.7rem" />
+          }
+        </Template>
+      </RadzenDataGridColumn>
+      <RadzenDataGridColumn TItem="MergedContact" Title="Actions" Width="100px"
+        Sortable="false" Filterable="false">
+        <Template Context="contact">
+          @if (contact.Source == "Manual" && contact.Id != null)
+          {
+            var original = Contacts?.FirstOrDefault(c => c.Id == contact.Id);
+            @if (original != null)
+            {
+              <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light" Size="ButtonSize.Small"
+                Click="@(() => OnEditContact.InvokeAsync(original))"
+                class="action-btn" />
+              <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Size="ButtonSize.Small"
+                Click="@(() => OnDeleteContact.InvokeAsync(original))"
+                class="action-btn" />
+            }
+          }
+        </Template>
+      </RadzenDataGridColumn>
+    </Columns>
+  </RadzenDataGrid>
+</div>
+
+@code {
+  [Parameter] public List<MergedContact>? MergedContacts { get; set; }
+  [Parameter] public PbapDeviceSyncInfoDto? ConnectedDeviceSyncInfo { get; set; }
+  [Parameter] public BluetoothStatusDto? BtStatus { get; set; }
+  [Parameter] public bool IsSyncing { get; set; }
+  [Parameter] public bool ShowSyncDropdown { get; set; }
+  [Parameter] public EventCallback<bool> ShowSyncDropdownChanged { get; set; }
+  [Parameter] public EventCallback<string> OnSyncFromDevice { get; set; }
+  [Parameter] public EventCallback OnAddContact { get; set; }
+  [Parameter] public EventCallback<ContactDto> OnEditContact { get; set; }
+  [Parameter] public EventCallback<ContactDto> OnDeleteContact { get; set; }
+  [Parameter] public List<ContactDto>? Contacts { get; set; }
+
+  private static string FormatTimeAgo(DateTime utcTime)
+  {
+    var span = DateTime.UtcNow - utcTime;
+    if (span.TotalMinutes < 1) return "just now";
+    if (span.TotalMinutes < 60) return $"{(int)span.TotalMinutes}m ago";
+    if (span.TotalHours < 24) return $"{(int)span.TotalHours}h ago";
+    return $"{(int)span.TotalDays}d ago";
+  }
+}

--- a/src/Radio.Web/Components/Pages/PhoneContactsPanel.razor
+++ b/src/Radio.Web/Components/Pages/PhoneContactsPanel.razor
@@ -3,7 +3,7 @@
 <div class="phone-contacts">
   @* Action bar: Sync dropdown + Add Contact *@
   <div class="contacts-header">
-    <h3 class="card-title">Contacts</h3>
+    <h3 class="phone-card-title">Contacts</h3>
     <div style="display:flex; gap:8px; align-items:center; position:relative">
       @* Sync from Phone dropdown *@
       <div style="position:relative">

--- a/src/Radio.Web/Components/Pages/PhoneDashboardPanel.razor
+++ b/src/Radio.Web/Components/Pages/PhoneDashboardPanel.razor
@@ -1,7 +1,7 @@
 @using Radio.Web.Models
 @using Radio.Web.Components.Shared
 
-<div class="dashboard">
+<div class="phone-dashboard">
   @* Left column, row 1: Hero *@
   <PhoneStatusHero CallState="CallState"
                    CallSource="@(CallState.CallState is "InCall" or "Dialing" ? "Bluetooth HFP" : "Rotary Phone")"
@@ -13,94 +13,94 @@
   <div style="display: flex; flex-direction: column; gap: 12px; grid-column: 2;
               grid-row: 1 / 3; min-height: 0; overflow: auto;">
     @* --- PR-1: existing markup using new CSS classes --- *@
-    <div class="card accent-green">
-      <div class="card-title title-green">
-        <span class="title-text">System Status</span>
-        <span class="pill @(IsAvailable ? "green" : "red")">@(IsAvailable ? "Healthy" : "Offline")</span>
+    <div class="phone-card accent-green">
+      <div class="phone-card-title phone-title-green">
+        <span class="phone-title-text">System Status</span>
+        <span class="phone-pill @(IsAvailable ? "green" : "red")">@(IsAvailable ? "Healthy" : "Offline")</span>
       </div>
-      <div class="status-list">
-        <div class="status-row">
+      <div class="phone-status-list">
+        <div class="phone-status-row">
           <span class="lbl">Platform</span>
           <span class="val">@(SystemStatus?.Platform ?? "Unknown")</span>
-          <span class="pill gray">@(SystemStatus?.IsRaspberryPi == true ? "Pi" : "x64")</span>
+          <span class="phone-pill gray">@(SystemStatus?.IsRaspberryPi == true ? "Pi" : "x64")</span>
         </div>
-        <div class="status-row">
+        <div class="phone-status-row">
           <span class="lbl">Bluetooth</span>
           <span class="val">@(SystemStatus?.BluetoothDeviceAddress ?? "--")</span>
-          <span class="pill @(SystemStatus?.BluetoothConnected == true ? "green" : "red")">
+          <span class="phone-pill @(SystemStatus?.BluetoothConnected == true ? "green" : "red")">
             @(SystemStatus?.BluetoothConnected == true ? "Connected" : "Disconnected")
           </span>
         </div>
-        <div class="status-row">
+        <div class="phone-status-row">
           <span class="lbl">SIP Device</span>
           <span class="val">@(SystemStatus?.SipListenAddress ?? "--"):@(SystemStatus?.SipPort)</span>
-          <span class="pill @(SystemStatus?.SipListening == true ? "green" : "red")">
+          <span class="phone-pill @(SystemStatus?.SipListening == true ? "green" : "red")">
             @(SystemStatus?.SipListening == true ? "Listening" : "Offline")
           </span>
         </div>
-        <div class="status-row">
+        <div class="phone-status-row">
           <span class="lbl">HT801 ATA</span>
           <span class="val">@(SystemStatus?.Ht801IpAddress ?? "--")</span>
-          <span class="pill @(SystemStatus?.Ht801Reachable == true ? "green" : "red")">
+          <span class="phone-pill @(SystemStatus?.Ht801Reachable == true ? "green" : "red")">
             @(SystemStatus?.Ht801Reachable == true ? "Online" : "Offline")
           </span>
         </div>
       </div>
     </div>
 
-    <div class="card accent-cyan">
-      <div class="card-title title-cyan">
-        <span class="title-text">Call Path</span>
+    <div class="phone-card accent-cyan">
+      <div class="phone-card-title phone-title-cyan">
+        <span class="phone-title-text">Call Path</span>
       </div>
-      <div class="callpath-row">
+      <div class="phone-callpath-row">
         <span class="sub">Active Mode</span>
-        <div class="mode-selector">
-          <button type="button" class="mode-btn @(GvActiveMode == "BluetoothHfp" ? "active" : "")"
+        <div class="phone-mode-selector">
+          <button type="button" class="phone-mode-btn @(GvActiveMode == "BluetoothHfp" ? "active" : "")"
                   @onclick="@(() => OnSwitchMode.InvokeAsync("BluetoothHfp"))"
                   disabled="@SwitchingMode">
             <RadzenIcon Icon="bluetooth" /> Bluetooth
           </button>
-          <button type="button" class="mode-btn @(GvActiveMode == "SipTrunk" ? "active" : "")"
+          <button type="button" class="phone-mode-btn @(GvActiveMode == "SipTrunk" ? "active" : "")"
                   @onclick="@(() => OnSwitchMode.InvokeAsync("SipTrunk"))"
                   disabled="@SwitchingMode">
             <RadzenIcon Icon="settings_phone" /> SIP Trunk
           </button>
-          <button type="button" class="mode-btn @(GvActiveMode == "GVApi" ? "active" : "")"
+          <button type="button" class="phone-mode-btn @(GvActiveMode == "GVApi" ? "active" : "")"
                   @onclick="@(() => OnSwitchMode.InvokeAsync("GVApi"))"
                   disabled="@SwitchingMode">
             <RadzenIcon Icon="language" /> GV API
           </button>
         </div>
       </div>
-      <div class="connector-row">
-        <div class="conn-meta">
-          <span class="conn-icon"><RadzenIcon Icon="language" /></span>
-          <div class="conn-name">
+      <div class="phone-connector-row">
+        <div class="phone-conn-meta">
+          <span class="phone-conn-icon"><RadzenIcon Icon="language" /></span>
+          <div class="phone-conn-name">
             <span>GV API</span>
             <span class="sub">@(GvBridgeAvailable ? "SIP-WSS Bridge" : "Bridge")</span>
           </div>
         </div>
-        <div class="right-cluster">
-          <span class="pill @(GvBridgeAvailable ? "green" : "red")">
+        <div class="phone-right-cluster">
+          <span class="phone-pill @(GvBridgeAvailable ? "green" : "red")">
             @(GvBridgeAvailable ? "Available" : "Unavailable")
           </span>
         </div>
       </div>
-      <div class="connector-row">
-        <div class="conn-meta">
-          <span class="conn-icon"><RadzenIcon Icon="settings_phone" /></span>
-          <div class="conn-name">
+      <div class="phone-connector-row">
+        <div class="phone-conn-meta">
+          <span class="phone-conn-icon"><RadzenIcon Icon="settings_phone" /></span>
+          <div class="phone-conn-name">
             <span>SIP Trunk</span>
             <span class="sub">voip.ms &middot; 5060</span>
           </div>
         </div>
-        <div class="right-cluster">
-          <span class="pill @(GvTrunkRegistered ? "green" : "red")">
+        <div class="phone-right-cluster">
+          <span class="phone-pill @(GvTrunkRegistered ? "green" : "red")">
             @(GvTrunkRegistered ? "Registered" : "Unregistered")
           </span>
           @if (!GvTrunkRegistered)
           {
-            <button type="button" class="link-btn" @onclick="OnReregisterTrunk">Re-register</button>
+            <button type="button" class="phone-link-btn" @onclick="OnReregisterTrunk">Re-register</button>
           }
         </div>
       </div>

--- a/src/Radio.Web/Components/Pages/PhoneDashboardPanel.razor
+++ b/src/Radio.Web/Components/Pages/PhoneDashboardPanel.razor
@@ -1,0 +1,141 @@
+@using Radio.Web.Models
+@using Radio.Web.Components.Shared
+
+<div class="dashboard">
+  @* Left column, row 1: Hero *@
+  <PhoneStatusHero CallState="CallState"
+                   CallSource="@(CallState.CallState is "InCall" or "Dialing" ? "Bluetooth HFP" : "Rotary Phone")"
+                   Contacts="Contacts"
+                   OnAnswer="@(() => OnSimulateHook.InvokeAsync(true))"
+                   OnHangup="@(() => OnSimulateHook.InvokeAsync(false))" />
+
+  @* Right column, spans both rows: existing System Status + Call Path *@
+  <div style="display: flex; flex-direction: column; gap: 12px; grid-column: 2;
+              grid-row: 1 / 3; min-height: 0; overflow: auto;">
+    @* --- PR-1: existing markup using new CSS classes --- *@
+    <div class="card accent-green">
+      <div class="card-title title-green">
+        <span class="title-text">System Status</span>
+        <span class="pill @(IsAvailable ? "green" : "red")">@(IsAvailable ? "Healthy" : "Offline")</span>
+      </div>
+      <div class="status-list">
+        <div class="status-row">
+          <span class="lbl">Platform</span>
+          <span class="val">@(SystemStatus?.Platform ?? "Unknown")</span>
+          <span class="pill gray">@(SystemStatus?.IsRaspberryPi == true ? "Pi" : "x64")</span>
+        </div>
+        <div class="status-row">
+          <span class="lbl">Bluetooth</span>
+          <span class="val">@(SystemStatus?.BluetoothDeviceAddress ?? "--")</span>
+          <span class="pill @(SystemStatus?.BluetoothConnected == true ? "green" : "red")">
+            @(SystemStatus?.BluetoothConnected == true ? "Connected" : "Disconnected")
+          </span>
+        </div>
+        <div class="status-row">
+          <span class="lbl">SIP Device</span>
+          <span class="val">@(SystemStatus?.SipListenAddress ?? "--"):@(SystemStatus?.SipPort)</span>
+          <span class="pill @(SystemStatus?.SipListening == true ? "green" : "red")">
+            @(SystemStatus?.SipListening == true ? "Listening" : "Offline")
+          </span>
+        </div>
+        <div class="status-row">
+          <span class="lbl">HT801 ATA</span>
+          <span class="val">@(SystemStatus?.Ht801IpAddress ?? "--")</span>
+          <span class="pill @(SystemStatus?.Ht801Reachable == true ? "green" : "red")">
+            @(SystemStatus?.Ht801Reachable == true ? "Online" : "Offline")
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <div class="card accent-cyan">
+      <div class="card-title title-cyan">
+        <span class="title-text">Call Path</span>
+      </div>
+      <div class="callpath-row">
+        <span class="sub">Active Mode</span>
+        <div class="mode-selector">
+          <button type="button" class="mode-btn @(GvActiveMode == "BluetoothHfp" ? "active" : "")"
+                  @onclick="@(() => OnSwitchMode.InvokeAsync("BluetoothHfp"))"
+                  disabled="@SwitchingMode">
+            <RadzenIcon Icon="bluetooth" /> Bluetooth
+          </button>
+          <button type="button" class="mode-btn @(GvActiveMode == "SipTrunk" ? "active" : "")"
+                  @onclick="@(() => OnSwitchMode.InvokeAsync("SipTrunk"))"
+                  disabled="@SwitchingMode">
+            <RadzenIcon Icon="settings_phone" /> SIP Trunk
+          </button>
+          <button type="button" class="mode-btn @(GvActiveMode == "GVApi" ? "active" : "")"
+                  @onclick="@(() => OnSwitchMode.InvokeAsync("GVApi"))"
+                  disabled="@SwitchingMode">
+            <RadzenIcon Icon="language" /> GV API
+          </button>
+        </div>
+      </div>
+      <div class="connector-row">
+        <div class="conn-meta">
+          <span class="conn-icon"><RadzenIcon Icon="language" /></span>
+          <div class="conn-name">
+            <span>GV API</span>
+            <span class="sub">@(GvBridgeAvailable ? "SIP-WSS Bridge" : "Bridge")</span>
+          </div>
+        </div>
+        <div class="right-cluster">
+          <span class="pill @(GvBridgeAvailable ? "green" : "red")">
+            @(GvBridgeAvailable ? "Available" : "Unavailable")
+          </span>
+        </div>
+      </div>
+      <div class="connector-row">
+        <div class="conn-meta">
+          <span class="conn-icon"><RadzenIcon Icon="settings_phone" /></span>
+          <div class="conn-name">
+            <span>SIP Trunk</span>
+            <span class="sub">voip.ms &middot; 5060</span>
+          </div>
+        </div>
+        <div class="right-cluster">
+          <span class="pill @(GvTrunkRegistered ? "green" : "red")">
+            @(GvTrunkRegistered ? "Registered" : "Unregistered")
+          </span>
+          @if (!GvTrunkRegistered)
+          {
+            <button type="button" class="link-btn" @onclick="OnReregisterTrunk">Re-register</button>
+          }
+        </div>
+      </div>
+    </div>
+  </div>
+
+  @* Left column, row 2: Dev Tray *@
+  <div style="grid-column: 1; grid-row: 2;">
+    <PhoneDevTray Expanded="DevTrayExpanded"
+                  ExpandedChanged="DevTrayExpandedChanged"
+                  CallState="@CallState.CallState"
+                  DialDigits="DialDigits"
+                  DialDigitsChanged="DialDigitsChanged"
+                  OnSimulateHook="OnSimulateHook"
+                  OnSimulateIncoming="OnSimulateIncoming"
+                  OnSimulateDial="OnSimulateDial" />
+  </div>
+</div>
+
+@code {
+  [Parameter] public PhoneCallStateDto CallState { get; set; } = new();
+  [Parameter] public PhoneSystemStatusDto? SystemStatus { get; set; }
+  [Parameter] public bool IsAvailable { get; set; }
+  [Parameter] public string GvActiveMode { get; set; } = "";
+  [Parameter] public bool GvBridgeAvailable { get; set; }
+  [Parameter] public bool GvTrunkRegistered { get; set; }
+  [Parameter] public bool SwitchingMode { get; set; }
+  [Parameter] public bool DevTrayExpanded { get; set; }
+  [Parameter] public EventCallback<bool> DevTrayExpandedChanged { get; set; }
+  [Parameter] public string DialDigits { get; set; } = "";
+  [Parameter] public EventCallback<string> DialDigitsChanged { get; set; }
+  [Parameter] public EventCallback<string> OnSwitchMode { get; set; }
+  [Parameter] public EventCallback OnReregisterTrunk { get; set; }
+  [Parameter] public EventCallback<bool> OnSimulateHook { get; set; }
+  [Parameter] public EventCallback OnSimulateIncoming { get; set; }
+  [Parameter] public EventCallback OnSimulateDial { get; set; }
+  [Parameter] public List<MergedContact>? Contacts { get; set; }
+}

--- a/src/Radio.Web/Components/Pages/PhoneHistoryPanel.razor
+++ b/src/Radio.Web/Components/Pages/PhoneHistoryPanel.razor
@@ -2,7 +2,7 @@
 
 <div class="phone-history">
   <div class="history-header">
-    <h3 class="card-title">Call History</h3>
+    <h3 class="phone-card-title">Call History</h3>
     <RadzenButton Text="Clear History" Icon="delete_sweep"
       Click="@OnClearHistory"
       ButtonStyle="ButtonStyle.Danger" Size="ButtonSize.Small"

--- a/src/Radio.Web/Components/Pages/PhoneHistoryPanel.razor
+++ b/src/Radio.Web/Components/Pages/PhoneHistoryPanel.razor
@@ -1,0 +1,61 @@
+@using Radio.Web.Models
+
+<div class="phone-history">
+  <div class="history-header">
+    <h3 class="card-title">Call History</h3>
+    <RadzenButton Text="Clear History" Icon="delete_sweep"
+      Click="@OnClearHistory"
+      ButtonStyle="ButtonStyle.Danger" Size="ButtonSize.Small"
+      Disabled="@(CallHistory == null || CallHistory.Count == 0)" />
+  </div>
+  @if (CallHistory == null || CallHistory.Count == 0)
+  {
+    <div class="empty-state">No calls recorded</div>
+  }
+  else
+  {
+    <div class="history-list">
+      @foreach (var entry in CallHistory)
+      {
+        <div class="history-item">
+          <RadzenIcon Icon="@GetCallDirectionIcon(entry)"
+            Style="@($"color: {GetCallDirectionColor(entry)}")" />
+          <div class="history-details">
+            <span class="phone-number">@entry.PhoneNumber</span>
+            <span class="history-time">@entry.StartTime.ToLocalTime().ToString("g")</span>
+          </div>
+          @if (entry.AnsweredOn != null)
+          {
+            <RadzenBadge Text="@entry.AnsweredOn"
+              BadgeStyle="@(entry.AnsweredOn == "RotaryPhone" ? BadgeStyle.Info : BadgeStyle.Light)" />
+          }
+          @if (entry.Duration != null)
+          {
+            <span class="call-duration">@entry.Duration</span>
+          }
+        </div>
+      }
+    </div>
+  }
+</div>
+
+@code {
+  [Parameter] public List<CallHistoryEntryDto>? CallHistory { get; set; }
+  [Parameter] public EventCallback OnClearHistory { get; set; }
+
+  private static string GetCallDirectionIcon(CallHistoryEntryDto entry) => entry.Direction switch
+  {
+    "Incoming" when entry.AnsweredOn != null => "call_received",
+    "Incoming" => "call_missed",
+    "Outgoing" => "call_made",
+    _ => "phone"
+  };
+
+  private static string GetCallDirectionColor(CallHistoryEntryDto entry) => entry.Direction switch
+  {
+    "Incoming" when entry.AnsweredOn != null => "var(--rz-success)",
+    "Incoming" => "var(--rz-danger)",
+    "Outgoing" => "var(--rz-info)",
+    _ => "var(--rz-text-color)"
+  };
+}

--- a/src/Radio.Web/Components/Pages/PhonePage.razor
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor
@@ -11,369 +11,72 @@
 
 <PageTitle>Phone - Radio Console</PageTitle>
 
-<div class="phone-page">
-  <RadzenTabs @bind-SelectedIndex="_selectedTab" class="phone-tabs">
+<div class="phone-shell">
+  <div class="tab-rail">
+    <span class="rail-heading">Phone</span>
+    <button type="button" class="rail-tab @(IsTab("dashboard") ? "active" : "")"
+            @onclick='@(() => _activeTab = "dashboard")'>
+      <RadzenIcon Icon="dashboard" />
+      <span class="rail-label">Dashboard</span>
+    </button>
+    <button type="button" class="rail-tab @(IsTab("contacts") ? "active" : "")"
+            @onclick='@(() => _activeTab = "contacts")'>
+      <RadzenIcon Icon="contacts" />
+      <span class="rail-label">Contacts</span>
+    </button>
+    <button type="button" class="rail-tab @(IsTab("history") ? "active" : "")"
+            @onclick='@(() => _activeTab = "history")'>
+      <RadzenIcon Icon="history" />
+      <span class="rail-label">Call History</span>
+    </button>
+  </div>
 
-    @* ═══ Tab 1: Dashboard ═══ *@
-    <Tabs>
-      <RadzenTabsItem Text="Dashboard" Icon="dashboard">
-        <div class="phone-dashboard">
-
-          @* ── System Status Bar ── *@
-          <RadzenCard class="phone-card system-status-card">
-            <h3 class="section-title section-title-green">SYSTEM STATUS</h3>
-            <div class="status-bar">
-              <div class="status-column">
-                <span class="status-column-label">PLATFORM</span>
-                <RadzenBadge BadgeStyle="BadgeStyle.Light" Text="@(_isAvailable ? "Linux" : "Unknown")" />
-              </div>
-              <div class="status-divider"></div>
-              <div class="status-column">
-                <span class="status-column-label">BLUETOOTH</span>
-                <RadzenBadge
-                  BadgeStyle="@(_systemStatus?.BluetoothConnected == true ? BadgeStyle.Success : BadgeStyle.Danger)"
-                  Text="@(_systemStatus?.BluetoothConnected == true ? "Connected" : "Disconnected")" />
-                @if (_systemStatus?.BluetoothDeviceAddress != null)
-                {
-                  <span class="status-detail">@_systemStatus.BluetoothDeviceAddress</span>
-                }
-              </div>
-              <div class="status-divider"></div>
-              <div class="status-column">
-                <span class="status-column-label">SIP DEVICE</span>
-                <RadzenBadge
-                  BadgeStyle="@(_systemStatus?.SipListening == true ? BadgeStyle.Success : BadgeStyle.Danger)"
-                  Text="@(_systemStatus?.SipListening == true ? "Listening" : "Offline")" />
-                @if (_systemStatus?.SipListenAddress != null)
-                {
-                  <span class="status-detail">@_systemStatus.SipListenAddress:@_systemStatus.SipPort</span>
-                }
-              </div>
-              <div class="status-divider"></div>
-              <div class="status-column">
-                <span class="status-column-label">HT801 ATA</span>
-                <RadzenBadge
-                  BadgeStyle="@(_systemStatus?.Ht801Reachable == true ? BadgeStyle.Success : BadgeStyle.Danger)"
-                  Text="@(_systemStatus?.Ht801Reachable == true ? "Online" : "Offline")" />
-                @if (_systemStatus?.Ht801IpAddress != null)
-                {
-                  <span class="status-detail">@_systemStatus.Ht801IpAddress</span>
-                }
-              </div>
-            </div>
-          </RadzenCard>
-
-          @* ── Call Path & GV Status ── *@
-          <RadzenCard class="phone-card call-path-card">
-            <h3 class="section-title section-title-cyan">CALL PATH</h3>
-            <div class="call-path-row">
-              @* Mode selector *@
-              <div class="call-path-modes">
-                <span class="status-column-label">ACTIVE MODE</span>
-                <div class="mode-buttons">
-                  <RadzenButton Text="Bluetooth"
-                    Icon="bluetooth"
-                    ButtonStyle="@(_gvActiveMode == "BluetoothHfp" ? ButtonStyle.Primary : ButtonStyle.Light)"
-                    Size="ButtonSize.Small"
-                    Click="@(() => SwitchModeAsync("BluetoothHfp"))"
-                    Disabled="@_switchingMode" />
-                  <RadzenButton Text="SIP Trunk"
-                    Icon="settings_phone"
-                    ButtonStyle="@(_gvActiveMode == "SipTrunk" ? ButtonStyle.Primary : ButtonStyle.Light)"
-                    Size="ButtonSize.Small"
-                    Click="@(() => SwitchModeAsync("SipTrunk"))"
-                    Disabled="@_switchingMode" />
-                  <RadzenButton Text="GV API"
-                    Icon="language"
-                    ButtonStyle="@(_gvActiveMode == "GVApi" ? ButtonStyle.Primary : ButtonStyle.Light)"
-                    Size="ButtonSize.Small"
-                    Click="@(() => SwitchModeAsync("GVApi"))"
-                    Disabled="@_switchingMode" />
-                </div>
-              </div>
-              <div class="status-divider"></div>
-              @* GV Bridge status — single Available/Unavailable badge sourced
-                 from the post-SIP-WSS server shape ({ available, activeMode }).
-                 SipRegistered + CookiesValid sub-states will land once RotaryPhone
-                 exposes them (Phase B). *@
-              <div class="status-column">
-                <span class="status-column-label">GV API</span>
-                <RadzenBadge
-                  BadgeStyle="@(_gvBridgeAvailable ? BadgeStyle.Success : BadgeStyle.Warning)"
-                  Text="@(_gvBridgeAvailable ? "Available" : "Unavailable")" />
-              </div>
-              <div class="status-divider"></div>
-              @* GV Trunk status *@
-              <div class="status-column">
-                <span class="status-column-label">SIP TRUNK</span>
-                <RadzenBadge
-                  BadgeStyle="@(_gvTrunkRegistered ? BadgeStyle.Success : BadgeStyle.Danger)"
-                  Text="@(_gvTrunkRegistered ? "Registered" : "Unregistered")" />
-                @if (!_gvTrunkRegistered)
-                {
-                  <RadzenButton Text="Re-register" Size="ButtonSize.ExtraSmall"
-                    ButtonStyle="ButtonStyle.Light"
-                    Click="@ReregisterTrunkAsync"
-                    Style="margin-top:4px" />
-                }
-              </div>
-            </div>
-          </RadzenCard>
-
-          @* ── Two-column layout: Status | Dev Controls ── *@
-          <div class="dashboard-columns">
-
-            @* Left: Phone Status *@
-            <RadzenCard class="phone-card phone-status-card">
-              <div class="phone-state-display">
-                <span class="current-status-label">CURRENT STATUS</span>
-                <RadzenBadge
-                  BadgeStyle="@GetCallStateBadgeStyle()"
-                  Text="@_callState.CallState.ToUpperInvariant()"
-                  class="call-state-badge" />
-                @if (_callState.CallState == "Ringing" && _callState.IncomingNumber != null)
-                {
-                  <div class="call-info">
-                    <RadzenIcon Icon="call_received" />
-                    <span class="phone-number">@_callState.IncomingNumber</span>
-                  </div>
-                }
-                else if (_callState.CallState == "InCall")
-                {
-                  <div class="call-info">
-                    <RadzenIcon Icon="phone_in_talk" />
-                    <span class="phone-number">@(_callState.IncomingNumber ?? _callState.DialedNumber ?? "Unknown")</span>
-                  </div>
-                }
-                else if (_callState.CallState == "Dialing" && _callState.DialedNumber != null)
-                {
-                  <div class="call-info">
-                    <RadzenIcon Icon="call_made" />
-                    <span class="phone-number">@_callState.DialedNumber</span>
-                  </div>
-                }
-              </div>
-            </RadzenCard>
-
-            @* Right: Dev Controls (always visible) *@
-            <RadzenCard class="phone-card dev-controls-card">
-              <h3 class="section-title section-title-amber">DEV CONTROLS</h3>
-              <p class="dev-description">Simulate hardware events when no rotary phone is connected.</p>
-              <div class="dev-controls">
-                <div class="dev-section">
-                  <span class="dev-label">HANDSET</span>
-                  <div class="dev-buttons">
-                    <RadzenButton Text="Lift Handset" Icon="phone"
-                      Click="@(() => SimulateHookAsync(true))"
-                      Disabled="@(_callState.CallState == "InCall")"
-                      ButtonStyle="ButtonStyle.Success" Size="ButtonSize.Small" />
-                    <RadzenButton Text="Drop Handset" Icon="phone_disabled"
-                      Click="@(() => SimulateHookAsync(false))"
-                      Disabled="@(_callState.CallState == "Idle")"
-                      ButtonStyle="ButtonStyle.Secondary" Size="ButtonSize.Small" />
-                  </div>
-                </div>
-                <div class="dev-section">
-                  <span class="dev-label">NETWORK</span>
-                  <div class="dev-buttons">
-                    <RadzenButton Text="Simulate Incoming Call" Icon="ring_volume"
-                      Click="@SimulateIncomingCallAsync"
-                      ButtonStyle="ButtonStyle.Warning" Size="ButtonSize.Small"
-                      class="full-width-btn" />
-                  </div>
-                </div>
-                <div class="dev-section">
-                  <span class="dev-label">DIALER</span>
-                  <div class="dev-dialer">
-                    <RadzenTextBox @bind-Value="_dialDigits" Placeholder="Digits"
-                      class="dial-input" />
-                    <RadzenButton Text="Dial" Icon="dialpad"
-                      Click="@SimulateDialAsync"
-                      Disabled="@(string.IsNullOrWhiteSpace(_dialDigits))"
-                      ButtonStyle="ButtonStyle.Secondary" Size="ButtonSize.Small" />
-                  </div>
-                </div>
-              </div>
-            </RadzenCard>
-
-          </div>
-        </div>
-      </RadzenTabsItem>
-
-      @* ═══ Tab 2: Contacts ═══ *@
-      <RadzenTabsItem Text="Contacts" Icon="contacts">
-        <div class="phone-contacts">
-          @* Action bar: Sync dropdown + Add Contact *@
-          <div class="contacts-header">
-            <h3 class="card-title">Contacts</h3>
-            <div style="display:flex; gap:8px; align-items:center; position:relative">
-              @* Sync from Phone dropdown *@
-              <div style="position:relative">
-                <RadzenButton Text="@(_isSyncing ? "Syncing..." : "Sync from Phone")"
-                  Icon="@(_isSyncing ? "" : "smartphone")"
-                  Click="@(() => _showSyncDropdown = !_showSyncDropdown)"
-                  ButtonStyle="ButtonStyle.Info" Size="ButtonSize.Small"
-                  Disabled="@_isSyncing">
-                  @if (_isSyncing)
-                  {
-                    <RadzenProgressBarCircular Size="ProgressBarCircularSize.Small"
-                      Mode="ProgressBarMode.Indeterminate" Style="margin-right:4px" />
-                  }
-                </RadzenButton>
-                @if (_showSyncDropdown && _btStatus != null)
-                {
-                  @* Click-away overlay *@
-                  <div style="position:fixed; top:0; left:0; right:0; bottom:0; z-index:99"
-                       @onclick="@(() => _showSyncDropdown = false)"
-                       @onclick:stopPropagation="true"></div>
-                  <div style="position:absolute; top:100%; right:0; margin-top:4px; background:var(--rz-base-800);
-                              border:1px solid var(--rz-base-600); border-radius:6px; padding:4px;
-                              min-width:240px; z-index:100; box-shadow:0 4px 12px rgba(0,0,0,0.5)">
-                    <div style="padding:6px 12px; font-size:0.75rem; color:var(--text-low);
-                                border-bottom:1px solid var(--rz-base-700)">Select device to sync:</div>
-                    @if (_btStatus.ConnectedDevice != null)
-                    {
-                      <div style="padding:8px 12px; font-size:0.85rem; cursor:pointer; border-radius:4px;
-                                  background:var(--rz-info-lighter, rgba(21,101,192,0.2))"
-                           @onclick="@(() => SyncFromDeviceAsync(_btStatus.ConnectedDevice.Address))"
-                           @onclick:stopPropagation="true">
-                        📱 @_btStatus.ConnectedDevice.Name
-                        <span style="color:var(--rz-success); font-size:0.7rem">(connected)</span>
-                      </div>
-                    }
-                    @foreach (var device in (_btStatus.PairedDevices ?? []).Where(d => !d.IsConnected))
-                    {
-                      <div style="padding:8px 12px; font-size:0.85rem; color:var(--text-low);
-                                  cursor:pointer; border-radius:4px"
-                           @onclick="@(() => SyncFromDeviceAsync(device.Address))"
-                           @onclick:stopPropagation="true">
-                        📱 @device.Name
-                        <span style="font-size:0.7rem">(paired)</span>
-                      </div>
-                    }
-                  </div>
-                }
-              </div>
-              <RadzenButton Text="Add Contact" Icon="person_add"
-                Click="@OpenAddContactDialog"
-                ButtonStyle="ButtonStyle.Primary" Size="ButtonSize.Small" />
-            </div>
-          </div>
-
-          @* Sync status bar *@
-          @if (ConnectedDeviceSyncInfo != null)
-          {
-            var syncInfo = ConnectedDeviceSyncInfo;
-            <div style="background:var(--rz-base-800); border-radius:4px; padding:8px 12px;
-                        display:flex; justify-content:space-between; align-items:center; font-size:0.8rem; margin-bottom:8px">
-              <span style="color:var(--text-low)">
-                Last synced from @(syncInfo.DeviceName ?? syncInfo.DeviceAddress):
-                @(syncInfo.LastSynced.HasValue ? FormatTimeAgo(syncInfo.LastSynced.Value) : "never")
-                — @syncInfo.ContactCount contacts
-              </span>
-              <RadzenBadge Text="@(syncInfo.IsStale ? "Stale" : "Fresh")"
-                BadgeStyle="@(syncInfo.IsStale ? BadgeStyle.Warning : BadgeStyle.Success)"
-                IsPill="true" />
-            </div>
-          }
-
-          @* Merged contacts grid *@
-          <RadzenDataGrid Data="@MergedContacts" TItem="MergedContact"
-            AllowSorting="true" AllowFiltering="true" FilterMode="FilterMode.Simple"
-            class="contacts-grid">
-            <Columns>
-              <RadzenDataGridColumn TItem="MergedContact" Property="Name" Title="Name" Width="200px" />
-              <RadzenDataGridColumn TItem="MergedContact" Property="Phone" Title="Phone" Width="160px">
-                <Template Context="contact">
-                  <span class="phone-number">@contact.Phone</span>
-                </Template>
-              </RadzenDataGridColumn>
-              <RadzenDataGridColumn TItem="MergedContact" Property="Email" Title="Email" />
-              <RadzenDataGridColumn TItem="MergedContact" Property="Source" Title="Source" Width="100px"
-                Sortable="true" Filterable="true">
-                <Template Context="contact">
-                  @if (contact.Source == "PBAP")
-                  {
-                    <RadzenBadge Text="📱 PBAP" BadgeStyle="BadgeStyle.Info" IsPill="true"
-                      Style="font-size:0.7rem" />
-                  }
-                  else
-                  {
-                    <RadzenBadge Text="✏️ Manual" BadgeStyle="BadgeStyle.Light" IsPill="true"
-                      Style="font-size:0.7rem" />
-                  }
-                </Template>
-              </RadzenDataGridColumn>
-              <RadzenDataGridColumn TItem="MergedContact" Title="Actions" Width="100px"
-                Sortable="false" Filterable="false">
-                <Template Context="contact">
-                  @if (contact.Source == "Manual" && contact.Id != null)
-                  {
-                    var original = _contacts?.FirstOrDefault(c => c.Id == contact.Id);
-                    @if (original != null)
-                    {
-                      <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light" Size="ButtonSize.Small"
-                        Click="@(() => OpenEditContactDialog(original))"
-                        class="action-btn" />
-                      <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Size="ButtonSize.Small"
-                        Click="@(() => DeleteContactAsync(original))"
-                        class="action-btn" />
-                    }
-                  }
-                </Template>
-              </RadzenDataGridColumn>
-            </Columns>
-          </RadzenDataGrid>
-        </div>
-      </RadzenTabsItem>
-
-      @* ═══ Tab 3: Call History ═══ *@
-      <RadzenTabsItem Text="Call History" Icon="history">
-        <div class="phone-history">
-          <div class="history-header">
-            <h3 class="card-title">Call History</h3>
-            <RadzenButton Text="Clear History" Icon="delete_sweep"
-              Click="@ClearCallHistoryAsync"
-              ButtonStyle="ButtonStyle.Danger" Size="ButtonSize.Small"
-              Disabled="@(_callHistory == null || _callHistory.Count == 0)" />
-          </div>
-          @if (_callHistory == null || _callHistory.Count == 0)
-          {
-            <div class="empty-state">No calls recorded</div>
-          }
-          else
-          {
-            <div class="history-list">
-              @foreach (var entry in _callHistory)
-              {
-                <div class="history-item">
-                  <RadzenIcon Icon="@GetCallDirectionIcon(entry)"
-                    Style="@($"color: {GetCallDirectionColor(entry)}")" />
-                  <div class="history-details">
-                    <span class="phone-number">@entry.PhoneNumber</span>
-                    <span class="history-time">@entry.StartTime.ToLocalTime().ToString("g")</span>
-                  </div>
-                  @if (entry.AnsweredOn != null)
-                  {
-                    <RadzenBadge Text="@entry.AnsweredOn"
-                      BadgeStyle="@(entry.AnsweredOn == "RotaryPhone" ? BadgeStyle.Info : BadgeStyle.Light)" />
-                  }
-                  @if (entry.Duration != null)
-                  {
-                    <span class="call-duration">@entry.Duration</span>
-                  }
-                </div>
-              }
-            </div>
-          }
-        </div>
-      </RadzenTabsItem>
-    </Tabs>
-  </RadzenTabs>
+  <div style="overflow: hidden; min-height: 0;">
+    @if (_activeTab == "dashboard")
+    {
+      <PhoneDashboardPanel CallState="_callState"
+                           SystemStatus="_systemStatus"
+                           IsAvailable="_isAvailable"
+                           GvActiveMode="_gvActiveMode"
+                           GvBridgeAvailable="_gvBridgeAvailable"
+                           GvTrunkRegistered="_gvTrunkRegistered"
+                           SwitchingMode="_switchingMode"
+                           DevTrayExpanded="_devTrayExpanded"
+                           DevTrayExpandedChanged="@((bool v) => { _devTrayExpanded = v; StateHasChanged(); })"
+                           DialDigits="_dialDigits"
+                           DialDigitsChanged="@((string v) => { _dialDigits = v; StateHasChanged(); })"
+                           OnSwitchMode="SwitchModeAsync"
+                           OnReregisterTrunk="ReregisterTrunkAsync"
+                           OnSimulateHook="SimulateHookAsync"
+                           OnSimulateIncoming="SimulateIncomingCallAsync"
+                           OnSimulateDial="SimulateDialStringAsync"
+                           Contacts="MergedContacts" />
+    }
+    else if (_activeTab == "contacts")
+    {
+      <PhoneContactsPanel MergedContacts="MergedContacts"
+                          ConnectedDeviceSyncInfo="ConnectedDeviceSyncInfo"
+                          BtStatus="_btStatus"
+                          IsSyncing="_isSyncing"
+                          ShowSyncDropdown="_showSyncDropdown"
+                          ShowSyncDropdownChanged="@((bool v) => { _showSyncDropdown = v; StateHasChanged(); })"
+                          OnSyncFromDevice="SyncFromDeviceAsync"
+                          OnAddContact="OpenAddContactDialog"
+                          OnEditContact="OpenEditContactDialog"
+                          OnDeleteContact="DeleteContactAsync"
+                          Contacts="_contacts" />
+    }
+    else if (_activeTab == "history")
+    {
+      <PhoneHistoryPanel CallHistory="_callHistory"
+                         OnClearHistory="ClearCallHistoryAsync" />
+    }
+  </div>
 </div>
 
 @code {
-  private int _selectedTab;
+  private string _activeTab = "dashboard";
+  private bool _devTrayExpanded;
   private PhoneSystemStatusDto? _systemStatus;
   private PhoneCallStateDto _callState = new();
   private List<ContactDto>? _contacts;
@@ -395,6 +98,8 @@
   private bool _gvBridgeAvailable;
   private bool _gvTrunkRegistered;
   private bool _switchingMode;
+
+  private bool IsTab(string t) => _activeTab == t;
 
   protected override async Task OnInitializedAsync()
   {
@@ -426,7 +131,7 @@
       _gvTrunkRegistered = trunkStatus.IsRegistered;
     }
 
-    // Load PBAP contacts — prefer connected device, fall back to most recently synced
+    // Load PBAP contacts -- prefer connected device, fall back to most recently synced
     var pbapDeviceAddress = _btStatus?.ConnectedDevice?.Address
       ?? _pbapStatus?.Devices.OrderByDescending(d => d.LastSynced).FirstOrDefault()?.DeviceAddress;
     if (pbapDeviceAddress != null)
@@ -435,8 +140,7 @@
     }
     RebuildMergedContacts();
 
-    // Subscribe to SignalR events. (RotaryPhone has no /hubs/gvbridge — GV-mode
-    // changes are picked up via the 30s status poll in PollStatusAsync.)
+    // Subscribe to SignalR events
     PhoneHub.CallStateChanged += OnCallStateChanged;
     PhoneHub.IncomingCall += OnIncomingCall;
     PhoneHub.CallHistoryUpdated += OnCallHistoryUpdated;
@@ -535,7 +239,7 @@
       _callHistory = await PhoneApi.GetCallHistoryAsync();
       if (!_disposed) await InvokeAsync(StateHasChanged);
     }
-    catch { /* Non-fatal — next poll will catch up */ }
+    catch { /* Non-fatal -- next poll will catch up */ }
   }
 
   private void OnSystemStatusChanged(object status)
@@ -551,9 +255,6 @@
       catch { /* Non-fatal */ }
     });
   }
-
-  // GV Trunk event handlers. (GV Bridge has no hub; mode changes are surfaced
-  // by the polling fallback in PollStatusAsync.)
 
   private void OnRegistrationChanged(bool registered)
   {
@@ -615,6 +316,15 @@
   }
 
   private async Task SimulateDialAsync()
+  {
+    if (!string.IsNullOrWhiteSpace(_dialDigits))
+    {
+      await PhoneApi.SimulateDialAsync(_dialDigits);
+      _dialDigits = "";
+    }
+  }
+
+  private async Task SimulateDialStringAsync()
   {
     if (!string.IsNullOrWhiteSpace(_dialDigits))
     {
@@ -690,22 +400,6 @@
     _ => BadgeStyle.Light
   };
 
-  private static string GetCallDirectionIcon(CallHistoryEntryDto entry) => entry.Direction switch
-  {
-    "Incoming" when entry.AnsweredOn != null => "call_received",
-    "Incoming" => "call_missed",
-    "Outgoing" => "call_made",
-    _ => "phone"
-  };
-
-  private static string GetCallDirectionColor(CallHistoryEntryDto entry) => entry.Direction switch
-  {
-    "Incoming" when entry.AnsweredOn != null => "var(--rz-success)",
-    "Incoming" => "var(--rz-danger)",
-    "Outgoing" => "var(--rz-info)",
-    _ => "var(--rz-text-color)"
-  };
-
   // PBAP Sync
 
   private async Task SyncFromDeviceAsync(string deviceAddress)
@@ -755,8 +449,6 @@
     if (span.TotalHours < 24) return $"{(int)span.TotalHours}h ago";
     return $"{(int)span.TotalDays}d ago";
   }
-
-  private record MergedContact(string? Id, string Name, string Phone, string? Email, string Source);
 
   private List<MergedContact> MergedContacts { get; set; } = [];
 

--- a/src/Radio.Web/Components/Pages/PhonePage.razor
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor
@@ -315,15 +315,6 @@
     await PhoneApi.SimulateIncomingCallAsync();
   }
 
-  private async Task SimulateDialAsync()
-  {
-    if (!string.IsNullOrWhiteSpace(_dialDigits))
-    {
-      await PhoneApi.SimulateDialAsync(_dialDigits);
-      _dialDigits = "";
-    }
-  }
-
   private async Task SimulateDialStringAsync()
   {
     if (!string.IsNullOrWhiteSpace(_dialDigits))
@@ -440,15 +431,6 @@
   private PbapDeviceSyncInfoDto? ConnectedDeviceSyncInfo =>
     _pbapStatus?.Devices.FirstOrDefault(d =>
       string.Equals(d.DeviceAddress, _btStatus?.ConnectedDevice?.Address, StringComparison.OrdinalIgnoreCase));
-
-  private static string FormatTimeAgo(DateTime utcTime)
-  {
-    var span = DateTime.UtcNow - utcTime;
-    if (span.TotalMinutes < 1) return "just now";
-    if (span.TotalMinutes < 60) return $"{(int)span.TotalMinutes}m ago";
-    if (span.TotalHours < 24) return $"{(int)span.TotalHours}h ago";
-    return $"{(int)span.TotalDays}d ago";
-  }
 
   private List<MergedContact> MergedContacts { get; set; } = [];
 

--- a/src/Radio.Web/Components/Pages/PhonePage.razor
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor
@@ -12,22 +12,22 @@
 <PageTitle>Phone - Radio Console</PageTitle>
 
 <div class="phone-shell">
-  <div class="tab-rail">
-    <span class="rail-heading">Phone</span>
-    <button type="button" class="rail-tab @(IsTab("dashboard") ? "active" : "")"
+  <div class="phone-tab-rail">
+    <span class="phone-rail-heading">Phone</span>
+    <button type="button" class="phone-rail-tab @(IsTab("dashboard") ? "active" : "")"
             @onclick='@(() => _activeTab = "dashboard")'>
       <RadzenIcon Icon="dashboard" />
-      <span class="rail-label">Dashboard</span>
+      <span class="phone-rail-label">Dashboard</span>
     </button>
-    <button type="button" class="rail-tab @(IsTab("contacts") ? "active" : "")"
+    <button type="button" class="phone-rail-tab @(IsTab("contacts") ? "active" : "")"
             @onclick='@(() => _activeTab = "contacts")'>
       <RadzenIcon Icon="contacts" />
-      <span class="rail-label">Contacts</span>
+      <span class="phone-rail-label">Contacts</span>
     </button>
-    <button type="button" class="rail-tab @(IsTab("history") ? "active" : "")"
+    <button type="button" class="phone-rail-tab @(IsTab("history") ? "active" : "")"
             @onclick='@(() => _activeTab = "history")'>
       <RadzenIcon Icon="history" />
-      <span class="rail-label">Call History</span>
+      <span class="phone-rail-label">Call History</span>
     </button>
   </div>
 

--- a/src/Radio.Web/Components/Pages/PhonePage.razor.css
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor.css
@@ -1,161 +1,17 @@
-/* Phone Page Styles */
-.phone-page { padding: 8px; height: 100%; display: flex; flex-direction: column; overflow: hidden; }
+/* PhonePage shell -- all visual styles are in design-system.css §Ph.
+   This file only handles CSS isolation for page-level layout. */
 
-/*
- * All layout selectors use ::deep because they're nested inside
- * Radzen component trees (RadzenTabs > RadzenTabsItem > RadzenCard).
- * Without ::deep, Blazor's CSS isolation attribute selectors don't
- * match elements rendered inside child component DOM.
- */
-
-::deep .phone-dashboard { display: flex; flex-direction: column; gap: 12px; }
-::deep .phone-card { padding: 16px; }
-
-/* Section titles — uppercase monospace like the Node version */
-::deep .section-title {
-  margin: 0 0 12px 0;
-  font-size: 1rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
-}
-::deep .section-title-green { color: var(--rz-success); }
-::deep .section-title-amber { color: #e8a838; }
-::deep .section-title-cyan { color: #26c6da; }
-
-/* ── System Status Bar ── */
-::deep .system-status-card { border-left: 3px solid var(--rz-success); }
-::deep .status-bar {
-  display: flex;
-  align-items: flex-start;
-}
-::deep .status-column {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 0 16px;
-}
-::deep .status-column:first-child { padding-left: 0; }
-::deep .status-column:last-child { padding-right: 0; }
-::deep .status-column-label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  color: var(--rz-text-secondary-color);
-  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
-}
-::deep .status-detail {
-  font-size: 0.8rem;
-  font-family: monospace;
-  opacity: 0.7;
-}
-::deep .status-divider {
-  width: 1px;
-  align-self: stretch;
-  min-height: 36px;
-  background: var(--rz-base-600);
-}
-
-/* ── Call Path Card ── */
-::deep .call-path-card { border-left: 3px solid #26c6da; }
-::deep .call-path-row {
-  display: flex;
-  align-items: flex-start;
-}
-::deep .call-path-modes {
-  flex: 1.5;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 0 16px 0 0;
-}
-::deep .mode-buttons { display: flex; gap: 8px; }
-
-/* ── Two-column Dashboard Layout ── */
-::deep .dashboard-columns {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
-}
-
-/* Left: Phone Status */
-::deep .phone-status-card {
-  border-left: 3px solid #e8a838;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-::deep .phone-state-display {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 24px 0;
-  width: 100%;
-  gap: 16px;
-}
-::deep .current-status-label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  color: var(--rz-text-secondary-color);
-  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
-}
-::deep .call-state-badge {
-  font-size: 1.4rem !important;
-  padding: 12px 40px !important;
-  letter-spacing: 0.1em;
-  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
-}
-::deep .call-info {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-}
-::deep .phone-number { font-family: monospace; font-size: 1.1rem; }
-::deep .caller-name { color: var(--rz-text-secondary-color); }
-::deep .call-duration { font-family: monospace; color: var(--rz-text-secondary-color); }
-
-/* Right: Dev Controls */
-::deep .dev-controls-card { border-left: 3px solid #e8a838; }
-::deep .dev-description {
-  font-size: 0.85rem;
-  color: var(--rz-text-secondary-color);
-  margin: 0 0 16px 0;
-}
-::deep .dev-controls { display: flex; flex-direction: column; gap: 16px; }
-::deep .dev-section { display: flex; flex-direction: column; gap: 8px; }
-::deep .dev-label {
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  color: var(--rz-text-color);
-  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
-}
-::deep .dev-buttons { display: flex; gap: 8px; }
-::deep .full-width-btn { width: 100%; }
-::deep .dev-dialer { display: flex; gap: 8px; align-items: center; }
-::deep .dial-input { flex: 1; }
-
-/* ── Flex height propagation: phone-page → tabs → panel → contacts → grid ── */
-::deep .phone-tabs { flex: 1; display: flex; flex-direction: column; overflow: hidden; min-height: 0; }
-::deep .phone-tabs > .rz-tabview-panels { flex: 1; display: flex; flex-direction: column; overflow: hidden; min-height: 0; }
-::deep .phone-tabs > .rz-tabview-panels > .rz-tabview-panel { flex: 1; display: flex; flex-direction: column; overflow: hidden; min-height: 0; }
+/* Flex height propagation for contacts and history stubs (Radzen grid) */
 ::deep .phone-contacts { flex: 1; display: flex; flex-direction: column; overflow: hidden; min-height: 0; }
 ::deep .contacts-grid { flex: 1; min-height: 0; }
 ::deep .contacts-grid .rz-data-grid { height: 100% !important; }
 ::deep .contacts-grid .rz-data-grid-data { overflow: auto !important; }
-
-/* ── Contacts Tab ── */
-::deep .card-title { margin: 0 0 12px 0; font-size: 1.1rem; display: flex; align-items: center; gap: 8px; }
 ::deep .contacts-header, ::deep .history-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+::deep .card-title { margin: 0 0 12px 0; font-size: 1.1rem; display: flex; align-items: center; gap: 8px; }
 ::deep .action-btn { margin: 0 2px; }
-
-/* ── Call History Tab ── */
 ::deep .empty-state { text-align: center; padding: 32px; color: var(--rz-text-secondary-color); }
 ::deep .history-list { display: flex; flex-direction: column; gap: 4px; }
 ::deep .history-item { display: flex; align-items: center; gap: 12px; padding: 8px 12px; border-radius: 4px; background: var(--rz-base-background-color); }
 ::deep .history-details { flex: 1; display: flex; flex-direction: column; }
 ::deep .history-time { font-size: 0.8rem; color: var(--rz-text-secondary-color); }
+::deep .phone-number { font-family: monospace; font-size: 1.1rem; }

--- a/src/Radio.Web/Components/Shared/PhoneDevTray.razor
+++ b/src/Radio.Web/Components/Shared/PhoneDevTray.razor
@@ -1,0 +1,83 @@
+@using Radio.Web.Models
+
+<div class="phone-dev-drawer @(Expanded ? "expanded" : "collapsed")">
+  <div class="phone-dev-header"
+       @onclick="@(() => ExpandedChanged.InvokeAsync(!Expanded))"
+       role="button"
+       aria-expanded="@Expanded">
+    <div class="left">
+      <RadzenIcon Icon="settings" /> Dev Tray &middot; Simulate Hardware Events
+    </div>
+    <div class="right">
+      <span style="display: inline-flex; align-items: center; gap: 8px;">
+        @if (!Expanded)
+        {
+          <span class="phone-dot-pulse"
+                style="width: 6px; height: 6px; border-radius: 50%;
+                       background: var(--signal-amber); display: inline-block;"></span>
+        }
+        @(Expanded ? "Click to collapse" : "Click to expand")
+        <RadzenIcon Icon="expand_more"
+                    Style="@(Expanded ? "transform: rotate(180deg);" : "")" />
+      </span>
+    </div>
+  </div>
+
+  @if (Expanded)
+  {
+    <div class="phone-dev-body">
+      <div class="phone-dev-section">
+        <span class="phone-dev-label">Handset</span>
+        <div class="phone-dev-buttons">
+          <button type="button" class="phone-btn-sm btn-success"
+                  disabled="@(CallState == "InCall")"
+                  @onclick="@(() => OnSimulateHook.InvokeAsync(true))">
+            <RadzenIcon Icon="phone" /> Lift
+          </button>
+          <button type="button" class="phone-btn-sm btn-danger"
+                  disabled="@(CallState == "Idle")"
+                  @onclick="@(() => OnSimulateHook.InvokeAsync(false))">
+            <RadzenIcon Icon="call_end" /> Drop
+          </button>
+        </div>
+      </div>
+
+      <div class="phone-dev-section">
+        <span class="phone-dev-label">Network</span>
+        <div class="phone-dev-buttons">
+          <button type="button" class="phone-btn-sm btn-warn"
+                  @onclick="OnSimulateIncoming">
+            <RadzenIcon Icon="ring_volume" /> Incoming Call
+          </button>
+        </div>
+      </div>
+
+      <div class="phone-dev-section">
+        <span class="phone-dev-label">Dialer</span>
+        <div class="phone-dev-buttons">
+          <input class="phone-input"
+                 placeholder="Digits"
+                 value="@DialDigits"
+                 @oninput="@(e => DialDigitsChanged.InvokeAsync(e.Value?.ToString() ?? ""))"
+                 style="flex: 1; min-width: 120px;" />
+          <button type="button" class="phone-btn-sm"
+                  disabled="@string.IsNullOrWhiteSpace(DialDigits)"
+                  @onclick="OnSimulateDial">
+            <RadzenIcon Icon="dialpad" /> Dial
+          </button>
+        </div>
+      </div>
+    </div>
+  }
+</div>
+
+@code {
+  [Parameter] public bool Expanded { get; set; }
+  [Parameter] public EventCallback<bool> ExpandedChanged { get; set; }
+  [Parameter] public string CallState { get; set; } = "Idle";
+  [Parameter] public string DialDigits { get; set; } = "";
+  [Parameter] public EventCallback<string> DialDigitsChanged { get; set; }
+  [Parameter] public EventCallback<bool> OnSimulateHook { get; set; }
+  [Parameter] public EventCallback OnSimulateIncoming { get; set; }
+  [Parameter] public EventCallback OnSimulateDial { get; set; }
+}

--- a/src/Radio.Web/Components/Shared/PhoneStatusHero.razor
+++ b/src/Radio.Web/Components/Shared/PhoneStatusHero.razor
@@ -1,17 +1,17 @@
 @using Radio.Web.Models
 @implements IDisposable
 
-<div class="hero"
-     style="--hero-state-color: @(StateColors.color);
-            --hero-state-glow: @(StateColors.glow);
-            --hero-glow-color: @(StateColors.glowBg);">
-  <div class="hero-glow"></div>
-  <div class="hero-body">
+<div class="phone-hero"
+     style="--phone-hero-state-color: @(StateColors.color);
+            --phone-hero-state-glow: @(StateColors.glow);
+            --phone-hero-glow-color: @(StateColors.glowBg);">
+  <div class="phone-hero-glow"></div>
+  <div class="phone-hero-body">
 
     @* Top row: state label + source tag *@
-    <div class="hero-top">
-      <span class="hero-state-label">@StateLabel</span>
-      <span class="hero-source-tag">
+    <div class="phone-hero-top">
+      <span class="phone-hero-state-label">@StateLabel</span>
+      <span class="phone-hero-source-tag">
         <span class="dot" style="background: @(StateColors.color);
               box-shadow: 0 0 6px @(StateColors.glow);"></span>
         via @CallSource
@@ -19,7 +19,7 @@
     </div>
 
     @* Big LED state word *@
-    <div class="hero-state @(CallState.CallState == "Ringing" ? "ring-pulse" : "")"
+    <div class="phone-hero-state @(CallState.CallState == "Ringing" ? "ring-pulse" : "")"
          style="color: @(StateColors.color);
                 text-shadow: 0 0 20px @(StateColors.glow);">
       @CallState.CallState.ToUpperInvariant()
@@ -28,37 +28,37 @@
     @* Caller info or empty state *@
     @if (ActiveNumber != null)
     {
-      <div class="hero-meta">
-        <div class="hero-meta-row">
-          <span class="hero-icon"
+      <div class="phone-hero-meta">
+        <div class="phone-hero-meta-row">
+          <span class="phone-hero-icon"
                 style="background: color-mix(in oklab, @(StateColors.color) 18%, transparent);
                        color: @(StateColors.color);">
             <RadzenIcon Icon="@HeroIcon" />
           </span>
           <div style="display: flex; flex-direction: column; gap: 2px;">
-            <span class="hero-number">@ActiveNumber</span>
+            <span class="phone-hero-number">@ActiveNumber</span>
             @if (CallerName != null)
             {
-              <span class="hero-name">@CallerName</span>
+              <span class="phone-hero-name">@CallerName</span>
             }
           </div>
           @if (CallState.CallState == "InCall")
           {
-            <span class="hero-duration">@FormattedDuration</span>
+            <span class="phone-hero-duration">@FormattedDuration</span>
           }
         </div>
       </div>
     }
     else
     {
-      <div class="hero-empty">
+      <div class="phone-hero-empty">
         <RadzenIcon Icon="phone" />
         Lift the handset to place a call, or wait for an incoming ring.
       </div>
     }
 
     @* Action buttons -- contextual to state *@
-    <div class="hero-actions">
+    <div class="phone-hero-actions">
       @switch (CallState.CallState)
       {
         case "Ringing":

--- a/src/Radio.Web/Components/Shared/PhoneStatusHero.razor
+++ b/src/Radio.Web/Components/Shared/PhoneStatusHero.razor
@@ -1,0 +1,219 @@
+@using Radio.Web.Models
+@implements IDisposable
+
+<div class="hero"
+     style="--hero-state-color: @(StateColors.color);
+            --hero-state-glow: @(StateColors.glow);
+            --hero-glow-color: @(StateColors.glowBg);">
+  <div class="hero-glow"></div>
+  <div class="hero-body">
+
+    @* Top row: state label + source tag *@
+    <div class="hero-top">
+      <span class="hero-state-label">@StateLabel</span>
+      <span class="hero-source-tag">
+        <span class="dot" style="background: @(StateColors.color);
+              box-shadow: 0 0 6px @(StateColors.glow);"></span>
+        via @CallSource
+      </span>
+    </div>
+
+    @* Big LED state word *@
+    <div class="hero-state @(CallState.CallState == "Ringing" ? "ring-pulse" : "")"
+         style="color: @(StateColors.color);
+                text-shadow: 0 0 20px @(StateColors.glow);">
+      @CallState.CallState.ToUpperInvariant()
+    </div>
+
+    @* Caller info or empty state *@
+    @if (ActiveNumber != null)
+    {
+      <div class="hero-meta">
+        <div class="hero-meta-row">
+          <span class="hero-icon"
+                style="background: color-mix(in oklab, @(StateColors.color) 18%, transparent);
+                       color: @(StateColors.color);">
+            <RadzenIcon Icon="@HeroIcon" />
+          </span>
+          <div style="display: flex; flex-direction: column; gap: 2px;">
+            <span class="hero-number">@ActiveNumber</span>
+            @if (CallerName != null)
+            {
+              <span class="hero-name">@CallerName</span>
+            }
+          </div>
+          @if (CallState.CallState == "InCall")
+          {
+            <span class="hero-duration">@FormattedDuration</span>
+          }
+        </div>
+      </div>
+    }
+    else
+    {
+      <div class="hero-empty">
+        <RadzenIcon Icon="phone" />
+        Lift the handset to place a call, or wait for an incoming ring.
+      </div>
+    }
+
+    @* Action buttons -- contextual to state *@
+    <div class="hero-actions">
+      @switch (CallState.CallState)
+      {
+        case "Ringing":
+          <button type="button" class="phone-btn btn-answer" @onclick="OnAnswer">
+            <RadzenIcon Icon="phone" /> Answer
+          </button>
+          <button type="button" class="phone-btn btn-hangup" disabled
+                  title="Physical handset only">
+            <RadzenIcon Icon="call_end" /> Reject
+          </button>
+          <button type="button" class="phone-btn btn-ghost" disabled
+                  title="Not yet implemented">
+            <RadzenIcon Icon="ring_volume" /> Silence
+          </button>
+          break;
+
+        case "InCall":
+          <button type="button" class="phone-btn btn-hangup" @onclick="OnHangup">
+            <RadzenIcon Icon="call_end" /> Hang Up
+          </button>
+          <button type="button" class="phone-btn btn-ghost" disabled
+                  title="Not yet implemented">
+            <RadzenIcon Icon="mic" /> Mute
+          </button>
+          <button type="button" class="phone-btn btn-ghost" disabled
+                  title="Not yet implemented">
+            <RadzenIcon Icon="dialpad" /> Keypad
+          </button>
+          <button type="button" class="phone-btn btn-ghost" disabled
+                  title="Not yet implemented">
+            <RadzenIcon Icon="swap_horiz" /> Move to Soundbar
+          </button>
+          break;
+
+        case "Dialing":
+          <button type="button" class="phone-btn btn-hangup" @onclick="OnHangup">
+            <RadzenIcon Icon="call_end" /> Cancel
+          </button>
+          <button type="button" class="phone-btn btn-ghost" disabled
+                  title="Not yet implemented">
+            <RadzenIcon Icon="speaker" /> Speaker
+          </button>
+          break;
+
+        default: // Idle
+          <button type="button" class="phone-btn btn-ghost" disabled
+                  title="Not yet implemented">
+            <RadzenIcon Icon="dialpad" /> New Call
+          </button>
+          <button type="button" class="phone-btn btn-ghost" disabled
+                  title="Not yet implemented">
+            <RadzenIcon Icon="contacts" /> Pick Contact
+          </button>
+          break;
+      }
+    </div>
+
+  </div>
+</div>
+
+@code {
+  [Parameter] public PhoneCallStateDto CallState { get; set; } = new();
+  [Parameter] public string CallSource { get; set; } = "Rotary Phone";
+  [Parameter] public EventCallback OnAnswer { get; set; }
+  [Parameter] public EventCallback OnHangup { get; set; }
+  [Parameter] public List<MergedContact>? Contacts { get; set; }
+
+  // State color computation
+  private (string color, string glow, string glowBg) StateColors => CallState.CallState switch
+  {
+    "Ringing" => ("var(--signal-amber)", "rgba(240,168,48,0.50)", "rgba(240,168,48,0.15)"),
+    "InCall"  => ("var(--signal-green)", "rgba(74,222,128,0.45)", "rgba(74,222,128,0.12)"),
+    "Dialing" => ("var(--signal-blue)",  "rgba(96,165,250,0.45)", "rgba(96,165,250,0.12)"),
+    _         => ("var(--text-medium)",  "transparent",            "transparent"),
+  };
+
+  // State label mapping
+  private string StateLabel => CallState.CallState switch
+  {
+    "Ringing" => "Incoming Call",
+    "InCall"  => "Active Call",
+    "Dialing" => "Dialing Out",
+    _         => "Awaiting Call",
+  };
+
+  // Active phone number
+  private string? ActiveNumber => CallState.CallState switch
+  {
+    "Ringing" => CallState.IncomingNumber,
+    "InCall"  => CallState.IncomingNumber ?? CallState.DialedNumber,
+    "Dialing" => CallState.DialedNumber,
+    _         => null,
+  };
+
+  // Caller name lookup (client-side contact match)
+  private string? CallerName
+  {
+    get
+    {
+      var number = ActiveNumber;
+      if (string.IsNullOrEmpty(number) || Contacts == null) return null;
+      // Normalize: strip non-digit chars, take last 10 digits for suffix match
+      var digits = new string(number.Where(char.IsDigit).ToArray());
+      var suffix = digits.Length > 10 ? digits[^10..] : digits;
+      if (suffix.Length < 7) return null; // too short for reliable match
+      return Contacts.FirstOrDefault(c =>
+      {
+        var cDigits = new string(c.Phone.Where(char.IsDigit).ToArray());
+        var cSuffix = cDigits.Length > 10 ? cDigits[^10..] : cDigits;
+        return cSuffix == suffix;
+      })?.Name;
+    }
+  }
+
+  // Hero icon per state
+  private string HeroIcon => CallState.CallState switch
+  {
+    "Ringing" => "call_received",
+    "Dialing" => "call_made",
+    "InCall"  => "phone_in_talk",
+    _         => "phone",
+  };
+
+  // InCall duration timer (client-side)
+  private DateTime? _inCallStartUtc;
+  private System.Threading.Timer? _durationTimer;
+  private TimeSpan _inCallDuration;
+
+  protected override void OnParametersSet()
+  {
+    if (CallState.CallState == "InCall" && _inCallStartUtc == null)
+    {
+      _inCallStartUtc = DateTime.UtcNow;
+      _durationTimer = new System.Threading.Timer(_ =>
+      {
+        _inCallDuration = DateTime.UtcNow - _inCallStartUtc.Value;
+        InvokeAsync(StateHasChanged);
+      }, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+    }
+    else if (CallState.CallState != "InCall")
+    {
+      _durationTimer?.Dispose();
+      _durationTimer = null;
+      _inCallStartUtc = null;
+      _inCallDuration = TimeSpan.Zero;
+    }
+  }
+
+  private string FormattedDuration =>
+    _inCallDuration.TotalHours >= 1
+      ? _inCallDuration.ToString(@"hh\:mm\:ss")
+      : _inCallDuration.ToString(@"mm\:ss");
+
+  public void Dispose()
+  {
+    _durationTimer?.Dispose();
+  }
+}

--- a/src/Radio.Web/Components/Shared/PhoneStatusHero.razor
+++ b/src/Radio.Web/Components/Shared/PhoneStatusHero.razor
@@ -191,19 +191,23 @@
   {
     if (CallState.CallState == "InCall" && _inCallStartUtc == null)
     {
-      _inCallStartUtc = DateTime.UtcNow;
+      var capturedStart = DateTime.UtcNow;
+      _inCallStartUtc = capturedStart;
       _durationTimer = new System.Threading.Timer(_ =>
       {
-        _inCallDuration = DateTime.UtcNow - _inCallStartUtc.Value;
+        // capturedStart is immutable — no race with OnParametersSet nulling _inCallStartUtc
+        _inCallDuration = DateTime.UtcNow - capturedStart;
         InvokeAsync(StateHasChanged);
       }, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
     }
     else if (CallState.CallState != "InCall")
     {
-      _durationTimer?.Dispose();
+      // Dispose after nulling shared refs so an in-flight callback sees null guard
+      var timerToDispose = _durationTimer;
       _durationTimer = null;
       _inCallStartUtc = null;
       _inCallDuration = TimeSpan.Zero;
+      timerToDispose?.Dispose();
     }
   }
 

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -1049,6 +1049,12 @@ public class PbapContactDto
   public List<string> PhoneNumbers { get; set; } = [];
 }
 
+/// <summary>
+/// Merged view of manual (ContactDto) and phone-synced (PbapContactDto) contacts.
+/// Used by PhonePage and PhoneContactsPanel for the unified contacts grid.
+/// </summary>
+public record MergedContact(string? Id, string Name, string Phone, string? Email, string Source);
+
 // GV Bridge DTOs (calls RotaryPhone.API /api/gvbridge)
 
 public class GvBridgeStatusDto

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -4893,3 +4893,546 @@ body {
   opacity: 0.35;
   cursor: not-allowed;
 }
+
+/* === §Ph  Phone Page Surface ================================================ */
+
+/* -- Shell & Tab Rail -------------------------------------------------------- */
+.phone-shell {
+  height: 100%;
+  display: grid;
+  grid-template-columns: 156px 1fr;
+  gap: 0;
+}
+
+.tab-rail {
+  background: var(--surface-inset);
+  border-right: 1px solid var(--surface-separator);
+  display: flex;
+  flex-direction: column;
+  padding: 16px 12px;
+  gap: 4px;
+}
+
+.rail-heading {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-low);
+  padding: 4px 8px 12px;
+}
+
+.rail-tab {
+  display: flex; align-items: center; gap: 10px;
+  height: 44px;
+  padding: 0 12px;
+  border-radius: 8px;
+  background: transparent;
+  border: none;
+  color: var(--text-medium);
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  transition: background 100ms ease, color 100ms ease;
+}
+.rail-tab .icon { font-size: 18px; }
+.rail-tab .rail-label {
+  font-size: 13px; font-weight: 500;
+  letter-spacing: 0.05em; text-transform: uppercase;
+}
+.rail-tab:hover { background: var(--surface-hover); color: var(--text-high); }
+.rail-tab.active {
+  background: var(--accent-dim);
+  color: var(--accent-primary);
+  position: relative;
+}
+.rail-tab.active::before {
+  content: '';
+  position: absolute;
+  left: -12px; top: 8px; bottom: 8px;
+  width: 3px; border-radius: 2px;
+  background: var(--accent-primary);
+  box-shadow: 0 0 8px var(--accent-glow);
+}
+
+.tab-pane {
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  grid-template-rows: 1fr auto;
+  gap: 12px;
+  padding: 14px;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* -- Cards (phone-specific, no collision with Radzen cards) ------------------ */
+.card {
+  background: var(--surface-raised);
+  border: 1px solid var(--surface-separator);
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow: hidden;
+  min-height: 0;
+}
+.card.accent-green  { border-left: 3px solid var(--signal-green); }
+.card.accent-cyan   { border-left: 3px solid var(--accent-primary); }
+.card.accent-amber  { border-left: 3px solid var(--signal-amber); }
+.card.accent-blue   { border-left: 3px solid var(--signal-blue); }
+
+.card-title {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--text-low);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.card-title .title-text { color: inherit; }
+.card-title.title-green  .title-text { color: var(--signal-green); }
+.card-title.title-cyan   .title-text { color: var(--accent-primary); }
+.card-title.title-amber  .title-text { color: var(--signal-amber); }
+.card-title.title-blue   .title-text { color: var(--signal-blue); }
+
+/* -- Phone Status Hero ------------------------------------------------------- */
+.hero {
+  grid-column: 1;
+  grid-row: 1;
+  background: var(--surface-raised);
+  border: 1px solid var(--surface-separator);
+  border-radius: 8px;
+  padding: 24px 28px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.hero-glow {
+  position: absolute; inset: 0;
+  pointer-events: none;
+  background: radial-gradient(ellipse at 30% 0%, var(--hero-glow-color, transparent) 0%, transparent 60%);
+  opacity: 0.5;
+  transition: background 300ms ease;
+}
+.hero-body {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  z-index: 1;
+  min-height: 0;
+}
+
+.hero-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.hero-state-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-low);
+}
+.hero-source-tag {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--text-medium);
+}
+.hero-source-tag .dot {
+  width: 8px; height: 8px; border-radius: 2px;
+  background: var(--signal-green);
+  box-shadow: 0 0 6px var(--signal-green-glow);
+}
+
+.hero-state {
+  font-family: var(--font-led);
+  font-size: 96px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 8px;
+  line-height: 1;
+  color: var(--hero-state-color, var(--text-high));
+  text-shadow: 0 0 20px var(--hero-state-glow, transparent);
+  margin-top: 16px;
+}
+
+.hero-meta {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.hero-meta-row {
+  display: flex; align-items: center; gap: 10px;
+}
+.hero-icon {
+  width: 44px; height: 44px;
+  border-radius: 8px;
+  background: var(--hero-icon-bg, rgba(255,255,255,0.04));
+  color: var(--hero-icon-color, var(--text-medium));
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 22px;
+}
+.hero-number {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--text-high);
+  letter-spacing: 1px;
+  font-variant-numeric: tabular-nums;
+}
+.hero-name {
+  font-size: 14px;
+  color: var(--text-medium);
+  font-weight: 500;
+}
+.hero-duration {
+  font-family: var(--font-led);
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--signal-amber);
+  text-shadow: 0 0 6px var(--signal-amber-glow);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 2px;
+  margin-left: auto;
+}
+
+.hero-actions {
+  margin-top: auto;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.hero-empty {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--text-low);
+  font-size: 14px;
+  margin-top: 24px;
+}
+
+/* -- Phone Action Buttons ---------------------------------------------------- */
+.phone-btn {
+  height: 56px;
+  padding: 0 24px;
+  border-radius: 28px;
+  border: 1px solid transparent;
+  display: inline-flex; align-items: center; gap: 10px;
+  background: var(--surface-elevated);
+  color: var(--text-high);
+  font-family: inherit;
+  font-size: 14px; font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 80ms ease, background 100ms ease, box-shadow 200ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.phone-btn .icon { font-size: 22px; }
+.phone-btn:hover { background: var(--surface-overlay); }
+.phone-btn:active { transform: scale(0.96); }
+
+.phone-btn.btn-answer {
+  background: var(--signal-green);
+  color: var(--text-inverse);
+  box-shadow: 0 0 24px var(--signal-green-glow);
+}
+.phone-btn.btn-answer:hover { background: #6ee69a; }
+
+.phone-btn.btn-hangup {
+  background: var(--signal-red);
+  color: var(--text-inverse);
+  box-shadow: 0 0 24px var(--signal-red-glow);
+}
+.phone-btn.btn-hangup:hover { background: #fa8888; }
+
+.phone-btn.btn-ghost {
+  background: transparent;
+  border-color: var(--surface-separator);
+  color: var(--text-medium);
+}
+.phone-btn.btn-ghost:hover { border-color: var(--accent-primary); color: var(--text-high); }
+
+.phone-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+
+/* -- Status mini-rows (compact system-status list) --------------------------- */
+.status-list {
+  display: flex; flex-direction: column;
+  gap: 6px;
+}
+.status-row {
+  display: grid;
+  grid-template-columns: 90px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--surface-inset);
+}
+.status-row .lbl {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-low);
+}
+.status-row .val {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-medium);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden; text-overflow: ellipsis;
+}
+
+/* -- Pill badges ------------------------------------------------------------- */
+.pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 22px; padding: 0 10px;
+  border-radius: 11px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+}
+.pill::before {
+  content: '';
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+}
+.pill.green  { background: rgba(74,222,128,0.10);  color: var(--signal-green); }
+.pill.red    { background: rgba(248,113,113,0.10); color: var(--signal-red); }
+.pill.amber  { background: rgba(240,168,48,0.10);  color: var(--signal-amber); }
+.pill.blue   { background: rgba(96,165,250,0.10);  color: var(--signal-blue); }
+.pill.cyan   { background: rgba(92,212,232,0.10);  color: var(--accent-primary); }
+.pill.gray   { background: rgba(181,188,201,0.08); color: var(--text-medium); }
+.pill.gray::before { box-shadow: none; opacity: 0.6; }
+
+/* -- Call Path card internals ------------------------------------------------ */
+.callpath {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.callpath-row {
+  display: flex; flex-direction: column; gap: 6px;
+}
+.callpath-row .sub {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-low);
+}
+
+.mode-selector {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 0;
+  background: var(--surface-inset);
+  border: 1px solid var(--surface-separator);
+  border-radius: 8px;
+  padding: 3px;
+  height: 40px;
+}
+.mode-btn {
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-medium);
+  font-family: inherit;
+  font-size: 11px; font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  cursor: pointer;
+  transition: background 100ms ease, color 100ms ease;
+}
+.mode-btn .icon { font-size: 16px; }
+.mode-btn:hover { color: var(--text-high); }
+.mode-btn.active {
+  background: var(--accent-dim);
+  color: var(--accent-primary);
+  box-shadow: inset 0 0 0 1px rgba(92,212,232,0.22);
+}
+
+.connector-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: var(--surface-inset);
+  gap: 12px;
+}
+.connector-row .conn-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.connector-row .conn-name {
+  font-size: 13px; font-weight: 500; color: var(--text-high);
+  display: flex; flex-direction: column; gap: 2px; min-width: 0;
+}
+.connector-row .conn-name .sub {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--text-low);
+  font-weight: 500;
+}
+.conn-icon {
+  width: 36px; height: 36px;
+  border-radius: 6px;
+  background: var(--surface-elevated);
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--text-medium);
+  font-size: 18px;
+  flex-shrink: 0;
+}
+.connector-row .right-cluster {
+  display: flex; align-items: center; gap: 8px;
+}
+
+.link-btn {
+  background: transparent;
+  border: 1px solid var(--surface-separator);
+  height: 26px; padding: 0 10px;
+  border-radius: 13px;
+  color: var(--text-medium);
+  font-family: var(--font-mono);
+  font-size: 10px; font-weight: 600;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  cursor: pointer;
+}
+.link-btn:hover { border-color: var(--accent-primary); color: var(--accent-primary); }
+
+/* -- Dev Drawer (phone-specific) --------------------------------------------- */
+.phone-dev-drawer {
+  grid-column: 1;
+  background: var(--surface-raised);
+  border: 1px solid var(--surface-separator);
+  border-left: 3px solid var(--signal-amber);
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  transition: max-height 200ms ease;
+}
+.phone-dev-drawer.collapsed { max-height: 44px; }
+.phone-dev-drawer.expanded { max-height: 240px; }
+
+.phone-dev-header {
+  height: 44px;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 14px;
+  cursor: pointer;
+  user-select: none;
+  background: var(--surface-raised);
+  flex-shrink: 0;
+}
+.phone-dev-header:hover { background: var(--surface-overlay); }
+.phone-dev-header .left {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--signal-amber);
+}
+.phone-dev-header .left .icon { font-size: 16px; }
+.phone-dev-header .right {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-low);
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+}
+.phone-dev-body {
+  padding: 6px 16px 14px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 16px;
+}
+.phone-dev-section { display: flex; flex-direction: column; gap: 6px; }
+.phone-dev-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-low);
+}
+.phone-dev-buttons { display: flex; gap: 6px; flex-wrap: wrap; }
+
+/* -- Phone form controls (small utility buttons and inputs) ------------------ */
+.phone-btn-sm {
+  height: 36px;
+  padding: 0 12px;
+  border-radius: 6px;
+  background: var(--surface-elevated);
+  border: 1px solid var(--surface-separator);
+  color: var(--text-high);
+  font-family: inherit;
+  font-size: 12px; font-weight: 500;
+  letter-spacing: 0.04em;
+  display: inline-flex; align-items: center; gap: 6px;
+  cursor: pointer;
+  transition: background 100ms ease, border-color 100ms ease;
+}
+.phone-btn-sm .icon { font-size: 16px; }
+.phone-btn-sm:hover { background: var(--surface-overlay); border-color: rgba(255,255,255,0.10); }
+.phone-btn-sm:disabled { opacity: 0.35; cursor: not-allowed; }
+.phone-btn-sm.btn-success { background: rgba(74,222,128,0.12); color: var(--signal-green); border-color: rgba(74,222,128,0.30); }
+.phone-btn-sm.btn-danger  { background: rgba(248,113,113,0.12); color: var(--signal-red);   border-color: rgba(248,113,113,0.30); }
+.phone-btn-sm.btn-warn    { background: rgba(240,168,48,0.12); color: var(--signal-amber); border-color: rgba(240,168,48,0.30); }
+
+.phone-input {
+  height: 36px;
+  padding: 0 12px;
+  border-radius: 6px;
+  background: var(--surface-inset);
+  border: 1px solid var(--surface-separator);
+  color: var(--text-high);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 1px;
+  outline: none;
+}
+.phone-input:focus { border-color: var(--accent-primary); }
+
+/* -- Animations -------------------------------------------------------------- */
+@keyframes ringPulse {
+  0%, 100% { opacity: 0.45; transform: scale(1); }
+  50%      { opacity: 1; transform: scale(1.04); }
+}
+.ring-pulse { animation: ringPulse 1.2s ease-in-out infinite; }
+
+@keyframes phoneDotPulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.35; }
+}
+.phone-dot-pulse { animation: phoneDotPulse 1.4s ease-in-out infinite; }

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -206,18 +206,13 @@ html, body {
 }
 .topbar-sources::-webkit-scrollbar { display: none; }
 
-.topbar-clock {
-  font-family: var(--font-led);
-  /* Hot-fix off PR #371: Orbitron at the previous DSEG14 size reads too
-     thick for the topbar; nudge slightly smaller while keeping the bold
-     weight that gives the clock its "display chrome" presence. */
-  font-size: 26px;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  color: var(--signal-amber);
-  text-shadow: 0 0 8px var(--signal-amber-glow);
-  min-width: 100px;
-  letter-spacing: 2px;
+/* Time cluster — fixed min-width prevents the topbar from jittering as the
+   clock digits change. Orbitron lacks an OpenType tabular-nums table, so
+   proportional digit widths (e.g. "1" narrower than "0") cause layout
+   shifts every second. The min-width accommodates the widest format string
+   ("12:00:00 PM" in 12h+seconds mode) so downstream nav pills stay put. */
+.cluster-time {
+  min-width: 130px;
 }
 
 .topbar-zone {

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -4899,7 +4899,7 @@ body {
   gap: 0;
 }
 
-.tab-rail {
+.phone-tab-rail {
   background: var(--surface-inset);
   border-right: 1px solid var(--surface-separator);
   display: flex;
@@ -4908,7 +4908,7 @@ body {
   gap: 4px;
 }
 
-.rail-heading {
+.phone-rail-heading {
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.16em;
@@ -4917,7 +4917,7 @@ body {
   padding: 4px 8px 12px;
 }
 
-.rail-tab {
+.phone-rail-tab {
   display: flex; align-items: center; gap: 10px;
   height: 44px;
   padding: 0 12px;
@@ -4930,18 +4930,18 @@ body {
   text-align: left;
   transition: background 100ms ease, color 100ms ease;
 }
-.rail-tab .icon { font-size: 18px; }
-.rail-tab .rail-label {
+.phone-rail-tab .icon { font-size: 18px; }
+.phone-rail-tab .phone-rail-label {
   font-size: 13px; font-weight: 500;
   letter-spacing: 0.05em; text-transform: uppercase;
 }
-.rail-tab:hover { background: var(--surface-hover); color: var(--text-high); }
-.rail-tab.active {
+.phone-rail-tab:hover { background: var(--surface-hover); color: var(--text-high); }
+.phone-rail-tab.active {
   background: var(--accent-dim);
   color: var(--accent-primary);
   position: relative;
 }
-.rail-tab.active::before {
+.phone-rail-tab.active::before {
   content: '';
   position: absolute;
   left: -12px; top: 8px; bottom: 8px;
@@ -4950,14 +4950,14 @@ body {
   box-shadow: 0 0 8px var(--accent-glow);
 }
 
-.tab-pane {
+.phone-tab-pane {
   height: 100%;
   overflow: hidden;
   display: flex;
   flex-direction: column;
 }
 
-.dashboard {
+.phone-dashboard {
   display: grid;
   grid-template-columns: 1.5fr 1fr;
   grid-template-rows: 1fr auto;
@@ -4968,7 +4968,7 @@ body {
 }
 
 /* -- Cards (phone-specific, no collision with Radzen cards) ------------------ */
-.card {
+.phone-card {
   background: var(--surface-raised);
   border: 1px solid var(--surface-separator);
   border-radius: 8px;
@@ -4979,12 +4979,12 @@ body {
   overflow: hidden;
   min-height: 0;
 }
-.card.accent-green  { border-left: 3px solid var(--signal-green); }
-.card.accent-cyan   { border-left: 3px solid var(--accent-primary); }
-.card.accent-amber  { border-left: 3px solid var(--signal-amber); }
-.card.accent-blue   { border-left: 3px solid var(--signal-blue); }
+.phone-card.accent-green  { border-left: 3px solid var(--signal-green); }
+.phone-card.accent-cyan   { border-left: 3px solid var(--accent-primary); }
+.phone-card.accent-amber  { border-left: 3px solid var(--signal-amber); }
+.phone-card.accent-blue   { border-left: 3px solid var(--signal-blue); }
 
-.card-title {
+.phone-card-title {
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.16em;
@@ -4996,14 +4996,14 @@ body {
   justify-content: space-between;
   gap: 8px;
 }
-.card-title .title-text { color: inherit; }
-.card-title.title-green  .title-text { color: var(--signal-green); }
-.card-title.title-cyan   .title-text { color: var(--accent-primary); }
-.card-title.title-amber  .title-text { color: var(--signal-amber); }
-.card-title.title-blue   .title-text { color: var(--signal-blue); }
+.phone-card-title .phone-title-text { color: inherit; }
+.phone-card-title.phone-title-green  .phone-title-text { color: var(--signal-green); }
+.phone-card-title.phone-title-cyan   .phone-title-text { color: var(--accent-primary); }
+.phone-card-title.phone-title-amber  .phone-title-text { color: var(--signal-amber); }
+.phone-card-title.phone-title-blue   .phone-title-text { color: var(--signal-blue); }
 
 /* -- Phone Status Hero ------------------------------------------------------- */
-.hero {
+.phone-hero {
   grid-column: 1;
   grid-row: 1;
   background: var(--surface-raised);
@@ -5015,14 +5015,14 @@ body {
   display: flex;
   flex-direction: column;
 }
-.hero-glow {
+.phone-hero-glow {
   position: absolute; inset: 0;
   pointer-events: none;
-  background: radial-gradient(ellipse at 30% 0%, var(--hero-glow-color, transparent) 0%, transparent 60%);
+  background: radial-gradient(ellipse at 30% 0%, var(--phone-hero-glow-color, transparent) 0%, transparent 60%);
   opacity: 0.5;
   transition: background 300ms ease;
 }
-.hero-body {
+.phone-hero-body {
   position: relative;
   flex: 1;
   display: flex;
@@ -5031,20 +5031,20 @@ body {
   min-height: 0;
 }
 
-.hero-top {
+.phone-hero-top {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
-.hero-state-label {
+.phone-hero-state-label {
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--text-low);
 }
-.hero-source-tag {
+.phone-hero-source-tag {
   display: inline-flex; align-items: center; gap: 8px;
   font-family: var(--font-mono);
   font-size: 11px;
@@ -5052,42 +5052,42 @@ body {
   text-transform: uppercase;
   color: var(--text-medium);
 }
-.hero-source-tag .dot {
+.phone-hero-source-tag .dot {
   width: 8px; height: 8px; border-radius: 2px;
   background: var(--signal-green);
   box-shadow: 0 0 6px var(--signal-green-glow);
 }
 
-.hero-state {
+.phone-hero-state {
   font-family: var(--font-led);
   font-size: 96px;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   letter-spacing: 8px;
   line-height: 1;
-  color: var(--hero-state-color, var(--text-high));
-  text-shadow: 0 0 20px var(--hero-state-glow, transparent);
+  color: var(--phone-hero-state-color, var(--text-high));
+  text-shadow: 0 0 20px var(--phone-hero-state-glow, transparent);
   margin-top: 16px;
 }
 
-.hero-meta {
+.phone-hero-meta {
   margin-top: 20px;
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
-.hero-meta-row {
+.phone-hero-meta-row {
   display: flex; align-items: center; gap: 10px;
 }
-.hero-icon {
+.phone-hero-icon {
   width: 44px; height: 44px;
   border-radius: 8px;
-  background: var(--hero-icon-bg, rgba(255,255,255,0.04));
-  color: var(--hero-icon-color, var(--text-medium));
+  background: var(--phone-hero-icon-bg, rgba(255,255,255,0.04));
+  color: var(--phone-hero-icon-color, var(--text-medium));
   display: inline-flex; align-items: center; justify-content: center;
   font-size: 22px;
 }
-.hero-number {
+.phone-hero-number {
   font-family: var(--font-mono);
   font-size: 28px;
   font-weight: 600;
@@ -5095,12 +5095,12 @@ body {
   letter-spacing: 1px;
   font-variant-numeric: tabular-nums;
 }
-.hero-name {
+.phone-hero-name {
   font-size: 14px;
   color: var(--text-medium);
   font-weight: 500;
 }
-.hero-duration {
+.phone-hero-duration {
   font-family: var(--font-led);
   font-size: 22px;
   font-weight: 600;
@@ -5111,14 +5111,14 @@ body {
   margin-left: auto;
 }
 
-.hero-actions {
+.phone-hero-actions {
   margin-top: auto;
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
 }
 
-.hero-empty {
+.phone-hero-empty {
   display: flex;
   align-items: center;
   gap: 12px;
@@ -5171,11 +5171,11 @@ body {
 .phone-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 
 /* -- Status mini-rows (compact system-status list) --------------------------- */
-.status-list {
+.phone-status-list {
   display: flex; flex-direction: column;
   gap: 6px;
 }
-.status-row {
+.phone-status-row {
   display: grid;
   grid-template-columns: 90px 1fr auto;
   align-items: center;
@@ -5184,14 +5184,14 @@ body {
   border-radius: 6px;
   background: var(--surface-inset);
 }
-.status-row .lbl {
+.phone-status-row .lbl {
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--text-low);
 }
-.status-row .val {
+.phone-status-row .val {
   font-family: var(--font-mono);
   font-size: 12px;
   color: var(--text-medium);
@@ -5201,7 +5201,7 @@ body {
 }
 
 /* -- Pill badges ------------------------------------------------------------- */
-.pill {
+.phone-pill {
   display: inline-flex; align-items: center; gap: 6px;
   height: 22px; padding: 0 10px;
   border-radius: 11px;
@@ -5211,31 +5211,31 @@ body {
   letter-spacing: 0.10em;
   text-transform: uppercase;
 }
-.pill::before {
+.phone-pill::before {
   content: '';
   width: 6px; height: 6px;
   border-radius: 50%;
   background: currentColor;
   box-shadow: 0 0 6px currentColor;
 }
-.pill.green  { background: rgba(74,222,128,0.10);  color: var(--signal-green); }
-.pill.red    { background: rgba(248,113,113,0.10); color: var(--signal-red); }
-.pill.amber  { background: rgba(240,168,48,0.10);  color: var(--signal-amber); }
-.pill.blue   { background: rgba(96,165,250,0.10);  color: var(--signal-blue); }
-.pill.cyan   { background: rgba(92,212,232,0.10);  color: var(--accent-primary); }
-.pill.gray   { background: rgba(181,188,201,0.08); color: var(--text-medium); }
-.pill.gray::before { box-shadow: none; opacity: 0.6; }
+.phone-pill.green  { background: rgba(74,222,128,0.10);  color: var(--signal-green); }
+.phone-pill.red    { background: rgba(248,113,113,0.10); color: var(--signal-red); }
+.phone-pill.amber  { background: rgba(240,168,48,0.10);  color: var(--signal-amber); }
+.phone-pill.blue   { background: rgba(96,165,250,0.10);  color: var(--signal-blue); }
+.phone-pill.cyan   { background: rgba(92,212,232,0.10);  color: var(--accent-primary); }
+.phone-pill.gray   { background: rgba(181,188,201,0.08); color: var(--text-medium); }
+.phone-pill.gray::before { box-shadow: none; opacity: 0.6; }
 
 /* -- Call Path card internals ------------------------------------------------ */
-.callpath {
+.phone-callpath {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
 }
-.callpath-row {
+.phone-callpath-row {
   display: flex; flex-direction: column; gap: 6px;
 }
-.callpath-row .sub {
+.phone-callpath-row .sub {
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.14em;
@@ -5243,7 +5243,7 @@ body {
   color: var(--text-low);
 }
 
-.mode-selector {
+.phone-mode-selector {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 0;
@@ -5253,7 +5253,7 @@ body {
   padding: 3px;
   height: 40px;
 }
-.mode-btn {
+.phone-mode-btn {
   background: transparent;
   border: none;
   border-radius: 6px;
@@ -5265,15 +5265,15 @@ body {
   cursor: pointer;
   transition: background 100ms ease, color 100ms ease;
 }
-.mode-btn .icon { font-size: 16px; }
-.mode-btn:hover { color: var(--text-high); }
-.mode-btn.active {
+.phone-mode-btn .icon { font-size: 16px; }
+.phone-mode-btn:hover { color: var(--text-high); }
+.phone-mode-btn.active {
   background: var(--accent-dim);
   color: var(--accent-primary);
   box-shadow: inset 0 0 0 1px rgba(92,212,232,0.22);
 }
 
-.connector-row {
+.phone-connector-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -5282,17 +5282,17 @@ body {
   background: var(--surface-inset);
   gap: 12px;
 }
-.connector-row .conn-meta {
+.phone-connector-row .phone-conn-meta {
   display: flex;
   align-items: center;
   gap: 10px;
   min-width: 0;
 }
-.connector-row .conn-name {
+.phone-connector-row .phone-conn-name {
   font-size: 13px; font-weight: 500; color: var(--text-high);
   display: flex; flex-direction: column; gap: 2px; min-width: 0;
 }
-.connector-row .conn-name .sub {
+.phone-connector-row .phone-conn-name .sub {
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.10em;
@@ -5300,7 +5300,7 @@ body {
   color: var(--text-low);
   font-weight: 500;
 }
-.conn-icon {
+.phone-conn-icon {
   width: 36px; height: 36px;
   border-radius: 6px;
   background: var(--surface-elevated);
@@ -5309,11 +5309,11 @@ body {
   font-size: 18px;
   flex-shrink: 0;
 }
-.connector-row .right-cluster {
+.phone-connector-row .phone-right-cluster {
   display: flex; align-items: center; gap: 8px;
 }
 
-.link-btn {
+.phone-link-btn {
   background: transparent;
   border: 1px solid var(--surface-separator);
   height: 26px; padding: 0 10px;
@@ -5324,7 +5324,7 @@ body {
   letter-spacing: 0.10em; text-transform: uppercase;
   cursor: pointer;
 }
-.link-btn:hover { border-color: var(--accent-primary); color: var(--accent-primary); }
+.phone-link-btn:hover { border-color: var(--accent-primary); color: var(--accent-primary); }
 
 /* -- Dev Drawer (phone-specific) --------------------------------------------- */
 .phone-dev-drawer {

--- a/tests/Radio.Web.Tests/Components/Pages/PhonePageTests.cs
+++ b/tests/Radio.Web.Tests/Components/Pages/PhonePageTests.cs
@@ -75,41 +75,44 @@ public class PhonePageTests : TestContext
   public void PhonePage_Renders_SystemStatusSection()
   {
     var cut = RenderComponent<PhonePage>();
-    Assert.Contains("SYSTEM STATUS", cut.Markup);
-    Assert.Contains("BLUETOOTH", cut.Markup);
-    Assert.Contains("SIP DEVICE", cut.Markup);
+    Assert.Contains("System Status", cut.Markup);
+    // Status row labels are now lowercase mono text in .lbl class
+    Assert.Contains("Bluetooth", cut.Markup);
+    Assert.Contains("SIP Device", cut.Markup);
     Assert.Contains("HT801 ATA", cut.Markup);
   }
 
   [Fact]
-  public void PhonePage_Renders_PhoneStatusSection()
+  public void PhonePage_Renders_HeroIdleState()
   {
     var cut = RenderComponent<PhonePage>();
-    Assert.Contains("CURRENT STATUS", cut.Markup);
+    Assert.Contains("Awaiting Call", cut.Markup);
+    Assert.Contains("IDLE", cut.Markup);
   }
 
   [Fact]
-  public void PhonePage_Renders_DeveloperControls()
+  public void PhonePage_Renders_DevTray()
   {
     var cut = RenderComponent<PhonePage>();
-    Assert.Contains("DEV CONTROLS", cut.Markup);
+    // Dev tray is collapsed by default; header text is always visible
+    Assert.Contains("Dev Tray", cut.Markup);
+    Assert.Contains("Simulate Hardware Events", cut.Markup);
   }
 
   [Fact]
   public void PhonePage_Renders_CallPathSection()
   {
     var cut = RenderComponent<PhonePage>();
-    Assert.Contains("CALL PATH", cut.Markup);
+    Assert.Contains("Call Path", cut.Markup);
     Assert.Contains("GV API", cut.Markup);
-    Assert.Contains("SIP TRUNK", cut.Markup);
+    Assert.Contains("SIP Trunk", cut.Markup);
   }
 
   [Fact]
   public void PhonePage_ContactsTab_Renders_SourceColumn()
   {
-    // RadzenTabs only renders the active tab body; the Contacts tab item
-    // (header) is always present. Verify the tab renders without error and
-    // the Contacts tab item is in the output.
+    // Rail tab buttons are always present. Verify the component renders
+    // without error and the Contacts tab label is in the output.
     var cut = RenderComponent<PhonePage>();
     Assert.Contains("Contacts", cut.Markup);
     Assert.NotNull(cut);
@@ -118,12 +121,37 @@ public class PhonePageTests : TestContext
   [Fact]
   public void PhonePage_ContactsTab_Renders_SyncButton()
   {
-    // RadzenTabs only renders the active tab body; the Contacts tab item
-    // (header) is always present. Verify the component renders successfully
-    // with PbapApiService and BluetoothApiService injected (no DI error).
+    // Verify the component renders successfully with PbapApiService and
+    // BluetoothApiService injected (no DI error).
     var cut = RenderComponent<PhonePage>();
     Assert.Contains("Contacts", cut.Markup);
     Assert.DoesNotContain("NullReferenceException", cut.Markup);
+  }
+
+  [Fact]
+  public void PhonePage_TabRail_DefaultsToDashboard()
+  {
+    var cut = RenderComponent<PhonePage>();
+    // Dashboard tab should have the "active" class
+    var dashButton = cut.FindAll("button.rail-tab")
+      .FirstOrDefault(b => b.TextContent.Contains("Dashboard"));
+    Assert.NotNull(dashButton);
+    Assert.Contains("active", dashButton.ClassList);
+  }
+
+  [Fact]
+  public void PhonePage_HeroShowsEmptyStateHint_WhenIdle()
+  {
+    var cut = RenderComponent<PhonePage>();
+    Assert.Contains("Lift the handset to place a call", cut.Markup);
+  }
+
+  [Fact]
+  public void PhonePage_DevTray_CollapsedByDefault()
+  {
+    var cut = RenderComponent<PhonePage>();
+    Assert.Contains("Click to expand", cut.Markup);
+    Assert.DoesNotContain("Handset", cut.Markup); // body not rendered when collapsed
   }
 
   private class EmptyResponseHandler : HttpMessageHandler

--- a/tests/Radio.Web.Tests/Components/Pages/PhonePageTests.cs
+++ b/tests/Radio.Web.Tests/Components/Pages/PhonePageTests.cs
@@ -133,7 +133,7 @@ public class PhonePageTests : TestContext
   {
     var cut = RenderComponent<PhonePage>();
     // Dashboard tab should have the "active" class
-    var dashButton = cut.FindAll("button.rail-tab")
+    var dashButton = cut.FindAll("button.phone-rail-tab")
       .FirstOrDefault(b => b.TextContent.Contains("Dashboard"));
     Assert.NotNull(dashButton);
     Assert.Contains("active", dashButton.ClassList);


### PR DESCRIPTION
## Summary

- **Left-rail tab shell**: Replaces Radzen top-tab layout with a 156px left rail (Dashboard / Contacts / Call History). SignalR subscriptions remain at the page level so tab switching does not cause reconnection.
- **Phone Status Hero**: LED state word (IDLE/RINGING/INCALL/DIALING) with color-coded glow, caller lookup via last-10 suffix match against merged contacts, in-call duration timer, and contextual action buttons per call state.
- **Phone Dev Tray**: Collapsible amber-bordered drawer with simulate controls for handset (Lift/Drop), network (Incoming Call), and dialer (digit input + Dial). Replaces the always-visible dev controls card.
- **CSS selectors (design-system.css section Ph)**: ~380 lines of phone-specific CSS lifted from the design handoff prototype with all generic names renamed to phone-prefixed variants to avoid collisions (.dev-drawer -> .phone-dev-drawer, .btn -> .phone-btn-sm, .input -> .phone-input, dotPulse -> phoneDotPulse).
- **Component extraction**: PhonePage.razor reduced from 797 to 488 lines (thin shell + retained state machine). Dashboard panel, Hero, Dev Tray, Contacts stub, and History stub extracted as separate components.
- **MergedContact record** moved from PhonePage @code block to ApiModels.cs for cross-component access.

## Pre-merge review

- No naming collisions with existing design-system selectors (verified by grep)
- No stale `::deep` selectors referencing Radzen tab internals remain
- All old Contacts and History markup moved verbatim to stub panels (no functional change)
- `color-mix(in oklab, ...)` used for Hero icon background is supported in kiosk Chromium
- Timer disposal handled via IDisposable on PhoneStatusHero component
- Pre-existing SrcVariableResamplerTests failures (4) are unrelated (native libsamplerate dependency)

## Test plan

- [x] `dotnet build --configuration Release` -- 0 errors, 47 pre-existing IDE0011 warnings
- [x] `dotnet test --configuration Release` -- all Radio.Web.Tests pass (644 tests, 10 PhonePage tests)
- [x] PhonePage_Renders_WithTabs -- tab rail contains Dashboard, Contacts, Call History
- [x] PhonePage_Renders_SystemStatusSection -- System Status card with status rows
- [x] PhonePage_Renders_HeroIdleState -- Hero shows "Awaiting Call" and "IDLE"
- [x] PhonePage_Renders_DevTray -- Dev Tray header visible when collapsed
- [x] PhonePage_Renders_CallPathSection -- Call Path card with mode selector
- [x] PhonePage_TabRail_DefaultsToDashboard -- Dashboard tab has active class
- [x] PhonePage_HeroShowsEmptyStateHint_WhenIdle -- empty-state hint text
- [x] PhonePage_DevTray_CollapsedByDefault -- collapsed state, body not rendered
- [ ] User UATs in browser at 1920x720 (known gap -- no browser MCP session active)

## Operator note

No deploy-relevant changes. CSS-only + Blazor component refactor. No new API endpoints, no database changes, no configuration changes.

## Docs impact

None for PR-1. Phone page documentation updates deferred to PR-3 when the full redesign is complete.

---

**Scope:** Design handoff PR-1 of 3. PR-2 adds Phase B system status fields; PR-3 redesigns Contacts + History panels.

Generated with [Claude Code](https://claude.com/claude-code)