### PR TITLE
fix(web): deserialize phone call-history direction/answeredOn as int-backed enums

### DIFF
--- a/src/Radio.Web/Components/Pages/PhoneHistoryPanel.razor
+++ b/src/Radio.Web/Components/Pages/PhoneHistoryPanel.razor
@@ -24,10 +24,10 @@
             <span class="phone-number">@entry.PhoneNumber</span>
             <span class="history-time">@entry.StartTime.ToLocalTime().ToString("g")</span>
           </div>
-          @if (entry.AnsweredOn != null)
+          @if (entry.AnsweredOn != CallAnsweredOn.NotAnswered)
           {
-            <RadzenBadge Text="@entry.AnsweredOn"
-              BadgeStyle="@(entry.AnsweredOn == "RotaryPhone" ? BadgeStyle.Info : BadgeStyle.Light)" />
+            <RadzenBadge Text="@entry.AnsweredOn.ToString()"
+              BadgeStyle="@(entry.AnsweredOn == CallAnsweredOn.RotaryPhone ? BadgeStyle.Info : BadgeStyle.Light)" />
           }
           @if (entry.Duration != null)
           {
@@ -45,17 +45,17 @@
 
   private static string GetCallDirectionIcon(CallHistoryEntryDto entry) => entry.Direction switch
   {
-    "Incoming" when entry.AnsweredOn != null => "call_received",
-    "Incoming" => "call_missed",
-    "Outgoing" => "call_made",
+    CallDirection.Incoming when entry.AnsweredOn != CallAnsweredOn.NotAnswered => "call_received",
+    CallDirection.Incoming => "call_missed",
+    CallDirection.Outgoing => "call_made",
     _ => "phone"
   };
 
   private static string GetCallDirectionColor(CallHistoryEntryDto entry) => entry.Direction switch
   {
-    "Incoming" when entry.AnsweredOn != null => "var(--rz-success)",
-    "Incoming" => "var(--rz-danger)",
-    "Outgoing" => "var(--rz-info)",
+    CallDirection.Incoming when entry.AnsweredOn != CallAnsweredOn.NotAnswered => "var(--rz-success)",
+    CallDirection.Incoming => "var(--rz-danger)",
+    CallDirection.Outgoing => "var(--rz-info)",
     _ => "var(--rz-text-color)"
   };
 }

--- a/src/Radio.Web/Models/ApiModels.cs
+++ b/src/Radio.Web/Models/ApiModels.cs
@@ -1020,10 +1020,35 @@ public class CallHistoryEntryDto
   public DateTime StartTime { get; set; }
   public DateTime? EndTime { get; set; }
   public string? Duration { get; set; }
-  public string Direction { get; set; } = "Incoming";
+  // RotaryPhone serializes the CallDirection/CallAnsweredOn enums as int
+  // (System.Text.Json default — no JsonStringEnumConverter is registered on
+  // RotaryPhone). Typing these as string threw JsonException ("Cannot get the
+  // value of a token type 'Number' as a string") and silently dropped the whole
+  // list, so the Call History tab showed an empty state. Use matching int-backed
+  // enums so deserialization succeeds against the numeric payload.
+  public CallDirection Direction { get; set; } = CallDirection.Incoming;
   public string PhoneNumber { get; set; } = "";
-  public string? AnsweredOn { get; set; }
+  public string? CallerName { get; set; }
+  public CallAnsweredOn AnsweredOn { get; set; } = CallAnsweredOn.NotAnswered;
   public string? PhoneId { get; set; }
+}
+
+// Must match the ordinal values of
+// RotaryPhoneController.Core.CallHistory.CallDirection (Incoming = 0, Outgoing = 1).
+public enum CallDirection
+{
+  Incoming = 0,
+  Outgoing = 1
+}
+
+// Must match the ordinal values of
+// RotaryPhoneController.Core.CallHistory.CallAnsweredOn
+// (NotAnswered = 0, RotaryPhone = 1, CellPhone = 2).
+public enum CallAnsweredOn
+{
+  NotAnswered = 0,
+  RotaryPhone = 1,
+  CellPhone = 2
 }
 
 // PBAP DTOs

--- a/tests/Radio.Web.Tests/Services/PhoneApiServiceTests.cs
+++ b/tests/Radio.Web.Tests/Services/PhoneApiServiceTests.cs
@@ -85,21 +85,37 @@ public class PhoneApiServiceTests
   }
 
   [Fact]
-  public async Task GetCallHistoryAsync_ReturnsList()
+  public async Task GetCallHistoryAsync_DeserializesLiveNumericShape()
   {
-    var expected = new List<CallHistoryEntryDto>
-    {
-      new() { Direction = "Incoming", PhoneNumber = "555-9876", AnsweredOn = "RotaryPhone" }
-    };
-    var handler = new MockHttpHandler(JsonSerializer.Serialize(expected, JsonOptions));
+    // Captured live from RotaryPhone GET http://radio:5004/api/callhistory on
+    // 2026-06-13. RotaryPhone serializes the CallDirection/CallAnsweredOn enums
+    // as JSON numbers (no JsonStringEnumConverter registered). Regression guard:
+    // a string-typed DTO threw JsonException at $[0].direction, dropping the
+    // entire list so the Call History tab silently showed "No calls recorded".
+    const string liveJson = """
+      [
+        {"id":"473e6334-2514-4d3e-9ab3-f9eca4c3b2de","phoneNumber":"9193718044","callerName":null,"direction":1,"answeredOn":0,"startTime":"2026-06-13T14:09:48.33-04:00","endTime":"2026-06-13T14:10:26.30-04:00","duration":"00:00:37.97","phoneId":"default"},
+        {"id":"b9e4962b-9e99-400f-83c9-fa01bcf83d67","phoneNumber":"+19193718044","callerName":null,"direction":0,"answeredOn":1,"startTime":"2026-06-13T14:08:58.68-04:00","endTime":"2026-06-13T14:09:22.48-04:00","duration":"00:00:23.80","phoneId":"default"}
+      ]
+      """;
+    var handler = new MockHttpHandler(liveJson);
     var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5004") };
     var service = CreateService(httpClient);
 
     var result = await service.GetCallHistoryAsync();
 
+    // The list must NOT be dropped (null/empty would mean the deserialize threw).
     Assert.NotNull(result);
-    Assert.Single(result);
-    Assert.Equal("RotaryPhone", result[0].AnsweredOn);
+    Assert.Equal(2, result.Count);
+
+    // First entry: outgoing, not answered.
+    Assert.Equal(CallDirection.Outgoing, result[0].Direction);
+    Assert.Equal(CallAnsweredOn.NotAnswered, result[0].AnsweredOn);
+    Assert.Equal("9193718044", result[0].PhoneNumber);
+
+    // Second entry: incoming, answered on the rotary phone.
+    Assert.Equal(CallDirection.Incoming, result[1].Direction);
+    Assert.Equal(CallAnsweredOn.RotaryPhone, result[1].AnsweredOn);
   }
 
   [Fact]


### PR DESCRIPTION
## Summary
Fixes the **Call History** tab on `/phone` silently showing "No calls recorded" even when calls exist (surfaced during the diagnostics-panel UAT, PR #430 — pre-existing, not introduced there).

**Root cause:** RotaryPhone.API serializes its `CallDirection` / `CallAnsweredOn` enums as JSON **numbers** (no `JsonStringEnumConverter` on its side), but `CallHistoryEntryDto` typed `direction` as `string` and `answeredOn` as `string?`. `GetFromJsonAsync` threw `JsonException: Cannot get the value of a token type 'Number' as a string` (Path `$[0].direction`); `PhoneApiService.GetCallHistoryAsync` caught it and returned `null`, so `PhoneHistoryPanel` fell into its empty-state branch.

**Fix** (mirrors the existing `GvSmsType` int-backed-enum idiom; ordinals confirmed against RotaryPhone's canonical `CallHistoryEntry.cs`, read-only — RotaryPhone unchanged):
- `Direction`: `string` → `CallDirection` enum (`Incoming=0, Outgoing=1`).
- `AnsweredOn`: `string?` → `CallAnsweredOn` enum (`NotAnswered=0, RotaryPhone=1, CellPhone=2`).
- Added the previously-missing `CallerName` field.
- `PhoneHistoryPanel.razor`: direction icon/label switch + "answered" highlight updated to the enums.

**Test:** replaced a weak round-trip test with `GetCallHistoryAsync_DeserializesLiveNumericShape` — feeds the captured live numeric JSON through a handler stub, asserts the list is **not** dropped and the enums parse to the expected values.

## Test plan
- Release build: **0 errors**. `Radio.Web.Tests`: **666/666**.
- Browser UAT pending (confirm Call History populates on the live kiosk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)