### PR TITLE
fix(deploy): stop needless wireplumber restart on every deploy

### DIFF
--- a/deploy/Deploy-ToLinux.ps1
+++ b/deploy/Deploy-ToLinux.ps1
@@ -263,7 +263,11 @@ function Sync-WpRule($name, $remoteDir) {
     Write-Host "  WARNING: install $name failed" -ForegroundColor Yellow
     return $false
   }
-  if ($result -match 'changed') {
+  # Exact-match the sentinel. NOT `-match 'changed'` — that is a regex/substring
+  # test, and "unchanged" CONTAINS "changed", so every UNCHANGED rule was reported
+  # as changed → a needless `systemctl --user restart wireplumber` (which cycles
+  # BT/audio) fired on every single deploy. Trim() guards a trailing newline from ssh.
+  if ("$result".Trim() -eq 'changed') {
     Write-Host "    + $remoteDir/$name" -ForegroundColor DarkGray
     return $true
   }


### PR DESCRIPTION
## Summary
Every deploy restarted WirePlumber (cycling BT/audio) even when no rule changed — which repeatedly knocked out the GV call-audio capture after each ship.

**Root cause:** `Sync-WpRule` tested the remote sentinel with `if ($result -match 'changed')`. `-match` is a regex/substring test, and **"unchanged" contains "changed"** — so even when `cmp` found the rule byte-identical (echoing `"unchanged"`), the check returned true → `systemctl --user restart wireplumber` on every deploy.

**Fix:** exact comparison `if ("$result".Trim() -eq 'changed')`. WirePlumber now restarts only when a rule's content genuinely changes.

## Verification
- `'unchanged' -match 'changed'` = **True** ← the bug
- `'unchanged'.Trim() -eq 'changed'` = **False** ← fixed (no restart)
- `'changed'.Trim() -eq 'changed'` = **True** ← genuine change still restarts
- Confirmed on the box: both installed rules are `cmp` byte-identical to the repo copies (always "unchanged"; the restart was purely the substring false-positive).

Deploy-script change only — takes effect on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)