### PR TITLE
feat(web): hydrate call history with contact names

### DIFF
--- a/src/Radio.Web/Components/Pages/PhoneHistoryPanel.razor
+++ b/src/Radio.Web/Components/Pages/PhoneHistoryPanel.razor
@@ -1,4 +1,9 @@
 @using Radio.Web.Models
+@using Radio.Core.Utilities
+
+<style>
+  .history-subnumber { font-size: 0.78rem; color: var(--text-low, #8A8895); }
+</style>
 
 <div class="phone-history">
   <div class="history-header">
@@ -21,7 +26,12 @@
           <RadzenIcon Icon="@GetCallDirectionIcon(entry)"
             Style="@($"color: {GetCallDirectionColor(entry)}")" />
           <div class="history-details">
-            <span class="phone-number">@entry.PhoneNumber</span>
+            @{ var contactName = ResolveContactName(entry); }
+            <span class="phone-number">@(contactName ?? entry.PhoneNumber)</span>
+            @if (contactName is not null && !string.IsNullOrEmpty(entry.PhoneNumber))
+            {
+              <span class="history-subnumber">@entry.PhoneNumber</span>
+            }
             <span class="history-time">@entry.StartTime.ToLocalTime().ToString("g")</span>
           </div>
           @if (entry.AnsweredOn != CallAnsweredOn.NotAnswered)
@@ -42,6 +52,39 @@
 @code {
   [Parameter] public List<CallHistoryEntryDto>? CallHistory { get; set; }
   [Parameter] public EventCallback OnClearHistory { get; set; }
+
+  /// <summary>Merged contact set (PBAP phonebook + RotaryPhone contacts) used to
+  /// hydrate call-history entries with a contact name instead of a bare number.</summary>
+  [Parameter] public List<MergedContact>? Contacts { get; set; }
+
+  // Normalized phone digits -> contact name, rebuilt when parameters change so the
+  // per-entry lookup is O(1). First contact wins for a shared number.
+  private Dictionary<string, string> _nameByNumber = new();
+
+  protected override void OnParametersSet()
+  {
+    var map = new Dictionary<string, string>(StringComparer.Ordinal);
+    if (Contacts is not null)
+    {
+      foreach (var c in Contacts)
+      {
+        if (string.IsNullOrWhiteSpace(c.Phone) || string.IsNullOrWhiteSpace(c.Name)) continue;
+        var key = PhoneNumberNormalizer.Normalize(c.Phone);
+        if (key.Length > 0) map.TryAdd(key, c.Name);
+      }
+    }
+    _nameByNumber = map;
+  }
+
+  // Resolution precedence: a name RotaryPhone already attached (CallerName) → a
+  // normalized match in the merged contact set → null (the caller renders the number).
+  private string? ResolveContactName(CallHistoryEntryDto entry)
+  {
+    if (!string.IsNullOrWhiteSpace(entry.CallerName)) return entry.CallerName;
+    if (string.IsNullOrWhiteSpace(entry.PhoneNumber)) return null;
+    var key = PhoneNumberNormalizer.Normalize(entry.PhoneNumber);
+    return key.Length > 0 && _nameByNumber.TryGetValue(key, out var name) ? name : null;
+  }
 
   private static string GetCallDirectionIcon(CallHistoryEntryDto entry) => entry.Direction switch
   {

--- a/src/Radio.Web/Components/Pages/PhonePage.razor
+++ b/src/Radio.Web/Components/Pages/PhonePage.razor
@@ -74,6 +74,7 @@
     else if (_activeTab == "history")
     {
       <PhoneHistoryPanel CallHistory="_callHistory"
+                         Contacts="MergedContacts"
                          OnClearHistory="ClearCallHistoryAsync" />
     }
     else if (_activeTab == "diagnostics")

--- a/tests/Radio.Web.Tests/Components/Pages/PhoneHistoryPanelTests.cs
+++ b/tests/Radio.Web.Tests/Components/Pages/PhoneHistoryPanelTests.cs
@@ -21,15 +21,21 @@ public class PhoneHistoryPanelTests : TestContext
     JSInterop.Mode = JSRuntimeMode.Loose;
   }
 
-  private static CallHistoryEntryDto Entry(string? duration) => new()
+  private static CallHistoryEntryDto Entry(string? duration = null, string phoneNumber = "9195551212", string? callerName = null) => new()
   {
     Id = "1",
-    PhoneNumber = "9195551212",
+    PhoneNumber = phoneNumber,
+    CallerName = callerName,
     StartTime = new DateTime(2026, 6, 13, 14, 9, 48, DateTimeKind.Local),
     Direction = CallDirection.Incoming,
     AnsweredOn = CallAnsweredOn.RotaryPhone,
     Duration = duration
   };
+
+  private IRenderedComponent<PhoneHistoryPanel> RenderWith(CallHistoryEntryDto entry, List<MergedContact>? contacts = null)
+    => RenderComponent<PhoneHistoryPanel>(p => p
+         .Add(x => x.CallHistory, new List<CallHistoryEntryDto> { entry })
+         .Add(x => x.Contacts, contacts ?? new List<MergedContact>()));
 
   [Fact]
   public void Duration_StripsSubSecondPrecision_ToMinSec()
@@ -57,5 +63,37 @@ public class PhoneHistoryPanelTests : TestContext
       .Add(x => x.CallHistory, new List<CallHistoryEntryDto> { Entry(null) }));
 
     cut.FindAll(".call-duration").Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Name_ResolvesFromContacts_AcrossNumberFormats()
+  {
+    // Contact stored as "+1 (919) 371-8044"; call logged as "9193718044" — must
+    // still match via PhoneNumberNormalizer.
+    var contacts = new List<MergedContact> { new(null, "Mom", "+1 (919) 371-8044", null, "PBAP") };
+
+    var cut = RenderWith(Entry(phoneNumber: "9193718044"), contacts);
+
+    cut.Find(".phone-number").TextContent.Trim().Should().Be("Mom");
+    cut.Find(".history-subnumber").TextContent.Trim().Should().Be("9193718044");
+  }
+
+  [Fact]
+  public void Name_FallsBackToNumber_WhenNoContactMatch()
+  {
+    var cut = RenderWith(Entry(phoneNumber: "5550000000"));
+
+    cut.Find(".phone-number").TextContent.Trim().Should().Be("5550000000");
+    cut.FindAll(".history-subnumber").Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Name_PrefersServerCallerName_OverContactLookup()
+  {
+    var contacts = new List<MergedContact> { new(null, "Mom", "9193718044", null, "PBAP") };
+
+    var cut = RenderWith(Entry(phoneNumber: "9193718044", callerName: "Dad"), contacts);
+
+    cut.Find(".phone-number").TextContent.Trim().Should().Be("Dad");
   }
 }


### PR DESCRIPTION
## Summary
Call History rendered only the raw phone number — now each entry resolves to a **contact name** when known.

- Resolve `entry.PhoneNumber` → name from **`MergedContacts`** (PBAP phonebook synced over BT + RotaryPhone contacts) using `PhoneNumberNormalizer`, so stored formats match the logged number (`9193718044` ↔ `+1 (919) 371-8044`).
- Precedence: server `CallerName` (if RotaryPhone populates it) → normalized contact match → the number.
- When a name resolves, the number shows as a muted subtitle. `PhonePage` passes `MergedContacts` into `PhoneHistoryPanel`.

Lives in RTest (not RP) because RTest holds the richest contact set — the PBAP-synced phonebook RotaryPhone doesn't have.

## Test plan
- `PhoneHistoryPanelTests` +3: resolves across number formats; falls back to the number when unmatched; prefers a server `CallerName`.
- Release build clean; `Radio.Web.Tests` **672/672**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)