### PR TITLE
fix(web): poll call history on /phone so new calls always appear

### DIFF
--- a/src/Radio.Web/Components/Pages/PhonePage.razor
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor
@@ -211,6 +211,14 @@
         var callState = await PhoneApi.GetCallStateAsync();
         if (callState != null) _callState = callState;
         _systemStatus = await PhoneApi.GetSystemStatusAsync();
+        // Poll-based fallback for call history. The SignalR CallHistoryUpdated
+        // event (OnCallHistoryUpdated) is the primary trigger, but if it's missed
+        // — hub reconnect after a deploy/service restart, or not fired for a given
+        // call path — the list would otherwise never catch up. This is the "next
+        // poll will catch up" the OnCallHistoryUpdated catch-block assumes. Guard
+        // on non-null so a transient fetch failure doesn't blank the existing list.
+        var history = await PhoneApi.GetCallHistoryAsync();
+        if (history != null) _callHistory = history;
         // Refresh GV status every 6th poll (30s) as SignalR fallback
         if (++_pollCount % 6 == 0)
         {


### PR DESCRIPTION
## Summary
A successful call wasn't appearing in the `/phone` Call History — upstream (`radio:5004/api/callhistory`) had it; the RTest UI never re-fetched.

**Root cause:** history is refreshed only by the SignalR `CallHistoryUpdated` event + on init/availability-flip. The 5s status poll refreshes call state + system status but **not** history — even though `OnCallHistoryUpdated`'s catch-block comments *"next poll will catch up."* So a missed `CallHistoryUpdated` (hub reconnect after a deploy/restart, or not fired for a call path) leaves new calls invisible until a full page reload.

**Fix:** re-fetch call history in the poll's `available` branch (null-guarded so a transient failure doesn't blank the list). New calls now surface within ~5s regardless of the SignalR event — making the assumed fallback real.

## Test plan
- Release build clean; `Radio.Web.Tests` **669/669** (no regression).
- Live: make a call → appears in Call History within ~5s, no reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)