### PR TITLE
fix(web): RDS scroll smoothness + de-dup + saved-station card redesign (Proposal A)

### DIFF
--- a/src/Radio.API/Models/RadioDtos.cs
+++ b/src/Radio.API/Models/RadioDtos.cs
@@ -147,6 +147,20 @@ public class RadioStateDto
   /// Polish arc.
   /// </summary>
   public string? NowPlayingMatchId { get; set; }
+
+  /// <summary>
+  /// Per-broadcast discriminator (NOT persisted device state). True when this
+  /// broadcast carries a change to an RDS- or tuning-relevant field
+  /// (frequency, band, step, any RDS PS/PTY/RT/PI/stable field, or
+  /// NowPlayingMatchId); false when only volatile signal telemetry
+  /// (RSSI/signal-strength/gain/stereo/scan) changed. The Web RDS marquee
+  /// path reads this to avoid re-running the RDS accumulator + restarting the
+  /// CSS ticker ~twice a second on pure-telemetry ticks. Telemetry consumers
+  /// (signal meter, gain readout, recognition NOW-row) ignore it and read the
+  /// full DTO every broadcast. Defaults true so any non-broadcast construction
+  /// (REST /api/radio/state) is treated as a full refresh.
+  /// </summary>
+  public bool RdsRelevantChanged { get; set; } = true;
 }
 
 /// <summary>

--- a/src/Radio.API/Services/AudioStateUpdateService.cs
+++ b/src/Radio.API/Services/AudioStateUpdateService.cs
@@ -436,10 +436,17 @@ public class AudioStateUpdateService : BackgroundService
 
     if (HasRadioStateChanged(_lastRadioState, currentRadioState))
     {
+      // Stamp the per-broadcast discriminator BEFORE caching/sending so the
+      // Web RDS path can skip its accumulator append on telemetry-only ticks.
+      // Computed against the PREVIOUS state (the same baseline HasRadioStateChanged
+      // used), so the very first broadcast (_lastRadioState == null) is RDS-relevant.
+      currentRadioState.RdsRelevantChanged = HasRdsRelevantChanged(_lastRadioState, currentRadioState);
+
       _lastRadioState = currentRadioState;
       await _hubContext.Clients.Group("RadioState")
         .SendAsync("RadioStateChanged", currentRadioState, cancellationToken);
-      _logger.LogDebug("Broadcast RadioStateChanged: {Frequency} {Band}", currentRadioState.Frequency, currentRadioState.Band);
+      _logger.LogDebug("Broadcast RadioStateChanged: {Frequency} {Band} RdsRelevant={Rds}",
+        currentRadioState.Frequency, currentRadioState.Band, currentRadioState.RdsRelevantChanged);
     }
   }
 
@@ -581,6 +588,37 @@ public class AudioStateUpdateService : BackgroundService
            // PR 2 of the Radio Controller Polish arc — the recognition stream's
            // NOW row anchors on this. Changes must broadcast so the UI's
            // amber-border row tracks the actively-playing fingerprint match.
+           previous.NowPlayingMatchId != current.NowPlayingMatchId;
+  }
+
+  /// <summary>
+  /// True when an RDS- or tuning-relevant field changed between broadcasts —
+  /// the fields the Web RDS card, frequency well, and active-preset highlight
+  /// bind to. Deliberately EXCLUDES volatile signal telemetry (signal strength,
+  /// RSSI, clip, applied/manual gain, AGC, stereo, equalizer, device volume,
+  /// scan state) so the RDS marquee doesn't re-run its accumulator ~twice a
+  /// second. A null previous (first broadcast after tune/source-switch) counts
+  /// as relevant so the card populates immediately.
+  ///
+  /// This is a strict subset of <see cref="HasRadioStateChanged"/>'s conditions
+  /// (RDS/tuning rows only), so any tick that is RDS-relevant is also a
+  /// broadcast — the flag can never be true without a broadcast happening.
+  /// </summary>
+  private static bool HasRdsRelevantChanged(RadioStateDto? previous, RadioStateDto? current)
+  {
+    if (previous == null || current == null)
+    {
+      return true;
+    }
+
+    return Math.Abs(previous.Frequency - current.Frequency) > 0.001 ||
+           previous.Band != current.Band ||
+           Math.Abs(previous.Step - current.Step) > 0.001 ||
+           previous.RdsStationName != current.RdsStationName ||
+           previous.RdsStationNameStable != current.RdsStationNameStable ||
+           previous.RdsProgramType != current.RdsProgramType ||
+           previous.RdsPi != current.RdsPi ||
+           previous.RdsRadioText != current.RdsRadioText ||
            previous.NowPlayingMatchId != current.NowPlayingMatchId;
   }
 

--- a/src/Radio.Web/Components/Pages/RadioPage.razor
+++ b/src/Radio.Web/Components/Pages/RadioPage.razor
@@ -146,21 +146,14 @@
           <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px;">
             @foreach (var preset in _presets.OrderBy(p => p.CreatedAt))
             {
-              <div class="list-item-touch" style="flex-direction: column; align-items: stretch; padding: 12px; border-radius: 8px; border: 1px solid var(--surface-separator); cursor: pointer;"
-                   @onclick="@(() => LoadPresetAsync(preset.Id))">
-                <div style="font-size: 16px; font-weight: 600; color: var(--text-high);">@preset.Name</div>
-                <div style="font-size: 14px; color: var(--signal-amber); font-family: var(--font-mono);">
-                  @FormatFrequency(preset.Frequency, preset.Band)
-                </div>
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-top: 4px;">
-                  <span style="font-size: 13px; color: var(--text-low);">@preset.Band</span>
-                  <div @onclick:stopPropagation="true">
-                    <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Size="ButtonSize.Small"
-                                  Variant="Variant.Text"
-                                  Click="@(() => DeletePresetAsync(preset.Id))" title="Delete" />
-                  </div>
-                </div>
-              </div>
+              <PresetCard Variant="PresetCardVariant.Card"
+                          PresetId="@preset.Id"
+                          Name="@preset.Name"
+                          Frequency="@preset.Frequency"
+                          Band="@preset.Band"
+                          IsActive="@(IsActivePreset(preset))"
+                          OnSelect="LoadPresetAsync"
+                          OnDelete="DeletePresetAsync" />
             }
           </div>
         }
@@ -644,6 +637,22 @@
   // Frequency formatting — delegates to shared FrequencyFormatter
   private static string FormatFrequency(double frequencyHz, string band) => FrequencyFormatter.FormatFrequency(frequencyHz, band);
   private static string FormatStep(double stepHz, string band) => FrequencyFormatter.FormatStep(stepHz);
+
+  /// <summary>
+  /// True when the given preset matches the currently-tuned band + frequency.
+  /// Mirrors <c>RadioControlPanel.IsActivePreset</c> so the Radio page presets
+  /// panel highlights the active station consistently with the Home rail
+  /// (PresetCard a11y active cue: amber border + inset left bar).
+  /// </summary>
+  private bool IsActivePreset(RadioPresetDto preset)
+  {
+    if (_radioState == null)
+    {
+      return false;
+    }
+    return string.Equals(preset.Band, _radioState.Band, StringComparison.OrdinalIgnoreCase)
+      && Math.Abs(preset.Frequency - _radioState.Frequency) < 1.0;
+  }
 
   private double GetDialogStep() =>
     _radioState == null ? 0.1 : FrequencyFormatter.GetDialogStep(_radioState.Step, _radioState.Band);

--- a/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
+++ b/src/Radio.Web/Components/Shared/NowPlayingPanel.razor
@@ -57,14 +57,12 @@
         </div>
       }
 
-      @* RDS station cell — hidden when RDS hasn't surfaced a station name. *@
-      @if (_isTunerSource && !string.IsNullOrEmpty(_radioState?.RdsStationName))
-      {
-        <div class="np-status-cell np-status-cell-rds">
-          <span class="np-status-rds-station">@_radioState.RdsStationName</span>
-          <span class="np-status-rds-tag">RDS</span>
-        </div>
-      }
+      @* RDS station cell removed (Item 2): the RdsCard marquee in the radio
+         panel is the single RDS readout. This status-strip cell duplicated the
+         PS station name on top of that card ("RDS data shown twice"). The
+         frequency cell above and the gain cell below still bind to _radioState,
+         and the source/provenance match badge further down ("RDS · station-
+         supplied") stays — only this duplicate readout is gone. *@
 
       @* Gain cell — entry point for the popover. Always rendered; the
          popover's auto pill / peak meter / slider live in GainControlPopover. *@

--- a/src/Radio.Web/Components/Shared/PresetCard.razor
+++ b/src/Radio.Web/Components/Shared/PresetCard.razor
@@ -1,0 +1,129 @@
+@* PresetCard — the single saved-station renderer (Proposal A). Two visual
+   variants share one field hierarchy + token set so the Home MEMORY rail and
+   the standalone Radio page can't drift (HANDOFF-saved-station-display §8).
+
+   Variant.Rail  → compact 1-row grid (slot · name+band · freq · kebab),
+                   used in RadioControlPanel's 200px MEMORY rail. Active cue +
+                   slot + kebab + long-press gestures live here.
+   Variant.Card  → 2-column-grid card body (name line, then band + freq + delete
+                   row), used in RadioPage's 480px presets panel.
+
+   All states from the handoff (§6) are honoured in BOTH variants:
+   selected/active (a11y non-color cue), long-name ellipsis + tooltip,
+   no-name→freq-as-primary fallback. Empty-slot + empty-list remain the
+   PARENT's responsibility (they're list-level chrome, not per-card) — see
+   the migration tasks. *@
+
+@{
+  var hasName = !string.IsNullOrWhiteSpace(Name);
+  var freqValue = FrequencyFormatter.FrequencyValue(Frequency, Band);
+  var freqFull = FrequencyFormatter.FormatFrequency(Frequency, Band);
+  var fullLabel = hasName ? Name : freqFull;
+  var rowTitle = $"{fullLabel} — {Band} {freqFull}";
+}
+
+@if (Variant == PresetCardVariant.Rail)
+{
+  <div class="rcp-preset-item @(IsActive ? "is-active" : "")"
+       data-preset-id="@PresetId"
+       @onclick="@(() => OnSelect.InvokeAsync(PresetId))"
+       @onpointerdown="@(_ => OnPointerDown.InvokeAsync(PresetId))"
+       @onpointerup="@(_ => OnPointerUp.InvokeAsync(PresetId))"
+       @onpointerleave="@(_ => OnPointerCancel.InvokeAsync())"
+       @onpointercancel="@(_ => OnPointerCancel.InvokeAsync())"
+       role="button"
+       tabindex="0"
+       title="@($"{rowTitle}. Click to tune; long-press or use ⋮ for rename / delete")">
+    @* Non-color active cue (a11y, handoff §7): a 3px amber inset left bar
+       rendered via CSS on .is-active — no extra element needed here. *@
+    <span class="rcp-preset-slot">@(SlotNumber > 0 ? SlotNumber.ToString("00") : "")</span>
+    @if (hasName)
+    {
+      <span class="rcp-preset-text">
+        <span class="rcp-preset-name">@Name</span>
+        <span class="rcp-preset-band">@Band</span>
+      </span>
+      <span class="rcp-preset-freq">@freqValue</span>
+    }
+    else
+    {
+      @* No-name fallback (handoff §6): promote the frequency to the
+         primary line; drop the dim freq tail. Band sub-line stays. The
+         empty freq cell keeps the 4-column grid intact (kebab in col 4). *@
+      <span class="rcp-preset-text">
+        <span class="rcp-preset-name rcp-preset-name-freq">@freqValue</span>
+        <span class="rcp-preset-band">@Band</span>
+      </span>
+      <span class="rcp-preset-freq"></span>
+    }
+    <button type="button"
+            class="rcp-preset-kebab"
+            aria-label="Rename or delete preset @fullLabel"
+            title="Rename / delete"
+            @onclick="@(_ => OnKebab.InvokeAsync(PresetId))"
+            @onclick:stopPropagation="true">⋮</button>
+  </div>
+}
+else
+{
+  <div class="preset-card @(IsActive ? "is-active" : "")"
+       @onclick="@(() => OnSelect.InvokeAsync(PresetId))"
+       role="button"
+       tabindex="0"
+       title="@rowTitle">
+    @if (hasName)
+    {
+      <div class="preset-card-name">@Name</div>
+    }
+    else
+    {
+      @* No-name fallback: frequency becomes the primary line. *@
+      <div class="preset-card-name preset-card-name-freq">@freqValue</div>
+    }
+    <div class="preset-card-meta">
+      <span class="preset-card-band">@Band</span>
+      <span class="preset-card-meta-right">
+        @if (hasName)
+        {
+          @* Freq demoted: small dim mono tail, no amber, no glow (Proposal A). *@
+          <span class="preset-card-freq">@freqValue</span>
+        }
+        @if (OnDelete.HasDelegate)
+        {
+          <span @onclick:stopPropagation="true">
+            @* Radzen.Variant qualified explicitly — this component has its own
+               Variant parameter (PresetCardVariant) which would otherwise shadow
+               the Radzen Variant enum here. *@
+            <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Size="ButtonSize.Small"
+                          Variant="Radzen.Variant.Text"
+                          Click="@(() => OnDelete.InvokeAsync(PresetId))" title="Delete" />
+          </span>
+        }
+      </span>
+    </div>
+  </div>
+}
+
+@code {
+  /// <summary>Stable preset id, echoed back through the callbacks.</summary>
+  [Parameter, EditorRequired] public string PresetId { get; set; } = string.Empty;
+  /// <summary>Station name. Empty/whitespace triggers the freq-as-primary fallback.</summary>
+  [Parameter] public string? Name { get; set; }
+  /// <summary>Frequency in Hz (raw API units).</summary>
+  [Parameter, EditorRequired] public double Frequency { get; set; }
+  /// <summary>Band token ("FM"/"AM"/...). Drives unit selection + the sub-line.</summary>
+  [Parameter, EditorRequired] public string Band { get; set; } = string.Empty;
+  /// <summary>One-based per-band slot number. 0 → blank slot cell (Rail only).</summary>
+  [Parameter] public int SlotNumber { get; set; }
+  /// <summary>Active/selected station — amber border + slot + non-color left bar.</summary>
+  [Parameter] public bool IsActive { get; set; }
+  /// <summary>Which surface this card renders for.</summary>
+  [Parameter] public PresetCardVariant Variant { get; set; } = PresetCardVariant.Rail;
+
+  [Parameter] public EventCallback<string> OnSelect { get; set; }
+  [Parameter] public EventCallback<string> OnKebab { get; set; }
+  [Parameter] public EventCallback<string> OnDelete { get; set; }
+  [Parameter] public EventCallback<string> OnPointerDown { get; set; }
+  [Parameter] public EventCallback<string> OnPointerUp { get; set; }
+  [Parameter] public EventCallback OnPointerCancel { get; set; }
+}

--- a/src/Radio.Web/Components/Shared/PresetCardVariant.cs
+++ b/src/Radio.Web/Components/Shared/PresetCardVariant.cs
@@ -1,0 +1,11 @@
+namespace Radio.Web.Components.Shared;
+
+/// <summary>
+/// Visual variant for <see cref="PresetCard"/>. Rail = compact 1-row grid for
+/// the Home MEMORY rail; Card = 2-line card body for the Radio page presets panel.
+/// </summary>
+public enum PresetCardVariant
+{
+  Rail,
+  Card
+}

--- a/src/Radio.Web/Components/Shared/RadioControlPanel.razor
+++ b/src/Radio.Web/Components/Shared/RadioControlPanel.razor
@@ -263,30 +263,18 @@
           @foreach (var preset in _presets)
           {
             var isActivePreset = IsActivePreset(preset);
-            var presetId = preset.Id;
-            <div class="rcp-preset-item @(isActivePreset ? "is-active" : "")"
-                 data-preset-id="@presetId"
-                 @onclick="@(() => HandlePresetRowClickAsync(presetId))"
-                 @onpointerdown="@(e => HandlePresetPointerDown(presetId))"
-                 @onpointerup="@(e => HandlePresetPointerUp(presetId))"
-                 @onpointerleave="@(e => HandlePresetPointerCancel())"
-                 @onpointercancel="@(e => HandlePresetPointerCancel())"
-                 role="button"
-                 tabindex="0"
-                 title="Click to tune; long-press or use ⋮ for rename / delete">
-              <span class="rcp-preset-slot">@(preset.SlotNumber > 0 ? preset.SlotNumber.ToString("00") : "")</span>
-              <span class="rcp-preset-text">
-                <span class="rcp-preset-name">@preset.Name</span>
-                <span class="rcp-preset-band">@preset.Band</span>
-              </span>
-              <span class="rcp-preset-freq">@FormatFrequency(preset.Frequency, preset.Band)</span>
-              <button type="button"
-                      class="rcp-preset-kebab"
-                      aria-label="Rename or delete preset @preset.Name"
-                      title="Rename / delete"
-                      @onclick="@(e => HandleKebabClickAsync(presetId))"
-                      @onclick:stopPropagation="true">⋮</button>
-            </div>
+            <PresetCard Variant="PresetCardVariant.Rail"
+                        PresetId="@preset.Id"
+                        Name="@preset.Name"
+                        Frequency="@preset.Frequency"
+                        Band="@preset.Band"
+                        SlotNumber="@preset.SlotNumber"
+                        IsActive="@isActivePreset"
+                        OnSelect="HandlePresetRowClickAsync"
+                        OnKebab="HandleKebabClickAsync"
+                        OnPointerDown="HandlePresetPointerDown"
+                        OnPointerUp="HandlePresetPointerUp"
+                        OnPointerCancel="HandlePresetPointerCancel" />
           }
         }
 
@@ -1052,19 +1040,29 @@
 
   private async Task HandleRadioStateChanged(RadioStateDto dto)
   {
-    // Use the SignalR payload directly instead of re-fetching via REST.
-    // The hub broadcast carries NowPlayingMatchId; the REST endpoint cannot.
+    // Always refresh _radioState: the signal meter, gain readout, freq well,
+    // STEREO badge, and active-preset highlight all bind to it and legitimately
+    // change on telemetry ticks. The hub broadcast carries NowPlayingMatchId;
+    // the REST endpoint cannot. The child ShouldRender guards (RdsCard /
+    // RdsScrollMarquee) keep the marquee from restarting even on these renders.
     // Hot-fix off PR #371: presets are no longer band-filtered, so a band
     // change doesn't require a re-fetch — the empty-slot placeholder
     // re-evaluates against the new band's count on the next render.
     _radioState = dto;
 
-    // HANDOFF-rds-accumulating-scroll — order matters: reset BEFORE append.
-    // If the station changed, the buffer's dedup tracker resets so the first
-    // chunk on the new station can't accidentally match the last chunk on
-    // the prior station.
-    _rdsBuffer.ResetOnTuneChange(dto.Band, dto.Frequency, dto.RdsPi);
-    _rdsBuffer.AppendChunk(dto.RdsRadioText);
+    // Only touch the RDS accumulator when the broadcast actually carried an
+    // RDS/tuning change. On telemetry-only ticks (RdsRelevantChanged == false)
+    // we skip ResetOnTuneChange + AppendChunk entirely — the buffer text is
+    // unchanged, so RdsCard's ShouldRender suppresses the marquee re-render.
+    if (dto.RdsRelevantChanged)
+    {
+      // HANDOFF-rds-accumulating-scroll — order matters: reset BEFORE append.
+      // If the station changed, the buffer's dedup tracker resets so the first
+      // chunk on the new station can't accidentally match the last chunk on
+      // the prior station.
+      _rdsBuffer.ResetOnTuneChange(dto.Band, dto.Frequency, dto.RdsPi);
+      _rdsBuffer.AppendChunk(dto.RdsRadioText);
+    }
 
     await InvokeAsync(StateHasChanged);
   }

--- a/src/Radio.Web/Components/Shared/RdsCard.razor
+++ b/src/Radio.Web/Components/Shared/RdsCard.razor
@@ -31,11 +31,11 @@
          - PS empty → "{RT}" alone (no leading separator)
          The CSS override .rds-card .rcp-rds-rt-track restyles the track
          to inherit PS typography (blue 14 px 700) so the marquee reads
-         as the PS slot rather than as the dim 11 px standalone variant. *@
-      var trackText = string.IsNullOrEmpty(StationName)
-        ? RadioText
-        : $"{StationName}{Separator}{RadioText}";
-      <RdsScrollMarquee Text="@trackText"
+         as the PS slot rather than as the dim 11 px standalone variant.
+         _trackText is composed in OnParametersSet (not inline) so the
+         compose + nested-marquee diff don't re-run on every telemetry tick;
+         the ShouldRender guard below gates that churn. *@
+      <RdsScrollMarquee Text="@_trackText"
                         ScrollSpeedPxPerSec="@ScrollSpeedPxPerSec" />
     }
     else if (!string.IsNullOrEmpty(StationName))
@@ -100,4 +100,43 @@
   /// value through; tests can pass an explicit value to assert on it.
   /// </summary>
   [Parameter] public string Separator { get; set; } = " • ";
+
+  // Cached composed marquee track + last-rendered inputs. The parent
+  // re-renders ~2x/second on signal telemetry; this guard stops that churn
+  // from propagating into the nested RdsScrollMarquee diff when nothing the
+  // user sees has changed.
+  private string? _trackText;
+  private string? _renderedStation;
+  private string? _renderedRadioText;
+  private string? _renderedProgramType;
+  private int _renderedSpeed;
+  private string _renderedSeparator = string.Empty;
+
+  protected override void OnParametersSet()
+  {
+    _trackText = string.IsNullOrEmpty(StationName)
+      ? RadioText
+      : $"{StationName}{Separator}{RadioText}";
+  }
+
+  protected override bool ShouldRender()
+  {
+    var changed =
+      !string.Equals(_renderedStation, StationName, StringComparison.Ordinal) ||
+      !string.Equals(_renderedRadioText, RadioText, StringComparison.Ordinal) ||
+      !string.Equals(_renderedProgramType, ProgramType, StringComparison.Ordinal) ||
+      !string.Equals(_renderedSeparator, Separator, StringComparison.Ordinal) ||
+      _renderedSpeed != ScrollSpeedPxPerSec;
+
+    if (changed)
+    {
+      _renderedStation = StationName;
+      _renderedRadioText = RadioText;
+      _renderedProgramType = ProgramType;
+      _renderedSeparator = Separator;
+      _renderedSpeed = ScrollSpeedPxPerSec;
+    }
+
+    return changed;
+  }
 }

--- a/src/Radio.Web/Components/Shared/RdsScrollMarquee.razor
+++ b/src/Radio.Web/Components/Shared/RdsScrollMarquee.razor
@@ -14,11 +14,11 @@
      enough that the natural width fits inside the well (max-width 420 px
      ≈ 7 px/char in 11 px mono with 0.04em letter-spacing), skip the
      animation entirely and render static centered text. Less twitchy on
-     stations with a single short tagline. *@
-  var isStatic = ApproximateTextWidthPx() <= ContainerMaxWidthPx;
-  var durationSeconds = ComputeScrollDurationSeconds();
-
-  <div class="rcp-rds-rt-scroll @(isStatic ? "is-static" : string.Empty)"
+     stations with a single short tagline.
+     Both _isStatic and _durationSeconds are recomputed in OnParametersSet
+     (NOT inline here) so they aren't recomputed on every no-op re-render —
+     see the ShouldRender guard below. *@
+  <div class="rcp-rds-rt-scroll @(_isStatic ? "is-static" : string.Empty)"
        tabindex="0"
        aria-label="RDS RadioText"
        title="@Text">
@@ -26,7 +26,7 @@
        below carries the readable copy). *@
     <div class="rcp-rds-rt-track"
          aria-hidden="true"
-         style="@($"--scroll-duration: {durationSeconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}s;")">
+         style="@($"--scroll-duration: {_durationSeconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}s;")">
       @Text
     </div>
 
@@ -68,6 +68,57 @@
   /// tests; production callers stick with the default.
   /// </summary>
   [Parameter] public double ApproximateCharWidthPx { get; set; } = 7.0;
+
+  // Cached render inputs — recomputed in OnParametersSet, read by the markup.
+  // We deliberately do NOT recompute these on every render: the parent
+  // (RadioControlPanel) re-renders ~2x/second because the SignalR radio-state
+  // broadcast lumps volatile signal telemetry (RSSI/signal-strength) in with
+  // RDS text. Recomputing + re-attributing the track div on every one of those
+  // restarts the CSS marquee keyframes, which is the "jerk + dropped chars"
+  // the user reported. ShouldRender() below suppresses the no-op renders.
+  private string? _renderedText;
+  private int _renderedSpeed;
+  private int _renderedContainerWidth;
+  private double _renderedCharWidth;
+  private bool _isStatic;
+  private double _durationSeconds;
+
+  protected override void OnParametersSet()
+  {
+    _isStatic = ApproximateTextWidthPx() <= ContainerMaxWidthPx;
+    _durationSeconds = ComputeScrollDurationSeconds();
+  }
+
+  /// <summary>
+  /// Suppress re-renders that wouldn't change anything the user can see. The
+  /// CSS marquee animation restarts whenever this component re-renders (the
+  /// track div is re-created and the inline --scroll-duration is re-emitted),
+  /// so a no-op render visibly snaps the ticker back to the right edge. We
+  /// only re-render when an input that affects the visible track changed.
+  /// Blazor always renders the first frame regardless of ShouldRender, so the
+  /// cache-priming below correctly captures the first-render inputs.
+  /// </summary>
+  protected override bool ShouldRender()
+  {
+    var changed =
+      !string.Equals(_renderedText, Text, StringComparison.Ordinal) ||
+      _renderedSpeed != ScrollSpeedPxPerSec ||
+      _renderedContainerWidth != ContainerMaxWidthPx ||
+      // ApproximateCharWidthPx feeds _isStatic + _durationSeconds via
+      // OnParametersSet; include it so a (test-only) change to it can't be
+      // swallowed by the guard.
+      _renderedCharWidth != ApproximateCharWidthPx;
+
+    if (changed)
+    {
+      _renderedText = Text;
+      _renderedSpeed = ScrollSpeedPxPerSec;
+      _renderedContainerWidth = ContainerMaxWidthPx;
+      _renderedCharWidth = ApproximateCharWidthPx;
+    }
+
+    return changed;
+  }
 
   /// <summary>
   /// Approximate visual width of the current Text, in pixels. Used to decide

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -342,7 +342,13 @@ public record RadioStateDto(
   // Task #80 v4 — raw RDS PI code, exposed for diagnostics so the
   // decode that drives RdsStationNameStable is debuggable from the
   // wire without log scraping. Null for non-RDS sources or pre-lock.
-  ushort? RdsPi = null
+  ushort? RdsPi = null,
+  // Per-broadcast discriminator mirrored from the API DTO — true on RDS/tuning
+  // changes, false on telemetry-only ticks. The RDS marquee path reads it to
+  // skip the accumulator append + card refresh when nothing it shows changed.
+  // Defaults true so REST /api/radio/state (which can't compute a delta) is
+  // always treated as a full refresh.
+  bool RdsRelevantChanged = true
 );
 
 public record RadioPowerStateDto(

--- a/src/Radio.Web/wwwroot/css/design-system.css
+++ b/src/Radio.Web/wwwroot/css/design-system.css
@@ -4248,7 +4248,10 @@ body {
    mirrors the band-pill long-press-to-save gesture from PR 3. */
 .rcp-preset-item {
   display: grid;
-  grid-template-columns: 22px 1fr 64px 24px;
+  /* Proposal A (HANDOFF-saved-station-display §5): freq column 64px → auto
+     (intrinsic) so a 4-6 char freq like "90.3" takes ~34px instead of a hard-
+     reserved 64px, handing ~30px back to the station name. */
+  grid-template-columns: 22px 1fr auto 24px;
   gap: 8px;
   align-items: center;
   padding: 6px 8px;
@@ -4269,6 +4272,11 @@ body {
 .rcp-preset-item.is-active {
   border-color: var(--signal-amber);
   background: color-mix(in srgb, var(--signal-amber) 8%, transparent);
+  /* Non-color-dependent active cue (a11y, handoff §7): 3px amber inset left
+     bar, mirrors the border-left pattern used elsewhere. Inset box-shadow
+     avoids reflowing the grid the way border-left would. The amber slot
+     number (below) stays as a second redundant cue. */
+  box-shadow: inset 3px 0 0 0 var(--signal-amber);
 }
 
 .rcp-preset-slot {
@@ -4296,7 +4304,9 @@ body {
 /* Override the legacy `.rcp-preset-name` (which had right-padding for an
    absolute slot badge) — under the grid layout the slot has its own column. */
 .rcp-preset-item .rcp-preset-name {
-  font-size: 12px;
+  /* Proposal A §5: name is the primary field — 14px (up from 12px),
+     high-contrast, single line, fits ~20-24 chars before ellipsis. */
+  font-size: 14px;
   font-weight: 500;
   color: var(--text-high);
   white-space: nowrap;
@@ -4304,6 +4314,14 @@ body {
   text-overflow: ellipsis;
   padding-right: 0;
   line-height: 1.25;
+}
+
+/* No-name preset: the frequency is promoted to the primary line. Mono (not
+   LED), high-contrast, 14px to match the name slot it replaces (handoff §6). */
+.rcp-preset-item .rcp-preset-name.rcp-preset-name-freq {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
 }
 
 /* Override legacy `.rcp-preset-band` (which was inline-amber inside the freq
@@ -4318,26 +4336,28 @@ body {
   line-height: 1.25;
 }
 
-/* Override legacy `.rcp-preset-freq` (which was a block sibling). Under the
-   grid it's the right-most cell, amber, right-aligned, with glow when
-   the row is the active preset. Hot-fix off PR #371 swapped DSEG14 for
-   Orbitron via --font-led — bold + tabular-nums keeps the column
-   visually a "display chrome" cell and stops the kHz/MHz numerals from
-   jittering between rows. */
+/* Proposal A §5: freq is the SECONDARY datum — de-styled from the old amber
+   LED/Orbitron "display chrome" to a small dim mono tail. Mono (was --font-led),
+   11px (was 13px), weight 500 (was 700), --text-medium (was --signal-amber),
+   no glow (text-shadow removed). tabular-nums keeps the column aligned. */
 .rcp-preset-item .rcp-preset-freq {
-  font-family: var(--font-led);
-  font-weight: 700;
+  font-family: var(--font-mono);
+  font-weight: 500;
   font-variant-numeric: tabular-nums;
-  font-size: 13px;
+  font-size: 11px;
   text-align: right;
-  color: var(--signal-amber);
-  text-shadow: 0 0 4px color-mix(in srgb, var(--signal-amber) 30%, transparent);
+  color: var(--text-medium);
+  text-shadow: none;
   margin-top: 0;
   line-height: 1.25;
 }
 
+/* Active state (handoff §6): freq lifts from dim to high-contrast, but stays
+   mono / no-glow — the active cue is the border + slot + left bar, NOT a
+   glowing freq. The name color does NOT change on active (kept high-contrast). */
 .rcp-preset-item.is-active .rcp-preset-freq {
-  text-shadow: 0 0 6px color-mix(in srgb, var(--signal-amber) 60%, transparent);
+  color: var(--text-high);
+  text-shadow: none;
 }
 
 /* Empty next-slot placeholder. Dashed border, dim hint text spans columns 2-3. */
@@ -4460,6 +4480,63 @@ body {
   content: none;
 }
 
+/* Shared PresetCard — Card variant (Radio page 480px presets panel). Proposal A
+   hierarchy at card scale: name-primary high-contrast, freq dim mono no-glow.
+   Mirrors the Rail variant's token map at the card's larger sizes. */
+.preset-card {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid var(--surface-separator);
+  cursor: pointer;
+  transition: all 80ms ease;
+}
+.preset-card:hover {
+  border-color: color-mix(in srgb, var(--signal-amber) 25%, var(--surface-separator));
+}
+.preset-card.is-active {
+  border-color: var(--signal-amber);
+  box-shadow: inset 3px 0 0 0 var(--signal-amber); /* non-color a11y cue */
+}
+.preset-card-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-high);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.preset-card-name.preset-card-name-freq {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+.preset-card-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 4px;
+}
+.preset-card-band {
+  font-size: 13px;
+  color: var(--text-low);
+}
+.preset-card-meta-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.preset-card-freq {
+  font-size: 13px;
+  color: var(--text-medium);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+.preset-card.is-active .preset-card-freq {
+  color: var(--text-high);
+}
+
 
 /* ─── §Y  NowPlaying Status Strip (Radio Controller Polish PR 4) ──────────── *
  * Unified Source · Frequency · RDS · Gain strip at the top of NowPlayingPanel.
@@ -4557,25 +4634,9 @@ body {
   border-radius: 4px;
 }
 
-/* RDS cell — cyan accent station name + dim "RDS" tag. */
-.np-status-rds-station {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--accent-primary);
-  letter-spacing: 0.10em;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-  max-width: 120px;
-}
-
-.np-status-rds-tag {
-  font-family: var(--font-mono);
-  font-size: 9px;
-  letter-spacing: 0.10em;
-  text-transform: uppercase;
-  color: var(--text-low);
-}
+/* RDS status-strip cell styles removed with the duplicate readout (Item 2):
+   .np-status-rds-station / .np-status-rds-tag had no remaining markup. The
+   single RDS readout is the RdsCard marquee in the radio panel. */
 
 /* Gain cell — tappable; cyan to suggest interactivity. */
 .np-status-cell-gain {

--- a/tests/Radio.API.Tests/Services/AudioStateUpdateServiceTests.cs
+++ b/tests/Radio.API.Tests/Services/AudioStateUpdateServiceTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Radio.API.Hubs;
+using Radio.API.Models;
 using Radio.API.Services;
 using Radio.Core.Models.Audio;
 
@@ -161,5 +162,81 @@ public class AudioStateUpdateServiceTests
     InvokeUpdateCurrentMatchAnchor(svc, snapshot);
 
     Assert.Null(ReadCurrentMatchId(svc));
+  }
+
+  // ─── RDS broadcast-split predicate (Item A) ───────────────────────────────
+  // HasRadioStateChanged keeps deciding WHETHER to broadcast (telemetry
+  // consumers — signal meter, gain, recognition NOW-row — stay fed). The new
+  // HasRdsRelevantChanged predicate decides the per-broadcast flag value that
+  // lets the Web RDS marquee path skip its accumulator append on telemetry-only
+  // ticks. Both are private static — reached via reflection like the existing
+  // anchor tests above.
+
+  private static bool InvokeHasRdsRelevantChanged(RadioStateDto? prev, RadioStateDto? curr)
+  {
+    var m = typeof(AudioStateUpdateService).GetMethod(
+      "HasRdsRelevantChanged",
+      BindingFlags.NonPublic | BindingFlags.Static);
+    Assert.NotNull(m);
+    return (bool)m!.Invoke(null, new object?[] { prev, curr })!;
+  }
+
+  private static bool InvokeHasRadioStateChanged(RadioStateDto? prev, RadioStateDto? curr)
+  {
+    var m = typeof(AudioStateUpdateService).GetMethod(
+      "HasRadioStateChanged",
+      BindingFlags.NonPublic | BindingFlags.Static);
+    Assert.NotNull(m);
+    return (bool)m!.Invoke(null, new object?[] { prev, curr })!;
+  }
+
+  [Fact]
+  public void RdsRelevant_False_OnTelemetryOnlyChange()
+  {
+    // RSSI / signal-strength drift every poll on a live station. That MUST still
+    // broadcast (the meter needs it) but MUST NOT flag the RDS path — otherwise
+    // the RDS accumulator re-runs + the CSS marquee restarts ~twice a second.
+    var prev = new RadioStateDto { Frequency = 105_100_000, Band = "FM", RssiDbu = 0, SignalStrength = 40, RdsRadioText = "Hotel California" };
+    var curr = new RadioStateDto { Frequency = 105_100_000, Band = "FM", RssiDbu = 5, SignalStrength = 60, RdsRadioText = "Hotel California" };
+
+    Assert.True(InvokeHasRadioStateChanged(prev, curr));   // still broadcasts for the signal meter
+    Assert.False(InvokeHasRdsRelevantChanged(prev, curr)); // but does NOT flag the RDS path
+  }
+
+  [Fact]
+  public void RdsRelevant_True_OnRadioTextChange()
+  {
+    var prev = new RadioStateDto { Frequency = 105_100_000, Band = "FM", RdsRadioText = "Hotel California" };
+    var curr = new RadioStateDto { Frequency = 105_100_000, Band = "FM", RdsRadioText = "Life in the Fast Lane" };
+
+    Assert.True(InvokeHasRdsRelevantChanged(prev, curr));
+  }
+
+  [Fact]
+  public void RdsRelevant_True_OnFrequencyTune()
+  {
+    var prev = new RadioStateDto { Frequency = 105_100_000, Band = "FM" };
+    var curr = new RadioStateDto { Frequency = 98_500_000, Band = "FM" };
+
+    Assert.True(InvokeHasRdsRelevantChanged(prev, curr));
+  }
+
+  [Fact]
+  public void RdsRelevant_True_OnNowPlayingMatchIdChange()
+  {
+    var prev = new RadioStateDto { Frequency = 105_100_000, Band = "FM", NowPlayingMatchId = null };
+    var curr = new RadioStateDto { Frequency = 105_100_000, Band = "FM", NowPlayingMatchId = "abc123" };
+
+    Assert.True(InvokeHasRdsRelevantChanged(prev, curr));
+  }
+
+  [Fact]
+  public void RdsRelevant_True_WhenPreviousNull()
+  {
+    // First broadcast after a tune / source-switch (no baseline) must populate
+    // the RDS card immediately.
+    var curr = new RadioStateDto { Frequency = 105_100_000, Band = "FM" };
+
+    Assert.True(InvokeHasRdsRelevantChanged(null, curr));
   }
 }

--- a/tests/Radio.Web.Tests/Components/Shared/NowPlayingPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/NowPlayingPanelTests.cs
@@ -478,8 +478,12 @@ public class NowPlayingPanelTests : TestContext
   }
 
   [Fact]
-  public void StatusStrip_RendersAllFourCells_WhenTunerActiveWithRds()
+  public void StatusStrip_RendersThreeCells_WhenTunerActiveWithRds()
   {
+    // The duplicate RDS station cell was removed (Item 2 of the RDS-UX work):
+    // the single RDS readout is the RdsCard marquee in the radio panel, so the
+    // status strip now carries three cells (source · frequency · gain) even
+    // when RDS surfaces a station name.
     var radioState = new RadioStateDto(
       Frequency: 92.5e6, Band: "FM", Step: 100e3,
       SignalStrength: 70, IsScanning: false, ScanDirection: null,
@@ -494,11 +498,11 @@ public class NowPlayingPanelTests : TestContext
     var strip = cut.Find(".np-status-strip");
     Assert.NotNull(strip);
 
-    // All four cells present and in order: source, freq, rds, gain.
+    // Three cells present and in order: source, freq, gain. No RDS cell.
     Assert.Single(cut.FindAll(".np-status-cell-source"));
     Assert.Single(cut.FindAll(".np-status-cell-frequency"));
-    Assert.Single(cut.FindAll(".np-status-cell-rds"));
     Assert.Single(cut.FindAll(".np-status-cell-gain"));
+    Assert.Empty(cut.FindAll(".np-status-cell-rds"));
   }
 
   [Fact]
@@ -565,8 +569,12 @@ public class NowPlayingPanelTests : TestContext
   }
 
   [Fact]
-  public void StatusStrip_RdsCell_RendersStationName()
+  public void StatusStrip_OmitsDuplicateRdsCell_EvenWithStationName()
   {
+    // Item 2 of the RDS-UX work removed the status-strip RDS cell that
+    // duplicated the PS station name on top of the RdsCard marquee ("RDS data
+    // shown twice"). Even with a live station name, the strip must NOT render
+    // the old .np-status-cell-rds / .np-status-rds-station / .np-status-rds-tag.
     var radioState = new RadioStateDto(
       Frequency: 92.5e6, Band: "FM", Step: 100e3,
       SignalStrength: 70, IsScanning: false, ScanDirection: null,
@@ -577,11 +585,9 @@ public class NowPlayingPanelTests : TestContext
     var cut = RenderComponent<NowPlayingPanel>();
     SetStatusStripState(cut, "RTLSDRCore", "SDR Radio", radioState);
 
-    var rds = cut.Find(".np-status-rds-station");
-    Assert.Equal("WKQX", rds.TextContent);
-    // The dim tag carries the literal "RDS".
-    var tag = cut.Find(".np-status-rds-tag");
-    Assert.Equal("RDS", tag.TextContent);
+    Assert.Empty(cut.FindAll(".np-status-cell-rds"));
+    Assert.Empty(cut.FindAll(".np-status-rds-station"));
+    Assert.Empty(cut.FindAll(".np-status-rds-tag"));
   }
 
   [Fact]
@@ -813,10 +819,12 @@ public class NowPlayingPanelTests : TestContext
 
     await cut.InvokeAsync(() => handler!.Invoke(dto));
 
+    // The frequency cell still updates live off the RadioStateChanged hub push
+    // (it binds to _radioState, which is refreshed every tick). The duplicate
+    // RDS station cell was removed (Item 2), so it must not reappear here.
     var freq = cut.Find(".np-status-cell-frequency").TextContent;
     Assert.Contains("88.10", freq);
-    var rds = cut.Find(".np-status-rds-station");
-    Assert.Equal("KFOG", rds.TextContent);
+    Assert.Empty(cut.FindAll(".np-status-rds-station"));
   }
 
   // ─── Task #15 PR E item #47: gain-popover backdrop portal wiring ─────────

--- a/tests/Radio.Web.Tests/Components/Shared/PresetCardTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/PresetCardTests.cs
@@ -1,0 +1,210 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Radzen;
+using Radio.Web.Components.Shared;
+
+namespace Radio.Web.Tests.Components.Shared;
+
+/// <summary>
+/// bUnit tests for the shared <see cref="PresetCard"/> component — the single
+/// saved-station renderer (Proposal A, HANDOFF-saved-station-display). One
+/// component, two variants (Rail = Home MEMORY rail compact row; Card = Radio
+/// page 480px card) so the two surfaces can't drift.
+///
+/// Contract under test:
+///   - Rail + name → .rcp-preset-name carries the name, .rcp-preset-freq the
+///     unit-less frequency value (no "MHz" in the row face).
+///   - Rail + no name → .rcp-preset-name.rcp-preset-name-freq promotes the
+///     frequency to the primary line; the freq tail is empty.
+///   - Card + name → .preset-card-name carries the name, .preset-card-freq the
+///     unit-less value.
+///   - IsActive → root carries .is-active (both variants).
+///   - OnSelect fires with the PresetId on click (both variants).
+///   - OnKebab fires on the rail kebab; rail row title carries the full name +
+///     full MHz/kHz unit.
+/// </summary>
+public class PresetCardTests : TestContext
+{
+  public PresetCardTests()
+  {
+    Services.AddRadzenComponents();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+  }
+
+  [Fact]
+  public void Rail_WithName_RendersNameAndUnitlessFreq()
+  {
+    var cut = RenderComponent<PresetCard>(p => p
+      .Add(x => x.Variant, PresetCardVariant.Rail)
+      .Add(x => x.PresetId, "p1")
+      .Add(x => x.Name, "KEXP Seattle")
+      .Add(x => x.Frequency, 90_300_000)
+      .Add(x => x.Band, "FM")
+      .Add(x => x.SlotNumber, 1));
+
+    cut.Find(".rcp-preset-name").TextContent.Trim().Should().Be("KEXP Seattle");
+    // Unit-less value in the row face: "90.30", NOT "90.30 MHz".
+    var freq = cut.Find(".rcp-preset-freq").TextContent.Trim();
+    freq.Should().Be("90.30");
+    freq.Should().NotContain("MHz");
+  }
+
+  [Fact]
+  public void Rail_NoName_PromotesFreqToPrimaryLine()
+  {
+    var cut = RenderComponent<PresetCard>(p => p
+      .Add(x => x.Variant, PresetCardVariant.Rail)
+      .Add(x => x.PresetId, "p2")
+      .Add(x => x.Name, "   ")
+      .Add(x => x.Frequency, 88_500_000)
+      .Add(x => x.Band, "FM"));
+
+    // The primary line carries the freq with the promotion class.
+    var primary = cut.Find(".rcp-preset-name.rcp-preset-name-freq");
+    primary.TextContent.Trim().Should().Be("88.50");
+
+    // The dim freq tail is present but empty (keeps the 4-column grid intact).
+    cut.Find(".rcp-preset-freq").TextContent.Trim().Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Rail_RowTitle_CarriesFullNameAndUnit()
+  {
+    var cut = RenderComponent<PresetCard>(p => p
+      .Add(x => x.Variant, PresetCardVariant.Rail)
+      .Add(x => x.PresetId, "p3")
+      .Add(x => x.Name, "Classic Vinyl Rock Channel")
+      .Add(x => x.Frequency, 105_100_000)
+      .Add(x => x.Band, "FM"));
+
+    var title = cut.Find(".rcp-preset-item").GetAttribute("title") ?? string.Empty;
+    title.Should().Contain("Classic Vinyl Rock Channel", "long names truncate visually but the tooltip has the full name");
+    title.Should().Contain("105.10 MHz", "the tooltip carries the full unit even though the row face drops it");
+  }
+
+  [Fact]
+  public void Rail_AmRowTitle_UsesKhzUnit()
+  {
+    var cut = RenderComponent<PresetCard>(p => p
+      .Add(x => x.Variant, PresetCardVariant.Rail)
+      .Add(x => x.PresetId, "p4")
+      .Add(x => x.Name, "AM 1010")
+      .Add(x => x.Frequency, 1_010_000)
+      .Add(x => x.Band, "AM"));
+
+    cut.Find(".rcp-preset-freq").TextContent.Trim().Should().Be("1010");
+    (cut.Find(".rcp-preset-item").GetAttribute("title") ?? string.Empty)
+      .Should().Contain("1010 kHz");
+  }
+
+  [Fact]
+  public void Card_WithName_RendersNameAndUnitlessFreq()
+  {
+    var cut = RenderComponent<PresetCard>(p => p
+      .Add(x => x.Variant, PresetCardVariant.Card)
+      .Add(x => x.PresetId, "c1")
+      .Add(x => x.Name, "KQED Public Radio")
+      .Add(x => x.Frequency, 88_500_000)
+      .Add(x => x.Band, "FM"));
+
+    cut.Find(".preset-card-name").TextContent.Trim().Should().Be("KQED Public Radio");
+    cut.Find(".preset-card-freq").TextContent.Trim().Should().Be("88.50");
+  }
+
+  [Fact]
+  public void Card_NoName_PromotesFreqToPrimaryLine()
+  {
+    var cut = RenderComponent<PresetCard>(p => p
+      .Add(x => x.Variant, PresetCardVariant.Card)
+      .Add(x => x.PresetId, "c2")
+      .Add(x => x.Name, null)
+      .Add(x => x.Frequency, 98_500_000)
+      .Add(x => x.Band, "FM"));
+
+    cut.Find(".preset-card-name.preset-card-name-freq").TextContent.Trim().Should().Be("98.50");
+    // No-name card has no separate dim freq tail.
+    cut.FindAll(".preset-card-freq").Should().BeEmpty();
+  }
+
+  [Theory]
+  [InlineData(PresetCardVariant.Rail, "rcp-preset-item")]
+  [InlineData(PresetCardVariant.Card, "preset-card")]
+  public void IsActive_AddsActiveClass(PresetCardVariant variant, string rootClass)
+  {
+    var cut = RenderComponent<PresetCard>(p => p
+      .Add(x => x.Variant, variant)
+      .Add(x => x.PresetId, "a1")
+      .Add(x => x.Name, "Active Station")
+      .Add(x => x.Frequency, 90_300_000)
+      .Add(x => x.Band, "FM")
+      .Add(x => x.IsActive, true));
+
+    cut.Find($".{rootClass}").ClassList.Should().Contain("is-active");
+  }
+
+  [Fact]
+  public void Rail_OnSelect_FiresWithPresetId()
+  {
+    string? selected = null;
+    var cut = RenderComponent<PresetCard>(p => p
+      .Add(x => x.Variant, PresetCardVariant.Rail)
+      .Add(x => x.PresetId, "sel-rail")
+      .Add(x => x.Name, "KEXP")
+      .Add(x => x.Frequency, 90_300_000)
+      .Add(x => x.Band, "FM")
+      .Add(x => x.OnSelect, (string id) => { selected = id; }));
+
+    cut.Find(".rcp-preset-item").Click();
+
+    selected.Should().Be("sel-rail");
+  }
+
+  [Fact]
+  public void Card_OnSelect_FiresWithPresetId()
+  {
+    string? selected = null;
+    var cut = RenderComponent<PresetCard>(p => p
+      .Add(x => x.Variant, PresetCardVariant.Card)
+      .Add(x => x.PresetId, "sel-card")
+      .Add(x => x.Name, "KQED")
+      .Add(x => x.Frequency, 88_500_000)
+      .Add(x => x.Band, "FM")
+      .Add(x => x.OnSelect, (string id) => { selected = id; }));
+
+    cut.Find(".preset-card").Click();
+
+    selected.Should().Be("sel-card");
+  }
+
+  [Fact]
+  public void Rail_Kebab_FiresOnKebabWithPresetId()
+  {
+    string? kebabId = null;
+    var cut = RenderComponent<PresetCard>(p => p
+      .Add(x => x.Variant, PresetCardVariant.Rail)
+      .Add(x => x.PresetId, "keb-1")
+      .Add(x => x.Name, "KEXP")
+      .Add(x => x.Frequency, 90_300_000)
+      .Add(x => x.Band, "FM")
+      .Add(x => x.OnKebab, (string id) => { kebabId = id; }));
+
+    cut.Find(".rcp-preset-kebab").Click();
+
+    kebabId.Should().Be("keb-1");
+  }
+
+  [Fact]
+  public void Card_OmitsDeleteButton_WhenNoDeleteDelegate()
+  {
+    // The Card variant only renders the delete button when OnDelete is wired.
+    var cut = RenderComponent<PresetCard>(p => p
+      .Add(x => x.Variant, PresetCardVariant.Card)
+      .Add(x => x.PresetId, "nodel")
+      .Add(x => x.Name, "KQED")
+      .Add(x => x.Frequency, 88_500_000)
+      .Add(x => x.Band, "FM"));
+
+    cut.FindAll("button.rz-button").Should().BeEmpty();
+  }
+}

--- a/tests/Radio.Web.Tests/Components/Shared/RdsCardTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/RdsCardTests.cs
@@ -133,6 +133,53 @@ public class RdsCardTests : TestContext
       "the .rds-card-station rule in design-system.css must bind colour to --accent-primary");
   }
 
+  // --- Render-guard parity test (RDS scroll-stability fix) ---
+  // RdsCard composes the marquee track + passes it to the nested
+  // RdsScrollMarquee. Its ShouldRender guard stops telemetry-tick churn from
+  // re-running the nested-component diff when nothing the user sees changed.
+
+  [Fact]
+  public void Card_DoesNotReRender_WhenInputsUnchanged()
+  {
+    var cut = RenderComponent<RdsCard>(p => p
+      .Add(x => x.StationName, "WUNC")
+      .Add(x => x.RadioText, "Morning Edition"));
+
+    // ShouldRender primes its cache on the first consult (the first identical
+    // update below), so we assert the steady-state: the SECOND identical
+    // update — i.e. the ~2x/second telemetry ticks on a live station — is
+    // suppressed and doesn't re-run the nested marquee diff.
+    cut.SetParametersAndRender(p => p
+      .Add(x => x.StationName, "WUNC")
+      .Add(x => x.RadioText, "Morning Edition"));
+
+    var afterPrime = cut.RenderCount;
+
+    cut.SetParametersAndRender(p => p
+      .Add(x => x.StationName, "WUNC")
+      .Add(x => x.RadioText, "Morning Edition"));
+
+    cut.RenderCount.Should().Be(afterPrime,
+      "unchanged RDS inputs must not re-run the nested marquee diff");
+  }
+
+  [Fact]
+  public void Card_ReRenders_WhenRadioTextChanges()
+  {
+    var cut = RenderComponent<RdsCard>(p => p
+      .Add(x => x.StationName, "WUNC")
+      .Add(x => x.RadioText, "Morning Edition"));
+
+    var before = cut.RenderCount;
+
+    cut.SetParametersAndRender(p => p
+      .Add(x => x.StationName, "WUNC")
+      .Add(x => x.RadioText, "All Things Considered"));
+
+    cut.RenderCount.Should().BeGreaterThan(before,
+      "a changed RadioText must re-render so the new buffer scrolls");
+  }
+
   /// <summary>
   /// Locate the design-system.css source file by walking up from the test
   /// binary directory until we find the Radio.Web/wwwroot/css folder. The

--- a/tests/Radio.Web.Tests/Components/Shared/RdsScrollMarqueeTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/RdsScrollMarqueeTests.cs
@@ -174,4 +174,71 @@ public class RdsScrollMarqueeTests : TestContext
     var scroll = cut.Find(".rcp-rds-rt-scroll");
     scroll.GetAttribute("title").Should().Be(bufferText);
   }
+
+  // --- Render-guard regression tests (RDS scroll-stability fix) ---
+  // The CSS marquee animation restarts whenever this component re-renders (the
+  // track div is re-created and the inline --scroll-duration re-emitted). The
+  // parent (RadioControlPanel) re-renders ~2x/second on signal telemetry, so a
+  // no-op render visibly snaps the ticker back to the right edge ("jerk +
+  // dropped chars"). ShouldRender() suppresses the no-op renders.
+
+  [Fact]
+  public void Marquee_DoesNotReRender_WhenTextUnchanged()
+  {
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, "WUNC News • Morning Edition"));
+
+    // ShouldRender is NOT consulted before the first frame, so it primes its
+    // last-rendered cache on the FIRST consult (the first SetParametersAndRender).
+    // That first identical update therefore renders once to prime; from then on,
+    // steady-state identical telemetry ticks are suppressed. We assert the
+    // steady state — which is what happens ~2x/second on a live station.
+    cut.SetParametersAndRender(p => p
+      .Add(x => x.Text, "WUNC News • Morning Edition"));
+
+    var afterPrime = cut.RenderCount;
+
+    // Simulate the parent re-rendering on a telemetry tick with identical RDS text.
+    cut.SetParametersAndRender(p => p
+      .Add(x => x.Text, "WUNC News • Morning Edition"));
+
+    cut.RenderCount.Should().Be(afterPrime,
+      "an unchanged Text must not re-render the marquee (no CSS animation restart)");
+  }
+
+  [Fact]
+  public void Marquee_ReRenders_WhenTextChanges()
+  {
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, "WUNC News"));
+
+    var before = cut.RenderCount;
+
+    cut.SetParametersAndRender(p => p
+      .Add(x => x.Text, "WUNC News • Morning Edition"));
+
+    cut.RenderCount.Should().BeGreaterThan(before,
+      "a changed Text must re-render so the new buffer scrolls");
+  }
+
+  [Fact]
+  public void Marquee_DurationStable_AcrossNoOpReRender()
+  {
+    // Fallback assertion (plan §Task 3): the animation restart is what the
+    // re-emitted --scroll-duration style causes, so an identical-input render
+    // must keep the style string byte-identical (and ideally not re-render).
+    var cut = RenderComponent<RdsScrollMarquee>(p => p
+      .Add(x => x.Text, new string('A', 100))
+      .Add(x => x.ScrollSpeedPxPerSec, 40));
+
+    var styleBefore = cut.Find(".rcp-rds-rt-track").GetAttribute("style");
+
+    cut.SetParametersAndRender(p => p
+      .Add(x => x.Text, new string('A', 100))
+      .Add(x => x.ScrollSpeedPxPerSec, 40));
+
+    var styleAfter = cut.Find(".rcp-rds-rt-track").GetAttribute("style");
+    styleAfter.Should().Be(styleBefore,
+      "an unchanged buffer must not re-emit a new --scroll-duration (which would restart the keyframes)");
+  }
 }


### PR DESCRIPTION
## Summary

Three user-reported Radio-UX problems, batched into one PR because they share two surfaces (`RadioControlPanel.razor` + `design-system.css`) and one adjacent surface (`NowPlayingPanel.razor`). Implements `design/plans/PLAN-rds-ux-and-saved-station-redesign.md` (rev 2, 15 tasks) and the design spec `docs/design-handoffs/HANDOFF-saved-station-display.md` (Proposal A).

**1. RDS marquee jerk / dropped characters — fixed.**
- Root cause: the CSS `@keyframes` marquee restarted on every Blazor re-render, and re-renders fired ~2x/second because the SignalR radio-state broadcast lumps volatile signal telemetry (RSSI/signal-strength) in with RDS text.
- Fix (primary): `ShouldRender()` guards on `RdsScrollMarquee` and `RdsCard` — they only re-render when their composed text / duration / inputs actually change. `_isStatic`/`_durationSeconds`/`_trackText` are now cached in `OnParametersSet` instead of recomputed inline every render, so the track `<div>` and inline `--scroll-duration` are no longer re-emitted on a no-op render (which is what restarted the keyframes).
- Fix (defense-in-depth, upstream): API broadcast split via a **flag on the existing event**. Added `bool RdsRelevantChanged` (default `true`) to both `RadioStateDto` records. A new `HasRdsRelevantChanged` predicate (frequency/band/step + all RDS fields + `NowPlayingMatchId`) — a strict subset of `HasRadioStateChanged` — computes the flag, which is stamped onto the DTO before `SendAsync`. `HasRadioStateChanged` is unchanged, so the signal meter / gain readout / recognition NOW-row stay fed every tick. `RadioControlPanel.HandleRadioStateChanged` now skips the RDS-buffer `ResetOnTuneChange`/`AppendChunk` when the flag is `false`, while still refreshing `_radioState` every tick.

**2. Duplicate now-playing RDS readout — removed.**
- Deleted the `np-status-cell-rds` block in `NowPlayingPanel.razor` (it rendered the PS station name a second time on top of the `RdsCard` marquee — "RDS data shown twice"). Kept `_radioState` + its SignalR wiring (the frequency cell, gain cell, and fingerprint/recognition NOW-row depend on it) and kept the source-provenance match badge ("RDS · station-supplied"). Removed the now-dead `.np-status-rds-station` / `.np-status-rds-tag` CSS.

**3. Saved-station cards over-truncate the name — redesigned per Proposal A, on both renderers.**
- New shared `PresetCard` component (`Rail` / `Card` variants via a `PresetCardVariant` enum) owns Proposal A in exactly one place, so the Home MEMORY rail and the standalone Radio-page presets panel can't drift. Both renderers migrated onto it; empty-slot / empty-list chrome stays in the parents (list-level).
- Proposal A: station name promoted to the primary field (14px / 16px high-contrast, single line, ellipsis), frequency demoted to a small dim mono tail (was amber LED/Orbitron 13px/700 + glow -> now `--font-mono` 11px/13px, `--text-medium`, no glow, `tabular-nums`), freq grid column `64px -> auto`, no-name -> frequency-as-primary fallback, and a non-color a11y active cue (3px amber inset left bar; name stays high-contrast, not recolored amber).
- The Radio-page presets panel now also highlights the active preset, consistent with the rail (new `RadioPage.IsActivePreset` mirroring `RadioControlPanel.IsActivePreset`).

## Pre-merge fixes (self-review, high effort)

- **LOW (fixed):** `RdsScrollMarquee.ShouldRender` tracked `Text`/`Speed`/`ContainerWidth` but not `ApproximateCharWidthPx`, which also feeds the cached `_isStatic`/`_durationSeconds`. Not reachable in production (only tests set that param, and never post-mount), but a real latent gap in the exact guard this PR is about — added it to the comparison. All tests still green.
- No HIGH/MEDIUM findings. Verified: `HasRdsRelevantChanged` is a strict subset of `HasRadioStateChanged` (no telemetry-consumer starvation), the duplicate-cell removal preserves `_radioState` + the match badge, the empty-slot grid span (`2/5`) stays correct under the `auto` freq column, and no orphaned CSS selectors remain.

## Test Plan / UAT results

**Local gates:** `dotnet build -c Release` = 0 warnings / 0 errors (full solution). `Radio.Web.Tests` 661/661, `Radio.API.Tests` 318/318 green. New tests: render-guard tests (marquee + card: RenderCount + style-stability), `HasRdsRelevantChanged` predicate tests (telemetry-only / RT-change / tune / match-id / null-previous), `PresetCard` component tests (both variants, states, callbacks). Stale `NowPlayingPanel` status-strip tests updated for the removed RDS cell.

**Live browser UAT (Tester, deployed to `radio` linux-x64 @ 1920x720, commit `55a3764`):** all 6 flows PASS.
- [x] RDS scroll smoothness — 32 s / 127-sample marquee instrumentation: **0 animation resets across 8 RDS updates**; constant-speed full passes, no mid-scroll snap-back, no dropped glyphs.
- [x] Telemetry stays live during those same updates (signal meter + gain keep moving ~2x/s) while the marquee stays still — the whole point of the split.
- [x] Exactly **one** RDS readout (the `RdsCard` marquee); the now-playing status strip no longer shows a second RDS cell; freq / gain / fingerprint badge cells intact.
- [x] Saved-station cards: name-primary high-contrast, freq dim mono single-line (no `105.10 / MHz` wrap), tabular-aligned; active preset shows amber border + slot + left bar with the name un-recolored; no-name -> freq-as-primary; **7 presets fit at 1920x720 without new scrolling**.
- [x] Both renderers reflect Proposal A from the one shared `PresetCard`; Radio-page active highlight works.
- [x] Layout regression: frequency well + STEREO badge visible, **#416 not reapparent**; **0 console errors**.

**Polisher:** 0 blockers, 0 should-fix, 3 nice-to-haves. SHIP-READY.

## Deferred / follow-up (NOT a blocker — user approved shipping Proposal A now)

- **Saved-station name width on the narrow MEMORY rail:** Proposal A's `auto` freq column + dropped unit hands the name only ~10-11 chars (vs ~8-10 before) on the ~200px Home rail — marginal on the freq-heavy test preset names. The user will re-save presets with clean names and then decide whether to apply the Designer's **Proposal B** (two-line rail: name owns the full top line, freq joins the band sub-line) as a fast-follow. Deliberately deferred, not a blocker for this PR.

## Operator note

No deploy-config / service-file / boundary changes. Deployed to `radio` (Ubuntu x64) during UAT; no migration, no schema change. The new `RdsRelevantChanged` DTO field round-trips by name via System.Text.Json and defaults `true` (full refresh) when absent, so no coordinated API/Web version bump is required.

## Test-environment caveats (truthful, pre-existing — NOT regressions)

- `Radio.Infrastructure.Tests` shows 4 failures on the **Windows dev box** only: `DllNotFoundException: libsamplerate.so.0` (a Linux `.so` that can't load on Windows — `SrcVariableResamplerTests`). These pass on the Linux target. No Infrastructure files were touched.
- `Radio.Fingerprinting.Tests` has one flaky test (passes on retry — external-process timing). No Fingerprinting files were touched.

## Docs Impact

- Plan & design spec referenced above; no audience-doc (`user/`/`operator/`/`developer/`/`architecture/`) changes required for these UI/transport-internal fixes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
