### PR TITLE
feat(web): phone Diagnostics tab — live GV audio-bridge / SIP / timeline panel

### DIFF
--- a/src/Radio.Web/Components/Pages/PhoneDiagnosticsPanel.razor
+++ b/src/Radio.Web/Components/Pages/PhoneDiagnosticsPanel.razor
@@ -1,0 +1,199 @@
+@using Radio.Web.Models
+@using Radio.Web.Services.ApiClients
+@inject DiagnosticsApiService DiagnosticsApi
+@inject GvBridgeApiService GvBridgeApi
+@implements IDisposable
+
+@*
+  Call-audio diagnostics panel (Diagnostics tab on /phone). Read-only view of
+  RotaryPhone's /api/diagnostics/* over the existing phone API link — consume-only
+  per the BT/audio boundary; no RotaryPhone changes. Built to watch a live GV call's
+  media flow while debugging "no call audio": is the audio bridge active, are RTP
+  frames moving in each direction, and the SIP INVITE→Ringing→Answer→BYE sequence.
+
+  Self-polls every 2s while mounted. The panel only renders when the Diagnostics tab
+  is active (PhonePage swaps the @if), so polling starts on tab-open and stops on
+  tab-change / navigate-away via Dispose — no load on the rest of the phone page.
+*@
+
+<style>
+  .phone-diagnostics-panel { padding: 16px 20px; height: 100%; overflow-y: auto; color: var(--text-high, #F0EFF4); }
+  .phone-diag-heading { display: flex; align-items: center; gap: 8px; font-size: 1.05rem; font-weight: 600; margin-bottom: 14px; }
+  .phone-diag-heading .phone-diag-status { font-size: 0.78rem; color: var(--text-low, #8A8895); font-weight: 400; }
+  .phone-diag-card { background: var(--surface-raised, #161620); border: 1px solid var(--border-subtle, #2A2A38); border-radius: 10px; padding: 12px 14px; margin-bottom: 12px; }
+  .phone-diag-card-title { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-low, #8A8895); margin-bottom: 10px; }
+  .phone-diag-bridge-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+  .phone-diag-metric { display: flex; flex-direction: column; gap: 3px; }
+  .phone-diag-metric-label { font-size: 0.72rem; color: var(--text-low, #8A8895); }
+  .phone-diag-metric-value { font-family: var(--font-mono, monospace); font-size: 1.15rem; }
+  .phone-diag-metric-value.is-warn { color: var(--signal-red, #E8635C); }
+  .phone-diag-badge { display: inline-block; padding: 2px 9px; border-radius: 6px; font-size: 0.78rem; font-weight: 600; background: var(--border-subtle, #2A2A38); color: var(--text-low, #8A8895); width: fit-content; }
+  .phone-diag-badge.is-on { background: color-mix(in srgb, var(--signal-amber, #5CD4E8) 28%, transparent); color: var(--signal-amber, #5CD4E8); }
+  .phone-diag-table { width: 100%; border-collapse: collapse; font-size: 0.78rem; font-family: var(--font-mono, monospace); }
+  .phone-diag-table th { text-align: left; color: var(--text-low, #8A8895); font-weight: 500; padding: 3px 6px; border-bottom: 1px solid var(--border-subtle, #2A2A38); }
+  .phone-diag-table td { padding: 3px 6px; border-bottom: 1px solid color-mix(in srgb, var(--border-subtle, #2A2A38) 50%, transparent); white-space: nowrap; }
+  .phone-diag-peer { color: var(--text-low, #8A8895); }
+  .phone-diag-empty { color: var(--text-low, #8A8895); font-size: 0.85rem; font-style: italic; }
+  .phone-diag-timeline { list-style: none; margin: 0; padding: 0; font-size: 0.8rem; }
+  .phone-diag-timeline li { display: flex; gap: 10px; padding: 3px 0; }
+  .phone-diag-timeline .phone-diag-time { font-family: var(--font-mono, monospace); color: var(--text-low, #8A8895); }
+  .phone-diag-timeline .phone-diag-event { font-weight: 600; min-width: 96px; }
+</style>
+
+<div class="phone-diagnostics-panel">
+  <div class="phone-diag-heading">
+    <RadzenIcon Icon="monitor_heart" />
+    <span>Call Audio Diagnostics</span>
+    <span class="phone-diag-status">@(_lastError ? "· RotaryPhone API unreachable" : $"· updated {_lastUpdated:HH:mm:ss}")</span>
+  </div>
+
+  @* GV audio-bridge live card — the key "is media flowing" view. *@
+  <div class="phone-diag-card">
+    <div class="phone-diag-card-title">GV Audio Bridge</div>
+    @if (_audio is null)
+    {
+      <div class="phone-diag-empty">No data — RotaryPhone API unreachable.</div>
+    }
+    else
+    {
+      <div class="phone-diag-bridge-grid">
+        <div class="phone-diag-metric">
+          <span class="phone-diag-metric-label">Bridge</span>
+          <span class="phone-diag-badge @(_audio.IsActive ? "is-on" : "is-off")">@(_audio.IsActive ? "ACTIVE" : "inactive")</span>
+        </div>
+        <div class="phone-diag-metric">
+          <span class="phone-diag-metric-label">Audio</span>
+          <span class="phone-diag-badge @(_audio.BidirectionalAudio ? "is-on" : "is-off")">@(_audio.BidirectionalAudio ? "2-way" : "none")</span>
+        </div>
+        <div class="phone-diag-metric">
+          <span class="phone-diag-metric-label">errors</span>
+          <span class="phone-diag-metric-value @((_audio.InboundErrors + _audio.OutboundErrors) > 0 ? "is-warn" : "")">@(_audio.InboundErrors + _audio.OutboundErrors)</span>
+        </div>
+        <div class="phone-diag-metric">
+          <span class="phone-diag-metric-label">→ phone (in frames)</span>
+          <span class="phone-diag-metric-value">@_audio.InboundFramesSent</span>
+        </div>
+        <div class="phone-diag-metric">
+          <span class="phone-diag-metric-label">← phone (out frames)</span>
+          <span class="phone-diag-metric-value">@_audio.OutboundFramesReceived</span>
+        </div>
+        <div class="phone-diag-metric">
+          <span class="phone-diag-metric-label">mode</span>
+          <span class="phone-diag-metric-value" style="font-size:0.9rem;">@(_gvMode ?? "—")</span>
+        </div>
+      </div>
+    }
+  </div>
+
+  @* SIP message log — INVITE / Trying / Ringing / OK / BYE with status codes. *@
+  <div class="phone-diag-card">
+    <div class="phone-diag-card-title">SIP Log</div>
+    @if (_sipLog.Count == 0)
+    {
+      <div class="phone-diag-empty">No SIP messages yet.</div>
+    }
+    else
+    {
+      <table class="phone-diag-table">
+        <thead>
+          <tr><th>Time</th><th>Dir</th><th>Method</th><th>Status</th><th>Peer</th></tr>
+        </thead>
+        <tbody>
+          @foreach (var m in Newest(_sipLog))
+          {
+            <tr>
+              <td>@m.Timestamp.ToLocalTime().ToString("HH:mm:ss")</td>
+              <td>@(m.Direction == 0 ? "→" : "←")</td>
+              <td>@m.Method</td>
+              <td>@(m.StatusCode is null ? "" : $"{m.StatusCode} {m.StatusText}")</td>
+              <td class="phone-diag-peer">@(m.Direction == 0 ? m.ToAddress : m.FromAddress)</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    }
+  </div>
+
+  @* Call timeline — semantic events (REGISTER / INVITE_SENT / RINGING / ANSWERED / ENDED). *@
+  <div class="phone-diag-card">
+    <div class="phone-diag-card-title">Call Timeline</div>
+    @if (_timeline.Count == 0)
+    {
+      <div class="phone-diag-empty">No timeline events yet.</div>
+    }
+    else
+    {
+      <ul class="phone-diag-timeline">
+        @foreach (var e in Newest(_timeline))
+        {
+          <li>
+            <span class="phone-diag-time">@e.Timestamp.ToLocalTime().ToString("HH:mm:ss")</span>
+            <span class="phone-diag-event">@e.EventType</span>
+            <span class="phone-diag-desc">@e.Description</span>
+          </li>
+        }
+      </ul>
+    }
+  </div>
+</div>
+
+@code {
+  private AudioBridgeStatsDto? _audio;
+  private List<SipMessageDto> _sipLog = [];
+  private List<CallTimelineDto> _timeline = [];
+  private string? _gvMode;
+  private DateTime _lastUpdated;
+  private bool _lastError;
+  private System.Timers.Timer? _timer;
+  private bool _disposed;
+
+  // Cap the rendered rows so a long-running session's ring buffer doesn't blow
+  // up the DOM; newest-first for at-a-glance reading.
+  private static IEnumerable<T> Newest<T>(List<T> source)
+    => Enumerable.Reverse(source).Take(20);
+
+  protected override async Task OnInitializedAsync()
+  {
+    // Active call path (GVApi / BluetoothHfp / SipTrunk) — stable during a session,
+    // fetched once so the 2s poll loop stays light.
+    _gvMode = (await GvBridgeApi.GetStatusAsync())?.ActiveMode;
+    await RefreshAsync();
+    _timer = new System.Timers.Timer(2000) { AutoReset = true };
+    _timer.Elapsed += OnTick;
+    _timer.Start();
+  }
+
+  private void OnTick(object? sender, System.Timers.ElapsedEventArgs e)
+    => _ = InvokeAsync(RefreshAsync);
+
+  private async Task RefreshAsync()
+  {
+    if (_disposed) return;
+    try
+    {
+      var audioTask = DiagnosticsApi.GetAudioBridgeAsync();
+      var sipTask = DiagnosticsApi.GetSipLogAsync(30);
+      var timelineTask = DiagnosticsApi.GetTimelineAsync(30);
+      await Task.WhenAll(audioTask, sipTask, timelineTask);
+
+      _audio = audioTask.Result;
+      _sipLog = sipTask.Result;
+      _timeline = timelineTask.Result;
+      _lastError = _audio is null && _sipLog.Count == 0 && _timeline.Count == 0;
+      _lastUpdated = DateTime.Now;
+      StateHasChanged();
+    }
+    catch (ObjectDisposedException) { /* component torn down mid-poll */ }
+  }
+
+  public void Dispose()
+  {
+    _disposed = true;
+    if (_timer is not null)
+    {
+      _timer.Elapsed -= OnTick;
+      _timer.Stop();
+      _timer.Dispose();
+    }
+  }
+}

--- a/src/Radio.Web/Components/Pages/PhonePage.razor
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor
@@ -29,6 +29,11 @@
       <RadzenIcon Icon="history" />
       <span class="phone-rail-label">Call History</span>
     </button>
+    <button type="button" class="phone-rail-tab @(IsTab("diagnostics") ? "active" : "")"
+            @onclick='@(() => _activeTab = "diagnostics")'>
+      <RadzenIcon Icon="monitor_heart" />
+      <span class="phone-rail-label">Diagnostics</span>
+    </button>
   </div>
 
   <div style="overflow: hidden; min-height: 0;">
@@ -70,6 +75,10 @@
     {
       <PhoneHistoryPanel CallHistory="_callHistory"
                          OnClearHistory="ClearCallHistoryAsync" />
+    }
+    else if (_activeTab == "diagnostics")
+    {
+      <PhoneDiagnosticsPanel />
     }
   </div>
 </div>

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -1085,6 +1085,44 @@ public class GvModeEntryDto
   public string Mode { get; set; } = "";
 }
 
+// ── Diagnostics (RotaryPhone /api/diagnostics/*) — consumed read-only by
+// PhoneDiagnosticsPanel over the existing phone API link (consume-only per the
+// BT/audio boundary). Shapes verified against live responses 2026-06-13.
+
+/// <summary>Live GV audio-bridge stats from <c>/api/diagnostics/audio-bridge</c>.</summary>
+public class AudioBridgeStatsDto
+{
+  public bool IsActive { get; set; }
+  public int InboundFramesSent { get; set; }
+  public int OutboundFramesReceived { get; set; }
+  public int InboundErrors { get; set; }
+  public int OutboundErrors { get; set; }
+  public bool BidirectionalAudio { get; set; }
+}
+
+/// <summary>One SIP message from <c>/api/diagnostics/sip-log</c>. <c>Direction</c>: 0 = Sent, 1 = Received.</summary>
+public class SipMessageDto
+{
+  public DateTime Timestamp { get; set; }
+  public int Direction { get; set; }
+  public string Method { get; set; } = "";
+  public string? FromAddress { get; set; }
+  public string? ToAddress { get; set; }
+  public int? StatusCode { get; set; }
+  public string? StatusText { get; set; }
+  public string? DiagnosticNote { get; set; }
+  public string? CallId { get; set; }
+}
+
+/// <summary>One call-timeline event from <c>/api/diagnostics/timeline</c>.</summary>
+public class CallTimelineDto
+{
+  public DateTime Timestamp { get; set; }
+  public string EventType { get; set; } = "";
+  public string Description { get; set; } = "";
+  public Dictionary<string, string>? Metadata { get; set; }
+}
+
 public class GvSmsNotificationDto
 {
   public string FromNumber { get; set; } = "";

--- a/src/Radio.Web/Program.cs
+++ b/src/Radio.Web/Program.cs
@@ -350,6 +350,20 @@ builder.Services.AddHttpClient<GvTrunkApiService>(client =>
   return handler;
 });
 
+// Diagnostics API client (same RotaryPhone service) — consumed by PhoneDiagnosticsPanel
+builder.Services.AddHttpClient<DiagnosticsApiService>(client =>
+{
+  client.BaseAddress = new Uri(phoneApiBaseUrl);
+  client.Timeout = TimeSpan.FromSeconds(10);
+})
+.AddHttpMessageHandler<ApiConnectionLoggingHandler>()
+.ConfigurePrimaryHttpMessageHandler(() =>
+{
+  var handler = new HttpClientHandler();
+  ConfigureHttpClientHandler(handler);
+  return handler;
+});
+
 // Register SignalR hub services as singletons (Phase 1 Task 1.3, Phase 10)
 builder.Services.AddSingleton<AudioStateHubService>();
 builder.Services.AddSingleton<AudioVisualizationHubService>();

--- a/src/Radio.Web/Services/ApiClients/DiagnosticsApiService.cs
+++ b/src/Radio.Web/Services/ApiClients/DiagnosticsApiService.cs
@@ -1,0 +1,75 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Radio.Web.Models;
+
+namespace Radio.Web.Services.ApiClients;
+
+/// <summary>
+/// HTTP client for RotaryPhone.API diagnostics endpoints (<c>/api/diagnostics/*</c>).
+/// Read-only consumption per the BT/audio boundary (RotaryPhone is consume-only from
+/// Radio.Web) — surfaces the GV audio-bridge stats, the SIP message log, and the call
+/// timeline for <c>PhoneDiagnosticsPanel</c> so an operator can watch a call's media
+/// flow live while debugging "no call audio".
+/// Failures are logged at Debug (this is polled ~2s while the Diagnostics tab is open;
+/// the shared <c>ApiConnectionLoggingHandler</c> already throttles connection-refused).
+/// </summary>
+public class DiagnosticsApiService
+{
+  private readonly HttpClient _httpClient;
+  private readonly ILogger<DiagnosticsApiService> _logger;
+  private static readonly JsonSerializerOptions JsonOptions = new()
+  {
+    PropertyNameCaseInsensitive = true
+  };
+
+  public DiagnosticsApiService(HttpClient httpClient, ILogger<DiagnosticsApiService> logger)
+  {
+    _httpClient = httpClient;
+    _logger = logger;
+  }
+
+  /// <summary>Live GV audio-bridge stats. <c>null</c> when the API is unreachable.</summary>
+  public async Task<AudioBridgeStatsDto?> GetAudioBridgeAsync(CancellationToken ct = default)
+  {
+    try
+    {
+      return await _httpClient.GetFromJsonAsync<AudioBridgeStatsDto>(
+        "/api/diagnostics/audio-bridge", JsonOptions, ct);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Failed to get audio-bridge diagnostics");
+      return null;
+    }
+  }
+
+  /// <summary>Recent SIP messages (newest last). Empty list on failure.</summary>
+  public async Task<List<SipMessageDto>> GetSipLogAsync(int count = 30, CancellationToken ct = default)
+  {
+    try
+    {
+      return await _httpClient.GetFromJsonAsync<List<SipMessageDto>>(
+        $"/api/diagnostics/sip-log?count={count}", JsonOptions, ct) ?? [];
+    }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Failed to get SIP log");
+      return [];
+    }
+  }
+
+  /// <summary>Recent call-timeline events (newest last). Empty list on failure.</summary>
+  public async Task<List<CallTimelineDto>> GetTimelineAsync(int count = 30, CancellationToken ct = default)
+  {
+    try
+    {
+      return await _httpClient.GetFromJsonAsync<List<CallTimelineDto>>(
+        $"/api/diagnostics/timeline?count={count}", JsonOptions, ct) ?? [];
+    }
+    catch (Exception ex)
+    {
+      _logger.LogDebug(ex, "Failed to get call timeline");
+      return [];
+    }
+  }
+}

--- a/tests/Radio.Web.Tests/Services/DiagnosticsApiServiceTests.cs
+++ b/tests/Radio.Web.Tests/Services/DiagnosticsApiServiceTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Radio.Web.Services.ApiClients;
+using Xunit;
+
+namespace Radio.Web.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="DiagnosticsApiService"/> — pins deserialization against the
+/// exact JSON shapes RotaryPhone's /api/diagnostics/* endpoints return (captured live
+/// 2026-06-13) and the graceful-degradation behaviour when the API is unreachable.
+/// </summary>
+public class DiagnosticsApiServiceTests
+{
+  private sealed class StubHandler(string json, HttpStatusCode status) : HttpMessageHandler
+  {
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+      => Task.FromResult(new HttpResponseMessage(status)
+      {
+        Content = new StringContent(json, Encoding.UTF8, "application/json")
+      });
+  }
+
+  private static DiagnosticsApiService Make(string json, HttpStatusCode status = HttpStatusCode.OK)
+  {
+    var http = new HttpClient(new StubHandler(json, status)) { BaseAddress = new Uri("http://radio:5004") };
+    return new DiagnosticsApiService(http, NullLogger<DiagnosticsApiService>.Instance);
+  }
+
+  [Fact]
+  public async Task GetAudioBridge_DeserializesLiveShape()
+  {
+    var svc = Make("""{"isActive":true,"inboundFramesSent":120,"outboundFramesReceived":118,"inboundErrors":0,"outboundErrors":2,"bidirectionalAudio":true}""");
+
+    var dto = await svc.GetAudioBridgeAsync();
+
+    dto.Should().NotBeNull();
+    dto!.IsActive.Should().BeTrue();
+    dto.InboundFramesSent.Should().Be(120);
+    dto.OutboundFramesReceived.Should().Be(118);
+    dto.OutboundErrors.Should().Be(2);
+    dto.BidirectionalAudio.Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task GetSipLog_DeserializesDirectionAndStatus()
+  {
+    var svc = Make("""[{"timestamp":"2026-06-13T15:17:55.11Z","direction":1,"method":"INVITE","fromAddress":"udp:192.168.86.22:5060","toAddress":"udp:0.0.0.0:5060","statusCode":180,"statusText":"Ringing","diagnosticNote":null,"callId":"abc"}]""");
+
+    var log = await svc.GetSipLogAsync(10);
+
+    log.Should().HaveCount(1);
+    log[0].Direction.Should().Be(1);
+    log[0].Method.Should().Be("INVITE");
+    log[0].StatusCode.Should().Be(180);
+    log[0].StatusText.Should().Be("Ringing");
+  }
+
+  [Fact]
+  public async Task GetTimeline_DeserializesEventAndMetadata()
+  {
+    var svc = Make("""[{"timestamp":"2026-06-13T15:17:55.10Z","eventType":"INVITE_SENT","description":"INVITE sent","metadata":{"callId":"abc"}}]""");
+
+    var tl = await svc.GetTimelineAsync(10);
+
+    tl.Should().HaveCount(1);
+    tl[0].EventType.Should().Be("INVITE_SENT");
+    tl[0].Metadata.Should().ContainKey("callId");
+  }
+
+  [Fact]
+  public async Task GetAudioBridge_ReturnsNull_OnError()
+  {
+    var svc = Make("error", HttpStatusCode.InternalServerError);
+    (await svc.GetAudioBridgeAsync()).Should().BeNull();
+  }
+
+  [Fact]
+  public async Task GetSipLog_ReturnsEmpty_OnError()
+  {
+    var svc = Make("error", HttpStatusCode.InternalServerError);
+    (await svc.GetSipLogAsync()).Should().BeEmpty();
+  }
+}


### PR DESCRIPTION
## Summary
Adds a read-only **Diagnostics** tab to `/phone` that consumes RotaryPhone's `/api/diagnostics/*` (audio-bridge stats, SIP log, call timeline) over the existing phone API link — consume-only per the BT/audio boundary, **no RotaryPhone changes**. Built to watch a live GV call's media flow while debugging call audio.

- `DiagnosticsApiService` (typed HttpClient, mirrors `GvBridgeApiService`) + `AudioBridgeStatsDto` / `SipMessageDto` / `CallTimelineDto` (shapes verified against live responses).
- `PhoneDiagnosticsPanel.razor` + Diagnostics tab on `PhonePage`. Self-polls every 2s while the tab is open; stops on tab-change/dispose.
- `DiagnosticsApiServiceTests` (5) pinning deserialization + offline degradation.

## Test plan
- Release build clean; **Radio.Web.Tests 666/666** (5 new).
- **Automated UAT** (local stack + live `radio:5004`): all three cards render with real data matching the upstream endpoints field-for-field; live 2s polling confirmed (advancing "updated" stamp, poll restarts on tab re-mount); **0 console errors**; Dashboard/Contacts/History tabs unaffected. SIP log shows the full `INVITE→100→180→200→BYE` sequence and the bridge frame counters show media has flowed (call-audio resolved on the RotaryPhone side).

## Out of scope (pre-existing, surfaced by UAT — not this branch)
- **Call History** tab silently empties due to a JSON mismatch in `PhoneApiService.cs:187` (`direction` returned as number, `CallHistoryDto` expects string). Untouched by this branch — separate follow-up.
- Minor Diagnostics-tab layout whitespace on the 1920×720 kiosk — Polisher/Designer note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)