### PR TITLE
fix(web): sleep time display — weather "as of" stamp + live time-format toggle

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,16 +1,5 @@
 {
   "mcpServers": {
-    "playwright": {
-      "type": "stdio",
-      "command": "cmd",
-      "args": [
-        "/c",
-        "npx",
-        "-y",
-        "@playwright/mcp@latest"
-      ],
-      "env": {}
-    },
     "ssh-mcp": {
       "type": "stdio",
       "command": "cmd",

--- a/src/Radio.API/Controllers/ConfigurationController.cs
+++ b/src/Radio.API/Controllers/ConfigurationController.cs
@@ -5,6 +5,8 @@ using Radio.Core.Configuration;
 using Radio.Configuration.Abstractions;
 using Radio.Configuration.Exceptions;
 using IRadioConfigurationManager = Radio.Configuration.Abstractions.IConfigurationManager;
+using Microsoft.AspNetCore.SignalR;
+using Radio.API.Hubs;
 
 namespace Radio.API.Controllers;
 
@@ -21,6 +23,7 @@ public class ConfigurationController : ControllerBase
   private readonly IOptionsMonitor<VisualizerOptions> _visualizerOptions;
   private readonly IOptionsMonitor<AudioOutputOptions> _outputOptions;
   private readonly IRadioConfigurationManager _configurationManager;
+  private readonly IHubContext<AudioStateHub> _hubContext;
 
   /// <summary>
   /// Initializes a new instance of the ConfigurationController.
@@ -30,13 +33,15 @@ public class ConfigurationController : ControllerBase
     IOptionsMonitor<AudioOptions> audioOptions,
     IOptionsMonitor<VisualizerOptions> visualizerOptions,
     IOptionsMonitor<AudioOutputOptions> outputOptions,
-    IRadioConfigurationManager configurationManager)
+    IRadioConfigurationManager configurationManager,
+    IHubContext<AudioStateHub> hubContext)
   {
     _logger = logger;
     _audioOptions = audioOptions;
     _visualizerOptions = visualizerOptions;
     _outputOptions = outputOptions;
     _configurationManager = configurationManager;
+    _hubContext = hubContext;
   }
 
   /// <summary>
@@ -385,6 +390,13 @@ public class ConfigurationController : ControllerBase
       }
 
       _logger.LogInformation("Configuration section {Section} updated successfully with {Count} keys", section, data.Count);
+
+      // Cross-process hot-reload bridge (see BroadcastConfigChangedAsync). radio-web
+      // runs as a separate process; without this its IOptionsMonitor snapshot stays
+      // stale until restart (e.g. the Display:TimeFormat clock format wouldn't
+      // repaint live on the topbar / sleep screen).
+      await BroadcastConfigChangedAsync(section);
+
       return Ok(new { message = "Configuration updated successfully", section });
     }
     catch (Exception ex)
@@ -551,6 +563,9 @@ public class ConfigurationController : ControllerBase
           "Configuration updated successfully: {Section}:{Key}",
           request.Section, request.Key);
 
+        // Cross-process hot-reload bridge (see BroadcastConfigChangedAsync).
+        await BroadcastConfigChangedAsync(request.Section);
+
         return Ok(new
         {
           message = "Configuration updated successfully",
@@ -574,6 +589,27 @@ public class ConfigurationController : ControllerBase
     {
       _logger.LogError(ex, "Error updating configuration");
       return StatusCode(500, new { error = "Failed to update configuration" });
+    }
+  }
+
+  /// <summary>
+  /// Notifies connected clients — notably radio-web, which runs as a SEPARATE
+  /// process — that a configuration section changed, so they can reload their
+  /// SQLite-backed IConfiguration / IOptionsMonitor snapshot. The in-process
+  /// ConfigStoreChangeNotifier only fires change tokens within this process, so
+  /// this SignalR fan-out is the cross-process bridge (radio-web subscribes in
+  /// AudioStateHubService and calls its own NotifyReload on receipt). Best-effort:
+  /// a broadcast failure is logged but never fails the configuration write.
+  /// </summary>
+  private async Task BroadcastConfigChangedAsync(string section)
+  {
+    try
+    {
+      await _hubContext.Clients.All.SendAsync("ConfigChanged", section);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "Failed to broadcast ConfigChanged for section {Section}", section);
     }
   }
 

--- a/src/Radio.Web/Components/Shared/SleepForecastPane.razor
+++ b/src/Radio.Web/Components/Shared/SleepForecastPane.razor
@@ -216,9 +216,14 @@
 
   protected override void OnParametersSet()
   {
-    // Compose the sub-line. Fresh data: "<City> · <Day> <Time>". Stale data
-    // (>12h old) prepends a relative qualifier per the v1 stale rules —
-    // "<City> · yesterday at HH:mm" or "<City> · N days ago at HH:mm".
+    // Compose the sub-line as a DATA-FRESHNESS stamp ("<City> · as of <time>"),
+    // NOT a live clock — the alternating clock pane already carries the current
+    // time. `clockString` is Forecast.GeneratedAtUtc (when the NWS data was
+    // pulled); the explicit "as of" prefix labels it so the fetch time can't be
+    // misread as the current time. Matches the design mockup
+    // (HANDOFF-sleep-mode-weather-forecast.md §2: "· as of 3:00 PM", stale
+    // "· as of 1:00 PM yesterday"). DateTime.Now is used ONLY to bucket the
+    // freshness qualifier (hoursOld) — never to build the displayed time.
     var localGenerated = Forecast.GeneratedAtUtc.LocalDateTime;
     var hoursOld = (DateTime.Now - localGenerated).TotalHours;
     var clockString = FormatClock?.Invoke(localGenerated)
@@ -227,20 +232,16 @@
 
     if (hoursOld < 12)
     {
-      // Use today's full weekday name for the sub-line. The forecast cards
-      // still use 3-letter abbreviations (DayName from the API) because
-      // horizontal width matters there — the sub-line has its own slot.
-      var dayName = DateTime.Now.ToString("dddd", CultureInfo.InvariantCulture);
-      _subLineText = $"{locationDisplay} · {dayName} {clockString}";
+      _subLineText = $"{locationDisplay} · as of {clockString}";
     }
     else if (hoursOld < 36)
     {
-      _subLineText = $"{locationDisplay} · yesterday at {clockString}";
+      _subLineText = $"{locationDisplay} · as of {clockString} yesterday";
     }
     else
     {
       var daysOld = (int)Math.Floor(hoursOld / 24.0);
-      _subLineText = $"{locationDisplay} · {daysOld} days ago at {clockString}";
+      _subLineText = $"{locationDisplay} · as of {clockString} {daysOld} days ago";
     }
 
     // Aria-live label — single sentence the screen reader can read end-to-end.

--- a/src/Radio.Web/Services/Hub/AudioStateHubService.cs
+++ b/src/Radio.Web/Services/Hub/AudioStateHubService.cs
@@ -1,6 +1,7 @@
 using System.Net.Sockets;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
+using Radio.Configuration.Bridge;
 using Radio.Web.Models;
 
 namespace Radio.Web.Services.Hub;
@@ -15,6 +16,12 @@ public class AudioStateHubService : IAsyncDisposable
 {
   private readonly ILogger<AudioStateHubService> _logger;
   private readonly IConfiguration _configuration;
+  // Web-process instance of the SQLite-config reload notifier. Calling
+  // NotifyReload() forces this process's SqliteConfigurationProvider to re-read
+  // the shared config DB — the cross-process half of the ConfigChanged bridge.
+  // Optional so the ~9 test fixtures that new this service up directly keep
+  // compiling; production always injects the registered singleton.
+  private readonly ConfigStoreChangeNotifier? _configStoreNotifier;
   private HubConnection? _hubConnection;
   private bool _isDisposed;
   private readonly SemaphoreSlim _connectionLock = new(1, 1);
@@ -42,6 +49,10 @@ public class AudioStateHubService : IAsyncDisposable
   public event Func<Task>? VisualizationModeChanged;
   public event Func<Task>? EncoderConnectionChanged;
   public event Func<bool, Task>? SleepStateChanged;
+  // Fired after a cross-process ConfigChanged push has reloaded this process's
+  // config snapshot. Optional for subscribers that want an immediate re-render;
+  // the topbar / sleep clocks don't need it (their 1 s timers repaint anyway).
+  public event Func<Task>? ConfigChanged;
 
   // Throttle disconnect log messages to avoid spam when API is down
   private static DateTime _lastDisconnectLogUtc = DateTime.MinValue;
@@ -50,10 +61,14 @@ public class AudioStateHubService : IAsyncDisposable
   public bool IsConnected => _hubConnection?.State == HubConnectionState.Connected;
   public HubConnectionState ConnectionState => _hubConnection?.State ?? HubConnectionState.Disconnected;
 
-  public AudioStateHubService(ILogger<AudioStateHubService> logger, IConfiguration configuration)
+  public AudioStateHubService(
+    ILogger<AudioStateHubService> logger,
+    IConfiguration configuration,
+    ConfigStoreChangeNotifier? configStoreNotifier = null)
   {
     _logger = logger;
     _configuration = configuration;
+    _configStoreNotifier = configStoreNotifier;
   }
 
   public async Task StartAsync(CancellationToken cancellationToken = default)
@@ -209,6 +224,23 @@ public class AudioStateHubService : IAsyncDisposable
         if (SleepStateChanged != null)
         {
           await SleepStateChanged.Invoke(isSleeping);
+        }
+      });
+
+      // Server sends ConfigChanged (section name) when a config write lands in the
+      // API process. radio-web is a SEPARATE process, so the in-process
+      // ConfigStoreChangeNotifier never fired here — trigger it now so the
+      // SQLite-backed IOptionsMonitor snapshots (e.g. DisplayOptions.TimeFormat)
+      // re-read the shared store and the topbar / sleep clocks repaint on their
+      // next 1 s tick. See ConfigurationController.BroadcastConfigChangedAsync.
+      _hubConnection.On<string>("ConfigChanged", async (section) =>
+      {
+        _logger.LogDebug("Received ConfigChanged event for section {Section}", section);
+        _configStoreNotifier?.NotifyReload();
+        var handler = ConfigChanged;
+        if (handler != null)
+        {
+          await handler.Invoke();
         }
       });
 

--- a/tests/Radio.Web.Tests/Components/Shared/SleepForecastPaneCurrentObservationTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/SleepForecastPaneCurrentObservationTests.cs
@@ -212,7 +212,8 @@ public class SleepForecastPaneCurrentObservationTests : TestContext
     // qualifier should appear in the sub-line — they cover orthogonal
     // failure modes (forecast freshness vs. observation availability).
     var subline = cut.Find(".sleep-forecast-subline");
-    subline.TextContent.Should().Contain("yesterday at");
+    subline.TextContent.Should().Contain("as of");
+    subline.TextContent.Should().Contain("yesterday");
     cut.Find(".sleep-forecast-subline-fallback").TextContent.Should().Contain("forecast only");
   }
 

--- a/tests/Radio.Web.Tests/Components/Shared/SleepForecastPaneTests.cs
+++ b/tests/Radio.Web.Tests/Components/Shared/SleepForecastPaneTests.cs
@@ -36,7 +36,7 @@ public class SleepForecastPaneTests : TestContext
   /// reference-image data (60/77/66, "Partly Sunny") so the assertions stay
   /// easy to read.
   /// </summary>
-  private static WeatherForecast BuildForecast(int dayCount, bool isStale = false)
+  private static WeatherForecast BuildForecast(int dayCount, bool isStale = false, DateTime? generatedAtUtc = null)
   {
     var days = new List<WeatherDay>
     {
@@ -51,9 +51,10 @@ public class SleepForecastPaneTests : TestContext
     return new WeatherForecast(
       Zip: "27312",
       LocationName: "Pittsboro, NC",
-      // Fresh: 1 hour old; Stale: 25 hours old so the "yesterday at HH:mm"
-      // sub-line branch fires.
-      GeneratedAtUtc: DateTime.UtcNow.AddHours(isStale ? -25 : -1),
+      // Fresh: 1 hour old; Stale: 25 hours old so the "as of … yesterday"
+      // sub-line branch fires. Callers can pin an explicit timestamp to make
+      // time-of-day assertions deterministic.
+      GeneratedAtUtc: generatedAtUtc ?? DateTime.UtcNow.AddHours(isStale ? -25 : -1),
       FetchedAtUtc: DateTime.UtcNow.AddMinutes(-1),
       IsStale: isStale,
       Days: days.Take(dayCount).ToList(),
@@ -233,7 +234,7 @@ public class SleepForecastPaneTests : TestContext
   // ── Sub-line contract ───────────────────────────────────────────────────
 
   [Fact]
-  public void Pane_SubLine_RendersWithLocationDayAndTime_WhenFresh()
+  public void Pane_SubLine_RendersLocationAndAsOfStamp_WhenFresh()
   {
     var cut = RenderComponent<SleepForecastPane>(p => p
       .Add(x => x.Forecast, BuildForecast(3))
@@ -250,23 +251,38 @@ public class SleepForecastPaneTests : TestContext
     // The middle-dot separator is rendered as a literal "·" inside the
     // text node — verifies the format string is wired correctly.
     text.Should().Contain("·");
+
+    // Fresh data reads as an "as of <time>" freshness stamp.
+    text.Should().Contain("as of");
   }
 
   [Fact]
-  public void Pane_SubLine_RendersFullWeekdayName_NotAbbreviation()
+  public void Pane_SubLine_RendersAsOfFreshnessStamp_NotCurrentWeekday()
   {
-    // Spec §3: the sub-line uses the full weekday name ("Sunday") rather
-    // than the 3-letter abbreviation; abbreviations live only in the
-    // forecast cards. Compute the expected weekday for "today" so the test
-    // doesn't drift over time.
-    var expectedDay = DateTime.Now.ToString("dddd",
+    // Bug fix: the fresh sub-line is a DATA-FRESHNESS stamp ("as of <fetch
+    // time>"), not a live clock. It must show the forecast's generation time,
+    // explicitly labeled "as of", and must NOT show the current weekday — the
+    // old code glued today's DateTime.Now weekday onto the generation time,
+    // which read like a (wrong) wall clock. Pin GeneratedAtUtc so the
+    // time-of-day assertion is deterministic.
+    var generatedUtc = DateTime.UtcNow.AddHours(-1);
+    var expectedTime = generatedUtc.ToLocalTime().ToString("HH:mm",
       System.Globalization.CultureInfo.InvariantCulture);
 
     var cut = RenderComponent<SleepForecastPane>(p => p
-      .Add(x => x.Forecast, BuildForecast(3))
+      .Add(x => x.Forecast, BuildForecast(3, generatedAtUtc: generatedUtc))
       .Add(x => x.TemperatureUnit, "F"));
 
-    cut.Find(".sleep-forecast-subline").TextContent.Should().Contain(expectedDay);
+    var text = cut.Find(".sleep-forecast-subline").TextContent;
+    text.Should().Contain("as of");
+    text.Should().Contain(expectedTime,
+      "the sub-line shows the forecast's generation time, labeled 'as of'");
+
+    var currentWeekday = DateTime.Now.ToString("dddd",
+      System.Globalization.CultureInfo.InvariantCulture);
+    text.Should().NotContain(currentWeekday,
+      "the fresh sub-line must not show the current weekday — that made the "
+      + "forecast-generation time masquerade as a (wrong) live clock");
   }
 
   // ── Stale state contract ────────────────────────────────────────────────
@@ -294,10 +310,11 @@ public class SleepForecastPaneTests : TestContext
       .Add(x => x.Forecast, BuildForecast(3, isStale: true))
       .Add(x => x.TemperatureUnit, "F"));
 
-    // 25h-old forecast (BuildForecast stale path) — sub-line prepends
-    // "yesterday at HH:mm" per spec §3 State B.
+    // 25h-old forecast (BuildForecast stale path) — sub-line reads
+    // "as of HH:mm yesterday" per the design mockup (§2 State C).
     var subline = cut.Find(".sleep-forecast-subline");
-    subline.TextContent.Should().Contain("yesterday at");
+    subline.TextContent.Should().Contain("as of");
+    subline.TextContent.Should().Contain("yesterday");
   }
 
   [Fact]


### PR DESCRIPTION
## Summary
Fixes two sleep/clock time-display bugs reported from the kiosk, plus a small MCP-config dedup.

### Bug 1 — sleep weather sub-line showed a fake clock
The forecast pane's sub-line glued today's weekday (`DateTime.Now`) onto the forecast's *generation* time (`Forecast.GeneratedAtUtc`), rendering e.g. `Pittsboro · Saturday 06:08` — which read as a (wrong) current clock. Restored the design's data-freshness stamp (HANDOFF-sleep-mode-weather-forecast §2): now `Pittsboro · as of 6:08 AM`, with the fetch time explicitly labeled "as of" so it can't be mistaken for the wall clock. Stale branches read `as of <time> yesterday` / `… N days ago`.

### Bug 2 — time-format toggle didn't update the live display
`Display:TimeFormat` writes land in radio-api, but `ConfigStoreChangeNotifier` only fires `IOptionsMonitor` change tokens in-process, so radio-web's snapshot stayed stale until restart (documented caveat in `Radio.Web/Program.cs`). Bridged it over the existing SignalR channel: `ConfigurationController` broadcasts `ConfigChanged` after a write; `AudioStateHubService` receives it and calls the web process's `NotifyReload()`, so the topbar/sleep clocks repaint within ~1s. Mirrors the existing `SleepStateChanged` push. (Notifier is an optional ctor arg so existing hub-service test fixtures keep compiling.)

### Chore — drop duplicate playwright MCP server from `.mcp.json`
Removed the redundant project `playwright` stdio entry that duplicated `plugin:playwright:playwright`.

## Test plan
- Release build: 0 errors.
- Unit: Radio.Web.Tests **661/661**, Radio.API.Tests **318/318**. New "as of" sub-line assertions; stale-qualifier + current-observation tests updated.
- Automated UAT (local, two-process shared config DB, Playwright):
  - **Bug 2:** topbar flipped 24h→12h **live** (~4s, no reload), confirmed by matched API-write / Web-receive `ConfigChanged` log timestamps.
  - **Bug 1:** sleep sub-line rendered `Pittsboro · as of 10:39` (no fake weekday clock).
- On-device verification pending on the radio console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)