### PR TITLE
fix(web): format call-history duration as m:ss (drop tick precision)

### DIFF
--- a/src/Radio.Web/Components/Pages/PhoneHistoryPanel.razor
+++ b/src/Radio.Web/Components/Pages/PhoneHistoryPanel.razor
@@ -29,9 +29,9 @@
             <RadzenBadge Text="@entry.AnsweredOn.ToString()"
               BadgeStyle="@(entry.AnsweredOn == CallAnsweredOn.RotaryPhone ? BadgeStyle.Info : BadgeStyle.Light)" />
           }
-          @if (entry.Duration != null)
+          @if (!string.IsNullOrEmpty(entry.Duration))
           {
-            <span class="call-duration">@entry.Duration</span>
+            <span class="call-duration">@FormatDuration(entry.Duration)</span>
           }
         </div>
       }
@@ -58,4 +58,20 @@
     CallDirection.Outgoing => "var(--rz-info)",
     _ => "var(--rz-text-color)"
   };
+
+  // Call durations arrive from RotaryPhone as a raw TimeSpan string with full
+  // tick precision (e.g. "00:00:37.9710594"). Strip the sub-second noise and
+  // show a compact "m:ss" (or "h:mm:ss" for calls of an hour or more). Falls
+  // back to the raw string if it ever arrives in an unparseable format.
+  private static string FormatDuration(string? raw)
+  {
+    if (string.IsNullOrWhiteSpace(raw)
+        || !TimeSpan.TryParse(raw, System.Globalization.CultureInfo.InvariantCulture, out var ts))
+    {
+      return raw ?? "";
+    }
+
+    ts = TimeSpan.FromSeconds(Math.Round(ts.TotalSeconds));
+    return ts.TotalHours >= 1 ? ts.ToString(@"h\:mm\:ss") : ts.ToString(@"m\:ss");
+  }
 }

--- a/tests/Radio.Web.Tests/Components/Pages/PhoneHistoryPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Pages/PhoneHistoryPanelTests.cs
@@ -1,0 +1,61 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Radzen;
+using Radio.Web.Components.Pages;
+using Radio.Web.Models;
+using Xunit;
+
+namespace Radio.Web.Tests.Components.Pages;
+
+/// <summary>
+/// bUnit tests for <see cref="PhoneHistoryPanel"/> — pins the call-duration
+/// display formatting (raw TimeSpan strings from RotaryPhone carry full tick
+/// precision; the panel must render a clean m:ss / h:mm:ss).
+/// </summary>
+public class PhoneHistoryPanelTests : TestContext
+{
+  public PhoneHistoryPanelTests()
+  {
+    Services.AddRadzenComponents();
+    JSInterop.Mode = JSRuntimeMode.Loose;
+  }
+
+  private static CallHistoryEntryDto Entry(string? duration) => new()
+  {
+    Id = "1",
+    PhoneNumber = "9195551212",
+    StartTime = new DateTime(2026, 6, 13, 14, 9, 48, DateTimeKind.Local),
+    Direction = CallDirection.Incoming,
+    AnsweredOn = CallAnsweredOn.RotaryPhone,
+    Duration = duration
+  };
+
+  [Fact]
+  public void Duration_StripsSubSecondPrecision_ToMinSec()
+  {
+    var cut = RenderComponent<PhoneHistoryPanel>(p => p
+      .Add(x => x.CallHistory, new List<CallHistoryEntryDto> { Entry("00:00:37.9710594") }));
+
+    // 37.97s rounds to 38 → "0:38", not "00:00:37.9710594".
+    cut.Find(".call-duration").TextContent.Trim().Should().Be("0:38");
+  }
+
+  [Fact]
+  public void Duration_OverAnHour_UsesHoursMinutesSeconds()
+  {
+    var cut = RenderComponent<PhoneHistoryPanel>(p => p
+      .Add(x => x.CallHistory, new List<CallHistoryEntryDto> { Entry("01:02:05.2") }));
+
+    cut.Find(".call-duration").TextContent.Trim().Should().Be("1:02:05");
+  }
+
+  [Fact]
+  public void Duration_Null_OmitsDurationElement()
+  {
+    var cut = RenderComponent<PhoneHistoryPanel>(p => p
+      .Add(x => x.CallHistory, new List<CallHistoryEntryDto> { Entry(null) }));
+
+    cut.FindAll(".call-duration").Should().BeEmpty();
+  }
+}


### PR DESCRIPTION
## Summary
The Call History list rendered call durations verbatim — RotaryPhone sends them as raw `TimeSpan` strings with full tick precision (e.g. `00:00:37.9710594`), so the UI showed all the decimals.

Adds a `FormatDuration` helper in `PhoneHistoryPanel` that rounds to whole seconds and renders a compact **`m:ss`** (or **`h:mm:ss`** for calls ≥ 1h), falling back to the raw string if it ever arrives unparseable. **Display-only — no DTO/API change.**

## Test plan
- `PhoneHistoryPanelTests` (3): `00:00:37.97` → `0:38`, `01:02:05.2` → `1:02:05`, `null` → no duration element.
- Release build clean; targeted tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)